### PR TITLE
Refresh README diagram and drop Project status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,14 @@ The core idea in one sentence: **the `.md` file on disk is the durable source of
 
 Every change funnels through the same CRDT as operations, never whole-file overwrites. Whether it comes from a person typing, an AI rewriting a paragraph, or a teammate across the world, edits **merge** instead of overwriting each other.
 
-```
-   You / AI / Git                       Teammates
-        │                                   │
-   edit .md file                     edit in real time
-        │                                   │
-        ▼                                   ▼
-  ┌───────────────┐   operations    ┌────────────────┐
-  │  Markdown on  │ ◀────────────▶  │   Live CRDT     │
-  │     disk      │   (two-way)     │  (Yjs Y.Text)   │
-  └───────────────┘                 └────────────────┘
-   durable truth                     live sync + merge
-```
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/bridge-dark.svg">
+  <img alt="Markdown on disk and a live CRDT kept in sync by a two-way bridge of operations" src="docs/assets/bridge-light.svg" width="760">
+</picture>
+
+</div>
 
 Everything else (the desktop app, the search index, the sync server) is a rebuildable layer on top of your files.
 
@@ -186,22 +182,6 @@ claude mcp add --transport http context http://localhost:3010/api/mcp \
 self-hosted server, use your server URL plus `/api/mcp`.)
 
 The AI can now `read_note`, `search_notes`, `create_note`, `update_note`, and more. Its writes flow through the same sync engine, so if the note is open you'll watch the AI type in real time.
-
----
-
-## Project status
-
-🟢 **Released.** The core product is built, wired end-to-end, and tested. It delivers **10 of the 12** target requirements, including the two no other open-source tool combined: AI-editable plain files **and** built-in real-time collaboration.
-
-| Phase | Scope | Status |
-|---|---|---|
-| 0 | Single-user local app (open folder, edit, save, search) | ✅ Done |
-| 1 | Local file ↔ CRDT bridge | ✅ Done |
-| 2 | Sync server + accounts (multi-device) | ✅ Done |
-| 3 | Team collaboration (sharing, permissions, live cursors, attachments) | ✅ Done |
-| 4 | Polish & upgrades (WYSIWYG, semantic search, OAuth, iOS) | ⬜ Planned |
-
-See [`docs/STATUS.md`](docs/STATUS.md) for the detailed checklist.
 
 ---
 

--- a/docs/assets/bridge-dark.svg
+++ b/docs/assets/bridge-dark.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Markdown on disk and a live CRDT kept in sync by a two-way bridge">
+  <defs>
+    <linearGradient id="wire" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#58a6ff"/>
+      <stop offset="1" stop-color="#56d4e4"/>
+    </linearGradient>
+    <marker id="triN" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#6e7681"/>
+    </marker>
+    <marker id="triA" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#56c8e0"/>
+    </marker>
+  </defs>
+
+  <!-- top actors -->
+  <text x="220" y="46" text-anchor="middle" font-size="18" font-weight="700" fill="#e6edf3">You · AI · Git</text>
+  <text x="220" y="70" text-anchor="middle" font-size="13.5" fill="#8b949e">edit the .md file</text>
+  <text x="680" y="46" text-anchor="middle" font-size="18" font-weight="700" fill="#e6edf3">Teammates</text>
+  <text x="680" y="70" text-anchor="middle" font-size="13.5" fill="#8b949e">edit in real time</text>
+
+  <!-- down connectors -->
+  <line x1="220" y1="92" x2="220" y2="168" stroke="#6e7681" stroke-width="2" marker-end="url(#triN)"/>
+  <line x1="680" y1="92" x2="680" y2="168" stroke="#6e7681" stroke-width="2" marker-end="url(#triN)"/>
+
+  <!-- disk card -->
+  <rect x="70" y="176" width="300" height="112" rx="16" fill="#161b22" stroke="#30363d"/>
+  <text x="220" y="222" text-anchor="middle" font-size="21" font-weight="700" fill="#e6edf3">Markdown on disk</text>
+  <rect x="196" y="234" width="48" height="3" rx="1.5" fill="#58a6ff"/>
+  <text x="220" y="262" text-anchor="middle" font-size="13.5" fill="#8b949e">durable source of truth</text>
+
+  <!-- crdt card -->
+  <rect x="530" y="176" width="300" height="112" rx="16" fill="#161b22" stroke="#30363d"/>
+  <text x="680" y="222" text-anchor="middle" font-size="21" font-weight="700" fill="#e6edf3">Live CRDT</text>
+  <rect x="656" y="234" width="48" height="3" rx="1.5" fill="#56d4e4"/>
+  <text x="680" y="262" text-anchor="middle" font-size="13.5" fill="#8b949e">Yjs Y.Text · live sync + merge</text>
+
+  <!-- two-way bridge -->
+  <text x="450" y="216" text-anchor="middle" font-size="13" font-weight="600" fill="#56d4e4">operations</text>
+  <line x1="382" y1="232" x2="518" y2="232" stroke="url(#wire)" stroke-width="2.75" marker-start="url(#triA)" marker-end="url(#triA)"/>
+  <text x="450" y="260" text-anchor="middle" font-size="12.5" fill="#8b949e">two-way</text>
+</svg>

--- a/docs/assets/bridge-light.svg
+++ b/docs/assets/bridge-light.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" role="img" aria-label="Markdown on disk and a live CRDT kept in sync by a two-way bridge">
+  <defs>
+    <linearGradient id="wire" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2f81f7"/>
+      <stop offset="1" stop-color="#0ca7bd"/>
+    </linearGradient>
+    <marker id="triN" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9aa4af"/>
+    </marker>
+    <marker id="triA" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1e97b8"/>
+    </marker>
+  </defs>
+
+  <!-- top actors -->
+  <text x="220" y="46" text-anchor="middle" font-size="18" font-weight="700" fill="#1f2328">You · AI · Git</text>
+  <text x="220" y="70" text-anchor="middle" font-size="13.5" fill="#59636e">edit the .md file</text>
+  <text x="680" y="46" text-anchor="middle" font-size="18" font-weight="700" fill="#1f2328">Teammates</text>
+  <text x="680" y="70" text-anchor="middle" font-size="13.5" fill="#59636e">edit in real time</text>
+
+  <!-- down connectors -->
+  <line x1="220" y1="92" x2="220" y2="168" stroke="#9aa4af" stroke-width="2" marker-end="url(#triN)"/>
+  <line x1="680" y1="92" x2="680" y2="168" stroke="#9aa4af" stroke-width="2" marker-end="url(#triN)"/>
+
+  <!-- disk card -->
+  <rect x="70" y="176" width="300" height="112" rx="16" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="220" y="222" text-anchor="middle" font-size="21" font-weight="700" fill="#1f2328">Markdown on disk</text>
+  <rect x="196" y="234" width="48" height="3" rx="1.5" fill="#2f81f7"/>
+  <text x="220" y="262" text-anchor="middle" font-size="13.5" fill="#59636e">durable source of truth</text>
+
+  <!-- crdt card -->
+  <rect x="530" y="176" width="300" height="112" rx="16" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="680" y="222" text-anchor="middle" font-size="21" font-weight="700" fill="#1f2328">Live CRDT</text>
+  <rect x="656" y="234" width="48" height="3" rx="1.5" fill="#0ca7bd"/>
+  <text x="680" y="262" text-anchor="middle" font-size="13.5" fill="#59636e">Yjs Y.Text · live sync + merge</text>
+
+  <!-- two-way bridge -->
+  <text x="450" y="216" text-anchor="middle" font-size="13" font-weight="600" fill="#1e97b8">operations</text>
+  <line x1="382" y1="232" x2="518" y2="232" stroke="url(#wire)" stroke-width="2.75" marker-start="url(#triA)" marker-end="url(#triA)"/>
+  <text x="450" y="260" text-anchor="middle" font-size="12.5" fill="#59636e">two-way</text>
+</svg>


### PR DESCRIPTION
Replaces the ASCII bridge diagram with a theme-aware SVG (light/dark via <picture>) and removes the Project status section.