### PR TITLE
docs: clean up product film block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <div align="center">
 
-<video src="https://github.com/naveedharri/baalda/raw/main/docs/baalda-product-film.mp4" controls muted loop playsinline width="80%"></video>
+<!-- Inline player: edit this file in GitHub's web editor and drag the product film mp4 onto the line below. GitHub inserts a user-attachments URL that renders as a play-in-place player. -->
 
 [▶ Watch the product film](https://github.com/naveedharri/baalda/raw/main/docs/baalda-product-film.mp4)
 


### PR DESCRIPTION
Removes the committed-file <video> tag (GitHub doesn't render an inline player from a repo file) and keeps a working Watch link. The inline player will be added by dragging the mp4 into the README web editor.