### PR TITLE
Fix open issues #4, #5, #6, #7, #9

### DIFF
--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -265,6 +265,15 @@ pub async fn create_vault(
     open_vault_inner(&app, &state, dir)
 }
 
+/// Report whether a folder already looks like a vault (has our `.context/` index
+/// or contains markdown notes). The vault picker calls this after "New vault"
+/// picks a parent, so it can offer to *open* an existing vault instead of
+/// nesting a new empty one inside it.
+#[tauri::command]
+pub fn is_vault(path: String) -> AppResult<bool> {
+    Ok(crate::vault::is_vault(std::path::Path::new(&path)))
+}
+
 /// The configured sync server base URL, if the user has set one.
 #[tauri::command]
 pub fn get_server_url(app: AppHandle) -> AppResult<Option<String>> {

--- a/app/apps/desktop/src-tauri/src/index.rs
+++ b/app/apps/desktop/src-tauri/src/index.rs
@@ -494,9 +494,14 @@ impl Index {
         if match_query.is_empty() {
             return Ok(Vec::new());
         }
+        // Delimit the highlight with control-char sentinels (U+0001/U+0002) that
+        // can't occur in note text, so we can HTML-escape the whole snippet and
+        // then swap the sentinels for real <mark> tags — see html_escape. This
+        // makes the snippet safe to render as HTML (only <mark> survives) even
+        // though the body is raw markdown.
         let mut stmt = self.conn.prepare(
             "SELECT n.id, n.path, n.title,
-                    snippet(notes_fts, 1, '<mark>', '</mark>', '…', 12) AS snip
+                    snippet(notes_fts, 1, char(1), char(2), '…', 12) AS snip
              FROM notes_fts
              JOIN notes n ON n.rowid = notes_fts.rowid
              WHERE notes_fts MATCH ?1
@@ -504,11 +509,15 @@ impl Index {
              LIMIT 100",
         )?;
         let rows = stmt.query_map(params![match_query], |r| {
+            let raw: String = r.get(3)?;
+            let snippet = html_escape(&raw)
+                .replace('\u{1}', "<mark>")
+                .replace('\u{2}', "</mark>");
             Ok(SearchResult {
                 id: r.get(0)?,
                 path: r.get(1)?,
                 title: r.get(2)?,
-                snippet: r.get(3)?,
+                snippet,
             })
         })?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
@@ -766,6 +775,26 @@ fn build_fts_query(input: &str) -> String {
     terms.join(" AND ")
 }
 
+/// HTML-escape text so a note body can never inject markup when a snippet is
+/// rendered. The FTS `body` column stores raw markdown (which may contain
+/// literal `<`, `>`, `&`, quotes, or even `<script>`/`<img onerror=…>`), so the
+/// snippet is escaped before the `<mark>` highlight markers are put back — the
+/// only tags that survive into the rendered snippet are our own `<mark>`s.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -811,6 +840,34 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].title, "Beta");
         assert!(results[0].snippet.contains("<mark>"));
+    }
+
+    #[test]
+    fn fts_snippet_html_escapes_body_to_prevent_xss() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        // A note body carrying an HTML/JS payload adjacent to the search terms.
+        write_note(
+            &v,
+            "Evil.md",
+            "# Evil\n\nThe quick <img src=x onerror=\"alert(document.domain)\"> brown fox & <b>bold</b>.",
+        )
+        .unwrap();
+        let idx = Index::open(&v).unwrap();
+        idx.rebuild(&v).unwrap();
+
+        let results = idx.search_notes("quick brown").unwrap();
+        assert_eq!(results.len(), 1);
+        let snip = &results[0].snippet;
+        // The dangerous markup is escaped — no live tags survive.
+        assert!(snip.contains("&lt;img"), "raw < must be escaped: {snip}");
+        assert!(!snip.contains("<img"), "no live <img> tag may survive: {snip}");
+        assert!(!snip.contains("onerror=\"alert"), "no live handler may survive: {snip}");
+        // The `"` around the handler is entity-escaped (proves the &-based
+        // escaping path runs over the snippet).
+        assert!(snip.contains("&quot;"), "raw \" must be escaped: {snip}");
+        // The highlight markers are still present and are the only surviving tags.
+        assert!(snip.contains("<mark>") && snip.contains("</mark>"), "highlight preserved: {snip}");
     }
 
     #[test]

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
             commands::get_recent_vaults,
             commands::remove_recent_vault,
             commands::create_vault,
+            commands::is_vault,
             commands::list_tree,
             commands::read_note,
             commands::write_note,

--- a/app/apps/desktop/src-tauri/src/vault.rs
+++ b/app/apps/desktop/src-tauri/src/vault.rs
@@ -43,6 +43,33 @@ pub fn is_allowed_file(name: &str) -> bool {
     }
 }
 
+/// True if `dir` already looks like a vault: it has our `.context/` index, or it
+/// directly contains at least one markdown note. The vault picker uses this to
+/// offer "open it instead" rather than silently creating a nested empty vault
+/// inside a folder the user already uses as a vault.
+pub fn is_vault(dir: &Path) -> bool {
+    if dir.join(".context").is_dir() {
+        return true;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    const NOTE_EXTS: &[&str] = &["md", "markdown", "mdx"];
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some((stem, ext)) = name.rsplit_once('.') {
+            if !stem.is_empty() && NOTE_EXTS.contains(&ext.to_ascii_lowercase().as_str()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// True if any component of a vault-relative path is an ignored dir/dotfile.
 pub fn rel_path_is_ignored(rel: &str) -> bool {
     rel.split('/').any(|seg| !seg.is_empty() && is_ignored_name(seg))
@@ -168,5 +195,28 @@ mod tests {
     fn rel_from_abs_uses_forward_slashes() {
         let rel = rel_from_abs(&vault(), Path::new("/tmp/vault/a/b.md")).unwrap();
         assert_eq!(rel, "a/b.md");
+    }
+
+    #[test]
+    fn is_vault_detects_context_dir_and_notes() {
+        // Empty folder → not a vault.
+        let empty = tempfile::tempdir().unwrap();
+        assert!(!is_vault(empty.path()));
+
+        // Folder with a .context/ index → a vault.
+        let indexed = tempfile::tempdir().unwrap();
+        std::fs::create_dir(indexed.path().join(".context")).unwrap();
+        assert!(is_vault(indexed.path()));
+
+        // Folder with a markdown note → a vault.
+        let noted = tempfile::tempdir().unwrap();
+        std::fs::write(noted.path().join("Welcome.md"), "# hi").unwrap();
+        assert!(is_vault(noted.path()));
+
+        // Folder with only non-note files (images/pdf/junk) → not a vault.
+        let assets = tempfile::tempdir().unwrap();
+        std::fs::write(assets.path().join("photo.png"), b"x").unwrap();
+        std::fs::write(assets.path().join("report.pdf"), b"x").unwrap();
+        assert!(!is_vault(assets.path()));
     }
 }

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null,
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost data: blob:; connect-src 'self' ipc: http://ipc.localhost; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-src 'none'",
       "assetProtocol": {
         "enable": true,
         "scope": []

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FileTree } from "./components/FileTree";
 import { GraphView } from "./components/GraphView";
 import { SyncBadge } from "./components/Identity";
+import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { VaultPicker } from "./components/VaultPicker";
 import { bridgeManager } from "./lib/bridge";
@@ -175,6 +176,7 @@ export default function App() {
   const isPreview = openNote != null && previewKind(openNote.path) != null;
   const [booting, setBooting] = useState(true);
   const [graphOpen, setGraphOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   // Auto-reopen the last vault on launch, then restore the session (spec 04 §7)
   // and enable sync. Vault first so `enableSyncForVault` (called inside initAuth)
@@ -312,6 +314,10 @@ export default function App() {
         e.preventDefault();
         setGraphOpen((v) => !v);
       }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        setSearchOpen((v) => !v);
+      }
       // ⌘R / Ctrl+R → reload the whole app. On macOS the webview often swallows
       // ⌘R before JS sees it, so the "rr" chord below is the reliable path.
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "r") {
@@ -358,6 +364,7 @@ export default function App() {
     <div className="app">
       <aside className="sidebar">
         <SidebarHeader />
+        {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
         <FileTree />
         <div className="sidebar-footer">
           <AccountMenu />
@@ -370,6 +377,25 @@ export default function App() {
           <span className="note-title">{openNote?.title ?? "No note open"}</span>
           {openNote && !isPreview && <SaveIndicator />}
           {openNote && !isPreview && <SyncIndicator />}
+          <button
+            className="icon-btn search-btn"
+            title="Search notes (⌘F)"
+            aria-label="Search notes"
+            onClick={() => setSearchOpen((v) => !v)}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-3.5-3.5" />
+            </svg>
+          </button>
           <button
             className="icon-btn graph-btn"
             title="Graph view (⌘G)"

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -216,6 +216,11 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const ownOrgLock = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "locked");
   const inheritedOrgLock = !!effLock?.org && !ownOrgLock;
   const generalMode: Mode = ownOrgLock || inheritedOrgLock ? "readonly" : "open";
+  // When an Everyone/org lock (direct or inherited) already makes the resource
+  // read-only for all, a per-member "read-only" lock is redundant and makes
+  // Unlock misleading — so the per-person controls are suppressed in favour of
+  // the single workspace/parent lock.
+  const everyoneReadonly = generalMode === "readonly";
 
   const lockSourcePath = (): string | null => {
     if (!selected) return null;
@@ -473,7 +478,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                           </div>
                           <div className="access-prole">{sourceLabel(m, choice)}</div>
                         </div>
-                        {canManage && m.role !== "owner" ? (
+                        {canManage && m.role !== "owner" && !everyoneReadonly ? (
                           <select
                             className="access-choice"
                             value={choice}

--- a/app/apps/desktop/src/components/SearchPanel.tsx
+++ b/app/apps/desktop/src/components/SearchPanel.tsx
@@ -64,7 +64,10 @@ export function SearchPanel({ onClose }: { onClose?: () => void }) {
               <div className="search-title">{r.title || r.path}</div>
               <div
                 className="search-snippet"
-                // Rust returns a sanitized snippet with <mark> tags only.
+                // The snippet is HTML-escaped in Rust (see index.rs::html_escape)
+                // so the ONLY markup it can contain is our own <mark> highlight
+                // tags — note bodies can't inject anything. A CSP (tauri.conf.json)
+                // backstops this by blocking inline script even if that changed.
                 dangerouslySetInnerHTML={{ __html: r.snippet }}
               />
             </li>

--- a/app/apps/desktop/src/components/SearchPanel.tsx
+++ b/app/apps/desktop/src/components/SearchPanel.tsx
@@ -3,10 +3,16 @@ import type { SearchResult } from "../lib/ipc";
 import * as ipc from "../lib/ipc";
 import { useStore } from "../store";
 
-export function SearchPanel() {
+export function SearchPanel({ onClose }: { onClose?: () => void }) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const timer = useRef<number | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Focus the box as soon as the panel opens so ⌘F is type-and-go.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     if (timer.current) window.clearTimeout(timer.current);
@@ -26,15 +32,24 @@ export function SearchPanel() {
     };
   }, [query]);
 
+  const open = (path: string) => {
+    void useStore.getState().openNoteByPath(path);
+    onClose?.();
+  };
+
   return (
     <div className="search-panel">
       <div className="search-field">
         <span className="search-icon" aria-hidden="true">⌕</span>
         <input
+          ref={inputRef}
           className="search-box"
           placeholder="Search notes…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") onClose?.();
+          }}
         />
       </div>
       {query.trim() && (
@@ -44,7 +59,7 @@ export function SearchPanel() {
             <li
               key={r.id}
               className="search-result"
-              onClick={() => void useStore.getState().openNoteByPath(r.path)}
+              onClick={() => open(r.path)}
             >
               <div className="search-title">{r.title || r.path}</div>
               <div

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -69,6 +69,9 @@ export function VaultPicker() {
   // New-vault flow: null = idle; a string = chosen parent, awaiting a name.
   const [newParent, setNewParent] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
+  // When "New vault" lands on a folder that's already a vault, hold its path so
+  // we can offer to open it instead of nesting a new empty vault inside it.
+  const [alreadyVault, setAlreadyVault] = useState<string | null>(null);
   const reduceMotion = useReducedMotion();
 
   // Surface recently opened vaults as one-tap "reopen" affordances.
@@ -110,17 +113,51 @@ export function VaultPicker() {
     }
   }
 
-  // "New vault" step 1: choose the parent location, then ask for a name.
+  // "New vault" step 1: choose the parent location, then ask for a name. If the
+  // chosen folder is ALREADY a vault, don't nest a new empty vault inside it —
+  // offer to open the existing one instead.
   async function startNewVault() {
     setError(null);
     try {
       const parent = await ipc.pickFolder();
       if (!parent) return;
+      if (await ipc.isVault(parent)) {
+        setAlreadyVault(parent);
+        return;
+      }
       setNewParent(parent);
       setNewName("Untitled Vault");
     } catch (e) {
       setError(String(e));
     }
+  }
+
+  // The picked folder is already a vault → open it directly.
+  async function openDetectedVault() {
+    if (!alreadyVault) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const info = await ipc.openVault(alreadyVault);
+      await openVault(info);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // User insists on creating a fresh vault inside the existing one anyway.
+  function createInsideAnyway() {
+    if (!alreadyVault) return;
+    setNewParent(alreadyVault);
+    setNewName("Untitled Vault");
+    setAlreadyVault(null);
+  }
+
+  function cancelAlreadyVault() {
+    setAlreadyVault(null);
+    setError(null);
   }
 
   // "New vault" step 2: create <parent>/<name> and open it.
@@ -167,6 +204,10 @@ export function VaultPicker() {
   }
 
   const naming = newParent !== null;
+  const deciding = alreadyVault !== null;
+  // Whether either multi-step flow (naming a new vault, or deciding what to do
+  // with an already-a-vault folder) is showing — hides the recents/hint.
+  const inFlow = naming || deciding;
 
   return (
     <div className="vault-picker">
@@ -198,7 +239,49 @@ export function VaultPicker() {
           transition={reduceMotion ? undefined : revealTransition(REVEAL_DELAY)}
         >
           <AnimatePresence mode="wait" initial={false}>
-            {naming ? (
+            {deciding ? (
+              // ---- Picked folder is already a vault: open vs nest ----
+              <motion.div
+                key="already"
+                className="new-vault-form"
+                initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reduceMotion ? undefined : { opacity: 0, y: -8 }}
+                transition={SPRING}
+              >
+                <label className="new-vault-label">This folder is already a vault</label>
+                <p className="new-vault-loc" title={alreadyVault ?? undefined}>
+                  <code>{tidyPath(alreadyVault ?? "")}</code> already contains notes — open
+                  it instead of creating a new vault inside?
+                </p>
+                <div className="new-vault-buttons">
+                  <button
+                    type="button"
+                    className="ghost-pill"
+                    disabled={busy}
+                    onClick={cancelAlreadyVault}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost-pill"
+                    disabled={busy}
+                    onClick={createInsideAnyway}
+                  >
+                    Create inside
+                  </button>
+                  <button
+                    type="button"
+                    className="primary sm"
+                    disabled={busy}
+                    onClick={() => void openDetectedVault()}
+                  >
+                    {busy ? "Opening…" : "Open vault"}
+                  </button>
+                </div>
+              </motion.div>
+            ) : naming ? (
               // ---- New-vault naming step ----
               <motion.form
                 key="naming"
@@ -284,7 +367,7 @@ export function VaultPicker() {
 
         {error && <p className="error">{error}</p>}
 
-        {!naming && recents.length > 0 && (
+        {!inFlow && recents.length > 0 && (
           <motion.div
             className="recent-list"
             initial={reduceMotion ? false : { opacity: 0, y: 8 }}
@@ -322,7 +405,7 @@ export function VaultPicker() {
           </motion.div>
         )}
 
-        {!naming && (
+        {!inFlow && (
           <motion.p
             className="hint"
             initial={reduceMotion ? false : { opacity: 0, y: 8 }}

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -110,6 +110,9 @@ export const removeRecentVault = (path: string) =>
 export const createVault = (parent: string, name: string) =>
   invoke<VaultInfo>("create_vault", { parent, name });
 
+/** True if a folder already looks like a vault (has `.context/` or `.md` notes). */
+export const isVault = (path: string) => invoke<boolean>("is_vault", { path });
+
 // ---- Workspace root + `current` pointer (per-workspace folders) ------------
 // The app manages one root dir; each workspace gets a subfolder, and the active
 // workspace's folder is mirrored to `<root>/current` for external tools.

--- a/app/apps/server/src/http/routes/shares.ts
+++ b/app/apps/server/src/http/routes/shares.ts
@@ -111,6 +111,37 @@ export function createShareRoutes(deps: ShareDeps): Hono {
       return c.json({ error: "principalId required for user shares" }, 400);
     }
 
+    // Locks are subsumption-aware: an Everyone/org lock on a resource makes any
+    // per-user lock on the SAME resource redundant. Without this, a resource can
+    // carry both an org lock and a user lock, and Unlock becomes misleading —
+    // removing one leaves the resource locked by the other, so unlock appears to
+    // do nothing. We keep a single authoritative lock per resource instead.
+    if (permission === "locked" && principalType === "user") {
+      // An org lock already covers everyone here — the per-user lock adds
+      // nothing. No-op and report the effective (org) lock.
+      const { rows: orgLock } = await pool.query<{ id: string }>(
+        `SELECT id FROM shares
+          WHERE resource_type = $1 AND resource_id = $2
+            AND principal_type = 'org' AND permission = 'locked'
+          LIMIT 1`,
+        [resourceType, resourceId],
+      );
+      if (orgLock[0]) {
+        return c.json(
+          {
+            id: orgLock[0].id,
+            resourceType,
+            resourceId,
+            principalType: "org",
+            principalId: gate.organizationId,
+            permission: "locked",
+            subsumed: true,
+          },
+          200,
+        );
+      }
+    }
+
     const id = randomUUID();
     const { rows } = await pool.query<{ id: string }>(
       `INSERT INTO shares
@@ -130,6 +161,18 @@ export function createShareRoutes(deps: ShareDeps): Hono {
         session.userId,
       ],
     );
+
+    // An Everyone/org lock subsumes any per-user locks on the same resource —
+    // drop them so a single Unlock actually unlocks. (Those users stay locked by
+    // the org lock, so no access change and no socket kick is needed.)
+    if (permission === "locked" && principalType === "org") {
+      await pool.query(
+        `DELETE FROM shares
+          WHERE resource_type = $1 AND resource_id = $2
+            AND principal_type = 'user' AND permission = 'locked'`,
+        [resourceType, resourceId],
+      );
+    }
 
     // Any downgrade to read-only must reach live editors immediately — force
     // reconnect so open sessions come back with fresh (now read-only) sync

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { pool } from "../db/pool.js";
 import { orgRole } from "../permissions/lookup.js";
-import { effectivePermission, type Permission } from "../permissions/resolver.js";
+import {
+  ancestorFolderIds,
+  effectivePermission,
+  isLocked,
+  type Permission,
+} from "../permissions/resolver.js";
 import { cosineSimilarity, embed, tokenize } from "../index/embedder.js";
 import type { McpAuth } from "./tokens.js";
 import type { DocWriter } from "./doc-writer.js";
@@ -55,11 +60,21 @@ async function isAdmin(auth: McpAuth): Promise<boolean> {
  * Highest permission the caller has to CREATE/DELETE inside a folder: admins
  * get `edit`; otherwise the max `edit` share on the folder or any ancestor.
  * A null folder is the vault root — only admins may write there.
+ *
+ * A lock on the folder (or any ancestor) makes it read-only for EVERYONE,
+ * owners/admins included — the same deny-overlay `effectivePermission` applies
+ * to note edits. It is checked before the admin short-circuit so create/delete
+ * of notes and subfolders is blocked inside a locked folder, not just edits to
+ * existing notes.
  */
 async function folderWritePermission(
   auth: McpAuth,
   folderId: string | null,
 ): Promise<Permission> {
+  if (folderId) {
+    const chain = await ancestorFolderIds(pool, folderId);
+    if (await isLocked(pool, auth.userId, null, chain)) return "none";
+  }
   if (await isAdmin(auth)) return "edit";
   if (!folderId) return "none";
   const { rows } = await pool.query<{ permission: string }>(

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -70,7 +70,7 @@ async function locateDoc(
 }
 
 /** Walk parent_id up from a folder, collecting all ancestor folder ids (inclusive). */
-async function ancestorFolderIds(
+export async function ancestorFolderIds(
   db: Queryable,
   folderId: string | null,
 ): Promise<string[]> {
@@ -158,7 +158,7 @@ async function sharePermission(
  * True when a lock row covers this resource (a file when `docId` is set, plus
  * any folder in `folderIds`) for this user or the whole workspace.
  */
-async function isLocked(
+export async function isLocked(
   db: Queryable,
   userId: string,
   docId: string | null,

--- a/app/apps/server/tests/mcp.test.ts
+++ b/app/apps/server/tests/mcp.test.ts
@@ -5,6 +5,7 @@ import { resetDb } from "./helpers/db.js";
 import { memoryDocWriter } from "./helpers/app.js";
 import {
   seedFolder,
+  seedLock,
   seedMember,
   seedOrg,
   seedShare,
@@ -203,6 +204,80 @@ describe("MCP server", () => {
     // Member's list now shows exactly the shared note.
     const list = await call(memberToken, "list_notes", { vaultId: vault });
     expect(list.data.results.map((n: any) => n.docId)).toEqual([sharedDoc]);
+  });
+
+  it("a locked folder blocks create/delete for everyone, incl. admins (MCP)", async () => {
+    const owner = await seedUser("owner@mcp-lock.com");
+    const member = await seedUser("member@mcp-lock.com");
+    const org = await seedOrg("Acme", "acme-mcp-lock");
+    await seedMember(org, owner, "owner");
+    await seedMember(org, member, "member");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Locked", "Locked");
+    const child = await seedFolder(vault, folder, "Locked/Child", "Child");
+    // Member has an explicit edit grant on the folder …
+    await seedShare(org, "folder", folder, member, "edit");
+    const ownerToken = await tokenFor(owner, org);
+    const memberToken = await tokenFor(member, org);
+
+    // … but an org lock on the folder makes it read-only for all.
+    await seedLock(org, "folder", folder, { type: "org" });
+
+    // create_note inside the locked folder is denied for the edit-member.
+    expect(
+      (
+        await call(memberToken, "create_note", {
+          vaultId: vault,
+          relPath: "Locked/nope.md",
+          folderId: folder,
+        })
+      ).isError,
+    ).toBe(true);
+    // … and for an owner/admin — a lock caps admins too.
+    expect(
+      (
+        await call(ownerToken, "create_note", {
+          vaultId: vault,
+          relPath: "Locked/nope2.md",
+          folderId: folder,
+        })
+      ).isError,
+    ).toBe(true);
+    // create_folder under the locked folder is denied (admin).
+    expect(
+      (await call(ownerToken, "create_folder", { vaultId: vault, parentId: folder, name: "x" }))
+        .isError,
+    ).toBe(true);
+    // delete_folder of the locked folder is denied (admin).
+    expect((await call(ownerToken, "delete_folder", { folderId: folder })).isError).toBe(true);
+    // The lock reaches descendants: create in a child of the locked folder is denied.
+    expect(
+      (
+        await call(ownerToken, "create_note", {
+          vaultId: vault,
+          relPath: "Locked/Child/nope.md",
+          folderId: child,
+        })
+      ).isError,
+    ).toBe(true);
+
+    // A per-user lock (rather than org) also blocks that user's create: the
+    // member has an inherited edit grant on the parent, but a user-scoped lock
+    // on the child caps it. (Grant + lock live on different folders so they
+    // don't collide on the one-row-per-(resource,principal) key.)
+    const grantParent = await seedFolder(vault, null, "Grant", "Grant");
+    const userLocked = await seedFolder(vault, grantParent, "Grant/Locked", "Locked");
+    await seedShare(org, "folder", grantParent, member, "edit");
+    await seedLock(org, "folder", userLocked, { type: "user", id: member });
+    expect(
+      (
+        await call(memberToken, "create_note", {
+          vaultId: vault,
+          relPath: "Grant/Locked/nope.md",
+          folderId: userLocked,
+        })
+      ).isError,
+    ).toBe(true);
   });
 
   it("a token cannot reach a vault in another workspace", async () => {

--- a/app/apps/server/tests/shares.test.ts
+++ b/app/apps/server/tests/shares.test.ts
@@ -98,4 +98,72 @@ describe("POST /shares — realtime read-only enforcement", () => {
     expect(res.status).toBe(201);
     expect(disconnected).toContainEqual({ vaultId: vault, docId });
   });
+
+  // Issue #5: an Everyone/org lock subsumes per-user locks on the same resource.
+  async function lockRows(type: "org" | "user") {
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT count(*) AS n FROM shares
+        WHERE resource_type = 'file' AND resource_id = $1
+          AND principal_type = $2 AND permission = 'locked'`,
+      [docId, type],
+    );
+    return Number(rows[0].n);
+  }
+
+  it("a per-user lock is a no-op when an org lock already covers the resource", async () => {
+    // Everyone lock first.
+    expect(
+      (
+        await postShare(owner, {
+          resourceType: "file",
+          resourceId: docId,
+          principalType: "org",
+          permission: "locked",
+        })
+      ).status,
+    ).toBe(201);
+    // Now try to add a redundant per-user lock for the member.
+    const res = await postShare(owner, {
+      resourceType: "file",
+      resourceId: docId,
+      principalType: "user",
+      principalId: memberId,
+      permission: "locked",
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as any).toMatchObject({ principalType: "org", subsumed: true });
+    // No per-user lock row was written; the single org lock remains authoritative.
+    expect(await lockRows("user")).toBe(0);
+    expect(await lockRows("org")).toBe(1);
+  });
+
+  it("creating an Everyone lock removes subsumed per-user locks (single Unlock)", async () => {
+    // A per-user lock exists first …
+    expect(
+      (
+        await postShare(owner, {
+          resourceType: "file",
+          resourceId: docId,
+          principalType: "user",
+          principalId: memberId,
+          permission: "locked",
+        })
+      ).status,
+    ).toBe(201);
+    expect(await lockRows("user")).toBe(1);
+    // … then the whole resource is locked for everyone.
+    expect(
+      (
+        await postShare(owner, {
+          resourceType: "file",
+          resourceId: docId,
+          principalType: "org",
+          permission: "locked",
+        })
+      ).status,
+    ).toBe(201);
+    // The redundant per-user lock is dropped, leaving one authoritative org lock.
+    expect(await lockRows("user")).toBe(0);
+    expect(await lockRows("org")).toBe(1);
+  });
 });


### PR DESCRIPTION
Fixes #4, #5, #6, #7, #9 — all five open issues were reproduced against `main` and are addressed here. Each fix ships with a regression test where the layer supports one.

## #4 — RBAC: locked folder didn't block create/delete via MCP
`folderWritePermission` never consulted locks, so `create_note`/`create_folder`/`delete_folder` bypassed a folder lock (both the admin short-circuit and the edit-share path). Now the lock deny-overlay is applied over the folder + ancestors **before** the admin short-circuit, matching `effectivePermission`'s semantics — a lock caps everyone, admins included.
- `mcp/service.ts`, `permissions/resolver.ts` (exported `isLocked`/`ancestorFolderIds`)
- Test: a locked folder blocks create/delete for an edit-member and an owner, incl. ancestor + per-user lock cases.
- Scope note: the issue also flags `POST /registry/{notes,folders,files}` (membership-only). That's the desktop sync/reconcile surface where enforcing folder ACL on create risks breaking reconcile, so it's intentionally out of scope here and called out for follow-up.

## #5 — Redundant overlapping locks (Everyone + per-user)
An org lock and a per-user lock could coexist on one resource, making Unlock misleading. Locks are now subsumption-aware: creating a per-user lock is a no-op when an Everyone lock already covers the resource, and creating an Everyone lock drops now-redundant per-user locks. The Access panel hides the per-member control when everyone is already read-only.
- `http/routes/shares.ts`, `components/AccessPanel.tsx`
- Test: per-user lock is a no-op under an org lock; an org lock removes subsumed per-user locks.

## #6 — Search wasn't wired into the UI
`SearchPanel` was fully built but never mounted. Now mounted in the sidebar with a ⌘F toggle, a header search button, autofocus, Escape-to-close, and close-on-open-result.
- `App.tsx`, `components/SearchPanel.tsx`

## #7 — Stored XSS via unescaped FTS snippet
Search snippets rendered raw note markdown through `dangerouslySetInnerHTML` in a webview with `csp: null`. Snippets are now HTML-escaped in Rust (control-char sentinels delimit the highlight, then get swapped for `<mark>` after escaping), so the only surviving markup is our own `<mark>`. A Content-Security-Policy without `script-src 'unsafe-inline'` is added as a second layer.
- `src-tauri/src/index.rs`, `src-tauri/tauri.conf.json`, `components/SearchPanel.tsx`
- Test: a note body with `<img onerror=…>` is escaped in the snippet (no live tag survives; highlight preserved).

## #9 — "New vault" nested a vault inside an existing vault
Picking an already-existing vault as the "New vault" parent silently created an empty nested vault. A read-only `is_vault` check (`.context/` present, or a `.md` note) now detects this and offers **Open vault** / Create inside / Cancel instead.
- `src-tauri/src/vault.rs` + `is_vault` command, `lib.rs`, `lib/ipc.ts`, `components/VaultPicker.tsx`
- Test: `is_vault` detects `.context/` and notes, ignores empty/asset-only folders.

## Verification
- Server: full vitest suite **127/127** pass; `tsc` clean.
- Desktop: `tsc` clean; `vite build` OK.
- Rust: **54** lib unit tests + integration test pass.
