### PR TITLE
fix: prevent duplicate workspace membership from invite + join code (#14)

### DIFF
--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -431,7 +431,12 @@ export class ApiClient {
 
   async listOrganizations(): Promise<Organization[]> {
     const { data } = await this.request<Organization[]>("GET", "/api/auth/organization/list");
-    return data ?? [];
+    // Dedupe by id: a user can transiently hold more than one membership row for
+    // the same org (invite + join code both add a member), which would otherwise
+    // show the same workspace twice in the switcher. See issue #14.
+    const byId = new Map<string, Organization>();
+    for (const org of data ?? []) if (!byId.has(org.id)) byId.set(org.id, org);
+    return [...byId.values()];
   }
 
   async setActiveOrganization(organizationId: string): Promise<void> {

--- a/app/apps/server/migrations/011_member_unique.sql
+++ b/app/apps/server/migrations/011_member_unique.sql
@@ -1,0 +1,23 @@
+-- One membership row per (organization, user).
+--
+-- The `member` table shipped with only two separate non-unique indexes
+-- (001_better_auth.sql), so a user could accumulate several membership rows for
+-- the same org. That happens because the two join paths don't share a guard:
+-- POST /api/orgs/join checks orgRole() and skips the insert if already a member,
+-- but Better Auth's accept-invitation calls createMember unconditionally. Joining
+-- one org via both an invitation and a join code therefore produced two rows, and
+-- the workspace switcher listed the same org twice (see issue #14).
+
+-- 1) Dedupe existing rows: keep the earliest membership per (org, user), drop the
+--    rest (earliest createdAt wins; id breaks ties).
+DELETE FROM "member" m
+USING "member" keep
+WHERE m."organizationId" = keep."organizationId"
+  AND m."userId" = keep."userId"
+  AND (keep."createdAt" < m."createdAt"
+       OR (keep."createdAt" = m."createdAt" AND keep."id" < m."id"));
+
+-- 2) Enforce it going forward. A duplicate createMember now fails loudly instead
+--    of silently forking the membership.
+CREATE UNIQUE INDEX IF NOT EXISTS "member_org_user_uidx"
+  ON "member" ("organizationId", "userId");


### PR DESCRIPTION
Fixes #14.

## Problem
Joining the same organization via **both** an invitation and a join code created **two membership rows** for the same `(user, org)`, so the workspace switcher listed the same org twice (both marked "Current", since they share the `organizationId`).

## Why
`member` had no uniqueness guard on `(organizationId, userId)` — only two separate non-unique indexes (`001_better_auth.sql`). The two join paths don't share a dedupe:
- `POST /api/orgs/join` guards: checks `orgRole()` and returns `alreadyMember: true` without inserting.
- Better Auth's `accept-invitation` calls `adapter.createMember(...)` unconditionally (verified in `better-auth@1.6.23`, `crud-invites.mjs`) and does not run through `beforeAddMember`, so nothing stops the second row.

## Fix
1. **`migrations/011_member_unique.sql`** — de-dupes existing rows (keep earliest per `(org, user)`) then adds `UNIQUE(organizationId, userId)`. A duplicate `createMember` now fails loudly instead of silently forking the membership.
2. **`desktop/src/lib/api.ts`** — `listOrganizations()` dedupes by id. Fixes the visible duplicate immediately (even before the migration runs on an existing DB) and is defensive against any future stray rows.

## Notes / follow-up
- The migration takes effect when the server runs `npm run migrate`.
- With the constraint in place, accepting an invitation when you're *already* a member will now error on the insert rather than duplicate. A nicer follow-up would be to have that path return a clean "already a member" success (Better Auth doesn't expose a hook on `accept-invitation`, so it'd need a small wrapper). Out of scope here.

## Testing
- Manual: reproduced the double "Benos" entry, then confirmed the desktop dedupe collapses it to one.
- Migration SQL reviewed for the dedupe + unique-index path; applies in filename order via the existing `db/migrate.ts`.
