### PR TITLE
Polish workspace-folder prompt, graph empty state, and upgrade dialog

### DIFF
--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -3339,13 +3339,103 @@ button.primary.hero:hover:not(:disabled) {
 .workspace-folder-backdrop {
   z-index: 210;
 }
-.workspace-folder-prompt .muted {
-  margin-bottom: var(--sp-5);
+
+/* The workspace setup prompt gets a bespoke, minimal layout rather than the
+   generic modal-header/hero-button treatment: an accent folder badge, tight
+   type hierarchy, and two calm buttons (gradient primary + outlined ghost). */
+.workspace-folder-prompt {
+  width: 400px;
+  padding: var(--sp-6) var(--sp-6) var(--sp-5);
+  text-align: center;
+  border: 1px solid var(--border);
+}
+.wf-badge {
+  width: 46px;
+  height: 46px;
+  margin: 0 auto var(--sp-4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: var(--radius-lg);
+}
+.wf-title {
+  margin: 0 0 var(--sp-2);
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+.wf-title strong {
+  font-weight: 600;
+}
+.wf-desc {
+  margin: 0 auto var(--sp-6);
+  max-width: 34ch;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-body);
 }
 .workspace-folder-actions {
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
+}
+.wf-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  width: 100%;
+  padding: var(--sp-3) var(--sp-4);
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--t-fast) var(--ease),
+    border-color var(--t-fast) var(--ease),
+    transform var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
+}
+.wf-btn svg {
+  flex: none;
+}
+.wf-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.wf-btn-primary {
+  background: var(--accent-gradient);
+  color: var(--text-on-accent);
+  box-shadow: var(--shadow-sm);
+}
+.wf-btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+.wf-btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+.wf-btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-strong);
+}
+.wf-btn-ghost:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+}
+.wf-btn-ghost:active:not(:disabled) {
+  background: var(--bg-active);
+}
+.workspace-folder-prompt .error {
+  margin: var(--sp-4) 0 0;
 }
 .workspace-folder-prompt .link-btn {
   margin-top: var(--sp-4);

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -63,29 +63,39 @@ function WorkspaceFolderPrompt() {
   return (
     <div className="modal-backdrop workspace-folder-backdrop">
       <div className="modal workspace-folder-prompt" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">
-          <span>
-            Set up <strong>{pending.orgName}</strong>
-          </span>
+        <div className="wf-badge" aria-hidden="true">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 7a2 2 0 0 1 2-2h3.6a2 2 0 0 1 1.6.8l.9 1.2a2 2 0 0 0 1.6.8H19a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          </svg>
         </div>
-        <p className="muted">
+        <h2 className="wf-title">
+          Set up <strong>{pending.orgName}</strong>
+        </h2>
+        <p className="wf-desc">
           Choose the local folder this workspace syncs to. Each workspace keeps
           its own folder — separate from your other workspaces.
         </p>
         <div className="workspace-folder-actions">
           <button
-            className="primary hero"
+            className="wf-btn wf-btn-primary"
             disabled={busy}
             onClick={run(() => useStore.getState().chooseWorkspaceFolder())}
           >
-            Open a folder…
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M3 7a2 2 0 0 1 2-2h3.6a2 2 0 0 1 1.6.8l.9 1.2a2 2 0 0 0 1.6.8H19a2 2 0 0 1 2 2" />
+              <path d="M3 10h16.5a2 2 0 0 1 1.95 2.46l-1.1 5A2 2 0 0 1 18.4 19H5a2 2 0 0 1-2-2z" />
+            </svg>
+            <span>Open a folder…</span>
           </button>
           <button
-            className="secondary"
+            className="wf-btn wf-btn-ghost"
             disabled={busy}
             onClick={run(() => useStore.getState().startEmptyWorkspace())}
           >
-            Start with an empty folder
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            <span>Start with an empty folder</span>
           </button>
         </div>
         {error && <p className="error">{error}</p>}

--- a/app/apps/desktop/src/components/GraphView.tsx
+++ b/app/apps/desktop/src/components/GraphView.tsx
@@ -1003,7 +1003,18 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         )}
         {showEmpty && (
           <div className="graph-state">
-            <div className="graph-state-card">
+            <div className="graph-state-card graph-empty">
+              <div className="graph-empty-glyph" aria-hidden="true">
+                <svg width="72" height="72" viewBox="0 0 72 72" fill="none">
+                  <line x1="36" y1="36" x2="16" y2="18" className="ge-link" />
+                  <line x1="36" y1="36" x2="58" y2="22" className="ge-link" />
+                  <line x1="36" y1="36" x2="54" y2="56" className="ge-link" />
+                  <circle cx="16" cy="18" r="4" className="ge-node ge-node-dim" />
+                  <circle cx="58" cy="22" r="4" className="ge-node" />
+                  <circle cx="54" cy="56" r="4" className="ge-node" />
+                  <circle cx="36" cy="36" r="7" className="ge-node ge-node-hub" />
+                </svg>
+              </div>
               <strong>Your graph is empty</strong>
               <span>
                 Write a note, then link notes with{" "}

--- a/app/apps/desktop/src/components/UpgradeDialog.tsx
+++ b/app/apps/desktop/src/components/UpgradeDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { type BillingPlan } from "../lib/api";
 import { authManager } from "../lib/auth/authManager";
 import * as ipc from "../lib/ipc";
@@ -8,7 +9,7 @@ import { useStore } from "../store";
 const POLL_INTERVAL_MS = 3_000;
 const POLL_BUDGET_MS = 3 * 60 * 1000;
 
-/** Format a plan's amount (minor units) as a compact price, e.g. "$10", "$96". */
+/** Format a plan's amount (minor units) as a compact price, e.g. "$10", "$97". */
 function formatPrice(plan: BillingPlan): string {
   const major = plan.amount / 100;
   try {
@@ -129,7 +130,10 @@ export function UpgradeDialog({ onClose }: { onClose: () => void }) {
     if (!done) setPhase("timeout");
   };
 
-  return (
+  // Portalled to <body> so the fixed backdrop escapes the Settings modal's
+  // containing block (its `.modal` keeps a transform from the rise-in
+  // animation, which would otherwise trap this dialog inside that card).
+  return createPortal(
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal upgrade-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
@@ -262,6 +266,7 @@ export function UpgradeDialog({ onClose }: { onClose: () => void }) {
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/app/apps/desktop/src/components/graph.css
+++ b/app/apps/desktop/src/components/graph.css
@@ -153,25 +153,25 @@
 }
 
 .graph-state-card {
-  max-width: 340px;
+  max-width: 360px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--sp-3);
-  padding: var(--sp-6) var(--sp-7);
+  gap: var(--sp-2);
+  padding: var(--sp-7) var(--sp-8);
   text-align: center;
   /* The backdrop is a dark void in every theme, so these states use fixed
      light-on-dark colors instead of theme text vars (which would be dark, and
      thus invisible, in light mode). A faint glass panel lifts the copy off the
      void so it reads at any zoom. */
-  color: rgba(233, 236, 245, 0.78);
+  color: rgba(233, 236, 245, 0.72);
   font-size: var(--fs-md);
   line-height: var(--lh-body);
-  background: rgba(20, 23, 34, 0.62);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(10px);
+  background: rgba(22, 25, 37, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(14px);
 }
 
 .graph-state-card strong {
@@ -183,6 +183,10 @@
   letter-spacing: -0.01em;
 }
 
+.graph-state-card span {
+  max-width: 30ch;
+}
+
 .graph-state-card code {
   font-family: var(--font-mono);
   font-size: 0.9em;
@@ -192,6 +196,34 @@
   padding: 1px 6px;
   border-radius: var(--radius-sm);
   white-space: nowrap;
+}
+
+/* Empty state: a small constellation glyph anchors the copy — nodes + links,
+   a preview of what the graph becomes. */
+.graph-empty {
+  gap: var(--sp-3);
+}
+.graph-empty-glyph {
+  margin-bottom: var(--sp-1);
+  color: #8f84ff;
+}
+.graph-empty-glyph .ge-node {
+  fill: #8f84ff;
+}
+.graph-empty-glyph .ge-node-hub {
+  fill: #a49bff;
+  filter: drop-shadow(0 0 10px rgba(143, 132, 255, 0.7));
+}
+.graph-empty-glyph .ge-node-dim {
+  fill: none;
+  stroke: rgba(143, 132, 255, 0.55);
+  stroke-width: 1.5;
+  stroke-dasharray: 3 3;
+}
+.graph-empty-glyph .ge-link {
+  stroke: rgba(143, 132, 255, 0.35);
+  stroke-width: 1.5;
+  stroke-linecap: round;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary
Frontend polish across three surfaces:

- **Workspace-folder prompt** (`App.tsx` / `App.css`) — redesigned with an icon badge, title, and icon-led primary/ghost buttons.
- **Graph empty state** (`GraphView.tsx` / `graph.css`) — added an illustrative node-graph glyph to the "Your graph is empty" card.
- **Upgrade dialog** (`UpgradeDialog.tsx`) — portalled to `<body>` so the fixed backdrop escapes the Settings modal's transformed containing block.

No behavior changes to billing, sync, or data flow.