### PR TITLE
Live workspace sync, private-by-default sharing, and accurate sync status

### DIFF
--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -2319,6 +2319,17 @@ button.primary.hero:hover:not(:disabled) {
   background: var(--warning-soft);
   color: var(--warning);
 }
+.access-badge.priv {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+/* workspace-default posture block, above the per-item list */
+.access-ws {
+  margin-bottom: var(--sp-4);
+  padding-bottom: var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle, var(--border));
+}
 
 /* affected-people avatar stack */
 .access-avstack {
@@ -2958,6 +2969,10 @@ button.primary.hero:hover:not(:disabled) {
   padding: 3px var(--sp-3);
   background: var(--bg-hover);
   color: var(--text-secondary);
+  /* Ease the Saving…↔Synced tint change so the state shift feels smooth. */
+  transition:
+    background-color 260ms var(--ease, ease),
+    color 260ms var(--ease, ease);
 }
 .sync-dot {
   width: 6px;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -176,7 +176,15 @@ function SyncIndicator() {
   const status = useStore((s) => s.syncStatus);
   const syncEnabled = useStore((s) => s.syncEnabled);
   const lastSyncedAt = useStore((s) => s.lastSyncedAt);
-  return <SyncBadge status={status} enabled={syncEnabled} lastSyncedAt={lastSyncedAt} />;
+  const pending = useStore((s) => s.syncPending);
+  return (
+    <SyncBadge
+      status={status}
+      enabled={syncEnabled}
+      lastSyncedAt={lastSyncedAt}
+      pending={pending}
+    />
+  );
 }
 
 export default function App() {

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -13,12 +13,16 @@ import { useStore } from "../store";
 import { Avatar } from "./Identity";
 
 /**
- * Access — the unified locker. One structural view of the vault where every
- * folder/note has a mode (Open · Read-only · Private-coming-soon) plus a
- * resolved "who can access" list. Built on the existing shares model:
- *  - Read-only for everyone = an org-scope `locked` share on the resource.
- *  - Per-member Read-only    = a user-scope `locked` share.
- *  - Can view / Can edit     = a user-scope view/edit grant.
+ * Access — the unified locker. A workspace-default posture (Shared · Read-only ·
+ * Private) plus a per-folder/note override and a resolved "who can access" list.
+ * Built on the shares model:
+ *  - Workspace posture       = an org grant on the workspace (edit=Shared,
+ *    view=Read-only) or none (Private, the new default for new workspaces).
+ *  - "Shared" on an item      = an org edit grant on the folder/file.
+ *  - "Read-only" on an item   = an org view grant (Private workspace) or an
+ *    org `locked` share (Open workspace, where a lock caps the edit baseline).
+ *  - "Private" on an item     = no team row (only creator + explicit shares).
+ *  - Per-member view/edit     = a user-scope lock / edit grant.
  * Folder settings inherit to everything inside (server ACL + lock overlay).
  */
 
@@ -137,9 +141,36 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const [selectedKey, setSelectedKey] = useState<string>("");
   const [shares, setShares] = useState<Share[]>([]);
   const [access, setAccess] = useState<ResolvedMemberAccess[] | null>(null);
+  const [wsShares, setWsShares] = useState<Share[]>([]);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const orgId = session?.activeOrganizationId ?? null;
+
+  // Workspace posture: an org grant on the workspace is "Open" (edit) or
+  // "Read-only" (view); no grant is "Private" (members see only what they
+  // create or what's explicitly shared with them / the team).
+  const reloadWorkspace = async () => {
+    if (!canManage || !orgId) {
+      setWsShares([]);
+      return;
+    }
+    try {
+      setWsShares(await authManager.api.listWorkspaceShares(orgId));
+    } catch {
+      setWsShares([]);
+    }
+  };
+  useEffect(() => {
+    void reloadWorkspace();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canManage, orgId]);
+
+  const wsGrant = wsShares.find(
+    (s) => sharePrincipalType(s) === "org" && (s.permission === "edit" || s.permission === "view"),
+  );
+  const wsPosture: Mode = wsGrant ? (wsGrant.permission === "edit" ? "open" : "readonly") : "private";
 
   // Flatten every synced folder + note into an indented list.
   const resources = useMemo<Resource[]>(() => {
@@ -212,10 +243,20 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
 
   const effLock = lockMap.get(selected?.path ?? "");
   const ownScope = selected ? directScopes.get(selected.path) ?? null : null;
-  // An org lock on THIS resource (direct) vs inherited from a parent folder.
+  // Direct org rows on THIS resource: a lock, a read-only (view) grant, or a
+  // shared (edit) grant. Plus a lock inherited from a parent folder.
   const ownOrgLock = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "locked");
+  const ownOrgView = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "view");
+  const ownOrgEdit = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "edit");
   const inheritedOrgLock = !!effLock?.org && !ownOrgLock;
-  const generalMode: Mode = ownOrgLock || inheritedOrgLock ? "readonly" : "open";
+  // Resolve the resource's team mode: a direct lock/view → read-only; a direct
+  // edit grant → shared/open; nothing direct → inherit the workspace posture.
+  const generalMode: Mode =
+    ownOrgLock || inheritedOrgLock || ownOrgView
+      ? "readonly"
+      : ownOrgEdit
+        ? "open"
+        : wsPosture;
   // When an Everyone/org lock (direct or inherited) already makes the resource
   // read-only for all, a per-member "read-only" lock is redundant and makes
   // Unlock misleading — so the per-person controls are suppressed in favour of
@@ -239,13 +280,13 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   // --- writes ---------------------------------------------------------------
 
   const run = async (fn: () => Promise<void>) => {
-    if (!selected) return;
     setBusy(true);
     setError(null);
     try {
       await fn();
       await useStore.getState().refreshLocks();
-      await reload(selected);
+      await reloadWorkspace();
+      if (selected) await reload(selected);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -253,13 +294,61 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
     }
   };
 
+  /** Clear every DIRECT org row (grant or lock) on the selected resource. */
+  const clearResourceOrgRows = async () => {
+    if (!selected) return;
+    for (const s of shares) {
+      if (sharePrincipalType(s) !== "org") continue;
+      if (s.permission === "locked") await useStore.getState().removeLock(s.id);
+      else await authManager.api.revokeShare(s.id);
+    }
+  };
+
+  // Per-resource team mode. "Open" = share with the team (edit); "Read-only" =
+  // team can view; "Private" = no team access (only creator + explicit shares).
+  // Read-only is a lock when the workspace is Open (a lock caps the baseline
+  // edit at view); a plain org view grant when the workspace is Private (there
+  // is no baseline edit to cap, and a grant is what GIVES the team read).
   const setGeneral = (mode: Mode) => {
-    if (!selected || mode === "private" || mode === generalMode || inheritedOrgLock) return;
+    if (!selected || mode === generalMode || inheritedOrgLock) return;
     void run(async () => {
-      if (mode === "readonly") {
-        await useStore.getState().createLock(selected.kind, selected.id, null);
-      } else if (ownOrgLock) {
-        await useStore.getState().removeLock(ownOrgLock.id);
+      await clearResourceOrgRows();
+      if (mode === "open") {
+        await authManager.api.createShare({
+          resourceType: selected.kind,
+          resourceId: selected.id,
+          principalType: "org",
+          permission: "edit",
+        });
+      } else if (mode === "readonly") {
+        if (wsPosture === "private") {
+          await authManager.api.createShare({
+            resourceType: selected.kind,
+            resourceId: selected.id,
+            principalType: "org",
+            permission: "view",
+          });
+        } else {
+          await useStore.getState().createLock(selected.kind, selected.id, null);
+        }
+      }
+      // "private" = just the cleared state (no team row).
+    });
+  };
+
+  // Whole-workspace posture (Open / Read-only / Private) = the org grant on the
+  // workspace resource. Private removes it, falling back to per-item sharing.
+  const setWorkspacePosture = (mode: Mode) => {
+    if (!orgId || mode === wsPosture) return;
+    void run(async () => {
+      if (wsGrant) await authManager.api.revokeShare(wsGrant.id);
+      if (mode !== "private") {
+        await authManager.api.createShare({
+          resourceType: "workspace",
+          resourceId: orgId,
+          principalType: "org",
+          permission: mode === "open" ? "edit" : "view",
+        });
       }
     });
   };
@@ -315,10 +404,40 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   return (
     <div className="access-panel">
       <p className="access-intro">
-        Every item is <strong>Open</strong> — teammates read &amp; write and Claude can read and edit.
-        Set anything to <strong>Read-only</strong> to freeze it for everyone (admins included).
-        Folder settings flow down to everything inside.
+        Choose what the team can reach. Set the whole workspace below, then override any folder or
+        note — <strong>Shared</strong> (read &amp; write), <strong>Read-only</strong>, or{" "}
+        <strong>Private</strong> (just you). Folder settings flow down to everything inside.
       </p>
+
+      {canManage && orgId && (
+        <div className="access-ws">
+          <div className="access-seclabel">This workspace, by default</div>
+          <div className="access-seg" aria-disabled={busy}>
+            {(["open", "readonly", "private"] as Mode[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                className={`access-segbtn${wsPosture === m ? " active" : ""}`}
+                data-mode={m}
+                disabled={busy}
+                onClick={() => setWorkspacePosture(m)}
+              >
+                <span className="access-st-top">
+                  {m === "open" ? ICON.open : m === "readonly" ? ICON.lock : ICON.shield}
+                  {m === "open" ? "Shared" : MODE_LABEL[m]}
+                </span>
+                <span className="access-st-sub">
+                  {m === "open"
+                    ? "Everyone reads & writes everything."
+                    : m === "readonly"
+                      ? "Everyone can read everything, not edit."
+                      : "Members see only what they create or you share."}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {error && <div className="auth-error">{error}</div>}
 
@@ -357,9 +476,27 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                             ))}
                           </span>
                         )}
-                        <span className={`access-badge ${readOnly ? "ro" : "open"}`}>
-                          {readOnly ? ICON.lock : ICON.open}
-                          {readOnly ? (everyone ? "Read-only" : "Restricted") : "Open"}
+                        <span
+                          className={`access-badge ${
+                            readOnly ? "ro" : wsPosture === "private" ? "priv" : "open"
+                          }`}
+                        >
+                          {readOnly
+                            ? ICON.lock
+                            : wsPosture === "private"
+                              ? ICON.shield
+                              : wsPosture === "readonly"
+                                ? ICON.lock
+                                : ICON.open}
+                          {readOnly
+                            ? everyone
+                              ? "Read-only"
+                              : "Restricted"
+                            : wsPosture === "private"
+                              ? "Private"
+                              : wsPosture === "readonly"
+                                ? "Read-only"
+                                : "Shared"}
                         </span>
                       </span>
                     </button>
@@ -421,26 +558,32 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                   <button
                     key={m}
                     type="button"
-                    className={`access-segbtn${generalMode === m ? " active" : ""}${m === "private" ? " soon" : ""}`}
+                    className={`access-segbtn${generalMode === m ? " active" : ""}`}
                     data-mode={m}
-                    disabled={!canManage || inheritedOrgLock || m === "private" || busy}
+                    disabled={!canManage || inheritedOrgLock || busy}
                     onClick={() => setGeneral(m)}
                   >
                     <span className="access-st-top">
                       {m === "open" ? ICON.open : m === "readonly" ? ICON.lock : ICON.shield}
-                      {MODE_LABEL[m]}
-                      {m === "private" && <span className="access-soon-tag">Soon</span>}
+                      {m === "open" ? "Shared" : MODE_LABEL[m]}
                     </span>
                     <span className="access-st-sub">
                       {m === "open"
-                        ? "Read & write for the workspace."
+                        ? "The whole team can read & write."
                         : m === "readonly"
-                          ? "Frozen for everyone. Claude can read, not edit."
-                          : "Encrypted — even Claude can't read it."}
+                          ? "The team can read, not edit. Claude reads only."
+                          : "Only you and people you share it with."}
                     </span>
                   </button>
                 ))}
               </div>
+              {generalMode === "private" && wsPosture !== "private" && (
+                <div className="access-hint">
+                  This workspace is <strong>{MODE_LABEL[wsPosture]}</strong>, so everything is
+                  visible to the team by default. To make individual items private, set the whole
+                  workspace to <strong>Private</strong> above, then share the folders you want.
+                </div>
+              )}
 
               <div className="access-seclabel">
                 Who can access{loading ? " · resolving…" : ""}

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -176,6 +176,7 @@ function AccountPopover({
   const syncStatus = useStore((s) => s.syncStatus);
   const syncEnabled = useStore((s) => s.syncEnabled);
   const lastSyncedAt = useStore((s) => s.lastSyncedAt);
+  const syncPending = useStore((s) => s.syncPending);
 
   const [creating, setCreating] = useState(false);
   const [orgName, setOrgName] = useState("");
@@ -381,7 +382,12 @@ function AccountPopover({
           </button>
           <div className="menu-row">
             <span className="menu-row-label">Sync</span>
-            <SyncBadge status={syncStatus} enabled={syncEnabled} lastSyncedAt={lastSyncedAt} />
+            <SyncBadge
+              status={syncStatus}
+              enabled={syncEnabled}
+              lastSyncedAt={lastSyncedAt}
+              pending={syncPending}
+            />
           </div>
         </>
       )}

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -513,6 +513,13 @@ export function FileTree() {
     if (newPath === oldPath) return;
     try {
       await ipc.renamePath(oldPath, newPath);
+      // Propagate the rename/move to the server (folder subtree or single note;
+      // doc_ids are preserved) so teammates see it live.
+      try {
+        await syncManager.registry.renamePath(oldPath, newPath);
+      } catch (e) {
+        console.warn("[sync] renamePath failed", oldPath, e);
+      }
       // Keep the item's rank (and its subtree's arrangement) across the rename.
       const store = useStore.getState();
       store.setItemOrder(renameInOrder(store.itemOrder, oldPath, newPath));
@@ -563,6 +570,11 @@ export function FileTree() {
       if (from[i] === to[i]) continue;
       try {
         await ipc.renamePath(from[i], to[i]);
+        try {
+          await syncManager.registry.renamePath(from[i], to[i]);
+        } catch (e) {
+          console.warn("[sync] move propagate failed", from[i], e);
+        }
         movedOnDisk = true;
         if (openNote && (openNote.path === from[i] || openNote.path.startsWith(from[i] + "/"))) {
           await useStore.getState().openNoteByPath(openNote.path.replace(from[i], to[i]));
@@ -611,6 +623,13 @@ export function FileTree() {
       const candidate = i === 0 ? name : `${name} ${i}`;
       try {
         const path = await ipc.createFolder(dir, candidate);
+        // Push the folder to the server immediately so teammates see it live and
+        // it can be shared. A subsequent rename propagates via onRename.
+        try {
+          await syncManager.registry.registerFolder(path, candidate);
+        } catch (e) {
+          console.warn("[sync] registerFolder failed", path, e);
+        }
         await refreshAll();
         beginRename(path);
         return;
@@ -623,6 +642,13 @@ export function FileTree() {
   async function handleDelete(node: NodeApi<TreeNode>) {
     try {
       await ipc.deletePath(node.data.path);
+      // Propagate the delete (folder subtree or note) to the server so it
+      // disappears for teammates too.
+      try {
+        await syncManager.registry.deletePath(node.data.path);
+      } catch (e) {
+        console.warn("[sync] deletePath failed", node.data.path, e);
+      }
       const store = useStore.getState();
       store.setItemOrder(removeFromOrder(store.itemOrder, node.data.path));
       if (openNote && (openNote.path === node.data.path || openNote.path.startsWith(node.data.path + "/"))) {

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -67,6 +67,33 @@ export function relativeAgo(ts: number, now: number): string {
   return `${Math.floor(h / 24)}d ago`;
 }
 
+/**
+ * Pure label for the sync pill. Extracted so the (surprisingly load-bearing)
+ * "Saving…" vs "Synced · just now" logic is unit-testable without a DOM.
+ *
+ * `pending` (local edits not yet acked) wins over the timestamp: while flushing
+ * we show "Saving…"; once acked, the caller has bumped `lastSyncedAt`, so it
+ * reads "Synced · just now" and counts up from there.
+ */
+export function syncBadgeLabel(args: {
+  status: string;
+  pending?: boolean;
+  lastSyncedAt?: number | null;
+  now: number;
+  enabled?: boolean;
+}): string {
+  const { status, pending, lastSyncedAt, now, enabled } = args;
+  if (status === "synced") {
+    if (pending) return "Saving…";
+    return lastSyncedAt != null ? `Synced · ${relativeAgo(lastSyncedAt, now)}` : "Synced";
+  }
+  if (status === "read-only") return "Read-only";
+  if (status === "connecting") return "Syncing…";
+  if (status === "no-access") return "No access";
+  if (status === "error") return "Retrying…";
+  return enabled === false ? "Local only" : "Offline";
+}
+
 function useNowTick(active: boolean): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -81,32 +108,21 @@ export function SyncBadge({
   status,
   enabled,
   lastSyncedAt,
+  pending,
 }: {
   status: string;
   enabled?: boolean;
   /** When set and status is "synced", the badge reads "Synced · 1m ago". */
   lastSyncedAt?: number | null;
+  /** True while local edits are still flushing to the server → "Saving…". */
+  pending?: boolean;
 }) {
-  const now = useNowTick(status === "synced" && lastSyncedAt != null);
-  const label =
-    status === "synced"
-      ? lastSyncedAt != null
-        ? `Synced · ${relativeAgo(lastSyncedAt, now)}`
-        : "Synced"
-      : status === "read-only"
-        ? "Read-only"
-        : status === "connecting"
-          ? "Syncing…"
-          : status === "no-access"
-            ? "No access"
-            : status === "error"
-              ? "Retrying…"
-              : enabled === false
-                ? "Local only"
-                : "Offline";
+  // Only tick the relative clock once we're settled (synced, nothing pending).
+  const now = useNowTick(status === "synced" && !pending && lastSyncedAt != null);
+  const label = syncBadgeLabel({ status, pending, lastSyncedAt, now, enabled });
   return (
-    <span className={`sync-badge ${status}`}>
-      {status === "connecting" ? (
+    <span className={`sync-badge ${status}${pending ? " pending" : ""}`}>
+      {status === "connecting" || (status === "synced" && pending) ? (
         <span className="sync-progress" aria-hidden="true">
           <span className="sync-progress-fill" />
         </span>

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -113,22 +113,26 @@ export function VaultPicker() {
     }
   }
 
-  // "New vault" step 1: choose the parent location, then ask for a name. If the
-  // chosen folder is ALREADY a vault, don't nest a new empty vault inside it —
-  // offer to open the existing one instead.
+  // "New vault": pick a folder — and that folder *is* the vault. We initialize
+  // it in place (named after the folder), so there's no separate naming step:
+  // choosing the folder is the choice. If the chosen folder is ALREADY a vault,
+  // don't nest a new one inside it — offer to open the existing one instead.
   async function startNewVault() {
     setError(null);
     try {
-      const parent = await ipc.pickFolder();
-      if (!parent) return;
-      if (await ipc.isVault(parent)) {
-        setAlreadyVault(parent);
+      const picked = await ipc.pickFolder();
+      if (!picked) return;
+      if (await ipc.isVault(picked)) {
+        setAlreadyVault(picked);
         return;
       }
-      setNewParent(parent);
-      setNewName("Untitled Vault");
+      setBusy(true);
+      const info = await ipc.openVault(picked);
+      await openVault(info);
     } catch (e) {
       setError(String(e));
+    } finally {
+      setBusy(false);
     }
   }
 
@@ -282,7 +286,10 @@ export function VaultPicker() {
                 </div>
               </motion.div>
             ) : naming ? (
-              // ---- New-vault naming step ----
+              // ---- Naming step: only reached via "Create inside" an existing
+              //      vault, where a nested vault does need its own folder name.
+              //      The normal "New vault" flow skips this — the picked folder
+              //      is the vault. ----
               <motion.form
                 key="naming"
                 className="new-vault-form"

--- a/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
+++ b/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { syncBadgeLabel } from "../Identity";
+
+// The sync pill is the user-facing "is my work safe?" signal. These lock in the
+// fix for the bug where it drifted to "Synced · 5m ago" while actively editing:
+// pending edits must read "Saving…", and a fresh flush must read "just now".
+describe("syncBadgeLabel", () => {
+  const now = 1_000_000_000_000;
+
+  it("shows Saving… while local edits are pending, ignoring the timestamp", () => {
+    expect(
+      syncBadgeLabel({ status: "synced", pending: true, lastSyncedAt: now - 300_000, now }),
+    ).toBe("Saving…");
+  });
+
+  it("reads 'Synced · just now' immediately after a flush", () => {
+    expect(
+      syncBadgeLabel({ status: "synced", pending: false, lastSyncedAt: now, now }),
+    ).toBe("Synced · just now");
+  });
+
+  it("counts up from the last flush once settled", () => {
+    expect(
+      syncBadgeLabel({ status: "synced", pending: false, lastSyncedAt: now - 300_000, now }),
+    ).toBe("Synced · 5m ago");
+  });
+
+  it("falls back to 'Synced' when there is no timestamp yet", () => {
+    expect(syncBadgeLabel({ status: "synced", lastSyncedAt: null, now })).toBe("Synced");
+  });
+
+  it("maps the non-synced statuses to fixed labels", () => {
+    expect(syncBadgeLabel({ status: "read-only", now })).toBe("Read-only");
+    expect(syncBadgeLabel({ status: "connecting", now })).toBe("Syncing…");
+    expect(syncBadgeLabel({ status: "no-access", now })).toBe("No access");
+    expect(syncBadgeLabel({ status: "error", now })).toBe("Retrying…");
+    expect(syncBadgeLabel({ status: "offline", now })).toBe("Offline");
+    expect(syncBadgeLabel({ status: "offline", enabled: false, now })).toBe("Local only");
+  });
+});

--- a/app/apps/desktop/src/components/graph.css
+++ b/app/apps/desktop/src/components/graph.css
@@ -153,12 +153,12 @@
 }
 
 .graph-state-card {
-  max-width: 360px;
+  max-width: 460px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--sp-2);
-  padding: var(--sp-7) var(--sp-8);
+  gap: var(--sp-3);
+  padding: var(--sp-10) var(--sp-10) var(--sp-8);
   text-align: center;
   /* The backdrop is a dark void in every theme, so these states use fixed
      light-on-dark colors instead of theme text vars (which would be dark, and
@@ -176,24 +176,26 @@
 
 .graph-state-card strong {
   display: block;
+  margin-bottom: var(--sp-1);
   color: #f4f6fb;
   font-family: var(--font-display);
-  font-size: var(--fs-xl);
+  font-size: var(--fs-2xl);
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .graph-state-card span {
-  max-width: 30ch;
+  max-width: 34ch;
+  line-height: 1.6;
 }
 
 .graph-state-card code {
   font-family: var(--font-mono);
-  font-size: 0.9em;
+  font-size: 0.85em;
   color: #bcb2ff;
   background: rgba(127, 115, 255, 0.18);
   border: 1px solid rgba(127, 115, 255, 0.32);
-  padding: 1px 6px;
+  padding: 2px 7px;
   border-radius: var(--radius-sm);
   white-space: nowrap;
 }
@@ -201,10 +203,10 @@
 /* Empty state: a small constellation glyph anchors the copy — nodes + links,
    a preview of what the graph becomes. */
 .graph-empty {
-  gap: var(--sp-3);
+  gap: var(--sp-4);
 }
 .graph-empty-glyph {
-  margin-bottom: var(--sp-1);
+  margin-bottom: var(--sp-3);
   color: #8f84ff;
 }
 .graph-empty-glyph .ge-node {

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -648,6 +648,24 @@ export class ApiClient {
     return data;
   }
 
+  /** Rename/move a folder (rewrites descendant paths server-side; id stays). */
+  async updateFolder(
+    id: string,
+    input: { name?: string; path?: string; parentId?: string | null },
+  ): Promise<RegisteredFolder> {
+    const { data } = await this.request<RegisteredFolder>(
+      "PATCH",
+      `/api/folders/${encodeURIComponent(id)}`,
+      { body: input },
+    );
+    return data;
+  }
+
+  /** Delete a folder subtree (soft-deletes its notes). */
+  async deleteFolder(id: string): Promise<void> {
+    await this.request<unknown>("DELETE", `/api/folders/${encodeURIComponent(id)}`);
+  }
+
   async listNotes(vaultId: string): Promise<RegisteredNote[]> {
     const { data } = await this.request<{ notes: RegisteredNote[] }>("GET", "/api/notes", {
       query: { vaultId },
@@ -666,19 +684,46 @@ export class ApiClient {
     return data;
   }
 
+  /** Rename/move a note (rel_path/folder/title); doc_id is unchanged. */
+  async updateNote(
+    id: string,
+    input: { relPath?: string; title?: string | null; folderId?: string | null },
+  ): Promise<RegisteredNote> {
+    const { data } = await this.request<RegisteredNote>(
+      "PATCH",
+      `/api/notes/${encodeURIComponent(id)}`,
+      { body: input },
+    );
+    return data;
+  }
+
+  /** Soft-delete a note (keeps its doc_id row; drops it from the registry list). */
+  async deleteNote(id: string): Promise<void> {
+    await this.request<unknown>("DELETE", `/api/notes/${encodeURIComponent(id)}`);
+  }
+
   // ---- Shares -------------------------------------------------------------
 
-  async listShares(resourceType: "folder" | "file", resourceId: string): Promise<Share[]> {
+  async listShares(
+    resourceType: "folder" | "file" | "workspace",
+    resourceId: string,
+  ): Promise<Share[]> {
     const { data } = await this.request<{ shares: Share[] }>("GET", "/api/shares", {
       query: { resourceType, resourceId },
     });
     return data.shares ?? [];
   }
 
+  /** Workspace-level shares (the Open/Read-only posture: an org grant on the
+   *  workspace). resourceId is the organization id. */
+  async listWorkspaceShares(orgId: string): Promise<Share[]> {
+    return this.listShares("workspace", orgId);
+  }
+
   async createShare(input: {
-    resourceType: "folder" | "file";
+    resourceType: "folder" | "file" | "workspace";
     resourceId: string;
-    /** Required for user shares; ignored for org-wide locks. */
+    /** Required for user shares; ignored for org-wide grants/locks. */
     principalId?: string;
     principalType?: "user" | "org";
     permission: Permission | "locked";

--- a/app/apps/desktop/src/lib/sync/__tests__/integration.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/integration.test.ts
@@ -64,15 +64,15 @@ describe.skipIf(!RUN)("client↔server integration", () => {
     const invite = pending.find((i) => i.email === `b-${stamp}@it.test`) ?? pending[0];
     expect(invite).toBeTruthy();
     await b.acceptInvitation(invite.id);
-    // Workspaces default to Open (org-wide edit), so B starts writable. A makes
-    // B read-only on this file the way the Access panel does: a user-scope lock
-    // (a deny overlay capping B at view).
+    // Private-by-default: a new vault grants members nothing, so B starts with
+    // NO access. A shares this file with B read-only the way the Access panel
+    // does — a user-scope `view` grant (not a lock, which alone grants nothing).
     await a.createShare({
       resourceType: "file",
       resourceId: docId,
       principalId: bUser.id,
       principalType: "user",
-      permission: "locked",
+      permission: "view",
     });
 
     // ---- sync-token gating ----
@@ -123,6 +123,47 @@ describe.skipIf(!RUN)("client↔server integration", () => {
     textB.insert(0, "HACK ");
     await new Promise((r) => setTimeout(r, 1000));
     expect(textA.toString()).toBe(before); // A never sees B's rejected write
+  }, 40_000);
+
+  it("DocSync reports pending on a local edit and flushes to synced", async () => {
+    const stamp = Date.now();
+    const wsPoly = WebSocket as unknown;
+
+    const a = new ApiClient({ baseUrl: SERVER });
+    await a.signUp({ email: `flush-${stamp}@it.test`, password: "password123", name: "Flush A" });
+    const org = await a.createOrganization({ name: `FL ${stamp}`, slug: `fl-${stamp}` });
+    await a.setActiveOrganization(org.id);
+    const vault = await a.createVault({ name: `FlVault ${stamp}`, organizationId: org.id });
+    const note = await a.createNote({ vaultId: vault.id, relPath: "n/flush.md", title: "F" });
+    const docId = note.docId ?? note.id;
+
+    let pending = false;
+    let flushes = 0;
+    const doc = new Y.Doc();
+    const sync = new DocSync({
+      api: a,
+      doc,
+      docId,
+      vaultId: vault.id,
+      webSocketPolyfill: wsPoly,
+      onPending: (p) => {
+        pending = p;
+      },
+      onFlushed: () => {
+        flushes += 1;
+      },
+    });
+    created.push(sync);
+    await sync.whenSynced();
+
+    const flushesBefore = flushes;
+    doc.getText("content").insert(0, "hello");
+    // The edit must immediately mark pending, then flush back to not-pending
+    // once the server acks — this is the "Saving… → Synced · just now" signal.
+    await waitFor(() => pending === true, 4000, "edit marks pending");
+    await waitFor(() => pending === false, 8000, "edit flushes");
+    expect(flushes).toBeGreaterThan(flushesBefore);
+    expect(sync.pending).toBe(false);
   }, 40_000);
 
   it("attachment blob: A uploads → invited member B lists + downloads byte-identical", async () => {

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -48,6 +48,10 @@ export class SyncManager {
   /** The local user's chosen activity status, broadcast via awareness. */
   private status: ActivityStatus = "online";
   private onStatus?: (status: SyncStatus) => void;
+  private onPending?: (pending: boolean) => void;
+  private onFlushed?: () => void;
+  private onRegistryChanged?: () => void;
+  private registryPullTimer: ReturnType<typeof setTimeout> | null = null;
   private attachments: AttachmentSync | null = null;
 
   // Vault-wide background sync (spec 05): the engine (one WS to /vault-sync)
@@ -60,6 +64,43 @@ export class SyncManager {
   /** UI subscribes here to render the per-note sync indicator. */
   setStatusListener(cb: ((status: SyncStatus) => void) | undefined): void {
     this.onStatus = cb;
+  }
+
+  /**
+   * UI subscribes here for the live save/sync activity of the open note:
+   * `onPending(true)` the instant a local edit is made, `onFlushed()` once the
+   * server has acked everything. Drives "Saving…" → "Synced · just now".
+   */
+  setActivityListeners(cbs: {
+    onPending?: (pending: boolean) => void;
+    onFlushed?: () => void;
+  }): void {
+    this.onPending = cbs.onPending;
+    this.onFlushed = cbs.onFlushed;
+  }
+
+  /**
+   * UI subscribes here to refresh the sidebar tree after the registry catches up
+   * to a teammate's structural change (folder/note create/rename/move/delete).
+   */
+  setRegistryListener(cb: (() => void) | undefined): void {
+    this.onRegistryChanged = cb;
+  }
+
+  /**
+   * A `registry` signal arrived from the vault channel. Debounce a re-pull (a
+   * burst of changes — e.g. a folder move rewriting many rows — coalesces into
+   * one), then tell the UI to refresh the tree.
+   */
+  private handleRegistryChanged(): void {
+    if (this.registryPullTimer) clearTimeout(this.registryPullTimer);
+    this.registryPullTimer = setTimeout(() => {
+      this.registryPullTimer = null;
+      void this.registry
+        .pull()
+        .then(() => this.onRegistryChanged?.())
+        .catch((e) => console.warn("[sync] registry pull failed", e));
+    }, 250);
   }
 
   isEnabled(): boolean {
@@ -135,6 +176,8 @@ export class SyncManager {
       // (view↔edit, lock/unlock). Re-mint its token so the editor becomes
       // read-only/editable live — no reopen (spec 04 §4).
       onAclChanged: () => this.current?.refreshAccess(),
+      // A teammate changed the folder/note structure — re-pull + refresh tree.
+      onRegistryChanged: () => this.handleRegistryChanged(),
     });
     this.vaultEngine.start();
   }
@@ -202,6 +245,8 @@ export class SyncManager {
       docId: mapping.docId,
       vaultId: mapping.vaultId,
       onStatus: this.onStatus,
+      onPending: this.onPending,
+      onFlushed: this.onFlushed,
     });
     this.current = sync;
 
@@ -244,6 +289,9 @@ export class SyncManager {
     if (this.current) {
       this.current.destroy();
       this.current = null;
+      // The closed note can't have outstanding local edits anymore — clear any
+      // lingering "Saving…" so the next note starts clean.
+      this.onPending?.(false);
     }
     if (this.currentLocalAwareness) {
       this.currentLocalAwareness.destroy();

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -179,10 +179,34 @@ export class VaultRegistry {
       seeded = true;
     }
 
+    await this.syncStructure(vaultId, workingTree);
+    return { seeded };
+  }
+
+  /**
+   * Re-pull the server's folder/note set and reconcile it against the current
+   * local tree WITHOUT re-resolving the vault or seeding. Called when the vault
+   * channel signals a `registry` change (a teammate created/renamed/moved/
+   * deleted something) so this device's tree catches up live. Idempotent.
+   */
+  async pull(): Promise<void> {
+    if (!this.serverVaultId) return;
+    const tree = await ipc.listTree();
+    await this.syncStructure(this.serverVaultId, tree);
+  }
+
+  /**
+   * The shared core of reconcile/pull: make the server + this device agree on the
+   * folder/note set. Adopts existing rows by path, creates missing ones (reusing
+   * local doc_ids), materializes server-only notes onto disk, and persists the
+   * {relPath → docId} + {folderPath → id} maps to `.context/config.json`.
+   */
+  private async syncStructure(vaultId: string, workingTree: TreeNode): Promise<void> {
+    const serverFolders = await this.api.listFolders(vaultId);
+    const serverNotes = await this.api.listNotes(vaultId);
     const { folders, notes } = flattenTree(workingTree);
 
     // 2. Folders: adopt by path, create missing (parents first).
-    const serverFolders = await this.api.listFolders(vaultId);
     const folderIdByPath = new Map<string, string>();
     for (const f of serverFolders) folderIdByPath.set(f.path, f.id);
 
@@ -204,9 +228,8 @@ export class VaultRegistry {
     }
     this.folderByPath = folderIdByPath;
 
-    // 3. Notes: adopt by relPath, create missing. (`serverNotes` was listed
-    //    above, before any seeding — still accurate, since seeding only writes
-    //    to disk; the seeded files are created on the server by this loop.)
+    // 3. Notes: adopt by relPath, create missing. Any first-run seeding happened
+    //    in reconcile before this runs; the seeded files register here as docs.
     const docIdByPath = new Map<string, string>();
     for (const n of serverNotes) {
       const rp = noteRelPath(n);
@@ -271,8 +294,6 @@ export class VaultRegistry {
         console.warn("[registry] materialize failed", rp, e);
       }
     }
-
-    return { seeded };
   }
 
   /**
@@ -311,4 +332,143 @@ export class VaultRegistry {
       return null;
     }
   }
+
+  /**
+   * Register a newly-created folder on the server so teammates see it live and
+   * it can be shared. Idempotent (the server adopts an existing path). No-op if
+   * the vault isn't reconciled yet.
+   */
+  async registerFolder(relPath: string, name: string): Promise<string | null> {
+    if (!this.serverVaultId) return null;
+    const existing = this.folderByPath.get(relPath);
+    if (existing) return existing;
+    try {
+      const parentId = this.folderByPath.get(parentDir(relPath)) ?? null;
+      const created = await this.api.createFolder({
+        vaultId: this.serverVaultId,
+        name,
+        path: relPath,
+        parentId,
+      });
+      this.folderByPath.set(relPath, created.id);
+      await this.persist();
+      return created.id;
+    } catch (e) {
+      console.error("[registry] registerFolder failed", relPath, e);
+      return null;
+    }
+  }
+
+  /**
+   * Propagate a local rename/move to the server. Handles both a folder (with its
+   * whole subtree of paths) and a single note. doc_ids never change — only the
+   * path columns move — so open docs and backlinks survive (spec invariant).
+   */
+  async renamePath(oldPath: string, newPath: string): Promise<void> {
+    if (!this.serverVaultId) return;
+    const folderId = this.folderByPath.get(oldPath);
+    if (folderId) {
+      // Folder move: rewrite the server subtree, then the local prefix maps.
+      const parentId = this.folderByPath.get(parentDir(newPath)) ?? null;
+      try {
+        await this.api.updateFolder(folderId, { name: baseName(newPath), path: newPath, parentId });
+      } catch (e) {
+        console.error("[registry] updateFolder failed", oldPath, e);
+        return;
+      }
+      this.folderByPath = remapPrefix(this.folderByPath, oldPath, newPath);
+      this.byPath = remapPrefix(this.byPath, oldPath, newPath);
+      this.rebuildByDocId();
+      await this.persist();
+      return;
+    }
+    const mapping = this.byPath.get(oldPath);
+    if (mapping) {
+      const newFolderId = this.folderByPath.get(parentDir(newPath)) ?? null;
+      try {
+        await this.api.updateNote(mapping.docId, { relPath: newPath, folderId: newFolderId });
+      } catch (e) {
+        console.error("[registry] updateNote failed", oldPath, e);
+        return;
+      }
+      this.byPath.delete(oldPath);
+      this.byPath.set(newPath, mapping);
+      this.byDocId.set(mapping.docId, newPath);
+      await this.persist();
+    }
+  }
+
+  /** Propagate a local delete of a folder subtree or a note to the server. */
+  async deletePath(path: string): Promise<void> {
+    if (!this.serverVaultId) return;
+    const folderId = this.folderByPath.get(path);
+    if (folderId) {
+      try {
+        await this.api.deleteFolder(folderId);
+      } catch (e) {
+        console.error("[registry] deleteFolder failed", path, e);
+        return;
+      }
+      this.folderByPath = dropPrefix(this.folderByPath, path);
+      this.byPath = dropPrefix(this.byPath, path);
+      this.rebuildByDocId();
+      await this.persist();
+      return;
+    }
+    const mapping = this.byPath.get(path);
+    if (mapping) {
+      try {
+        await this.api.deleteNote(mapping.docId);
+      } catch (e) {
+        console.error("[registry] deleteNote failed", path, e);
+        return;
+      }
+      this.byPath.delete(path);
+      this.byDocId.delete(mapping.docId);
+      await this.persist();
+    }
+  }
+
+  /** Rebuild byDocId from byPath after a bulk prefix remap/drop. */
+  private rebuildByDocId(): void {
+    this.byDocId.clear();
+    for (const [rp, m] of this.byPath) this.byDocId.set(m.docId, rp);
+  }
+
+  /** Write the current in-memory maps back to `.context/config.json`. */
+  private async persist(): Promise<void> {
+    if (!this.serverVaultId) return;
+    const docs: Record<string, string> = {};
+    for (const [rp, m] of this.byPath) docs[rp] = m.docId;
+    const folders: Record<string, string> = {};
+    for (const [rp, id] of this.folderByPath) folders[rp] = id;
+    await this.saveConfig({ serverVaultId: this.serverVaultId, docs, folders });
+  }
+}
+
+/** basename of a vault-relative path. */
+function baseName(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+/** Rewrite every key at `oldPrefix` (exact or `oldPrefix/…`) to `newPrefix`. */
+function remapPrefix<V>(map: Map<string, V>, oldPrefix: string, newPrefix: string): Map<string, V> {
+  const out = new Map<string, V>();
+  for (const [k, v] of map) {
+    if (k === oldPrefix) out.set(newPrefix, v);
+    else if (k.startsWith(oldPrefix + "/")) out.set(newPrefix + k.slice(oldPrefix.length), v);
+    else out.set(k, v);
+  }
+  return out;
+}
+
+/** Drop every key at `prefix` (exact or `prefix/…`). */
+function dropPrefix<V>(map: Map<string, V>, prefix: string): Map<string, V> {
+  const out = new Map<string, V>();
+  for (const [k, v] of map) {
+    if (k === prefix || k.startsWith(prefix + "/")) continue;
+    out.set(k, v);
+  }
+  return out;
 }

--- a/app/apps/desktop/src/lib/sync/syncManager.ts
+++ b/app/apps/desktop/src/lib/sync/syncManager.ts
@@ -30,6 +30,25 @@ export interface DocSyncOptions {
   /** Base ws:// URL. Defaults to `deriveWsUrl(api base)` (see its doc). */
   wsUrl?: string;
   onStatus?: (status: SyncStatus) => void;
+  /**
+   * Fired when the set of *unsynced* local changes opens/closes: `true` the
+   * moment a local edit is made (not yet acked by the server), `false` once
+   * everything has flushed. Drives the "Saving…" badge state.
+   */
+  onPending?: (pending: boolean) => void;
+  /**
+   * Fired each time all local changes have been acknowledged by the server
+   * (unsynced count hit 0). This — not the one-time initial "synced" — is the
+   * real "last synced just now" signal during an active editing session.
+   */
+  onFlushed?: () => void;
+  /**
+   * How long (ms) the "Saving…" state lingers after the last change flushes
+   * before easing to "Synced". Smooths the badge so a burst of keystrokes (whose
+   * unsynced count bounces 0↔1 between acks) reads as one continuous "Saving…"
+   * instead of flickering. Default 700ms.
+   */
+  settleDelayMs?: number;
   /** Injected in tests (Node lacks a global WebSocket the provider likes). */
   webSocketPolyfill?: unknown;
 }
@@ -98,10 +117,15 @@ export class DocSync {
   private readonly api: ApiClient;
   private readonly docId: string;
   private readonly onStatus?: (status: SyncStatus) => void;
+  private readonly onPending?: (pending: boolean) => void;
+  private readonly onFlushed?: () => void;
+  private readonly settleDelayMs: number;
   private readonly refresher: TokenRefreshScheduler;
 
   private _status: SyncStatus = "connecting";
   private _readOnly = false;
+  private _pending = false;
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
   private destroyed = false;
   private reconnectPending = false;
 
@@ -109,6 +133,9 @@ export class DocSync {
     this.api = opts.api;
     this.docId = opts.docId;
     this.onStatus = opts.onStatus;
+    this.onPending = opts.onPending;
+    this.onFlushed = opts.onFlushed;
+    this.settleDelayMs = opts.settleDelayMs ?? 700;
 
     const wsUrl = opts.wsUrl ?? deriveWsUrl(this.api.getBaseUrl());
     const name = `vault:${opts.vaultId}/note:${opts.docId}`;
@@ -161,6 +188,35 @@ export class DocSync {
         if (!this.destroyed && this._status !== "no-access") {
           this.setStatus(this._readOnly ? "read-only" : "synced");
         }
+      },
+      // Fires on every local edit (count→>0) and every server ack (count→…→0).
+      // The provider only decrements toward 0 as the server acknowledges each
+      // update, so `number === 0` means the latest edit is durably on the
+      // server — the true "synced just now" moment (spec 03 §4). While offline
+      // the count stays >0 (no acks), so we correctly show "Saving…"/pending.
+      onUnsyncedChanges: ({ number }: { number: number }) => {
+        if (this.destroyed) return;
+        if (number > 0) {
+          // An edit is outstanding — show "Saving…" at once and cancel any
+          // in-flight settle so a typing burst stays continuous.
+          if (this.settleTimer) {
+            clearTimeout(this.settleTimer);
+            this.settleTimer = null;
+          }
+          this.setPending(true);
+          return;
+        }
+        // Everything acked. Debounce the ease to "Synced" so the rapid 0↔1
+        // bounce between keystrokes doesn't flicker the badge.
+        if (this.settleTimer) clearTimeout(this.settleTimer);
+        this.settleTimer = setTimeout(() => {
+          this.settleTimer = null;
+          if (this.destroyed || this._status === "no-access") return;
+          const wasPending = this._pending;
+          this.setPending(false);
+          // Only stamp "synced just now" on the real pending→settled edge.
+          if (wasPending) this.onFlushed?.();
+        }, this.settleDelayMs);
       },
     });
 
@@ -261,15 +317,29 @@ export class DocSync {
     }
   }
 
+  get pending(): boolean {
+    return this._pending;
+  }
+
   private setStatus(s: SyncStatus): void {
     if (this._status === s) return;
     this._status = s;
     this.onStatus?.(s);
   }
 
+  private setPending(p: boolean): void {
+    if (this._pending === p) return;
+    this._pending = p;
+    this.onPending?.(p);
+  }
+
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    if (this.settleTimer) {
+      clearTimeout(this.settleTimer);
+      this.settleTimer = null;
+    }
     this.refresher.cancel();
     try {
       this.provider.destroy();

--- a/app/apps/desktop/src/lib/sync/vaultProtocol.ts
+++ b/app/apps/desktop/src/lib/sync/vaultProtocol.ts
@@ -19,6 +19,7 @@ export type ServerControl =
   | { t: "ready" }
   | { t: "drop"; docId: string }
   | { t: "reauth" }
+  | { t: "registry" }
   | { t: "err"; message: string };
 
 export function encodeHello(frame: Omit<HelloFrame, "t">): string {
@@ -37,6 +38,7 @@ export function parseServerControl(text: string): ServerControl | null {
   const t = (v as { t?: unknown }).t;
   if (t === "ready") return { t: "ready" };
   if (t === "reauth") return { t: "reauth" };
+  if (t === "registry") return { t: "registry" };
   if (t === "drop" && typeof (v as { docId?: unknown }).docId === "string") {
     return { t: "drop", docId: (v as { docId: string }).docId };
   }

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -66,6 +66,10 @@ export interface VaultSyncEngineOptions {
    *  open note syncs over its own socket, not this feed, so the owner re-mints
    *  that doc's token to pick up a view↔edit / lock change in realtime. */
   onAclChanged?: () => void;
+  /** Fired when the folder/note structure changed in this vault (`registry`):
+   *  a teammate created/renamed/moved/deleted a folder or note. The client
+   *  re-pulls the registry so its local tree reflects the change live. */
+  onRegistryChanged?: () => void;
   /** Injected in tests. Defaults to the global WebSocket. */
   wsFactory?: WsFactory;
   /** Backoff bounds (ms). */
@@ -101,6 +105,7 @@ export class VaultSyncEngine {
   private readonly wsUrl: string;
   private readonly onStatus?: (s: VaultSyncStatus) => void;
   private readonly onAclChanged?: () => void;
+  private readonly onRegistryChanged?: () => void;
   private readonly wsFactory: WsFactory;
   private readonly baseMs: number;
   private readonly maxMs: number;
@@ -121,6 +126,7 @@ export class VaultSyncEngine {
     this.wsUrl = opts.wsUrl ?? deriveVaultWsUrl(this.api.getBaseUrl());
     this.onStatus = opts.onStatus;
     this.onAclChanged = opts.onAclChanged;
+    this.onRegistryChanged = opts.onRegistryChanged;
     this.wsFactory =
       opts.wsFactory ?? ((url) => new WebSocket(url) as unknown as WebSocketLike);
     this.baseMs = opts.reconnect?.baseMs ?? 500;
@@ -229,6 +235,9 @@ export class VaultSyncEngine {
         // ACL changed in this vault — the open note (synced over its own socket)
         // must re-mint its token to flip read-only/edit live. See onAclChanged.
         this.onAclChanged?.();
+      } else if (control.t === "registry") {
+        // Folder/note structure changed — re-pull the registry + refresh tree.
+        this.onRegistryChanged?.();
       } else if (control.t === "err") {
         // Server refused us mid-session (e.g. bad token) — reconnect fresh.
         this.onDisconnect();

--- a/app/apps/desktop/src/lib/vault/__tests__/seed.test.ts
+++ b/app/apps/desktop/src/lib/vault/__tests__/seed.test.ts
@@ -7,6 +7,7 @@ vi.mock("../../ipc", () => ({ writeNote: vi.fn(async () => {}) }));
 import * as ipc from "../../ipc";
 import type { TreeNode } from "../../ipc";
 import {
+  STARTER_NOTES,
   WELCOME_NOTE_PATH,
   seedWelcomeContent,
   vaultIsEmpty,
@@ -36,17 +37,34 @@ describe("vaultIsEmpty", () => {
 describe("seedWelcomeContent", () => {
   beforeEach(() => writeNote.mockClear());
 
-  it("writes a root welcome note plus a Getting Started walkthrough", async () => {
+  it("writes the full interlinked starter set, welcome note first", async () => {
     const path = await seedWelcomeContent();
     expect(path).toBe(WELCOME_NOTE_PATH);
 
     const written = writeNote.mock.calls.map((c) => c[0]);
-    expect(written).toEqual([
-      "Welcome.md",
-      "Getting Started/How Baalda works.md",
-    ]);
+    // Every note in the starter set is written, in declared order.
+    expect(written).toEqual(STARTER_NOTES.map((n) => n.path));
+    expect(written[0]).toBe(WELCOME_NOTE_PATH);
+    expect(written.length).toBe(18);
     // Welcome note leads with its own H1 (write_note is full-file, no auto title).
     expect(writeNote.mock.calls[0][1]).toMatch(/^# Welcome to Baalda/);
+  });
+
+  it("every wikilink target resolves to another starter note (no dangling links)", () => {
+    // Basenames the starter set defines (how links resolve — see resolve_all_links).
+    const basenames = new Set(
+      STARTER_NOTES.map((n) => n.path.replace(/^.*\//, "").replace(/\.md$/, "")),
+    );
+    for (const note of STARTER_NOTES) {
+      // `[[Target]]` / `[[Target|alias]]` — mirror the Rust WIKILINK_RE
+      // (`[^\]\n]+`, so a bare `[[` syntax hint on its own line never matches).
+      for (const m of note.body.matchAll(/\[\[([^\]\n]+)\]\]/g)) {
+        const target = m[1].split("|")[0].split("#")[0].trim();
+        // Skip the literal syntax examples like `[[wikilink]]` shown in prose.
+        if (/^wikilinks?$/i.test(target)) continue;
+        expect(basenames, `${note.path} → [[${target}]]`).toContain(target);
+      }
+    }
   });
 
   it("returns null (never throws) when a write fails", async () => {

--- a/app/apps/desktop/src/lib/vault/seed.ts
+++ b/app/apps/desktop/src/lib/vault/seed.ts
@@ -1,12 +1,16 @@
-// First-run vault seeding. A brand-new, empty vault gets a small amount of
-// starter content so it isn't an empty void: a root `Welcome` note that pitches
-// the idea, plus a `Getting Started` folder with a short walkthrough. This runs
-// once, only when the vault has no notes and no folders — see `vaultIsEmpty`.
+// First-run vault seeding. A brand-new, empty vault gets a starter set of
+// interlinked notes so it isn't an empty void — and so the graph view has
+// something to show from day one. The set is a small, self-explanatory second
+// brain: a root `Welcome`, a `Map of Content` hub, and three folders
+// (`Getting Started`, `Concepts`, `Examples`) whose notes link to one another
+// with `[[wikilinks]]`. Those links become graph edges (they resolve by
+// basename), so a fresh workspace opens onto a populated constellation.
 //
-// Content is written with `write_note` (full-file, atomic) rather than
-// `create_note` (which would prepend its own H1), so we control the exact
-// Markdown. `write_note` creates any missing parent folder, so the walkthrough
-// note materializes its folder on its own.
+// This runs once, only when the vault has no notes and no folders — see
+// `vaultIsEmpty`. Content is written with `write_note` (full-file, atomic)
+// rather than `create_note` (which would prepend its own H1), so we control the
+// exact Markdown. `write_note` creates any missing parent folder, so each note
+// materializes its folder on its own.
 
 import * as ipc from "../ipc";
 import type { TreeNode } from "../ipc";
@@ -14,9 +18,17 @@ import type { TreeNode } from "../ipc";
 /** Vault-relative path of the root welcome note (used to open it after seeding). */
 export const WELCOME_NOTE_PATH = "Welcome.md";
 
-const GETTING_STARTED_NOTE_PATH = "Getting Started/How Baalda works.md";
-
-const WELCOME_BODY = `# Welcome to Baalda 👋
+/**
+ * The full starter set, in write order. Each entry is a vault-relative path and
+ * the exact Markdown to write. Wikilinks reference other notes by basename
+ * (case-insensitive), so `[[How Baalda works]]` resolves regardless of folder.
+ * Keep every `[[…]]` target pointing at a real basename in this list — a typo
+ * just yields a dangling link (no graph edge), never an error.
+ */
+export const STARTER_NOTES: ReadonlyArray<{ path: string; body: string }> = [
+  {
+    path: WELCOME_NOTE_PATH,
+    body: `# Welcome to Baalda 👋
 
 Baalda is your **local-first second brain** — notes that live as plain Markdown
 files on your own computer.
@@ -32,12 +44,60 @@ What makes it different:
 
 Most tools give you one of these. Baalda is the bridge between all three.
 
-> New here? Open **Getting Started → How Baalda works** for a two-minute tour.
+## Start here
+
+- 🧭 [[Map of Content]] — a hand-made index of everything in this vault.
+- 🚀 [[How Baalda works]] — a two-minute tour of the essentials.
+- 🕸️ [[The graph view]] — see how these notes connect.
+
+> These starter notes are already linked together, which is why your graph
+> isn't empty. Delete them whenever you like — this is your space.
 
 Happy writing. ✍️
-`;
+`,
+  },
 
-const GETTING_STARTED_BODY = `# How Baalda works
+  {
+    path: "Map of Content.md",
+    body: `# Map of Content
+
+A **Map of Content** (MOC) is a note whose only job is to link to other notes.
+It's how you navigate a vault by hand instead of by folders. This one indexes
+your starter set — see [[Maps of Content]] for the idea behind it.
+
+## Getting started
+
+- [[How Baalda works]]
+- [[Keyboard shortcuts]]
+- [[Working with your AI]]
+- [[Collaborating with your team]]
+
+## Concepts
+
+- [[Local-first notes]]
+- [[Wikilinks and backlinks]]
+- [[Maps of Content]]
+- [[Atomic notes]]
+- [[Daily notes]]
+- [[The graph view]]
+
+## Examples
+
+- [[Reading list]]
+- [[How to Take Smart Notes]]
+- [[Website launch]]
+- [[Meeting notes]]
+- [[Ideas inbox]]
+- [[Weekly review]]
+
+← back to [[Welcome]]
+`,
+  },
+
+  // ── Getting Started ───────────────────────────────────────────────────────
+  {
+    path: "Getting Started/How Baalda works.md",
+    body: `# How Baalda works
 
 A quick tour of the essentials. This whole note is just a Markdown file — try
 editing it as you read.
@@ -45,31 +105,248 @@ editing it as you read.
 ## 1. Everything is a file
 
 Notes are plain \`.md\` files in this folder. Create one with **⌘N**, organise
-them into folders in the sidebar, and link between them with \`[[wikilinks]]\`.
-Anything you do here shows up as ordinary files on disk.
+them in the sidebar, and connect them with [[Wikilinks and backlinks]]. See
+[[Local-first notes]] for why that matters, and [[Keyboard shortcuts]] to move
+faster.
 
 ## 2. Work together in real time
 
 Sign in and create (or join) a **workspace** to sync this vault across your
-devices and with your team. Open the same note as a teammate and you'll see
-each other's cursors — edits merge instantly, nothing gets overwritten.
+devices and with your team — more in [[Collaborating with your team]].
 
 ## 3. Bring in your AI
 
-Baalda speaks **MCP**, so an assistant like **Claude** (in Claude Desktop or
-Cowork) can work in your vault directly:
+Baalda speaks **MCP**, so an assistant like Claude can work in your vault
+directly — see [[Working with your AI]].
+
+When you're ready, the [[Map of Content]] links to everything else.
+`,
+  },
+  {
+    path: "Getting Started/Keyboard shortcuts.md",
+    body: `# Keyboard shortcuts
+
+The handful worth memorising first:
+
+| Action | Shortcut |
+| --- | --- |
+| New note | **⌘N** |
+| Quick open / search | **⌘P** |
+| Toggle the [[The graph view]] | **⌘G** |
+| Bold / italic | **⌘B** / **⌘I** |
+| Insert a \`[[wikilink]]\` | type \`[[\` |
+
+Typing \`[[\` starts a link — that's the core move behind
+[[Wikilinks and backlinks]]. Back to [[How Baalda works]].
+`,
+  },
+  {
+    path: "Getting Started/Working with your AI.md",
+    body: `# Working with your AI
+
+Baalda exposes your vault over **MCP**, so an assistant like **Claude** (in
+Claude Desktop or Cowork) can read and write these notes directly.
 
 1. Open **Workspace Settings → MCP** and create a connection token.
 2. Add it to Claude as an MCP server.
-3. Ask Claude to read, search, and write your notes — its edits show up here
-   live, the same way a teammate's would.
+3. Ask Claude to search, summarise, and write notes — its edits appear here
+   live, exactly the way a teammate's would (see [[Collaborating with your team]]).
 
-Now your notes, your team, and your AI all share one source of truth.
+Good first tasks: turn your [[Ideas inbox]] into [[Atomic notes]], or draft a
+[[Weekly review]]. Back to [[How Baalda works]].
+`,
+  },
+  {
+    path: "Getting Started/Collaborating with your team.md",
+    body: `# Collaborating with your team
 
----
+A **workspace** syncs this vault across your devices and with people you invite.
 
-That's it. Delete these starter notes whenever you like — this is your space.
-`;
+- Open the same note as a teammate and you'll see each other's cursors.
+- Edits **merge** in real time — nothing gets overwritten.
+- Share a single folder or the whole vault; permissions are per-folder.
+
+Try it on [[Meeting notes]] or a [[Website launch]] plan. Your AI joins the same
+way — see [[Working with your AI]]. Back to [[How Baalda works]].
+`,
+  },
+
+  // ── Concepts ──────────────────────────────────────────────────────────────
+  {
+    path: "Concepts/Local-first notes.md",
+    body: `# Local-first notes
+
+**Local-first** means the source of truth lives on *your* device, not a server.
+Your notes are plain \`.md\` files you fully own — they work offline, open in any
+editor, and sync only when you choose.
+
+Syncing is additive, not a dependency: turn it on for
+[[Collaborating with your team]], turn it off and everything still works. This is
+the foundation the rest of [[How Baalda works]] builds on.
+`,
+  },
+  {
+    path: "Concepts/Wikilinks and backlinks.md",
+    body: `# Wikilinks and backlinks
+
+A **wikilink** connects one note to another: write \`[[Atomic notes]]\` and it
+becomes a link. The note you link *to* automatically gains a **backlink** —
+a list of everything pointing at it.
+
+Links are the real structure of a vault (folders are secondary). Enough of them
+and you get [[The graph view]], and you can curate them by hand with
+[[Maps of Content]]. This idea powers [[Atomic notes]] and [[Daily notes]].
+`,
+  },
+  {
+    path: "Concepts/Maps of Content.md",
+    body: `# Maps of Content
+
+A **Map of Content** (MOC) is a note that links to a cluster of related notes —
+a table of contents you write by hand. Use one whenever a topic grows past a few
+notes.
+
+They pair naturally with [[Wikilinks and backlinks]]: the MOC links out, the
+backlinks point home. Your vault's top-level MOC is the [[Map of Content]]. See
+also [[Atomic notes]].
+`,
+  },
+  {
+    path: "Concepts/Atomic notes.md",
+    body: `# Atomic notes
+
+An **atomic note** holds *one* idea, titled so you can link to it later. Small
+notes recombine — one idea can support many others through
+[[Wikilinks and backlinks]].
+
+It's the core habit from [[How to Take Smart Notes]]. Capture rough thoughts in
+your [[Ideas inbox]] first, then split them into atomic notes. Gather related
+ones under [[Maps of Content]].
+`,
+  },
+  {
+    path: "Concepts/Daily notes.md",
+    body: `# Daily notes
+
+A **daily note** is one page per day — a log, a scratchpad, a landing spot for
+whatever comes up. Link out from it liberally with [[Wikilinks and backlinks]].
+
+Daily notes feed two rhythms: drop half-formed thoughts into your
+[[Ideas inbox]], and roll the week up in your [[Weekly review]].
+`,
+  },
+  {
+    path: "Concepts/The graph view.md",
+    body: `# The graph view
+
+The **graph** draws every note as a node and every [[Wikilinks and backlinks]]
+connection as an edge. Press **⌘G** (see [[Keyboard shortcuts]]) to open it.
+
+It's a fast way to *see* your thinking: clusters are topics, hubs are your
+[[Maps of Content]], and lonely nodes are notes worth linking. The vault you're
+reading now is why your graph isn't empty. Back to the [[Map of Content]].
+`,
+  },
+
+  // ── Examples ──────────────────────────────────────────────────────────────
+  {
+    path: "Examples/Reading list.md",
+    body: `# Reading list
+
+A living list. Each book becomes its own note once you start taking
+[[Atomic notes]] from it.
+
+- 📖 [[How to Take Smart Notes]] — Sönke Ahrens *(reading)*
+- 📕 *Building a Second Brain* — Tiago Forte *(next)*
+- 📗 *How to Read a Book* — Adler & Van Doren *(someday)*
+
+New ideas from what you read land in the [[Ideas inbox]].
+`,
+  },
+  {
+    path: "Examples/How to Take Smart Notes.md",
+    body: `# How to Take Smart Notes
+
+Notes on Sönke Ahrens' book — the case for the *Zettelkasten* method.
+
+## Key ideas
+
+- Write **[[Atomic notes]]** in your own words — one idea each.
+- Link every note to others so ideas find each other later
+  ([[Wikilinks and backlinks]]).
+- Don't file by folder; let structure emerge, then curate with
+  [[Maps of Content]].
+
+Part of the [[Reading list]].
+`,
+  },
+  {
+    path: "Examples/Website launch.md",
+    body: `# Website launch
+
+A tiny project note, to show how work lives in the vault.
+
+## Milestones
+
+- [ ] Finalise copy
+- [ ] Design review — notes in [[Meeting notes]]
+- [ ] Ship 🚀
+
+Progress gets summarised in the [[Weekly review]]; coordinate with the team via
+[[Collaborating with your team]].
+`,
+  },
+  {
+    path: "Examples/Meeting notes.md",
+    body: `# Meeting notes — Design review
+
+**Attendees:** you + the team · **Project:** [[Website launch]]
+
+## Decisions
+
+- Ship the new landing page Friday.
+- Keep the pricing section for a follow-up.
+
+## Action items
+
+- [ ] Capture leftover ideas in the [[Ideas inbox]]
+- [ ] Review progress in the [[Weekly review]]
+
+Everyone edits this live — see [[Collaborating with your team]].
+`,
+  },
+  {
+    path: "Examples/Ideas inbox.md",
+    body: `# Ideas inbox
+
+A single place to dump raw thoughts fast, so nothing gets lost. Process it later
+into [[Atomic notes]] — that's the habit from [[How to Take Smart Notes]].
+
+- A graph filter for orphan notes?
+- Blog post: what "local-first" really means → [[Local-first notes]]
+- Follow up on the [[Website launch]] copy
+
+Empty this out during your [[Weekly review]]; it often fills from your
+[[Daily notes]].
+`,
+  },
+  {
+    path: "Examples/Weekly review.md",
+    body: `# Weekly review
+
+A five-minute ritual to keep the vault (and your head) tidy.
+
+## Checklist
+
+- [ ] Empty the [[Ideas inbox]] into [[Atomic notes]]
+- [ ] Skim this week's [[Daily notes]]
+- [ ] Update project notes like [[Website launch]]
+- [ ] Prune or link any lonely nodes in [[The graph view]]
+
+Start from the [[Map of Content]] and follow the links.
+`,
+  },
+];
 
 /** True when a vault has no notes and no folders (a brand-new, empty vault). */
 export function vaultIsEmpty(tree: TreeNode): boolean {
@@ -78,16 +355,17 @@ export function vaultIsEmpty(tree: TreeNode): boolean {
 
 /**
  * Write the first-run starter content into an (assumed empty) vault. Returns the
- * welcome note's vault-relative path so the caller can open it, or null if the
+ * welcome note's vault-relative path so the caller can open it, or null if any
  * write failed (seeding is best-effort — a failure must never block vault open).
  */
 export async function seedWelcomeContent(): Promise<string | null> {
   try {
-    await ipc.writeNote(WELCOME_NOTE_PATH, WELCOME_BODY);
-    await ipc.writeNote(GETTING_STARTED_NOTE_PATH, GETTING_STARTED_BODY);
+    for (const note of STARTER_NOTES) {
+      await ipc.writeNote(note.path, note.body);
+    }
     return WELCOME_NOTE_PATH;
   } catch (e) {
-    console.warn("[seed] failed to write welcome content", e);
+    console.warn("[seed] failed to write starter content", e);
     return null;
   }
 }

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -72,8 +72,12 @@ interface AppStore {
   userInvitations: Invitation[];
   syncEnabled: boolean;
   syncStatus: SyncStatus;
-  /** When the current doc last reached "synced" — drives "last synced Xm ago". */
+  /** When the current doc last flushed all changes to the server — drives
+   *  "Synced · just now". Bumped on every server ack, not just initial sync. */
   lastSyncedAt: number | null;
+  /** True while the open note has local edits not yet acked by the server
+   *  (drives the "Saving…" badge state). */
+  syncPending: boolean;
   /** Locks (read-only overlays) in the synced vault — drives tree badges. */
   locks: Share[];
   /** Per-item accent colors (vault-local preference), path → color id. */
@@ -165,6 +169,8 @@ interface AppStore {
 
   // Sync
   setSyncStatus: (status: SyncStatus) => void;
+  setSyncPending: (pending: boolean) => void;
+  markSynced: () => void;
   enableSyncForVault: () => Promise<void>;
 }
 
@@ -253,6 +259,7 @@ export const useStore = create<AppStore>((set, get) => ({
   syncEnabled: false,
   syncStatus: "offline",
   lastSyncedAt: null,
+  syncPending: false,
   locks: [],
   itemColors: {},
   itemOrder: {},
@@ -362,6 +369,16 @@ export const useStore = create<AppStore>((set, get) => ({
 
   initAuth: async () => {
     syncManager.setStatusListener((status) => get().setSyncStatus(status));
+    syncManager.setActivityListeners({
+      onPending: (pending) => get().setSyncPending(pending),
+      onFlushed: () => get().markSynced(),
+    });
+    // A teammate's folder/note change has been pulled into the registry — reflect
+    // it in the sidebar tree + title index live.
+    syncManager.setRegistryListener(() => {
+      void get().refreshTree();
+      void get().refreshTitles();
+    });
     try {
       const session = await authManager.init();
       set({ serverUrl: authManager.getServerUrl() });
@@ -453,6 +470,7 @@ export const useStore = create<AppStore>((set, get) => ({
       userInvitations: [],
       syncEnabled: false,
       syncStatus: "offline",
+      syncPending: false,
       locks: [],
       pendingWorkspaceFolder: null,
       billingConfig: null,
@@ -646,6 +664,7 @@ export const useStore = create<AppStore>((set, get) => ({
           locks: [],
           syncEnabled: false,
           syncStatus: "offline",
+          syncPending: false,
           pendingWorkspaceFolder: null,
         });
       }
@@ -766,8 +785,15 @@ export const useStore = create<AppStore>((set, get) => ({
     set(
       status === "synced"
         ? { syncStatus: status, lastSyncedAt: Date.now() }
-        : { syncStatus: status },
+        : // Leaving "synced" (new doc connecting, offline, error…) clears any
+          // stale "Saving…" — pending only makes sense while connected.
+          { syncStatus: status, syncPending: false },
     ),
+
+  setSyncPending: (pending) => set({ syncPending: pending }),
+
+  // A server ack of all pending changes: this is the real "synced just now".
+  markSynced: () => set({ lastSyncedAt: Date.now(), syncPending: false }),
 
   enableSyncForVault: async () => {
     const { session, vault } = get();

--- a/app/apps/server/migrations/012_folder_created_by.sql
+++ b/app/apps/server/migrations/012_folder_created_by.sql
@@ -1,0 +1,8 @@
+-- Track who created a folder, mirroring notes.created_by.
+--
+-- Needed for private-by-default sharing: a member sees a folder/note they
+-- created even without an explicit share, so the permission resolver must know
+-- the creator. (Notes already carried created_by since migration 002.)
+
+ALTER TABLE folders
+  ADD COLUMN IF NOT EXISTS created_by TEXT REFERENCES "user" (id) ON DELETE SET NULL;

--- a/app/apps/server/src/http/app.ts
+++ b/app/apps/server/src/http/app.ts
@@ -5,7 +5,7 @@ import { config } from "../config.js";
 import { auth } from "../auth/auth.js";
 import { oauthConnectRoutes } from "./routes/oauth-connect.js";
 import { blobRoutes } from "./routes/blobs.js";
-import { registryRoutes } from "./routes/registry.js";
+import { createRegistryRoutes } from "./routes/registry.js";
 import { syncTokenRoutes } from "./routes/sync-token.js";
 import { vaultTokenRoutes } from "./routes/vault-token.js";
 import { desktopOauthRoutes } from "./routes/desktop-oauth.js";
@@ -23,6 +23,8 @@ export interface AppDeps extends ShareDeps {
   docWriter: DocWriter;
   /** Payment provider. Defaults to Polar; tests inject a fake. */
   billingProvider?: BillingProvider;
+  /** Structure changed (folder/note create/rename/move/delete) → broadcast. */
+  onRegistryChanged?: (vaultId: string) => void;
 }
 
 /**
@@ -105,7 +107,7 @@ export function createApp(deps: AppDeps): Hono {
   app.route("/api", desktopOauthRoutes);
   app.route("/api", syncTokenRoutes);
   app.route("/api", vaultTokenRoutes);
-  app.route("/api", registryRoutes);
+  app.route("/api", createRegistryRoutes({ onRegistryChanged: deps.onRegistryChanged }));
   app.route("/api", blobRoutes);
   app.route("/api", createShareRoutes(deps));
   const billingProvider = deps.billingProvider ?? new PolarBillingProvider();

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -2,172 +2,336 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
+import { listReadableDocsInVault, listVisibleFolders } from "../../permissions/vault-docs.js";
 import { getSession } from "../session.js";
+
+export interface RegistryDeps {
+  /**
+   * Called after any change to a vault's folder/note structure (create, rename,
+   * move, delete). The vault channel broadcasts a `registry` control frame so
+   * every open client re-pulls the registry and updates its local tree live —
+   * without this, structural changes only surfaced on the next app restart.
+   */
+  onRegistryChanged?: (vaultId: string) => void;
+}
 
 /**
  * Registry API (session-authenticated). Lets the client map local vault files to
- * server doc_ids: create/list vaults, folders, notes, files. doc_id is the join
- * key between the .md file, the Yjs doc, and the relational rows.
+ * server doc_ids: create/list/rename/delete vaults, folders, notes, files.
+ * doc_id is the join key between the .md file, the Yjs doc, and the relational
+ * rows, and is NEVER changed by a rename/move — only the path columns move, so a
+ * note keeps one identity across devices (spec: "key by doc_id, never by path").
  */
-export const registryRoutes = new Hono();
+export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
+  const registryRoutes = new Hono();
+  const changed = (vaultId: string) => deps.onRegistryChanged?.(vaultId);
 
-// ── vaults ─────────────────────────────────────────────────────────────────
-registryRoutes.post("/vaults", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
+  // ── vaults ─────────────────────────────────────────────────────────────────
+  registryRoutes.post("/vaults", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
 
-  const body = await c.req.json().catch(() => ({}));
-  const name = body.name;
-  const organizationId = body.organizationId ?? session.activeOrganizationId;
-  if (typeof name !== "string" || !name) {
-    return c.json({ error: "name is required" }, 400);
-  }
-  if (typeof organizationId !== "string" || !organizationId) {
-    return c.json({ error: "organizationId is required (no active org)" }, 400);
-  }
+    const body = await c.req.json().catch(() => ({}));
+    const name = body.name;
+    const organizationId = body.organizationId ?? session.activeOrganizationId;
+    if (typeof name !== "string" || !name) {
+      return c.json({ error: "name is required" }, 400);
+    }
+    if (typeof organizationId !== "string" || !organizationId) {
+      return c.json({ error: "organizationId is required (no active org)" }, 400);
+    }
 
-  const role = await orgRole(organizationId, session.userId);
-  if (role !== "owner" && role !== "admin") {
-    return c.json({ error: "Only workspace owner/admin can create vaults" }, 403);
-  }
+    const role = await orgRole(organizationId, session.userId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json({ error: "Only workspace owner/admin can create vaults" }, 403);
+    }
 
-  const id = randomUUID();
+    const id = randomUUID();
+    await pool.query(
+      "INSERT INTO vaults (id, organization_id, name) VALUES ($1, $2, $3)",
+      [id, organizationId, name],
+    );
+    // Private-by-default: a new workspace grants NO org-wide access. Members see
+    // only what they create or what an owner/admin explicitly shares with the
+    // team (per-folder/file, or a workspace-wide grant) via the Access panel.
+    return c.json({ id, organizationId, name }, 201);
+  });
+
+  registryRoutes.get("/vaults", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const { rows } = await pool.query(
+      `SELECT v.id, v.organization_id, v.name, v.created_at
+         FROM vaults v
+         JOIN member m ON m."organizationId" = v.organization_id
+        WHERE m."userId" = $1
+        ORDER BY v.created_at ASC`,
+      [session.userId],
+    );
+    return c.json({ vaults: rows });
+  });
+
+  // ── folders ──────────────────────────────────────────────────────────────
+  registryRoutes.post("/folders", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+
+    const body = await c.req.json().catch(() => ({}));
+    const { vaultId, name, path, parentId } = body;
+    if (typeof vaultId !== "string" || typeof name !== "string" || typeof path !== "string") {
+      return c.json({ error: "vaultId, name, path are required" }, 400);
+    }
+    const org = await vaultOrg(vaultId);
+    if (!org) return c.json({ error: "Unknown vault" }, 404);
+    if (!(await orgRole(org, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+
+    // A given path maps to one folder per vault — adopt an existing row rather
+    // than duplicating it (reconcile and on-demand create can race).
+    const existing = await pool.query(
+      "SELECT id FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+      [vaultId, path],
+    );
+    if (existing.rows[0]) {
+      return c.json({ id: existing.rows[0].id, vaultId, parentId: parentId ?? null, name, path }, 200);
+    }
+
+    const id = randomUUID();
+    await pool.query(
+      `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [id, vaultId, parentId ?? null, name, path, body.sort ?? 0, session.userId],
+    );
+    changed(vaultId);
+    return c.json({ id, vaultId, parentId: parentId ?? null, name, path }, 201);
+  });
+
+  registryRoutes.get("/folders", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.query("vaultId");
+    if (!vaultId) return c.json({ error: "vaultId query param required" }, 400);
+    const org = await vaultOrg(vaultId);
+    if (!org || !(await orgRole(org, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    // Private-by-default: only folders the caller may see (created / shared /
+    // path-to-a-shared-note). Owner/admin + Open workspaces see everything.
+    const folders = await listVisibleFolders(session.userId, vaultId);
+    return c.json({ folders });
+  });
+
+  // Rename / move a folder. Rewrites the folder's own row AND every descendant
+  // folder + note's path prefix (old → new) in place — ids are untouched, so
+  // backlinks and CRDT docs survive the move.
+  registryRoutes.patch("/folders/:id", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const id = c.req.param("id");
+    const body = await c.req.json().catch(() => ({}));
+    const { rows } = await pool.query(
+      "SELECT vault_id, path FROM folders WHERE id = $1",
+      [id],
+    );
+    const row = rows[0];
+    if (!row) return c.json({ error: "Unknown folder" }, 404);
+    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    const oldPath: string = row.path;
+    const newPath = typeof body.path === "string" ? body.path : oldPath;
+    const newName = typeof body.name === "string" ? body.name : basename(newPath);
+    const newParentId = body.parentId === undefined ? undefined : (body.parentId ?? null);
+
+    await pool.query(
+      `UPDATE folders SET path = $1, name = $2${newParentId === undefined ? "" : ", parent_id = $4"}
+       WHERE id = $3`,
+      newParentId === undefined ? [newPath, newName, id] : [newPath, newName, id, newParentId],
+    );
+    if (newPath !== oldPath) {
+      await rewriteDescendantPaths(row.vault_id, oldPath, newPath);
+    }
+    changed(row.vault_id);
+    return c.json({ id, vaultId: row.vault_id, name: newName, path: newPath }, 200);
+  });
+
+  // Delete a folder subtree: soft-delete its notes (they keep their doc_id so a
+  // teammate who has one open just loses tree visibility), then remove the
+  // folder rows (ON DELETE CASCADE clears descendant folders).
+  registryRoutes.delete("/folders/:id", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const id = c.req.param("id");
+    const { rows } = await pool.query(
+      "SELECT vault_id, path FROM folders WHERE id = $1",
+      [id],
+    );
+    const row = rows[0];
+    if (!row) return c.json({ error: "Unknown folder" }, 404);
+    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    await pool.query(
+      `UPDATE notes SET deleted_at = now()
+        WHERE vault_id = $1 AND deleted_at IS NULL
+          AND (rel_path = $2 OR rel_path LIKE $2 || '/%')`,
+      [row.vault_id, row.path],
+    );
+    await pool.query("DELETE FROM folders WHERE id = $1", [id]);
+    changed(row.vault_id);
+    return c.json({ ok: true }, 200);
+  });
+
+  // ── notes (markdown docs; id == doc_id) ────────────────────────────────────
+  registryRoutes.post("/notes", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+
+    const body = await c.req.json().catch(() => ({}));
+    const { vaultId, folderId, title, relPath } = body;
+    if (typeof vaultId !== "string" || typeof relPath !== "string") {
+      return c.json({ error: "vaultId and relPath are required" }, 400);
+    }
+    const org = await vaultOrg(vaultId);
+    if (!org) return c.json({ error: "Unknown vault" }, 404);
+    if (!(await orgRole(org, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+
+    // Client may supply a stable doc_id (generated locally); else we mint one.
+    const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
+    await pool.query(
+      `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $1, $6)
+       ON CONFLICT (id) DO NOTHING`,
+      [id, vaultId, folderId ?? null, title ?? null, relPath, session.userId],
+    );
+    changed(vaultId);
+    return c.json(
+      { id, docId: id, vaultId, folderId: folderId ?? null, title: title ?? null, relPath },
+      201,
+    );
+  });
+
+  registryRoutes.get("/notes", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.query("vaultId");
+    if (!vaultId) return c.json({ error: "vaultId query param required" }, 400);
+    const org = await vaultOrg(vaultId);
+    if (!org || !(await orgRole(org, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    const { rows } = await pool.query(
+      `SELECT id, vault_id, folder_id, title, rel_path, doc_id, created_by, created_at, updated_at
+         FROM notes WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path`,
+      [vaultId],
+    );
+    // Private-by-default: hide notes the caller can't read (leaks title/path and
+    // would make the client materialize a note it can't sync). Owner/admin +
+    // Open workspaces get the full set from the readable-docs resolver.
+    const readable = await listReadableDocsInVault(session.userId, vaultId);
+    return c.json({ notes: rows.filter((n) => readable.has(n.id)) });
+  });
+
+  // Rename / move a single note (rel_path / folder / title). doc_id unchanged.
+  registryRoutes.patch("/notes/:id", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const id = c.req.param("id");
+    const body = await c.req.json().catch(() => ({}));
+    const { rows } = await pool.query(
+      "SELECT vault_id, rel_path, title, folder_id FROM notes WHERE id = $1 AND deleted_at IS NULL",
+      [id],
+    );
+    const row = rows[0];
+    if (!row) return c.json({ error: "Unknown note" }, 404);
+    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    const relPath = typeof body.relPath === "string" ? body.relPath : row.rel_path;
+    const title = body.title === undefined ? row.title : body.title;
+    const folderId = body.folderId === undefined ? row.folder_id : (body.folderId ?? null);
+    await pool.query(
+      "UPDATE notes SET rel_path = $1, title = $2, folder_id = $3, updated_at = now() WHERE id = $4",
+      [relPath, title, folderId, id],
+    );
+    changed(row.vault_id);
+    return c.json({ id, docId: id, vaultId: row.vault_id, relPath, title, folderId }, 200);
+  });
+
+  // Soft-delete a note (keeps its row/doc_id; excluded from the registry list).
+  registryRoutes.delete("/notes/:id", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const id = c.req.param("id");
+    const { rows } = await pool.query(
+      "SELECT vault_id FROM notes WHERE id = $1 AND deleted_at IS NULL",
+      [id],
+    );
+    const row = rows[0];
+    if (!row) return c.json({ error: "Unknown note" }, 404);
+    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    await pool.query("UPDATE notes SET deleted_at = now() WHERE id = $1", [id]);
+    changed(row.vault_id);
+    return c.json({ ok: true }, 200);
+  });
+
+  // ── files (generic vault-file <-> doc mapping; id == doc_id) ────────────────
+  registryRoutes.post("/files", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const body = await c.req.json().catch(() => ({}));
+    const { vaultId, folderId, path } = body;
+    if (typeof vaultId !== "string" || typeof path !== "string") {
+      return c.json({ error: "vaultId and path are required" }, 400);
+    }
+    const org = await vaultOrg(vaultId);
+    if (!org) return c.json({ error: "Unknown vault" }, 404);
+    if (!(await orgRole(org, session.userId))) {
+      return c.json({ error: "Not a member of this workspace" }, 403);
+    }
+    const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
+    await pool.query(
+      "INSERT INTO files (id, vault_id, folder_id, path) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING",
+      [id, vaultId, folderId ?? null, path],
+    );
+    changed(vaultId);
+    return c.json({ id, docId: id, vaultId, folderId: folderId ?? null, path }, 201);
+  });
+
+  return registryRoutes;
+}
+
+/** Rewrite the path prefix of every descendant folder + note of a moved folder.
+ *  `oldPath`/`newPath` are the folder's own paths; children share the prefix. */
+async function rewriteDescendantPaths(
+  vaultId: string,
+  oldPath: string,
+  newPath: string,
+): Promise<void> {
+  // Postgres substring is 1-indexed; keep everything AFTER the old prefix. The
+  // $4::int cast is load-bearing: a bare text param would select substring's
+  // REGEX overload (substring(text FROM text)) and silently return NULL.
+  const from = oldPath.length + 1;
   await pool.query(
-    "INSERT INTO vaults (id, organization_id, name) VALUES ($1, $2, $3)",
-    [id, organizationId, name],
+    `UPDATE folders
+        SET path = $2 || substring(path FROM $4::int)
+      WHERE vault_id = $1 AND path LIKE $3 || '/%'`,
+    [vaultId, newPath, oldPath, from],
   );
-  // New workspaces default to "Open": an org-wide edit grant so members can
-  // read/write shared content the moment they join. Owner can switch to
-  // Read-only or Private later (Access panel). Idempotent per workspace.
   await pool.query(
-    `INSERT INTO shares
-       (id, workspace_id, resource_type, resource_id, principal_type, principal_id, permission, created_by)
-     VALUES ($1, $2, 'workspace', $2, 'org', $2, 'edit', $3)
-     ON CONFLICT (resource_type, resource_id, principal_type, principal_id) DO NOTHING`,
-    [randomUUID(), organizationId, session.userId],
+    `UPDATE notes
+        SET rel_path = $2 || substring(rel_path FROM $4::int), updated_at = now()
+      WHERE vault_id = $1 AND rel_path LIKE $3 || '/%'`,
+    [vaultId, newPath, oldPath, from],
   );
-  return c.json({ id, organizationId, name }, 201);
-});
+}
 
-registryRoutes.get("/vaults", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
-  const { rows } = await pool.query(
-    `SELECT v.id, v.organization_id, v.name, v.created_at
-       FROM vaults v
-       JOIN member m ON m."organizationId" = v.organization_id
-      WHERE m."userId" = $1
-      ORDER BY v.created_at ASC`,
-    [session.userId],
-  );
-  return c.json({ vaults: rows });
-});
-
-// ── folders ──────────────────────────────────────────────────────────────
-registryRoutes.post("/folders", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
-
-  const body = await c.req.json().catch(() => ({}));
-  const { vaultId, name, path, parentId } = body;
-  if (typeof vaultId !== "string" || typeof name !== "string" || typeof path !== "string") {
-    return c.json({ error: "vaultId, name, path are required" }, 400);
-  }
-  const org = await vaultOrg(vaultId);
-  if (!org) return c.json({ error: "Unknown vault" }, 404);
-  if (!(await orgRole(org, session.userId))) {
-    return c.json({ error: "Not a member of this workspace" }, 403);
-  }
-
-  const id = randomUUID();
-  await pool.query(
-    `INSERT INTO folders (id, vault_id, parent_id, name, path, sort)
-     VALUES ($1, $2, $3, $4, $5, $6)`,
-    [id, vaultId, parentId ?? null, name, path, body.sort ?? 0],
-  );
-  return c.json({ id, vaultId, parentId: parentId ?? null, name, path }, 201);
-});
-
-registryRoutes.get("/folders", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
-  const vaultId = c.req.query("vaultId");
-  if (!vaultId) return c.json({ error: "vaultId query param required" }, 400);
-  const org = await vaultOrg(vaultId);
-  if (!org || !(await orgRole(org, session.userId))) {
-    return c.json({ error: "Not a member of this workspace" }, 403);
-  }
-  const { rows } = await pool.query(
-    "SELECT id, vault_id, parent_id, name, path, sort FROM folders WHERE vault_id = $1 ORDER BY sort, path",
-    [vaultId],
-  );
-  return c.json({ folders: rows });
-});
-
-// ── notes (markdown docs; id == doc_id) ────────────────────────────────────
-registryRoutes.post("/notes", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
-
-  const body = await c.req.json().catch(() => ({}));
-  const { vaultId, folderId, title, relPath } = body;
-  if (typeof vaultId !== "string" || typeof relPath !== "string") {
-    return c.json({ error: "vaultId and relPath are required" }, 400);
-  }
-  const org = await vaultOrg(vaultId);
-  if (!org) return c.json({ error: "Unknown vault" }, 404);
-  if (!(await orgRole(org, session.userId))) {
-    return c.json({ error: "Not a member of this workspace" }, 403);
-  }
-
-  // Client may supply a stable doc_id (generated locally); else we mint one.
-  const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
-  await pool.query(
-    `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by)
-     VALUES ($1, $2, $3, $4, $5, $1, $6)`,
-    [id, vaultId, folderId ?? null, title ?? null, relPath, session.userId],
-  );
-  return c.json(
-    { id, docId: id, vaultId, folderId: folderId ?? null, title: title ?? null, relPath },
-    201,
-  );
-});
-
-registryRoutes.get("/notes", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
-  const vaultId = c.req.query("vaultId");
-  if (!vaultId) return c.json({ error: "vaultId query param required" }, 400);
-  const org = await vaultOrg(vaultId);
-  if (!org || !(await orgRole(org, session.userId))) {
-    return c.json({ error: "Not a member of this workspace" }, 403);
-  }
-  const { rows } = await pool.query(
-    `SELECT id, vault_id, folder_id, title, rel_path, doc_id, created_by, created_at, updated_at
-       FROM notes WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path`,
-    [vaultId],
-  );
-  return c.json({ notes: rows });
-});
-
-// ── files (generic vault-file <-> doc mapping; id == doc_id) ────────────────
-registryRoutes.post("/files", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
-  const body = await c.req.json().catch(() => ({}));
-  const { vaultId, folderId, path } = body;
-  if (typeof vaultId !== "string" || typeof path !== "string") {
-    return c.json({ error: "vaultId and path are required" }, 400);
-  }
-  const org = await vaultOrg(vaultId);
-  if (!org) return c.json({ error: "Unknown vault" }, 404);
-  if (!(await orgRole(org, session.userId))) {
-    return c.json({ error: "Not a member of this workspace" }, 403);
-  }
-  const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
-  await pool.query(
-    "INSERT INTO files (id, vault_id, folder_id, path) VALUES ($1, $2, $3, $4)",
-    [id, vaultId, folderId ?? null, path],
-  );
-  return c.json({ id, docId: id, vaultId, folderId: folderId ?? null, path }, 201);
-});
+function basename(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}

--- a/app/apps/server/src/http/routes/shares.ts
+++ b/app/apps/server/src/http/routes/shares.ts
@@ -95,12 +95,9 @@ export function createShareRoutes(deps: ShareDeps): Hono {
         400,
       );
     }
-    // On a folder/file, org-wide rows only make sense as locks; plain grants
-    // stay per-user. A workspace resource is the exception: an org-wide
-    // edit/view grant IS the "Open"/"Read-only" workspace posture.
-    if (principalType === "org" && permission !== "locked" && resourceType !== "workspace") {
-      return c.json({ error: "org-wide shares must be locks (permission=locked)" }, 400);
-    }
+    // An org-wide edit/view grant on a folder/file is "Share with team" (spec:
+    // private-by-default). On a workspace resource it's the "Open"/"Read-only"
+    // posture. Both are allowed; locks (deny overlays) may also be org-wide.
 
     const gate = await canManage(session.userId, resourceType, resourceId);
     if (!gate.ok) return c.json({ error: gate.error }, (gate.status ?? 403) as 403 | 404);

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -34,6 +34,8 @@ async function main() {
     disconnectDoc: (vaultId, docId) => disconnectDoc(sync, vaultId, docId),
     // Share create/revoke → subscribers re-evaluate their readable-doc set.
     onAclChanged: (vaultId) => void vaultChannel.publishAclChanged(vaultId),
+    // Folder/note create/rename/move/delete → subscribers re-pull the registry.
+    onRegistryChanged: (vaultId) => void vaultChannel.publishRegistryChanged(vaultId),
     // MCP tools write notes through the same sync server, so AI edits persist,
     // re-index, and broadcast to open editors exactly like a human edit.
     docWriter: createDocWriter(sync),

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -35,6 +35,8 @@ interface DocLocation {
   vaultId: string;
   folderId: string | null;
   organizationId: string;
+  /** Creator of the note (null for files, which have no creator column). */
+  createdBy: string | null;
 }
 
 /**
@@ -49,12 +51,13 @@ async function locateDoc(
     vault_id: string;
     folder_id: string | null;
     organization_id: string;
+    created_by: string | null;
   }>(
-    `SELECT loc.vault_id, loc.folder_id, v.organization_id
+    `SELECT loc.vault_id, loc.folder_id, loc.created_by, v.organization_id
        FROM (
-         SELECT vault_id, folder_id FROM notes  WHERE id = $1 AND deleted_at IS NULL
+         SELECT vault_id, folder_id, created_by FROM notes  WHERE id = $1 AND deleted_at IS NULL
          UNION ALL
-         SELECT vault_id, folder_id FROM files  WHERE id = $1
+         SELECT vault_id, folder_id, NULL::text FROM files  WHERE id = $1
        ) loc
        JOIN vaults v ON v.id = loc.vault_id
       LIMIT 1`,
@@ -66,6 +69,7 @@ async function locateDoc(
     vaultId: row.vault_id,
     folderId: row.folder_id,
     organizationId: row.organization_id,
+    createdBy: row.created_by,
   };
 }
 
@@ -123,11 +127,16 @@ async function sharePermission(
   organizationId: string,
   isMember: boolean,
 ): Promise<Permission> {
-  // The org-wide ("Open"/"Read-only") grant applies ONLY to actual workspace
-  // members — never to outsiders who merely know a doc id. Per-user grants are
-  // inherently scoped to the user, so they need no membership gate.
+  // Team (org-wide) grants apply ONLY to actual workspace members — never to
+  // outsiders who merely know a doc id. They can target a specific folder/file
+  // ("Share with team", private-by-default) or the whole workspace (Open/
+  // Read-only). Per-user grants are inherently scoped, so they need no gate.
   const orgGrantClause = isMember
-    ? "OR (resource_type = 'workspace' AND resource_id = $4 AND principal_type = 'org')"
+    ? `OR (principal_type = 'org' AND principal_id = $4 AND (
+            ($2::text IS NOT NULL AND resource_type = 'file' AND resource_id = $2)
+            OR (resource_type = 'folder' AND resource_id = ANY($3::text[]))
+            OR (resource_type = 'workspace' AND resource_id = $4)
+          ))`
     : "";
   // $2 (the doc id) is always referenced with an explicit cast + null guard so
   // Postgres can infer its type even for a folder resource, where docId is null
@@ -196,6 +205,10 @@ export async function effectivePermission(
   const role = await memberRole(db, loc.organizationId, userId);
   let granted: Permission;
   if (role === "owner" || role === "admin") {
+    granted = "edit";
+  } else if (loc.createdBy && loc.createdBy === userId) {
+    // Private-by-default: a member always has edit on a note they created, even
+    // with no explicit share (that's what makes "my private notes" work).
     granted = "edit";
   } else {
     granted = await sharePermission(

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -21,6 +21,39 @@ type Queryable = Pick<pg.Pool, "query">;
  *
  * Read = view OR edit, so the channel streams content to view-only grantees too.
  */
+/** Resolve a user's vault-level posture: their org, role, and whether they have
+ *  vault-wide read (owner/admin, or a workspace-scoped Open/Read-only grant). */
+async function vaultAccess(
+  db: Queryable,
+  userId: string,
+  vaultId: string,
+): Promise<{ organizationId: string; role: string | null; vaultWide: boolean } | null> {
+  const org = await db.query<{ organization_id: string; role: string | null }>(
+    `SELECT v.organization_id, m.role
+       FROM vaults v
+       LEFT JOIN member m
+         ON m."organizationId" = v.organization_id AND m."userId" = $2
+      WHERE v.id = $1`,
+    [vaultId, userId],
+  );
+  const row = org.rows[0];
+  if (!row) return null;
+  let vaultWide = row.role === "owner" || row.role === "admin";
+  if (!vaultWide) {
+    const orgClause = row.role !== null ? "principal_type = 'org' OR" : "";
+    const grant = await db.query(
+      `SELECT 1 FROM shares
+        WHERE resource_type = 'workspace' AND resource_id = $1
+          AND permission IN ('view', 'edit')
+          AND (${orgClause} (principal_type = 'user' AND principal_id = $2))
+        LIMIT 1`,
+      [row.organization_id, userId],
+    );
+    vaultWide = (grant.rowCount ?? 0) > 0;
+  }
+  return { organizationId: row.organization_id, role: row.role, vaultWide };
+}
+
 export async function listReadableDocsInVault(
   userId: string,
   vaultId: string,
@@ -64,13 +97,22 @@ export async function listReadableDocsInVault(
     return new Set(rows.map((r) => r.id));
   }
 
-  // Non-privileged: walk down from every folder the user has a view/edit share
-  // on, plus any directly-shared file, restricted to this vault.
+  // Non-privileged (private-by-default): readable docs are the union of
+  //   - notes the user created (created_by);
+  //   - docs under a folder shared to the user OR the team (org grant), walking
+  //     the subtree since folder grants inherit down;
+  //   - files/notes shared directly to the user or the team.
+  // The org ($3) branches are gated by membership ($4) so a non-member with a
+  // stray doc id gets nothing. Mirrors resolver.sharePermission + creator rule.
+  const isMember = row.role !== null;
   const { rows } = await db.query<{ id: string }>(
     `WITH RECURSIVE shared_folders AS (
         SELECT resource_id AS id FROM shares
-         WHERE principal_type = 'user' AND principal_id = $1
-           AND resource_type = 'folder' AND permission IN ('view', 'edit')
+         WHERE resource_type = 'folder' AND permission IN ('view', 'edit')
+           AND (
+             (principal_type = 'user' AND principal_id = $1)
+             OR ($4 AND principal_type = 'org' AND principal_id = $3)
+           )
      ),
      subtree AS (
         SELECT id FROM folders WHERE id IN (SELECT id FROM shared_folders)
@@ -79,17 +121,91 @@ export async function listReadableDocsInVault(
      ),
      shared_files AS (
         SELECT resource_id AS id FROM shares
-         WHERE principal_type = 'user' AND principal_id = $1
-           AND resource_type = 'file' AND permission IN ('view', 'edit')
+         WHERE resource_type = 'file' AND permission IN ('view', 'edit')
+           AND (
+             (principal_type = 'user' AND principal_id = $1)
+             OR ($4 AND principal_type = 'org' AND principal_id = $3)
+           )
      )
      SELECT n.id FROM notes n
        WHERE n.vault_id = $2 AND n.deleted_at IS NULL
-         AND (n.folder_id IN (SELECT id FROM subtree) OR n.id IN (SELECT id FROM shared_files))
+         AND (
+           n.created_by = $1
+           OR n.folder_id IN (SELECT id FROM subtree)
+           OR n.id IN (SELECT id FROM shared_files)
+         )
      UNION
      SELECT fi.id FROM files fi
        WHERE fi.vault_id = $2
          AND (fi.folder_id IN (SELECT id FROM subtree) OR fi.id IN (SELECT id FROM shared_files))`,
-    [userId, vaultId],
+    [userId, vaultId, row.organization_id, isMember],
   );
   return new Set(rows.map((r) => r.id));
+}
+
+export interface VaultFolderRow {
+  id: string;
+  vault_id: string;
+  parent_id: string | null;
+  name: string;
+  path: string;
+  sort: number;
+  created_by: string | null;
+}
+
+/**
+ * Folders a user may SEE in the tree (private-by-default). Owner/admin or an
+ * Open/Read-only workspace get every folder; otherwise a member sees folders
+ * they created, folders shared to them or the team (+ their subtrees, since
+ * grants inherit down), and the ANCESTORS of anything visible so the path to a
+ * shared note/folder is never missing a link.
+ */
+export async function listVisibleFolders(
+  userId: string,
+  vaultId: string,
+  db: Queryable = defaultPool,
+): Promise<VaultFolderRow[]> {
+  const access = await vaultAccess(db, userId, vaultId);
+  if (!access) return [];
+  const all = await db.query<VaultFolderRow>(
+    "SELECT id, vault_id, parent_id, name, path, sort, created_by FROM folders WHERE vault_id = $1 ORDER BY sort, path",
+    [vaultId],
+  );
+  if (access.vaultWide) return all.rows;
+
+  const readable = await listReadableDocsInVault(userId, vaultId, db);
+  const isMember = access.role !== null;
+  const { rows: visibleIds } = await db.query<{ id: string }>(
+    `WITH RECURSIVE seed AS (
+        SELECT id FROM folders WHERE vault_id = $2 AND created_by = $1
+        UNION
+        SELECT resource_id AS id FROM shares
+         WHERE resource_type = 'folder' AND permission IN ('view', 'edit')
+           AND (
+             (principal_type = 'user' AND principal_id = $1)
+             OR ($4 AND principal_type = 'org' AND principal_id = $3)
+           )
+     ),
+     down AS (
+        SELECT id, parent_id FROM folders WHERE vault_id = $2 AND id IN (SELECT id FROM seed)
+        UNION ALL
+        SELECT f.id, f.parent_id FROM folders f JOIN down d ON f.parent_id = d.id
+     ),
+     note_folders AS (
+        SELECT DISTINCT folder_id AS id FROM notes
+         WHERE vault_id = $2 AND deleted_at IS NULL AND folder_id IS NOT NULL
+           AND id = ANY($5::text[])
+     ),
+     up AS (
+        SELECT id, parent_id FROM folders
+         WHERE vault_id = $2
+           AND id IN (SELECT id FROM down UNION SELECT id FROM note_folders)
+        UNION ALL
+        SELECT f.id, f.parent_id FROM folders f JOIN up u ON f.id = u.parent_id
+     )
+     SELECT DISTINCT id FROM up`,
+    [userId, vaultId, access.organizationId, isMember, [...readable]],
+  );
+  const visible = new Set(visibleIds.map((r) => r.id));
+  return all.rows.filter((f) => visible.has(f.id));
 }

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -11,6 +11,7 @@ import {
   encodeWsUpdate,
   encodePubsubUpdate,
   encodePubsubAclChanged,
+  encodePubsubRegistryChanged,
   decodePubsub,
   type ServerControl,
 } from "./vault-protocol.js";
@@ -59,6 +60,12 @@ export class VaultChannel {
   /** Signal that shares changed in a vault; subscribers re-evaluate their ACL set. */
   async publishAclChanged(vaultId: string): Promise<void> {
     await this.pubsub.publish(vaultTopic(vaultId), encodePubsubAclChanged());
+  }
+
+  /** Signal that the folder/note structure changed in a vault (create/rename/
+   *  move/delete); subscribers re-pull the registry to update their local tree. */
+  async publishRegistryChanged(vaultId: string): Promise<void> {
+    await this.pubsub.publish(vaultTopic(vaultId), encodePubsubRegistryChanged());
   }
 
   /** Wire the channel onto the HTTP server's upgrade at `config.vaultSyncPath`. */
@@ -187,6 +194,14 @@ class VaultConnection {
       if (this.readable.has(msg.docId)) {
         this.sendBinary(encodeWsUpdate(msg.docId, msg.update));
       }
+      return;
+    }
+    if (msg.type === "registry-changed") {
+      // The set of folders/notes changed. The ACL set may also have shifted (a
+      // new note the user can read, or one revoked), so re-evaluate that too —
+      // this drops/back-fills docs — and tell the client to re-pull the tree.
+      void this.refreshAcl();
+      this.send({ t: "registry" });
       return;
     }
     // acl-changed: re-evaluate; drop revoked docs, backfill newly-granted ones.

--- a/app/apps/server/src/sync/vault-protocol.ts
+++ b/app/apps/server/src/sync/vault-protocol.ts
@@ -31,6 +31,7 @@ export type ServerControl =
   | { t: "ready" } // initial backfill drained
   | { t: "drop"; docId: string } // access lost / doc removed -> client evicts
   | { t: "reauth" } // ACL changed in this vault -> client re-mints its open doc's token
+  | { t: "registry" } // folders/notes structure changed -> client re-pulls the registry
   | { t: "err"; message: string };
 
 export function parseHello(text: string): HelloFrame | null {
@@ -75,6 +76,7 @@ export function decodeWsUpdate(
 
 export const PS_UPDATE = 0x01;
 export const PS_ACL_CHANGED = 0x02;
+export const PS_REGISTRY_CHANGED = 0x03;
 
 export function encodePubsubUpdate(docId: string, update: Uint8Array): Uint8Array {
   const body = frameDocPayload(docId, update);
@@ -88,9 +90,14 @@ export function encodePubsubAclChanged(): Uint8Array {
   return new Uint8Array([PS_ACL_CHANGED]);
 }
 
+export function encodePubsubRegistryChanged(): Uint8Array {
+  return new Uint8Array([PS_REGISTRY_CHANGED]);
+}
+
 export type PubsubMessage =
   | { type: "update"; docId: string; update: Uint8Array }
-  | { type: "acl-changed" };
+  | { type: "acl-changed" }
+  | { type: "registry-changed" };
 
 export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
   if (bytes.length < 1) return null;
@@ -101,6 +108,8 @@ export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
     }
     case PS_ACL_CHANGED:
       return { type: "acl-changed" };
+    case PS_REGISTRY_CHANGED:
+      return { type: "registry-changed" };
     default:
       return null;
   }

--- a/app/apps/server/tests/permissions.test.ts
+++ b/app/apps/server/tests/permissions.test.ts
@@ -141,6 +141,41 @@ describe("effective-permission resolver matrix (spec 04 §3)", () => {
     expect(await effectivePermission(outsider, doc)).toBe("none");
   });
 
+  // ── private-by-default (opt-in team sharing) ──────────────────────────────
+
+  it("private-by-default: creator gets edit on their own note; another member gets none", async () => {
+    const org = await seedOrg("Acme", "acme-creator");
+    const author = await seedUser("author@a.com");
+    const other = await seedUser("other@a.com");
+    await seedMember(org, author, "member");
+    await seedMember(org, other, "member");
+    const vault = await seedVault(org); // no workspace grant → private
+    const doc = await seedNote(vault, null, "mine.md", author);
+    expect(await effectivePermission(author, doc)).toBe("edit"); // creator
+    expect(await effectivePermission(other, doc)).toBe("none"); // not shared
+  });
+
+  it("Share with team: an org grant on a folder gives every member access", async () => {
+    const org = await seedOrg("Acme", "acme-team-folder");
+    const author = await seedUser("author@a.com");
+    const other = await seedUser("other@a.com");
+    await seedMember(org, author, "member");
+    await seedMember(org, other, "member");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Team", "Team");
+    const doc = await seedNote(vault, folder, "Team/shared.md", author);
+    // "Share with team" = an org-principal edit grant on the folder.
+    await pool.query(
+      `INSERT INTO shares (id, workspace_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES (gen_random_uuid()::text, $1, 'folder', $2, 'org', $1, 'edit')`,
+      [org, folder],
+    );
+    expect(await effectivePermission(other, doc)).toBe("edit"); // now visible to team
+    // …but still not to a non-member who merely knows the id.
+    const outsider = await seedUser("out@a.com");
+    expect(await effectivePermission(outsider, doc)).toBe("none");
+  });
+
   it("a lock still caps an Open-workspace member at view", async () => {
     const org = await seedOrg("Acme", "acme-open-locked");
     const member = await seedUser("m@a.com");

--- a/app/apps/server/tests/registry.test.ts
+++ b/app/apps/server/tests/registry.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { seedFolder, seedMember, seedNote, seedVault } from "./helpers/seed.js";
+import { pool as pgPool } from "../src/db/pool.js";
+
+/**
+ * Registry structure API: create/rename/move/delete of folders + notes must
+ * update the relational rows correctly (preserving doc_ids on rename/move) AND
+ * fire onRegistryChanged so the vault channel can broadcast a live tree refresh.
+ */
+
+let changed: string[] = [];
+const app = createApp({
+  disconnectDoc: () => {},
+  docWriter: {
+    async setContent() {},
+    async appendContent() {},
+    async readContent() {
+      return "";
+    },
+  },
+  onRegistryChanged: (vaultId) => changed.push(vaultId),
+});
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+describe("registry structure sync", () => {
+  let owner: TestUser;
+  let vault: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    changed = [];
+    owner = await signUp("owner@registry.test");
+    const org = (await createOrg(owner, "Reg Co", "reg-co")).id;
+    vault = await seedVault(org);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("creating a folder and a note broadcasts a registry change", async () => {
+    const f = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    expect(f.status).toBe(201);
+    const n = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "Docs/note.md",
+      title: "Note",
+    });
+    expect(n.status).toBe(201);
+    expect(changed).toEqual([vault, vault]);
+  });
+
+  it("renaming a folder rewrites its own + descendant paths, keeping doc_ids", async () => {
+    const folderId = await seedFolder(vault, null, "Docs", "Docs");
+    await seedFolder(vault, folderId, "Sub", "Docs/Sub");
+    const noteId = await seedNote(vault, folderId, "Docs/Sub/deep.md", owner.userId);
+
+    const res = await req(owner, "PATCH", `/api/folders/${folderId}`, {
+      name: "Handbook",
+      path: "Handbook",
+    });
+    expect(res.status).toBe(200);
+
+    const folders = await pool.query(
+      "SELECT path FROM folders WHERE vault_id = $1 ORDER BY path",
+      [vault],
+    );
+    expect(folders.rows.map((r) => r.path)).toEqual(["Handbook", "Handbook/Sub"]);
+    const note = await pool.query("SELECT id, rel_path FROM notes WHERE id = $1", [noteId]);
+    expect(note.rows[0].rel_path).toBe("Handbook/Sub/deep.md"); // descendant moved
+    expect(note.rows[0].id).toBe(noteId); // doc_id preserved
+    expect(changed).toContain(vault);
+  });
+
+  it("renaming a note moves only that note and preserves its doc_id", async () => {
+    const noteId = await seedNote(vault, null, "old.md", owner.userId);
+    const res = await req(owner, "PATCH", `/api/notes/${noteId}`, {
+      relPath: "new.md",
+      title: "New",
+    });
+    expect(res.status).toBe(200);
+    const row = await pool.query("SELECT id, rel_path, title FROM notes WHERE id = $1", [noteId]);
+    expect(row.rows[0]).toMatchObject({ id: noteId, rel_path: "new.md", title: "New" });
+  });
+
+  it("deleting a folder soft-deletes its notes and removes the folder rows", async () => {
+    const folderId = await seedFolder(vault, null, "Trash", "Trash");
+    const noteId = await seedNote(vault, folderId, "Trash/gone.md", owner.userId);
+
+    const res = await req(owner, "DELETE", `/api/folders/${folderId}`);
+    expect(res.status).toBe(200);
+
+    const folders = await pool.query("SELECT id FROM folders WHERE id = $1", [folderId]);
+    expect(folders.rowCount).toBe(0);
+    const note = await pool.query("SELECT deleted_at FROM notes WHERE id = $1", [noteId]);
+    expect(note.rows[0].deleted_at).not.toBeNull(); // soft-deleted, doc_id kept
+    // GET /notes must exclude the soft-deleted note.
+    const list = await req(owner, "GET", `/api/notes?vaultId=${vault}`);
+    const body = (await list.json()) as { notes: Array<{ id: string }> };
+    expect(body.notes.find((x) => x.id === noteId)).toBeUndefined();
+  });
+
+  it("soft-deleting a note drops it from the listing", async () => {
+    const noteId = await seedNote(vault, null, "bye.md", owner.userId);
+    const res = await req(owner, "DELETE", `/api/notes/${noteId}`);
+    expect(res.status).toBe(200);
+    const list = await req(owner, "GET", `/api/notes?vaultId=${vault}`);
+    const body = (await list.json()) as { notes: Array<{ id: string }> };
+    expect(body.notes.find((x) => x.id === noteId)).toBeUndefined();
+  });
+
+  it("private-by-default: GET /notes and /folders hide another member's private items", async () => {
+    // A second member of the same workspace.
+    const member = await signUp("member@registry.test");
+    const org = (await pgPool.query(`SELECT organization_id FROM vaults WHERE id = $1`, [vault]))
+      .rows[0].organization_id as string;
+    await seedMember(org, member.userId, "member");
+
+    // Owner's private folder + note (owner created them).
+    const ownerFolder = await seedFolder(vault, null, "Owner", "Owner");
+    const ownerNote = await seedNote(vault, ownerFolder, "Owner/secret.md", owner.userId);
+    // The member's own folder + note, plus a folder shared with the team.
+    const memberFolder = await seedFolder(vault, null, "Mine", "Mine");
+    const memberNote = await seedNote(vault, memberFolder, "Mine/todo.md", member.userId);
+    const teamFolder = await seedFolder(vault, null, "Team", "Team");
+    const teamNote = await seedNote(vault, teamFolder, "Team/plan.md", owner.userId);
+    await pgPool.query(
+      `INSERT INTO shares (id, workspace_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES (gen_random_uuid()::text, $1, 'folder', $2, 'org', $1, 'edit')`,
+      [org, teamFolder],
+    );
+
+    const notes = (await (await req(member, "GET", `/api/notes?vaultId=${vault}`)).json()) as {
+      notes: Array<{ id: string }>;
+    };
+    const ids = notes.notes.map((n) => n.id);
+    expect(ids).toContain(memberNote); // own note
+    expect(ids).toContain(teamNote); // shared with team
+    expect(ids).not.toContain(ownerNote); // owner's private note hidden
+
+    const folders = (await (await req(member, "GET", `/api/folders?vaultId=${vault}`)).json()) as {
+      folders: Array<{ id: string }>;
+    };
+    const fids = folders.folders.map((f) => f.id);
+    expect(fids).toContain(memberFolder);
+    expect(fids).toContain(teamFolder);
+    expect(fids).not.toContain(ownerFolder); // owner's private folder hidden
+
+    // The owner still sees everything.
+    const ownerNotes = (await (await req(owner, "GET", `/api/notes?vaultId=${vault}`)).json()) as {
+      notes: Array<{ id: string }>;
+    };
+    expect(ownerNotes.notes.map((n) => n.id)).toEqual(
+      expect.arrayContaining([ownerNote, memberNote, teamNote]),
+    );
+  });
+});

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -106,6 +106,25 @@ describe("VaultChannel relay (spec 05 §3.1)", () => {
     expect(live.map((u) => u.docId)).toEqual(["A"]);
   });
 
+  it("tells the client to re-pull on a registry change", async () => {
+    let set = new Set(["A"]);
+    const { channel } = channelWith(() => set);
+    const ws = new FakeWs();
+    channel.handleConnection(ws as never);
+    ws.hello("good");
+    await waitFor(() => ws.controls().some((c) => c.t === "ready"));
+
+    // A teammate created a note "B" — the readable set grew AND a registry frame
+    // is sent so the client re-pulls its tree; the new doc also backfills.
+    set = new Set(["A", "B"]);
+    await channel.publishRegistryChanged("v1");
+    await waitFor(() => ws.controls().some((c) => c.t === "registry"));
+
+    expect(ws.controls().filter((c) => c.t === "registry")).toEqual([{ t: "registry" }]);
+    // Newly-readable "B" is backfilled off the same signal.
+    await waitFor(() => ws.updates().some((u) => u.docId === "B"));
+  });
+
   it("drops a doc when an acl change removes it from the readable set", async () => {
     let set = new Set(["A", "B"]);
     const { channel } = channelWith(() => set);

--- a/app/apps/server/tests/vault-protocol.test.ts
+++ b/app/apps/server/tests/vault-protocol.test.ts
@@ -5,6 +5,7 @@ import {
   decodeWsUpdate,
   encodePubsubUpdate,
   encodePubsubAclChanged,
+  encodePubsubRegistryChanged,
   decodePubsub,
 } from "../src/sync/vault-protocol.js";
 
@@ -27,6 +28,10 @@ describe("vault channel framing", () => {
 
   it("decodes the acl-changed control payload", () => {
     expect(decodePubsub(encodePubsubAclChanged())).toEqual({ type: "acl-changed" });
+  });
+
+  it("decodes the registry-changed control payload", () => {
+    expect(decodePubsub(encodePubsubRegistryChanged())).toEqual({ type: "registry-changed" });
   });
 
   it("returns null for a truncated frame and an unknown pubsub type", () => {


### PR DESCRIPTION
## Summary

Three related improvements to sync + sharing, plus a fix for the misleading sync badge.

### 1. Accurate sync status ("Synced · just now")
- The pill no longer drifts to "Synced · 5m ago" while you type. It was anchored to *connection* time and never re-stamped on edits.
- `DocSync` now tracks the Hocuspocus `unsyncedChanges` event: shows **Saving…** on edit and stamps **Synced · just now** the moment the server acks. A ~700ms debounce keeps a typing burst from flickering, with a smooth color transition.

### 2. Live workspace structure sync
- Create / rename / move / delete of folders & notes now propagate live between clients (previously only on restart).
- New `registry` control frame on the vault-sync channel; server rewrites descendant paths in place (preserving every `doc_id`); clients re-pull + refresh the tree.

### 3. Private-by-default team sharing (opt-in)
- **New** workspaces are private by default; **existing** workspaces keep their current Open access (no surprise changes).
- "Share with team" = a positive org grant on a folder/file (previously forbidden). Access panel gains a workspace posture (Shared / Read-only / Private) + per-item overrides, incl. a real Private mode.
- Resolver, live-sync readable-set, and `GET /notes`/`/folders` filtering updated in lockstep; creator always sees their own notes. Migration `012_folder_created_by`.

## Testing
- Server: 137 tests pass (new private-by-default + registry mutation/filtering suites), run against a throwaway DB.
- Desktop: 134 tests pass (+ new `syncBadgeLabel` unit tests); production build compiles.
- End-to-end (real WebSocket, two clients): 3/3 integration tests pass, incl. the badge pending→flush path and two-client convergence under the private model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)