### PR TITLE
fix: show a waiting state for abandoned/slow Google sign-in

### DIFF
--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -2721,6 +2721,14 @@ button.primary.hero:hover:not(:disabled) {
 .oauth-btn:disabled {
   opacity: 0.6;
 }
+/* Guidance shown while the Google flow waits on the system browser. */
+.auth-hint {
+  margin: calc(-1 * var(--sp-1)) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-body);
+  text-align: center;
+}
 .auth-divider {
   display: flex;
   align-items: center;

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -475,6 +475,10 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
   const [password, setPassword] = useState(import.meta.env.DEV ? "Context-Test-2026!" : "");
   const [urlDraft, setUrlDraft] = useState(serverUrl);
   const [busy, setBusy] = useState(false);
+  // Google sign-in runs in the system browser and the app just waits for the
+  // loopback handoff (up to a 3-min timeout). Its own busy flag lets us show a
+  // "waiting for your browser" state instead of a silently disabled button.
+  const [googleBusy, setGoogleBusy] = useState(false);
   // Google is only offered when the server is configured for it; ask on open
   // (and whenever the server changes) so a self-host without creds hides it.
   const [googleAvailable, setGoogleAvailable] = useState(false);
@@ -532,13 +536,13 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
   };
 
   const googleSignIn = async () => {
-    setBusy(true);
+    setGoogleBusy(true);
     try {
       await useStore.getState().signInWithGoogle();
     } catch {
-      /* error surfaced via authError */
+      /* error (incl. timeout / abandoned flow) surfaced via authError */
     } finally {
-      setBusy(false);
+      setGoogleBusy(false);
     }
   };
 
@@ -575,11 +579,18 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
               type="button"
               className="oauth-btn google"
               onClick={() => void googleSignIn()}
-              disabled={busy}
+              disabled={busy || googleBusy}
+              aria-busy={googleBusy}
             >
               <GoogleGlyph />
-              <span>Continue with Google</span>
+              <span>{googleBusy ? "Waiting for your browser…" : "Continue with Google"}</span>
             </button>
+            {googleBusy && (
+              <p className="auth-hint">
+                Finish signing in in the browser tab that just opened. This window updates
+                automatically once you approve.
+              </p>
+            )}
             <div className="auth-divider">
               <span>or</span>
             </div>
@@ -614,7 +625,7 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
             minLength={8}
             required
           />
-          <button className="primary" type="submit" disabled={busy}>
+          <button className="primary" type="submit" disabled={busy || googleBusy}>
             {busy ? "…" : mode === "sign-in" ? "Sign in" : "Create account"}
           </button>
         </form>


### PR DESCRIPTION
## Problem

Desktop Google sign-in opens the consent flow in the **system browser** and blocks on a `127.0.0.1` loopback handoff with a **180-second timeout** (`src-tauri/src/oauth.rs`). Until now the only feedback while waiting was a **disabled** "Continue with Google" button — no label change, no guidance.

So if a user closes the browser tab mid-flow (or is just slow to approve), the app sits silently for up to 3 minutes before the timeout error finally surfaces. It looks stuck.

## Fix

Give the Google flow its own busy state (`googleBusy`), separate from the email/password form's `busy`:

- The button now reads **"Waiting for your browser…"** while the flow is pending (with `aria-busy`), instead of a silently-disabled "Continue with Google".
- A short hint appears beneath it: *"Finish signing in in the browser tab that just opened. This window updates automatically once you approve."*
- The email/password submit is disabled while the Google flow is in flight, so the two paths can't be started at once.
- The eventual timeout / "was interrupted" message still surfaces via `authError` exactly as before.

Feedback-only — **no change to the 180s timeout** or any Rust/auth behavior. Two files: `AccountMenu.tsx` (UI + state) and `App.css` (one `.auth-hint` rule reusing existing tokens).

## Test plan

- `tsc --noEmit` passes.
- Manual: click **Continue with Google**, then close the browser tab → button shows the waiting state + hint immediately; the timeout error appears when the flow gives up. Completing the flow normally signs in as before.

## Notes

Surfaced while testing the local build; this is the UX papercut noted alongside the member-removal discussion (see issue #16 context). Does not add a Cancel/abort command — that would need a new Rust command to tear down the loopback listener and is out of scope here.
