### PR TITLE
feat: remove a member from a workspace (owner/admin)

### DIFF
--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { type McpToolInfo, type McpTokenRow } from "../lib/api";
+import { type McpToolInfo, type McpTokenRow, type Member } from "../lib/api";
 import { ITEM_COLORS, itemColorValue } from "../lib/appearance";
 import { authManager } from "../lib/auth/authManager";
 import { classifyLimitError, type LimitKind, limitFromError } from "../lib/billing";
@@ -1167,6 +1167,33 @@ function MembersTab({ canManage }: { canManage: boolean }) {
     null,
   );
   const [upgradeOpen, setUpgradeOpen] = useState(false);
+  // Member removal: an inline "Remove → Confirm" per row so it's never one click.
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+  const [removeBusy, setRemoveBusy] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  // The caller's own role in this workspace, so we mirror the server's rules and
+  // only show a Remove button where it would actually succeed: owners can remove
+  // anyone but themselves and the (single) owner; admins can remove plain members.
+  const myRole = members.find((m) => m.userId === session?.user.id)?.role;
+  const canRemove = (m: Member): boolean =>
+    canManage &&
+    m.userId !== session?.user.id &&
+    m.role !== "owner" &&
+    (myRole === "owner" || m.role === "member");
+
+  const doRemove = async (userId: string) => {
+    setRemoveBusy(true);
+    setRemoveError(null);
+    try {
+      await useStore.getState().removeMember(userId);
+      setConfirmRemoveId(null);
+    } catch (e) {
+      setRemoveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRemoveBusy(false);
+    }
+  };
 
   // The workspace's shareable join code (owner/admin only; server creates it
   // lazily). Older servers without the endpoint simply hide the section.
@@ -1275,10 +1302,40 @@ function MembersTab({ canManage }: { canManage: boolean }) {
                 {m.userId === session?.user.id && <span className="muted"> (you)</span>}
               </span>
               <span className={`member-role ${m.role}`}>{m.role}</span>
+              {canRemove(m) &&
+                (confirmRemoveId === m.userId ? (
+                  <>
+                    <button
+                      className="link-btn danger"
+                      disabled={removeBusy}
+                      onClick={() => void doRemove(m.userId)}
+                    >
+                      {removeBusy ? "Removing…" : "Confirm"}
+                    </button>
+                    <button
+                      className="link-btn"
+                      disabled={removeBusy}
+                      onClick={() => setConfirmRemoveId(null)}
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    className="link-btn danger"
+                    onClick={() => {
+                      setRemoveError(null);
+                      setConfirmRemoveId(m.userId);
+                    }}
+                  >
+                    Remove
+                  </button>
+                ))}
             </li>
           );
         })}
       </ul>
+      {removeError && <div className="auth-error">{removeError}</div>}
 
       {pendingInvitations.length > 0 && (
         <>

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -535,6 +535,19 @@ export class ApiClient {
     return data;
   }
 
+  /**
+   * Remove a member from a workspace (owner/admin). The server deletes the
+   * membership, purges any shares granted directly to that user, and force-closes
+   * their live sync sockets so access is revoked immediately. Throws ApiError 403
+   * if the caller lacks permission (e.g. an admin trying to remove another admin).
+   */
+  async removeMember(organizationId: string, userId: string): Promise<void> {
+    await this.request<{ removed: boolean }>(
+      "DELETE",
+      `/api/orgs/${encodeURIComponent(organizationId)}/members/${encodeURIComponent(userId)}`,
+    );
+  }
+
   // ---- MCP tokens ---------------------------------------------------------
 
   /** The MCP endpoint URL for this server (what an AI client connects to). */

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -134,6 +134,8 @@ interface AppStore {
   createOrganization: (name: string) => Promise<void>;
   setActiveOrganization: (organizationId: string) => Promise<void>;
   inviteMember: (email: string, role: "member" | "admin") => Promise<void>;
+  /** Remove a member from the active workspace (owner/admin), then refresh. */
+  removeMember: (userId: string) => Promise<void>;
   acceptInvitation: (invitationId: string) => Promise<void>;
   joinWorkspace: (code: string) => Promise<void>;
   /** Detach a workspace from THIS device (forget its folder, stop syncing it).
@@ -623,6 +625,13 @@ export const useStore = create<AppStore>((set, get) => ({
   inviteMember: async (email, role) => {
     const activeOrgId = get().session?.activeOrganizationId ?? undefined;
     await authManager.api.inviteMember({ email, role, organizationId: activeOrgId });
+    await get().refreshWorkspace();
+  },
+
+  removeMember: async (userId) => {
+    const activeOrgId = get().session?.activeOrganizationId;
+    if (!activeOrgId) throw new Error("No active workspace");
+    await authManager.api.removeMember(activeOrgId, userId);
     await get().refreshWorkspace();
   },
 

--- a/app/apps/server/src/http/routes/orgs.ts
+++ b/app/apps/server/src/http/routes/orgs.ts
@@ -227,5 +227,87 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
     return c.json({ deleted: true, vaults: vaultIds.length, docs: docIds.length });
   });
 
+  // Remove a member from a workspace (owner/admin). Revokes access on both paths
+  // that would otherwise let a departed member keep reading org data:
+  //   1. delete the `member` row — their org-wide "Open" grant stops applying
+  //      (the resolver gates it on membership) and the next sync-token mint 403s;
+  //   2. purge their per-user shares — those are NOT membership-gated, so a folder
+  //      or file shared directly to them would survive step 1 (see issue #16);
+  //   3. force-close live sockets so access dies now, not at token expiry.
+  // Owner can remove anyone but themselves; an admin can remove only plain members
+  // (not another admin or the owner). Self-removal ("leave") is intentionally not
+  // supported here yet.
+  orgRoutes.delete("/orgs/:orgId/members/:userId", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+
+    const orgId = c.req.param("orgId");
+    const targetUserId = c.req.param("userId");
+
+    const callerRole = await orgRole(orgId, session.userId);
+    if (!callerRole) return c.json({ error: "Unknown workspace" }, 404);
+    if (callerRole !== "owner" && callerRole !== "admin") {
+      return c.json({ error: "Only the workspace owner or an admin can remove members" }, 403);
+    }
+    if (targetUserId === session.userId) {
+      return c.json({ error: "You can't remove yourself from the workspace" }, 400);
+    }
+
+    const targetRole = await orgRole(orgId, targetUserId);
+    if (!targetRole) return c.json({ error: "That person isn't a member of this workspace" }, 404);
+    if (targetRole === "owner") {
+      return c.json({ error: "The workspace owner can't be removed" }, 403);
+    }
+    if (targetRole === "admin" && callerRole !== "owner") {
+      return c.json({ error: "Only the owner can remove an admin" }, 403);
+    }
+
+    // Snapshot the org's docs so we can kill any live sockets the removed member
+    // holds. closeConnections on a doc with no live socket is a cheap no-op, so
+    // covering every doc in the org is fine (member removal is rare).
+    const vaults = await pool.query<{ id: string }>(
+      "SELECT id FROM vaults WHERE organization_id = $1",
+      [orgId],
+    );
+    const vaultIds = vaults.rows.map((r) => r.id);
+    const docs = vaultIds.length
+      ? await pool.query<{ id: string; vault_id: string }>(
+          `SELECT id, vault_id FROM notes WHERE vault_id = ANY($1)
+           UNION ALL
+           SELECT id, vault_id FROM files WHERE vault_id = ANY($1)`,
+          [vaultIds],
+        )
+      : { rows: [] as Array<{ id: string; vault_id: string }> };
+
+    // Drop membership + direct grants together. `shares.workspace_id` scopes the
+    // purge to this org; shares the member *created for others* (created_by) are
+    // untouched — only grants TO this user (principal_id) are removed.
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `DELETE FROM member WHERE "organizationId" = $1 AND "userId" = $2`,
+        [orgId, targetUserId],
+      );
+      await client.query(
+        `DELETE FROM shares
+          WHERE workspace_id = $1 AND principal_type = 'user' AND principal_id = $2`,
+        [orgId, targetUserId],
+      );
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    // Membership is gone, so a reconnect now fails at token mint (403). Kick the
+    // live sockets AFTER the delete so the auto-reconnect can't re-mint a token.
+    for (const d of docs.rows) deps.disconnectDoc(d.vault_id, d.id);
+
+    return c.json({ removed: true });
+  });
+
   return orgRoutes;
 }

--- a/app/apps/server/tests/orgs-remove-member.test.ts
+++ b/app/apps/server/tests/orgs-remove-member.test.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { testAppDeps } from "./helpers/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { createOrg, signUp } from "./helpers/auth.js";
+
+const app = createApp(testAppDeps());
+
+function removeMember(token: string | null, orgId: string, userId: string) {
+  const headers: Record<string, string> = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  return app.fetch(
+    new Request(
+      `http://local/api/orgs/${encodeURIComponent(orgId)}/members/${encodeURIComponent(userId)}`,
+      { method: "DELETE", headers },
+    ),
+  );
+}
+
+async function addMember(orgId: string, userId: string, role: "member" | "admin" = "member") {
+  await pool.query(
+    `INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+     VALUES ($1, $2, $3, $4, now())`,
+    [randomUUID(), orgId, userId, role],
+  );
+}
+
+async function memberCount(orgId: string, userId: string): Promise<number> {
+  const { rows } = await pool.query<{ c: number }>(
+    `SELECT count(*)::int AS c FROM member WHERE "organizationId" = $1 AND "userId" = $2`,
+    [orgId, userId],
+  );
+  return rows[0].c;
+}
+
+async function shareCount(workspaceId: string, principalId: string): Promise<number> {
+  const { rows } = await pool.query<{ c: number }>(
+    `SELECT count(*)::int AS c FROM shares
+      WHERE workspace_id = $1 AND principal_type = 'user' AND principal_id = $2`,
+    [workspaceId, principalId],
+  );
+  return rows[0].c;
+}
+
+describe("remove a member from a workspace", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("owner removes a member: row deleted, their direct shares purged", async () => {
+    const owner = await signUp("owner@rm.com");
+    const org = await createOrg(owner, "Acme", "acme-rm1");
+    const member = await signUp("member@rm.com");
+    await addMember(org.id, member.userId);
+
+    // A folder shared directly to the member — must be purged on removal.
+    await pool.query(
+      `INSERT INTO shares
+         (id, workspace_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES ($1, $2, 'folder', $3, 'user', $4, 'edit')`,
+      [randomUUID(), org.id, randomUUID(), member.userId],
+    );
+    // A share to a DIFFERENT user must survive (scope check).
+    const bystander = await signUp("bystander@rm.com");
+    await addMember(org.id, bystander.userId);
+    await pool.query(
+      `INSERT INTO shares
+         (id, workspace_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES ($1, $2, 'folder', $3, 'user', $4, 'edit')`,
+      [randomUUID(), org.id, randomUUID(), bystander.userId],
+    );
+
+    expect(await memberCount(org.id, member.userId)).toBe(1);
+    expect(await shareCount(org.id, member.userId)).toBe(1);
+
+    const res = await removeMember(owner.token, org.id, member.userId);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ removed: true });
+
+    expect(await memberCount(org.id, member.userId)).toBe(0);
+    expect(await shareCount(org.id, member.userId)).toBe(0);
+    // The bystander's membership and share are untouched.
+    expect(await memberCount(org.id, bystander.userId)).toBe(1);
+    expect(await shareCount(org.id, bystander.userId)).toBe(1);
+  });
+
+  it("rejects anon (401), a plain member (403), self-removal (400), and removing the owner (403)", async () => {
+    const owner = await signUp("owner@rm2.com");
+    const org = await createOrg(owner, "Acme", "acme-rm2");
+    const member = await signUp("member@rm2.com");
+    await addMember(org.id, member.userId);
+
+    expect((await removeMember(null, org.id, member.userId)).status).toBe(401);
+    // A plain member can't remove anyone.
+    expect((await removeMember(member.token, org.id, owner.userId)).status).toBe(403);
+    // Owner can't remove themselves via this route.
+    expect((await removeMember(owner.token, org.id, owner.userId)).status).toBe(400);
+    // The owner can't be removed at all.
+    const admin = await signUp("admin@rm2.com");
+    await addMember(org.id, admin.userId, "admin");
+    expect((await removeMember(admin.token, org.id, owner.userId)).status).toBe(403);
+    // Membership is unchanged after the rejected attempts.
+    expect(await memberCount(org.id, owner.userId)).toBe(1);
+    expect(await memberCount(org.id, member.userId)).toBe(1);
+  });
+
+  it("admin can remove a plain member but not another admin", async () => {
+    const owner = await signUp("owner@rm3.com");
+    const org = await createOrg(owner, "Acme", "acme-rm3");
+    const admin = await signUp("admin@rm3.com");
+    await addMember(org.id, admin.userId, "admin");
+    const other = await signUp("other@rm3.com");
+    await addMember(org.id, other.userId);
+    const admin2 = await signUp("admin2@rm3.com");
+    await addMember(org.id, admin2.userId, "admin");
+
+    // Admin removes a plain member — allowed.
+    expect((await removeMember(admin.token, org.id, other.userId)).status).toBe(200);
+    expect(await memberCount(org.id, other.userId)).toBe(0);
+
+    // Admin can't remove another admin — only the owner can.
+    expect((await removeMember(admin.token, org.id, admin2.userId)).status).toBe(403);
+    expect(await memberCount(org.id, admin2.userId)).toBe(1);
+    expect((await removeMember(owner.token, org.id, admin2.userId)).status).toBe(200);
+    expect(await memberCount(org.id, admin2.userId)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #16.

## Problem

There was no way to remove someone from a workspace. When a person left the team they kept access to org data, because two paths stay open even if you delete the Better Auth `member` row by hand:

1. **Direct shares survive.** Per-user shares (`principal_type='user'`) are intentionally *not* membership-gated (`permissions/resolver.ts`), so a folder/file shared straight to that person still resolves to `edit`/`view`.
2. **Live sockets survive.** Per-doc sync tokens stay valid until expiry (`SYNC_TOKEN_TTL_SECONDS`, default 600s), so a removed user with a note open keeps syncing for minutes.

## What this does

New `DELETE /api/orgs/:orgId/members/:userId` (modeled on the existing org-delete route), which closes both doors in one transaction plus a socket kick:

- **Deletes the `member` row** — their org-wide "Open" grant stops applying (the resolver gates it on membership) and their next `sync-token` mint returns 403.
- **Purges shares granted directly to that user** — scoped by `shares.workspace_id`; shares they *created for others* (`created_by`) are untouched, only grants *to* them (`principal_id`) are removed.
- **Force-closes their live sockets** via `disconnectDoc`, after the row is gone, so an auto-reconnect can't re-mint a token. Access dies immediately, not at token expiry.

### Authorization
- Owner can remove anyone but themselves; the owner can't be removed.
- An admin can remove only plain members (not another admin or the owner).
- 401 anon · 403 forbidden · 400 self-removal · 404 not-a-member.

Self-removal ("Leave workspace") is intentionally out of scope for this PR.

## Client
- `ApiClient.removeMember(organizationId, userId)`
- store `removeMember(userId)` action → calls the API, then `refreshWorkspace()`
- Members tab: a **Remove → Confirm** control per member row (two-step, never one click), shown only where the caller is actually allowed to remove that member (mirrors the server rules so we never render a button that would 403).

## Tests
`tests/orgs-remove-member.test.ts` covers: owner removal deletes the row + purges only that user's shares (bystander untouched); anon/plain-member/self/owner rejections; admin-can-remove-member but not-another-admin. `tsc --noEmit` clean on both workspaces.

## Depends on
Builds on #14/#15 (the `UNIQUE(organizationId, userId)` guard), which makes removal a single unambiguous delete.
