### PR TITLE
fix: don't freeze the app during Google sign-in; allow cancel

### DIFF
--- a/app/apps/desktop/src-tauri/src/oauth.rs
+++ b/app/apps/desktop/src-tauri/src/oauth.rs
@@ -80,25 +80,39 @@ pub fn google_oauth_listen(state: State<AppState>) -> AppResult<u16> {
     Ok(port)
 }
 
-/// Block until the redirect arrives, returning the one-time code. Errors if the
-/// flow returned an OAuth error, timed out, or `listen` was never called.
+/// Wait for the redirect and return the one-time code. Errors if the flow
+/// returned an OAuth error, timed out, or `listen` was never called.
+///
+/// `async` + `spawn_blocking` is load-bearing: the receive blocks for up to the
+/// flow timeout, and a *synchronous* command would run that on the main thread
+/// and freeze the whole webview until it returns (so nothing — not even a Cancel
+/// button — could respond). Off the main thread the UI stays live throughout.
 #[tauri::command]
-pub fn google_oauth_await(state: State<AppState>) -> AppResult<String> {
-    let rx = state
-        .oauth_rx
-        .lock()
-        .map_err(|_| AppError::new("oauth: state poisoned"))?
-        .take()
-        .ok_or_else(|| AppError::new("oauth: no listen in progress"))?;
+pub async fn google_oauth_await(state: State<'_, AppState>) -> AppResult<String> {
+    // Take the receiver out (dropping the guard) before we await — a MutexGuard
+    // can't be held across an await point, and the receiver moves into the task.
+    let rx = {
+        let mut guard = state
+            .oauth_rx
+            .lock()
+            .map_err(|_| AppError::new("oauth: state poisoned"))?;
+        guard
+            .take()
+            .ok_or_else(|| AppError::new("oauth: no listen in progress"))?
+    };
 
     // A hair longer than the listener's own deadline so we surface its message
     // rather than a bare channel timeout.
-    match rx.recv_timeout(FLOW_TIMEOUT + Duration::from_secs(5)) {
+    let recv = tauri::async_runtime::spawn_blocking(move || {
+        rx.recv_timeout(FLOW_TIMEOUT + Duration::from_secs(5))
+    })
+    .await
+    .map_err(|e| AppError::new(format!("oauth: await task failed: {e}")))?;
+
+    match recv {
         Ok(Ok(code)) => Ok(code),
         Ok(Err(msg)) => Err(AppError::new(format!("Google sign-in failed: {msg}"))),
-        Err(RecvTimeoutError::Timeout) => {
-            Err(AppError::new("Google sign-in timed out"))
-        }
+        Err(RecvTimeoutError::Timeout) => Err(AppError::new("Google sign-in timed out")),
         Err(RecvTimeoutError::Disconnected) => {
             Err(AppError::new("Google sign-in was interrupted"))
         }

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -535,15 +535,35 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
     }
   };
 
+  // Each Google attempt gets a generation number. Cancelling (or starting a new
+  // attempt) bumps it, so when an abandoned flow finally rejects — the loopback
+  // listener waits out its ~3-min timeout — we can drop that stale result instead
+  // of flashing a "timed out" error at someone who already moved on.
+  const googleFlow = useRef(0);
+
   const googleSignIn = async () => {
+    const flow = ++googleFlow.current;
+    useStore.setState({ authError: null });
     setGoogleBusy(true);
     try {
       await useStore.getState().signInWithGoogle();
-    } catch {
-      /* error (incl. timeout / abandoned flow) surfaced via authError */
+    } catch (e) {
+      if (flow === googleFlow.current) {
+        useStore.setState({ authError: e instanceof Error ? e.message : String(e) });
+      }
+      // else: cancelled or superseded — the user isn't waiting on this anymore.
     } finally {
-      setGoogleBusy(false);
+      if (flow === googleFlow.current) setGoogleBusy(false);
     }
+  };
+
+  // Stop waiting on the browser and return to the form so the user can retry or
+  // sign in with email instead. The abandoned loopback listener harmlessly times
+  // out on its own; its late result is ignored via the generation check above.
+  const cancelGoogleSignIn = () => {
+    googleFlow.current++;
+    setGoogleBusy(false);
+    useStore.setState({ authError: null });
   };
 
   return (
@@ -587,8 +607,9 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
             </button>
             {googleBusy && (
               <p className="auth-hint">
-                Finish signing in in the browser tab that just opened. This window updates
-                automatically once you approve.
+                <button type="button" className="link-btn" onClick={cancelGoogleSignIn}>
+                  Cancel
+                </button>
               </p>
             )}
             <div className="auth-divider">

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -419,20 +419,18 @@ export const useStore = create<AppStore>((set, get) => ({
 
   signInWithGoogle: async () => {
     set({ authError: null });
-    try {
-      await authManager.signInWithGoogle();
-      const session = await authManager.currentSession();
-      set({ session, authStatus: session ? "signed-in" : "signed-out" });
-      if (session) {
-        await get().refreshWorkspace();
-        await get().refreshBillingConfig();
-        await get().refreshOrgBilling();
-        await get().enableSyncForVault();
-        await get().openWelcomeIfPresent();
-      }
-    } catch (e) {
-      set({ authError: errMsg(e) });
-      throw e;
+    // Errors (incl. the loopback timeout on an abandoned flow) propagate to the
+    // caller, which decides whether to surface them — a cancelled/superseded flow
+    // must NOT flash a late error. See AuthDialog.googleSignIn.
+    await authManager.signInWithGoogle();
+    const session = await authManager.currentSession();
+    set({ session, authStatus: session ? "signed-in" : "signed-out" });
+    if (session) {
+      await get().refreshWorkspace();
+      await get().refreshBillingConfig();
+      await get().refreshOrgBilling();
+      await get().enableSyncForVault();
+      await get().openWelcomeIfPresent();
     }
   },
 


### PR DESCRIPTION
## Problem

The desktop Google flow waits on the loopback handoff via `google_oauth_await`, which was a **synchronous** Tauri command doing a blocking `recv` for up to the ~3-minute flow timeout. Tauri runs sync commands on the main thread, so the **entire webview froze** for the whole wait. If the user closed the browser tab without signing in, nothing in the app responded — not the form, not any button — until the timeout finally fired with "timed out waiting for sign-in".

This is the real cause behind the "it's stuck / I can't do anything" reports. PR #19 added a waiting message but couldn't fix the freeze because the UI thread itself was blocked.

## Fix

- **Rust:** make `google_oauth_await` `async` and run the blocking `recv_timeout` on `tauri::async_runtime::spawn_blocking`, off the main thread. The MutexGuard is dropped before the await and the receiver moves into the task. The UI now stays responsive for the entire flow.
- **UI:** add a **Cancel** action to the waiting state so the user can abandon a dead flow and immediately retry or sign in with email. Each attempt carries a generation number; a cancelled or superseded flow's late rejection (when the listener finally times out) is dropped instead of flashing a stale error. The store no longer sets `authError` for the Google path — `AuthDialog` decides, respecting the generation check.

## Test plan

- `cargo check` and `tsc --noEmit` clean.
- Manual: **Continue with Google** → close the browser tab without signing in → the app stays fully responsive; **Cancel** returns to the form instantly, and email/password works. Completing the flow normally still signs in.

Follow-up to #19.
