### PR TITLE
Workspace switcher polish and app/server updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,13 @@ flow through the same sync server via `createDocWriter` so AI edits persist/broa
   `onChange` appends the binary update + schedules re-index. `disconnectDoc` force-closes sockets on revoke.
 - `yjs/persistence.ts` — binary-only store: `doc_updates` append log + `doc_snapshots` (compact past
   `COMPACTION_THRESHOLD`).
-- `permissions/resolver.ts` — `effectivePermission(userId, docId)`: owner/admin → edit; else max of
-  file share + ancestor-folder shares (walk `parent_id` up); a `locked` share caps at view even for admins.
-  `edit > view > none`; no grant → no sync access (403 at token mint).
+- `permissions/resolver.ts` — `effectivePermission(userId, docId)`: owner/admin → edit; a note's
+  **creator** → edit on their own note; else max of file/folder shares (walk `parent_id` up) — either
+  per-user or an org-wide "share with team" grant — plus any workspace grant; a `locked` share caps at
+  view even for admins. `edit > view > none`; no grant → no sync access (403 at token mint). **New
+  workspaces are private by default** (no org-wide grant); existing ones keep their Open grant. Keep this
+  in lockstep with `permissions/vault-docs.ts` (the readable-set dual that gates live sync + registry
+  listings).
 - `tokens/sync-token.ts` — HS256 per-doc JWT (`jose`), TTL `SYNC_TOKEN_TTL_SECONDS` (default 600).
 - `mcp/` — JSON-RPC 2.0 over Streamable HTTP at `POST /api/mcp` (no SSE; GET/DELETE → 405). Tools:
   `list_vaults/list_folders/create_folder/delete_folder/list_notes/read_note/search_notes/create_note/update_note/append_note/delete_note`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We scanned **41** open-source Obsidian-like apps against **12 core requirements*
 
 - 📄 **Your notes are just files.** Plain `.md` on disk. No lock-in, works with Git, and survives even if the server disappears.
 - 🤖 **AI-editable, two ways.** Local-first means a local agent (Claude Code, Codex, any CLI tool) edits the `.md` files directly, no integration needed. Autonomous and cloud agents use the built-in [MCP](#-connect-an-ai-mcp) endpoint, gated by the exact same permissions as a human. Both paths merge live with everyone else's edits.
-- 👥 **Real-time collaboration.** Invite teammates, share folders or single files (view or edit), and see live cursors and who's viewing a note.
+- 👥 **Real-time collaboration.** Invite teammates and edit together with live cursors. Notes are **private by default** — share a folder or single file with the whole team or one person (view or edit), and folders/renames/moves sync live too.
 - 🔒 **Local-first and private.** A full desktop app that works offline. Your Markdown never travels the network in plain text; only opaque binary sync updates do, and each device re-derives its own `.md` files.
 - 🔎 **Fast search and links.** Built-in full-text search (SQLite FTS5), backlinks, and tags, all indexed locally.
 - 🖥️ **Native and cross-platform.** A lightweight Tauri v2 app for macOS, Windows, and Linux (iOS planned).

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -425,6 +425,43 @@ button.primary.hero:hover:not(:disabled) {
   color: var(--text-tertiary);
   margin: 0 0 var(--sp-1) var(--sp-1);
 }
+/* Holds the recent cards. Collapsed it just stacks the 3 shown; once
+   "Load more" expands it, JS locks its height to that same collapsed footprint
+   and it scrolls internally — so the wordmark and action buttons above never
+   move (the whole card is vertically centered). */
+.recent-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+.recent-scroll.expanded {
+  overflow-y: auto;
+  padding-right: 2px; /* breathing room beside the scrollbar */
+  scrollbar-width: thin;
+}
+/* "Load more (N)" — a quiet full-width reveal under the collapsed list. */
+.recent-more {
+  margin-top: var(--sp-1);
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-2);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease);
+}
+.recent-more:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.recent-more:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
 .recent-card {
   display: flex;
   align-items: center;
@@ -1118,6 +1155,56 @@ button.primary.hero:hover:not(:disabled) {
   color: var(--warning);
 }
 
+/* Live presence — a small stack of teammate faces on the right of a row showing
+   who is currently viewing that note (or, on a collapsed folder, the notes
+   inside it). Mirrors the editor's PresenceAvatar ring treatment, shrunk to fit
+   a 32px row. Each face's colour arrives inline as --user-color. */
+.tree-presence {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--sp-1);
+  /* Sits between the label and the ⋯ button; never pushed off by a long name
+     (the label ellipsizes first). */
+}
+.tree-presence-avatar {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--bg-surface);
+  border: 1.5px solid var(--user-color, var(--border-strong));
+  padding: 1px;
+  box-sizing: border-box;
+  margin-left: -6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.tree-presence-avatar:first-child {
+  margin-left: 0;
+}
+.tree-presence-avatar svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: 50%;
+}
+.tree-presence-avatar.offline {
+  opacity: 0.7;
+}
+/* Overflow chip (+N) when more teammates are here than fit in the stack. */
+.tree-presence-overflow {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+  color: var(--text-secondary);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 /* ⋯ actions — whispers in on row hover; its own hover stays small and faint */
 .tree-more {
   flex-shrink: 0;
@@ -1479,6 +1566,33 @@ button.primary.hero:hover:not(:disabled) {
 .update-banner {
   background: var(--accent-soft, var(--warning-soft));
 }
+
+/* Member-joined celebration: same banner shape, an accent tint, and a gentle
+   entrance so it reads as a happy moment rather than an alert. */
+.celebrate-banner {
+  background: var(--accent-soft, var(--warning-soft));
+  border: 1px solid var(--accent, transparent);
+  animation: celebrate-in 260ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+@keyframes celebrate-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+/* Confetti overlays the whole window and never intercepts clicks. */
+.celebrate-confetti {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 9999;
+}
 .update-detail {
   display: flex;
   flex-direction: column;
@@ -1728,6 +1842,14 @@ button.primary.hero:hover:not(:disabled) {
 .presence-light.active {
   background: var(--success);
 }
+/* Chosen availability (see AccountMenu): away → amber, busy → red. Matches the
+   Settings status dots and the note-roster peer dots. */
+.presence-light.away {
+  background: #f59e0b;
+}
+.presence-light.busy {
+  background: var(--danger);
+}
 .presence-light.idle {
   background: var(--warning);
   animation: sync-pulse 1.3s var(--ease) infinite;
@@ -1886,6 +2008,24 @@ button.primary.hero:hover:not(:disabled) {
   background: var(--bg-surface);
   border-radius: var(--radius-pill);
   padding: 1px var(--sp-2);
+}
+/* State chip on a switcher row: Local vs Synced. Distinct from --accent so it
+   reads as metadata, not an action. */
+.ws-badge {
+  flex-shrink: 0;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: var(--radius-pill);
+  padding: 1px var(--sp-2);
+}
+.ws-badge.local {
+  color: var(--text-tertiary);
+  background: var(--bg-active);
+}
+.ws-badge.synced {
+  color: var(--accent);
+  background: var(--accent-soft);
 }
 .menu-item.subtle {
   color: var(--text-secondary);
@@ -2070,6 +2210,64 @@ button.primary.hero:hover:not(:disabled) {
   box-shadow: var(--shadow-sm);
   padding: var(--sp-6) var(--sp-8) var(--sp-8);
   animation: rise-in var(--t-fast) var(--ease) both;
+}
+/* A team section that isn't available until the workspace is synced. Shown
+   greyed in the nav (discoverable), with a lock glyph. */
+.settings-nav .menu-item.locked {
+  color: var(--text-tertiary);
+}
+.settings-nav .menu-item.locked .menu-icon {
+  opacity: 0.6;
+}
+.nav-lock {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+}
+/* Turn-on-sync promo card on the General tab of a local workspace. */
+.sync-promo {
+  margin: var(--sp-4) 0 var(--sp-2);
+  padding: var(--sp-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--accent-soft), transparent 70%);
+}
+.sync-promo-title {
+  margin: 0 0 var(--sp-2);
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  font-weight: 600;
+}
+.sync-promo-desc {
+  margin: 0 0 var(--sp-4);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-body);
+  max-width: 46ch;
+}
+/* Gate panel shown when a locked team section is opened on a local workspace. */
+.sync-gate {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  max-width: 44ch;
+  padding: var(--sp-6) 0;
+}
+.sync-gate-icon {
+  width: 30px;
+  height: 30px;
+  color: var(--accent);
+}
+.sync-gate h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  font-weight: 600;
+}
+.sync-gate p {
+  margin: 0;
 }
 .settings-section-title {
   margin: 0 0 var(--sp-5);
@@ -3064,7 +3262,9 @@ button.primary.hero:hover:not(:disabled) {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 200;
+  /* Above the full-screen settings page (z-index 200) so a modal opened from
+     within Settings — e.g. Sign in from the Turn-on-sync card — sits on top. */
+  z-index: 300;
   animation: fade-in var(--t-med) var(--ease) both;
 }
 .modal {

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./App.css";
 import { AccountMenu } from "./components/AccountMenu";
 import { BacklinksPanel } from "./components/BacklinksPanel";
@@ -15,6 +15,7 @@ import { BRAND_NAME } from "./lib/brand";
 import * as ipc from "./lib/ipc";
 import { syncManager } from "./lib/sync/docSession";
 import { checkForUpdate, installUpdate, useUpdateState } from "./lib/updater";
+import { runConfetti } from "./lib/celebrate/celebrate";
 import { previewKind } from "./lib/preview";
 import { useStore } from "./store";
 
@@ -33,6 +34,44 @@ function RemovedBanner() {
         </button>
       </div>
     </div>
+  );
+}
+
+/**
+ * Celebrates a teammate joining the workspace: a soft top banner (auto-fades
+ * after a few seconds) plus a one-shot confetti burst over the whole window.
+ * The chime is played by the store when the celebration is triggered.
+ */
+function MemberJoinedBanner() {
+  const memberJoined = useStore((s) => s.memberJoined);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // Fire confetti whenever a new celebration starts (`at` changes on each join).
+  useEffect(() => {
+    if (!memberJoined || !canvasRef.current) return;
+    const cancel = runConfetti(canvasRef.current);
+    return cancel;
+  }, [memberJoined?.at]);
+
+  if (!memberJoined) return null;
+
+  return (
+    <>
+      <canvas ref={canvasRef} className="celebrate-confetti" aria-hidden="true" />
+      <div className="banner celebrate-banner" role="status">
+        <span>
+          🎉 <strong>{memberJoined.name}</strong> joined the workspace
+        </span>
+        <div className="banner-actions">
+          <button
+            className="secondary"
+            onClick={() => useStore.getState().dismissMemberJoined()}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </>
   );
 }
 
@@ -390,6 +429,7 @@ export default function App() {
       </aside>
 
       <main className="main">
+        <MemberJoinedBanner />
         <UpdateBanner />
         <header className="main-header">
           <span className="note-title">{openNote?.title ?? "No note open"}</span>

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -444,7 +444,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
       <div className="access-body">
         {/* master list */}
         <div className="access-master">
-          <div className="access-listlabel">Your vault</div>
+          <div className="access-listlabel">Your workspace</div>
           {resources.length === 0 ? (
             <div className="muted perm-empty">Nothing synced yet.</div>
           ) : (

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -4,6 +4,7 @@ import { ITEM_COLORS, itemColorValue } from "../lib/appearance";
 import { authManager } from "../lib/auth/authManager";
 import { classifyLimitError, type LimitKind, limitFromError } from "../lib/billing";
 import * as ipc from "../lib/ipc";
+import type { RecentVault } from "../lib/ipc";
 import {
   checkForUpdate,
   currentVersion,
@@ -11,6 +12,7 @@ import {
   useUpdateState,
 } from "../lib/updater";
 import { readOrgVaults, useStore } from "../store";
+import { statusTone } from "../lib/presence/color";
 import { AccessPanel } from "./AccessPanel";
 import { AccountSettings } from "./AccountSettings";
 import { Avatar, SyncBadge } from "./Identity";
@@ -32,10 +34,14 @@ export function AccountMenu() {
   const userInvitations = useStore((s) => s.userInvitations);
   const syncStatus = useStore((s) => s.syncStatus);
   const syncEnabled = useStore((s) => s.syncEnabled);
+  const activityStatus = useStore((s) => s.activityStatus);
+  const vault = useStore((s) => s.vault);
 
   const [open, setOpen] = useState(false);
   const [authOpen, setAuthOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
+  // Which settings tab the workspace page should open on (View all → Workspaces).
+  const [settingsTab, setSettingsTab] = useState<SettingsTab | undefined>(undefined);
   const [accountOpen, setAccountOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -57,9 +63,18 @@ export function AccountMenu() {
   }, [open]);
 
   if (authStatus !== "signed-in" || !session) {
+    // Signed out is still local-first: the identity bar names the local
+    // workspace you're in (if any) and opens the switcher, so you can hop
+    // between local workspaces and sign in — not a dead-end "Sign in" button.
     return (
       <div className="account-menu" ref={rootRef}>
-        <button className="identity-bar" onClick={() => setAuthOpen(true)}>
+        <button
+          className={`identity-bar ${open ? "open" : ""}`}
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          title={vault ? `${vault.name} · Local` : "Sign in to sync & collaborate"}
+        >
           <span className="identity-avatar signed-out" aria-hidden="true">
             <svg
               viewBox="0 0 24 24"
@@ -74,14 +89,42 @@ export function AccountMenu() {
             </svg>
           </span>
           <span className="identity-meta">
-            <span className="identity-line1">Sign in</span>
-            <span className="identity-line2">Sync &amp; collaborate</span>
+            <span className="identity-line1">{vault?.name ?? "Sign in"}</span>
+            <span className="identity-line2">
+              {vault ? "Local · not synced" : "Sync & collaborate"}
+            </span>
           </span>
           <span className="identity-chevron" aria-hidden="true">
             ›
           </span>
         </button>
+        {open && (
+          <SignedOutPopover
+            onClose={() => setOpen(false)}
+            onSignIn={() => {
+              setOpen(false);
+              setAuthOpen(true);
+            }}
+            onOpenSettings={() => {
+              setOpen(false);
+              setSettingsTab(undefined);
+              setMembersOpen(true);
+            }}
+            onViewAllLocal={() => {
+              setOpen(false);
+              setSettingsTab("workspaces");
+              setMembersOpen(true);
+            }}
+          />
+        )}
         {authOpen && <AuthDialog onClose={() => setAuthOpen(false)} />}
+        {membersOpen && (
+          <WorkspaceSettingsDialog
+            onClose={() => setMembersOpen(false)}
+            onRequestSignIn={() => setAuthOpen(true)}
+            initialTab={settingsTab}
+          />
+        )}
       </div>
     );
   }
@@ -90,25 +133,35 @@ export function AccountMenu() {
     organizations.find((o) => o.id === session.activeOrganizationId) ?? null;
   const userLabel = session.user.name || session.user.email;
   const hasInvites = userInvitations.length > 0;
-  // Presence light on the avatar: green = live, amber = getting there, grey = offline.
+  // Presence light on the avatar. Connectivity gates it first — no-access is
+  // blocked, an in-flight socket is idle. Once we're actually live (synced or
+  // read-only), the user's *chosen* availability takes over: online → green,
+  // away → amber, busy → red, invisible → appears offline. This is what makes
+  // the Settings "Activity status" reflect on your own circle.
+  const connected = syncStatus === "synced" || syncStatus === "read-only";
   const presence =
-    syncStatus === "synced" || syncStatus === "read-only"
-      ? "active"
+    syncStatus === "no-access"
+      ? "blocked"
       : syncStatus === "connecting" || syncStatus === "error"
         ? "idle"
-        : syncStatus === "no-access"
-          ? "blocked"
+        : connected
+          ? // online → "active"; away/busy pass through; invisible → "offline".
+            ((t) => (t === "online" ? "active" : t))(statusTone(activityStatus))
           : "offline";
   const presenceLabel =
     presence === "active"
       ? "Active"
-      : presence === "idle"
-        ? "Idle"
-        : presence === "blocked"
-          ? "No access"
-          : syncEnabled
-            ? "Offline"
-            : "Local only";
+      : presence === "away"
+        ? "Away"
+        : presence === "busy"
+          ? "Busy"
+          : presence === "idle"
+            ? "Idle"
+            : presence === "blocked"
+              ? "No access"
+              : syncEnabled
+                ? "Offline"
+                : "Local only";
 
   return (
     <div className="account-menu" ref={rootRef}>
@@ -124,9 +177,11 @@ export function AccountMenu() {
           <span className={`presence-light ${presence}`} aria-label={presenceLabel} />
         </span>
         <span className="identity-meta">
-          <span className="identity-line1">{activeOrg?.name ?? userLabel}</span>
+          <span className="identity-line1">
+            {activeOrg?.name ?? vault?.name ?? userLabel}
+          </span>
           <span className="identity-line2">
-            {activeOrg ? userLabel : "No workspace yet"}
+            {activeOrg ? userLabel : vault ? "Local · not synced" : "No workspace yet"}
           </span>
         </span>
         {hasInvites && <span className="identity-alert" aria-label="Pending invitation" />}
@@ -140,6 +195,12 @@ export function AccountMenu() {
           onClose={() => setOpen(false)}
           onOpenMembers={() => {
             setOpen(false);
+            setSettingsTab(undefined);
+            setMembersOpen(true);
+          }}
+          onOpenWorkspaces={() => {
+            setOpen(false);
+            setSettingsTab("workspaces");
             setMembersOpen(true);
           }}
           onOpenAccount={() => {
@@ -148,24 +209,194 @@ export function AccountMenu() {
           }}
         />
       )}
-      {membersOpen && <WorkspaceSettingsDialog onClose={() => setMembersOpen(false)} />}
+      {membersOpen && (
+        <WorkspaceSettingsDialog
+          onClose={() => setMembersOpen(false)}
+          initialTab={settingsTab}
+        />
+      )}
       {accountOpen && <AccountSettings onClose={() => setAccountOpen(false)} />}
     </div>
   );
 }
 
-// How many workspaces the popover shows inline (the current one + a couple of
-// recents). Anything past this lives on the Workspaces settings page so a long
-// account list never turns the menu into a scroll trap.
-const POPOVER_WORKSPACE_LIMIT = 3;
+// How many workspaces of EACH kind (synced, local) the popover shows inline.
+// Anything past this lives on the Workspaces settings page — reached via
+// "View all" — so a long account never turns the menu into a scroll trap.
+const POPOVER_WORKSPACE_LIMIT = 2;
+
+/**
+ * Recent on-disk folders that aren't bound to a synced workspace — i.e. the
+ * user's LOCAL workspaces. A workspace is one concept in two states; these are
+ * the ones that just aren't syncing to an org yet.
+ */
+function useLocalWorkspaces(): RecentVault[] {
+  const [recents, setRecents] = useState<RecentVault[]>([]);
+  useEffect(() => {
+    let alive = true;
+    ipc
+      .getRecentVaults()
+      .then((l) => {
+        if (alive) setRecents(l);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const bound = new Set(Object.values(readOrgVaults()));
+  return recents.filter((r) => !bound.has(r.path));
+}
+
+/** Native-pick a folder and open it as a local workspace, then close the menu. */
+async function openFolderAsLocalWorkspace(onDone: () => void): Promise<void> {
+  try {
+    const picked = await ipc.pickFolder();
+    if (picked) {
+      await useStore.getState().openLocalWorkspace(picked);
+      onDone();
+    }
+  } catch {
+    /* picker cancelled/unavailable */
+  }
+}
+
+/**
+ * The "On this device" rows: local workspaces you can switch to with one click.
+ * `limit` caps how many show inline; when there are more, an `onViewAll` link
+ * hands off to the full Workspaces page (which lists local + synced together).
+ * The current local workspace is always pinned to the top so it never hides
+ * behind the cap.
+ */
+function LocalWorkspaceRows({
+  onClose,
+  limit,
+  onViewAll,
+}: {
+  onClose: () => void;
+  limit?: number;
+  onViewAll?: () => void;
+}) {
+  const locals = useLocalWorkspaces();
+  const vault = useStore((s) => s.vault);
+  const syncEnabled = useStore((s) => s.syncEnabled);
+  if (locals.length === 0) return null;
+  const isCurrentLocal = (path: string) => !syncEnabled && vault?.path === path;
+  const ordered = [
+    ...locals.filter((r) => isCurrentLocal(r.path)),
+    ...locals.filter((r) => !isCurrentLocal(r.path)),
+  ];
+  const shown = limit ? ordered.slice(0, limit) : ordered;
+  return (
+    <>
+      <div className="menu-label">On this device</div>
+      {shown.map((r) => {
+        const isCurrent = isCurrentLocal(r.path);
+        return (
+          <button
+            key={r.path}
+            className={`menu-item${isCurrent ? " active" : ""}`}
+            role="menuitemradio"
+            aria-checked={isCurrent}
+            title={r.path}
+            onClick={() => {
+              if (!isCurrent) void useStore.getState().openLocalWorkspace(r.path);
+              onClose();
+            }}
+          >
+            <span className="menu-swatch" aria-hidden="true">
+              {r.name[0]?.toUpperCase() ?? "?"}
+            </span>
+            <span className="menu-item-label">{r.name}</span>
+            {isCurrent ? (
+              <span className="menu-current">Current</span>
+            ) : (
+              <span className="ws-badge local">Local</span>
+            )}
+          </button>
+        );
+      })}
+      {limit && onViewAll && locals.length > limit && (
+        <button className="menu-item subtle" onClick={onViewAll}>
+          <span className="menu-swatch more" aria-hidden="true">
+            …
+          </span>
+          <span className="menu-item-label">All local workspaces ({locals.length})</span>
+        </button>
+      )}
+    </>
+  );
+}
+
+/**
+ * Signed-out switcher. Local-first: you can hop between local workspaces and
+ * open/create folders without an account; signing in is one item in the menu,
+ * not the only thing you can do.
+ */
+function SignedOutPopover({
+  onClose,
+  onSignIn,
+  onOpenSettings,
+  onViewAllLocal,
+}: {
+  onClose: () => void;
+  onSignIn: () => void;
+  onOpenSettings: () => void;
+  onViewAllLocal: () => void;
+}) {
+  const vault = useStore((s) => s.vault);
+  return (
+    <div className="account-popover" role="menu">
+      <div className="menu-label">Workspace</div>
+      <LocalWorkspaceRows
+        onClose={onClose}
+        limit={POPOVER_WORKSPACE_LIMIT}
+        onViewAll={onViewAllLocal}
+      />
+
+      <button
+        className="menu-item subtle"
+        onClick={() => void openFolderAsLocalWorkspace(onClose)}
+      >
+        <span className="menu-swatch plus" aria-hidden="true">
+          +
+        </span>
+        <span className="menu-item-label">New workspace</span>
+      </button>
+
+      {vault && (
+        <button className="menu-item" onClick={onOpenSettings}>
+          <MenuIcon>
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </MenuIcon>
+          <span className="menu-item-label">Workspace settings</span>
+          <span className="menu-hint">Turn on sync</span>
+        </button>
+      )}
+
+      <div className="menu-sep" />
+      <button className="menu-item" onClick={onSignIn}>
+        <MenuIcon>
+          <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+          <path d="M10 17l5-5-5-5M15 12H3" />
+        </MenuIcon>
+        <span className="menu-item-label">Sign in</span>
+        <span className="menu-hint">Sync &amp; collaborate</span>
+      </button>
+    </div>
+  );
+}
 
 function AccountPopover({
   onClose,
   onOpenMembers,
+  onOpenWorkspaces,
   onOpenAccount,
 }: {
   onClose: () => void;
   onOpenMembers: () => void;
+  onOpenWorkspaces: () => void;
   onOpenAccount: () => void;
 }) {
   const session = useStore((s) => s.session);
@@ -173,37 +404,21 @@ function AccountPopover({
   const members = useStore((s) => s.members);
   const pendingInvitations = useStore((s) => s.pendingInvitations);
   const userInvitations = useStore((s) => s.userInvitations);
-  const syncStatus = useStore((s) => s.syncStatus);
-  const syncEnabled = useStore((s) => s.syncEnabled);
-  const lastSyncedAt = useStore((s) => s.lastSyncedAt);
-  const syncPending = useStore((s) => s.syncPending);
+  const vault = useStore((s) => s.vault);
 
-  const [creating, setCreating] = useState(false);
-  const [orgName, setOrgName] = useState("");
   const [joining, setJoining] = useState(false);
   const [joinCode, setJoinCode] = useState("");
   const [joinError, setJoinError] = useState<string | null>(null);
-  const [createError, setCreateError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   if (!session) return null;
   const activeOrgId = session.activeOrganizationId;
   const userLabel = session.user.name || session.user.email;
-
-  const createOrg = async () => {
-    if (!orgName.trim()) return;
-    setBusy(true);
-    setCreateError(null);
-    try {
-      await useStore.getState().createOrganization(orgName.trim());
-      setOrgName("");
-      setCreating(false);
-    } catch (e) {
-      setCreateError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
+  // "Current" tracks the workspace whose folder is actually OPEN right now —
+  // not merely the account's active org. After signing in you can be viewing a
+  // local folder while an org is active; only one row may read "Current".
+  const openPath = vault?.path ?? null;
+  const boundVaults = readOrgVaults();
 
   const joinByCode = async () => {
     if (!joinCode.trim()) return;
@@ -261,7 +476,7 @@ function AccountPopover({
       ]
         .slice(0, POPOVER_WORKSPACE_LIMIT)
         .map((o) => {
-        const isActive = o.id === activeOrgId;
+        const isActive = openPath != null && boundVaults[o.id] === openPath;
         return (
           <button
             key={o.id}
@@ -279,6 +494,7 @@ function AccountPopover({
               {o.name[0]?.toUpperCase() ?? "?"}
             </span>
             <span className="menu-item-label">{o.name}</span>
+            {!isActive && <span className="ws-badge synced">Synced</span>}
             {isActive && (
               <>
                 <span className="menu-current">Current</span>
@@ -301,43 +517,33 @@ function AccountPopover({
       })}
 
       {organizations.length > POPOVER_WORKSPACE_LIMIT && (
-        <button className="menu-item subtle" onClick={onOpenMembers}>
+        <button className="menu-item subtle" onClick={onOpenWorkspaces}>
           <span className="menu-swatch more" aria-hidden="true">
             …
           </span>
           <span className="menu-item-label">
-            All workspaces ({organizations.length})
+            All synced workspaces ({organizations.length})
           </span>
         </button>
       )}
 
-      {creating ? (
-        <>
-          <div className="menu-create-org">
-            <input
-              autoFocus
-              placeholder="Workspace name"
-              value={orgName}
-              onChange={(e) => setOrgName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void createOrg();
-                if (e.key === "Escape") setCreating(false);
-              }}
-            />
-            <button className="primary sm" disabled={busy} onClick={() => void createOrg()}>
-              Create
-            </button>
-          </div>
-          {createError && <div className="auth-error">{createError}</div>}
-        </>
-      ) : (
-        <button className="menu-item subtle" onClick={() => setCreating(true)}>
-          <span className="menu-swatch plus" aria-hidden="true">
-            +
-          </span>
-          <span className="menu-item-label">New workspace</span>
-        </button>
-      )}
+      <LocalWorkspaceRows
+        onClose={onClose}
+        limit={POPOVER_WORKSPACE_LIMIT}
+        onViewAll={onOpenWorkspaces}
+      />
+
+      {/* "New workspace" = pick a folder; it becomes your (local) workspace,
+          then Turn on sync promotes it. Same action as the old "Open a folder". */}
+      <button
+        className="menu-item subtle"
+        onClick={() => void openFolderAsLocalWorkspace(onClose)}
+      >
+        <span className="menu-swatch plus" aria-hidden="true">
+          +
+        </span>
+        <span className="menu-item-label">New workspace</span>
+      </button>
 
       {/* Teammates join with the code shared from Workspace settings. */}
       {joining ? (
@@ -367,29 +573,22 @@ function AccountPopover({
       )}
       {joinError && <div className="auth-error">{joinError}</div>}
 
-      {activeOrgId && (
-        <>
-          <button className="menu-item" onClick={onOpenMembers}>
-            <MenuIcon>
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </MenuIcon>
-            <span className="menu-item-label">Workspace settings</span>
+      {vault && (
+        <button className="menu-item" onClick={onOpenMembers}>
+          <MenuIcon>
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </MenuIcon>
+          <span className="menu-item-label">Workspace settings</span>
+          {activeOrgId ? (
             <span className="menu-hint">
               {members.length} member{members.length === 1 ? "" : "s"}
               {pendingInvitations.length > 0 ? ` +${pendingInvitations.length}` : ""}
             </span>
-          </button>
-          <div className="menu-row">
-            <span className="menu-row-label">Sync</span>
-            <SyncBadge
-              status={syncStatus}
-              enabled={syncEnabled}
-              lastSyncedAt={lastSyncedAt}
-              pending={syncPending}
-            />
-          </div>
-        </>
+          ) : (
+            <span className="ws-badge local">Local</span>
+          )}
+        </button>
       )}
 
       <div className="menu-sep" />
@@ -644,6 +843,7 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
 }
 
 type SettingsTab =
+  | "general"
   | "workspaces"
   | "members"
   | "billing"
@@ -652,6 +852,22 @@ type SettingsTab =
   | "import-export"
   | "appearance"
   | "updates";
+
+// Sections that only make sense once the workspace is synced to an org. On a
+// local workspace they're shown but locked, with a "Turn on sync" gate.
+const TEAM_TABS = new Set<SettingsTab>(["members", "billing", "access", "mcp"]);
+
+/** General tab: name, folder, and sync state (incl. the Turn-on-sync CTA). */
+const GENERAL_TAB: { id: SettingsTab; label: string; icon: React.ReactNode } = {
+  id: "general",
+  label: "General",
+  icon: (
+    <MenuIcon>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+    </MenuIcon>
+  ),
+};
 
 const SETTINGS_TABS: Array<{ id: SettingsTab; label: string; icon: React.ReactNode }> = [
   {
@@ -747,13 +963,24 @@ const BILLING_TAB: { id: SettingsTab; label: string; icon: React.ReactNode } = {
  * the workspace lives here. Members (roster + join code + invites),
  * Permissions (RBAC locks), and Appearance (theme + item colors).
  */
-function WorkspaceSettingsDialog({ onClose }: { onClose: () => void }) {
+function WorkspaceSettingsDialog({
+  onClose,
+  onRequestSignIn,
+  initialTab,
+}: {
+  onClose: () => void;
+  onRequestSignIn?: () => void;
+  initialTab?: SettingsTab;
+}) {
   const session = useStore((s) => s.session);
   const organizations = useStore((s) => s.organizations);
   const members = useStore((s) => s.members);
   const billingConfig = useStore((s) => s.billingConfig);
+  const vault = useStore((s) => s.vault);
+  const syncEnabled = useStore((s) => s.syncEnabled);
+  const locals = useLocalWorkspaces();
 
-  const [tab, setTab] = useState<SettingsTab>("workspaces");
+  const [tab, setTab] = useState<SettingsTab>(initialTab ?? "general");
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -763,30 +990,42 @@ function WorkspaceSettingsDialog({ onClose }: { onClose: () => void }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  // Billing only appears when the server actually offers it (and the user is
-  // signed in — guaranteed here since this whole page requires a session).
-  const billingEnabled = billingConfig?.enabled === true;
-  const tabs = useMemo(() => {
-    if (!billingEnabled) return SETTINGS_TABS;
-    const out = [...SETTINGS_TABS];
-    const idx = out.findIndex((t) => t.id === "members");
-    out.splice(idx >= 0 ? idx + 1 : out.length, 0, BILLING_TAB);
-    return out;
-  }, [billingEnabled]);
-
-  if (!session) return null;
   const activeOrg =
-    organizations.find((o) => o.id === session.activeOrganizationId) ?? null;
-  const myMember = members.find((m) => m.userId === session.user.id);
+    organizations.find((o) => o.id === session?.activeOrganizationId) ?? null;
+  // Is the workspace we're looking at actually syncing to an org? A local
+  // workspace (signed out, or an unsynced local folder) shows a reduced page
+  // with the team sections locked behind "Turn on sync".
+  const isSynced = syncEnabled && !!activeOrg;
+  const billingEnabled = billingConfig?.enabled === true;
+
+  // "Workspaces" (switch/create/manage) is shown for an account OR when there
+  // are local folders to list — that's what "View all" opens into.
+  const showWorkspaces = !!session || locals.length > 0;
+  const tabs = useMemo(() => {
+    const out = [GENERAL_TAB];
+    if (showWorkspaces) out.push(...SETTINGS_TABS);
+    else out.push(...SETTINGS_TABS.filter((t) => t.id !== "workspaces"));
+    if (billingEnabled) {
+      const idx = out.findIndex((t) => t.id === "members");
+      out.splice(idx >= 0 ? idx + 1 : out.length, 0, BILLING_TAB);
+    }
+    return out;
+  }, [showWorkspaces, billingEnabled]);
+
+  if (!session && !vault) return null;
+  const myMember = members.find((m) => m.userId === session?.user.id);
   const canManage = myMember?.role === "owner" || myMember?.role === "admin";
   const activeTab = tabs.find((t) => t.id === tab) ?? tabs[0];
+  const lockedTab = TEAM_TABS.has(activeTab.id) && !isSynced;
 
   return (
     <div className="settings-page">
       <header className="settings-page-header">
         <div className="settings-title">
-          <span className="settings-eyebrow">Workspace settings</span>
-          <h1>{activeOrg?.name ?? "Workspace"}</h1>
+          <span className="settings-eyebrow">
+            {isSynced ? "Workspace settings" : "Local workspace"}
+          </span>
+          <h1>{activeOrg?.name ?? vault?.name ?? "Workspace"}</h1>
         </div>
         <button className="icon-btn" onClick={onClose} aria-label="Close settings" title="Close (Esc)">
           ✕
@@ -795,22 +1034,49 @@ function WorkspaceSettingsDialog({ onClose }: { onClose: () => void }) {
 
       <div className="settings-body">
         <nav className="settings-nav" aria-label="Settings sections">
-          {tabs.map((t) => (
-            <button
-              key={t.id}
-              type="button"
-              className={`menu-item${tab === t.id ? " active" : ""}`}
-              onClick={() => setTab(t.id)}
-            >
-              {t.icon}
-              <span className="menu-item-label">{t.label}</span>
-            </button>
-          ))}
+          {tabs.map((t) => {
+            const locked = TEAM_TABS.has(t.id) && !isSynced;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                className={`menu-item${tab === t.id ? " active" : ""}${locked ? " locked" : ""}`}
+                onClick={() => setTab(t.id)}
+                title={locked ? "Turn on sync to unlock" : undefined}
+              >
+                {t.icon}
+                <span className="menu-item-label">{t.label}</span>
+                {locked && (
+                  <svg
+                    className="nav-lock"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <rect x="5" y="11" width="14" height="10" rx="2" />
+                    <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
         </nav>
 
         <section className="settings-content" aria-label={activeTab.label}>
           <h2 className="settings-section-title">{activeTab.label}</h2>
-          {tab === "workspaces" ? (
+          {tab === "general" ? (
+            <GeneralTab
+              isSynced={isSynced}
+              activeOrgName={activeOrg?.name ?? null}
+              onRequestSignIn={onRequestSignIn}
+            />
+          ) : lockedTab ? (
+            <SyncGate label={activeTab.label} onGoToSync={() => setTab("general")} />
+          ) : tab === "workspaces" ? (
             <WorkspacesTab />
           ) : tab === "members" ? (
             <MembersTab canManage={canManage} />
@@ -834,6 +1100,170 @@ function WorkspaceSettingsDialog({ onClose }: { onClose: () => void }) {
 }
 
 /**
+ * General tab: the identity of the current workspace. Its heart is the
+ * Turn-on-sync card for a local workspace — which adopts the folder you're
+ * already in (files and all) rather than making you set up a new one.
+ */
+function GeneralTab({
+  isSynced,
+  activeOrgName,
+  onRequestSignIn,
+}: {
+  isSynced: boolean;
+  activeOrgName: string | null;
+  onRequestSignIn?: () => void;
+}) {
+  const vault = useStore((s) => s.vault);
+  const syncStatus = useStore((s) => s.syncStatus);
+  const syncEnabledState = useStore((s) => s.syncEnabled);
+  const lastSyncedAt = useStore((s) => s.lastSyncedAt);
+  const syncPending = useStore((s) => s.syncPending);
+  const serverUrl = useStore((s) => s.serverUrl);
+  const authStatus = useStore((s) => s.authStatus);
+
+  const [name, setName] = useState(vault?.name ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [limitNudge, setLimitNudge] = useState<{ kind: LimitKind; limit: number | null } | null>(
+    null,
+  );
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+
+  const turnOn = async () => {
+    if (authStatus !== "signed-in") {
+      // Not signed in yet — launch sign-in right here instead of dead-ending.
+      // After sign-in the button becomes "Turn on sync" (the page stays open).
+      onRequestSignIn?.();
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setLimitNudge(null);
+    try {
+      await useStore.getState().turnOnSyncForCurrentVault(name.trim() || undefined);
+    } catch (e) {
+      const kind = classifyLimitError(e);
+      if (kind) setLimitNudge({ kind, limit: limitFromError(e) });
+      else setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      {isSynced ? (
+        <>
+          <div className="muted">
+            This workspace syncs to your team. Its notes stay as plain files on
+            disk and live-sync to everyone with access.
+          </div>
+          <div className="menu-row">
+            <span className="menu-row-label">Sync</span>
+            <SyncBadge
+              status={syncStatus}
+              enabled={syncEnabledState}
+              lastSyncedAt={lastSyncedAt}
+              pending={syncPending}
+            />
+          </div>
+          <div className="menu-row">
+            <span className="menu-row-label">Server</span>
+            <code className="workspace-root-path" title={serverUrl}>
+              {serverUrl}
+            </code>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="muted">
+            {activeOrgName
+              ? "You're viewing a local folder. Turn on sync to keep this workspace on your account and across devices."
+              : "This workspace lives only on this computer. Turn on sync to reach it from other devices — or invite people to it."}
+          </div>
+
+          <div className="sync-promo">
+            <h3 className="sync-promo-title">Turn on sync &amp; sharing</h3>
+            <p className="sync-promo-desc">
+              Keeps the notes and folders already here — nothing to re-import.
+              Enables live collaboration and lets you invite people. Private by
+              default; you choose what to share.
+            </p>
+            <div className="row invite-bar">
+              <input
+                placeholder="Workspace name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void turnOn();
+                }}
+              />
+              <button className="primary" disabled={busy} onClick={() => void turnOn()}>
+                {busy
+                  ? "…"
+                  : authStatus === "signed-in"
+                    ? "Turn on sync"
+                    : "Sign in to turn on"}
+              </button>
+            </div>
+            {authStatus !== "signed-in" && (
+              <div className="muted">You'll need to sign in first — this button will prompt you.</div>
+            )}
+            {error && <div className="auth-error">{error}</div>}
+            {limitNudge && (
+              <LimitNudge
+                kind={limitNudge.kind}
+                limit={limitNudge.limit}
+                onUpgrade={() => setUpgradeOpen(true)}
+              />
+            )}
+          </div>
+        </>
+      )}
+
+      <div className="menu-sep" />
+      <div className="subhead">Folder on disk</div>
+      <div className="join-code-row">
+        <code className="workspace-root-path" title={vault?.path ?? ""}>
+          {vault?.path ?? "—"}
+        </code>
+      </div>
+
+      {upgradeOpen && <UpgradeDialog onClose={() => setUpgradeOpen(false)} />}
+    </>
+  );
+}
+
+/** Locked-section gate shown for a team tab on a local workspace. */
+function SyncGate({ label, onGoToSync }: { label: string; onGoToSync: () => void }) {
+  return (
+    <div className="sync-gate">
+      <svg
+        className="sync-gate-icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="4" y="11" width="16" height="10" rx="2" />
+        <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+      </svg>
+      <h3>{label} unlocks with sync</h3>
+      <p className="muted">
+        Turn on sync for this workspace to invite people, set sharing and
+        permissions, and connect AI clients.
+      </p>
+      <button className="primary" onClick={onGoToSync}>
+        Turn on sync &amp; sharing →
+      </button>
+    </div>
+  );
+}
+
+/**
  * Workspaces: switch between workspaces, create/join, and manage where their
  * local folders live. Each workspace owns one folder under the managed root;
  * switching swaps the sidebar to that workspace's folder and repoints the
@@ -843,6 +1273,9 @@ function WorkspacesTab() {
   const session = useStore((s) => s.session);
   const organizations = useStore((s) => s.organizations);
   const members = useStore((s) => s.members);
+  const vault = useStore((s) => s.vault);
+  const syncEnabled = useStore((s) => s.syncEnabled);
+  const locals = useLocalWorkspaces();
 
   const [root, setRoot] = useState<string | null>(null);
   const [bound, setBound] = useState<Record<string, string>>(() => readOrgVaults());
@@ -874,8 +1307,7 @@ function WorkspacesTab() {
     };
   }, []);
 
-  if (!session) return null;
-  const activeOrgId = session.activeOrganizationId;
+  const activeOrgId = session?.activeOrganizationId ?? null;
   // We only know the caller's role for the ACTIVE workspace (members are loaded
   // for it alone). On the active row we can therefore hide Delete from
   // non-owners; on other rows we can't tell, so we show it and let the server
@@ -883,7 +1315,7 @@ function WorkspacesTab() {
   // an explicit org id, so deleting a non-active workspace works without first
   // switching to it.
   const isActiveOwner =
-    members.find((m) => m.userId === session.user.id)?.role === "owner";
+    members.find((m) => m.userId === session?.user.id)?.role === "owner";
   const canDelete = (orgId: string) =>
     orgId === activeOrgId ? isActiveOwner : true;
 
@@ -892,11 +1324,27 @@ function WorkspacesTab() {
     return p ? (p.split("/").pop() ?? p) : null;
   };
 
+  // The org whose folder is actually open now — the true "Current", vs. merely
+  // the account's active org (you can be viewing a local folder with sync off).
+  const openPath = vault?.path ?? null;
+  const isOpenOrg = (orgId: string) => openPath != null && bound[orgId] === openPath;
+
   const switchTo = async (orgId: string) => {
-    if (orgId === activeOrgId || busy) return;
+    if (busy || isOpenOrg(orgId)) return;
     setBusy(true);
     try {
       await useStore.getState().setActiveOrganization(orgId);
+      setBound(readOrgVaults());
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const switchToLocal = async (path: string) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await useStore.getState().openLocalWorkspace(path);
       setBound(readOrgVaults());
     } finally {
       setBusy(false);
@@ -986,12 +1434,19 @@ function WorkspacesTab() {
     ...organizations.filter((o) => o.id !== activeOrgId),
   ];
 
+  const localsOrdered = [
+    ...locals.filter((r) => !syncEnabled && vault?.path === r.path),
+    ...locals.filter((r) => !(!syncEnabled && vault?.path === r.path)),
+  ];
+
   return (
     <>
+      {session && (
+        <>
       <div className="subhead">In this account ({organizations.length})</div>
       <ul className="member-list workspace-list">
         {ordered.map((o) => {
-          const isActive = o.id === activeOrgId;
+          const isActive = isOpenOrg(o.id);
           const fname = folderName(o.id);
           return (
             <li key={o.id}>
@@ -1118,22 +1573,70 @@ function WorkspacesTab() {
           onUpgrade={() => setUpgradeOpen(true)}
         />
       )}
+        </>
+      )}
 
-      <div className="menu-sep" />
-      <div className="subhead">Workspace folder location</div>
-      <div className="muted">
-        New workspaces get their own folder here. The active workspace is also
-        linked at <code>current</code> so tools like Claude Desktop can point at
-        one fixed path.
-      </div>
-      <div className="join-code-row">
-        <code className="workspace-root-path" title={root ?? ""}>
-          {root ?? "…"}
-        </code>
-        <button className="link-btn" onClick={() => void changeRoot()}>
-          Change…
-        </button>
-      </div>
+      {localsOrdered.length > 0 && (
+        <>
+          {session && <div className="menu-sep" />}
+          <div className="subhead">On this device ({localsOrdered.length})</div>
+          <div className="muted">
+            Local folders open on this computer. They aren't on your account —
+            turn on sync from a workspace's settings to reach it elsewhere.
+          </div>
+          <ul className="member-list workspace-list">
+            {localsOrdered.map((r) => {
+              const isCurrent = !syncEnabled && vault?.path === r.path;
+              return (
+                <li key={r.path}>
+                  <span className="menu-swatch" aria-hidden="true">
+                    {r.name[0]?.toUpperCase() ?? "?"}
+                  </span>
+                  <span className="member-name">
+                    {r.name}
+                    <span className="muted workspace-folder" title={r.path}>
+                      {" · Local"}
+                    </span>
+                  </span>
+                  <span className="workspace-row-actions">
+                    {isCurrent ? (
+                      <span className="member-role">Current</span>
+                    ) : (
+                      <button
+                        className="link-btn"
+                        disabled={busy}
+                        onClick={() => void switchToLocal(r.path)}
+                      >
+                        Switch
+                      </button>
+                    )}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+
+      {session && (
+        <>
+          <div className="menu-sep" />
+          <div className="subhead">Workspace folder location</div>
+          <div className="muted">
+            New workspaces get their own folder here. The active workspace is also
+            linked at <code>current</code> so tools like Claude Desktop can point at
+            one fixed path.
+          </div>
+          <div className="join-code-row">
+            <code className="workspace-root-path" title={root ?? ""}>
+              {root ?? "…"}
+            </code>
+            <button className="link-btn" onClick={() => void changeRoot()}>
+              Change…
+            </button>
+          </div>
+        </>
+      )}
 
       {upgradeOpen && <UpgradeDialog onClose={() => setUpgradeOpen(false)} />}
     </>
@@ -1927,7 +2430,7 @@ function ImportExportTab() {
       const dest = await ipc.pickFolder();
       if (!dest) return null;
       await ipc.exportPath("", dest);
-      return "Exported the vault.";
+      return "Exported the workspace.";
     });
 
   return (
@@ -1960,7 +2463,7 @@ function ImportExportTab() {
         </p>
         <div className="io-actions">
           <button className="primary" disabled={busy !== null} onClick={() => void exportVault()}>
-            {busy === "export" ? "Exporting…" : "Export entire vault…"}
+            {busy === "export" ? "Exporting…" : "Export entire workspace…"}
           </button>
         </div>
       </section>
@@ -2010,7 +2513,7 @@ function AppearanceTab() {
       </div>
 
       {items.length === 0 ? (
-        <div className="muted perm-empty">Open a vault to color its folders and notes.</div>
+        <div className="muted perm-empty">Open a workspace to color its folders and notes.</div>
       ) : (
         <>
           <ul className="appearance-list">

--- a/app/apps/desktop/src/components/Editor.tsx
+++ b/app/apps/desktop/src/components/Editor.tsx
@@ -13,7 +13,8 @@ import { bridgeManager } from "../lib/bridge";
 import { effectiveLockForPath, lockScopesByPath } from "../lib/locks";
 import { playPingSound } from "../lib/presence/ping";
 import { syncManager } from "../lib/sync/docSession";
-import { colorForUser, PRESENCE_OFFLINE } from "../lib/presence/color";
+import { colorForUser, PRESENCE_OFFLINE, statusTone, ringShowsColor } from "../lib/presence/color";
+import type { ActivityStatus } from "../lib/prefs";
 import { useStore } from "../store";
 import * as ipc from "../lib/ipc";
 import { HtmlView } from "./HtmlView";
@@ -25,6 +26,8 @@ interface Peer {
   id: string;
   name: string;
   color: string;
+  /** Their chosen availability status, broadcast via awareness (`user.status`). */
+  status?: ActivityStatus;
   /** Line their cursor is on (from the `activity` awareness field), if known. */
   line: number | null;
   /** Timestamp (ms) of their last activity update — powers "last active". */
@@ -32,7 +35,7 @@ interface Peer {
 }
 
 interface AwarenessPeerState {
-  user?: { id?: string; name?: string; color?: string };
+  user?: { id?: string; name?: string; color?: string; status?: ActivityStatus };
   activity?: { line?: number; at?: number };
   ping?: { to?: string; name?: string; at?: number };
 }
@@ -52,11 +55,13 @@ function readPeers(awareness: Awareness): Peer[] {
         id: u.id,
         name: u.name ?? "Someone",
         color: u.color ?? colorForUser(u.id),
+        status: u.status,
         line,
         lastActive: at,
       });
     } else {
       if (prev.line == null && line != null) prev.line = line;
+      if (prev.status == null && u.status != null) prev.status = u.status;
       if (at != null && (prev.lastActive == null || at > prev.lastActive)) {
         prev.lastActive = at;
       }
@@ -113,14 +118,19 @@ function PresenceAvatar({
 }: {
   peer: Peer;
   className?: string;
-  /** When false the ring goes neutral gray — the peer isn't live. */
+  /** When false the ring goes neutral gray — the local session isn't live. */
   online?: boolean;
 }) {
   const svg = useMemo(() => characterSvg(peer.name || peer.id || "?"), [peer.name, peer.id]);
+  // The ring shows the peer's unique colour only when the local session is live
+  // AND the peer's own availability reads as present (online/busy). Away/invisible
+  // peers — or any peer when we're offline — get the neutral gray ring.
+  const tone = statusTone(peer.status);
+  const live = online && ringShowsColor(tone);
   return (
     <span
-      className={`presence-avatar${online ? "" : " offline"}${className ? ` ${className}` : ""}`}
-      style={{ "--user-color": online ? peer.color : PRESENCE_OFFLINE } as CSSProperties}
+      className={`presence-avatar tone-${tone}${live ? "" : " offline"}${className ? ` ${className}` : ""}`}
+      style={{ "--user-color": live ? peer.color : PRESENCE_OFFLINE } as CSSProperties}
       aria-hidden="true"
       dangerouslySetInnerHTML={{ __html: svg }}
     />
@@ -181,6 +191,17 @@ function PeerRow({
 }) {
   const [pinged, setPinged] = useState(false);
   const editing = peer.line != null;
+  const tone = statusTone(peer.status);
+  // Availability wins over cursor activity: an away/busy teammate reads as
+  // away/busy even if their caret is still parked on a line.
+  const statusLabel =
+    tone === "away" || tone === "offline"
+      ? "Away"
+      : tone === "busy"
+        ? "Busy"
+        : editing
+          ? `Editing line ${peer.line}`
+          : "Viewing";
   return (
     <div className="peer-row">
       <PresenceAvatar peer={peer} className="sm" />
@@ -190,8 +211,8 @@ function PeerRow({
           {isSelf && <span className="muted"> (you)</span>}
         </span>
         <span className="peer-row-status">
-          <span className={`peer-dot${editing ? " active" : ""}`} />
-          {editing ? `Editing line ${peer.line}` : "Viewing"}
+          <span className={`peer-dot tone-${tone}${editing && tone === "online" ? " active" : ""}`} />
+          {statusLabel}
           {peer.lastActive != null && (
             <span className="peer-row-ago"> · {relativeAgo(peer.lastActive, now)}</span>
           )}

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import {
   Tree,
   type CursorProps,
@@ -26,6 +26,9 @@ import { activeNoteEditable, insertIntoActiveNote } from "../lib/editor/activeVi
 import { useStore } from "../store";
 import { shareResourceId } from "../lib/api";
 import { syncManager } from "../lib/sync/docSession";
+import type { VaultPeer } from "../lib/sync/vaultSyncEngine";
+import { PRESENCE_OFFLINE, ringShowsColor, statusTone } from "../lib/presence/color";
+import { characterSvg } from "./Identity";
 import { ShareDialog, type ShareTarget } from "./ShareDialog";
 
 interface Dimensions {
@@ -136,6 +139,7 @@ export function FileTree() {
   const openNote = useStore((s) => s.openNote);
   const syncEnabled = useStore((s) => s.syncEnabled);
   const locks = useStore((s) => s.locks);
+  const vaultPresence = useStore((s) => s.vaultPresence);
   const session = useStore((s) => s.session);
   const members = useStore((s) => s.members);
   const itemColors = useStore((s) => s.itemColors);
@@ -165,6 +169,19 @@ export function FileTree() {
   // onActivate is captured by arborist; read the live mode through a ref.
   const selectModeRef = useRef(false);
   selectModeRef.current = selectMode;
+
+  // Group live presence by the note (docId) each teammate is viewing, so a row
+  // can look up "who's here" in O(1). Rebuilt only when the roster changes.
+  const presenceByDoc = useMemo(() => {
+    const map = new Map<string, VaultPeer[]>();
+    for (const peer of vaultPresence) {
+      if (!peer.docId) continue;
+      const arr = map.get(peer.docId);
+      if (arr) arr.push(peer);
+      else map.set(peer.docId, [peer]);
+    }
+    return map;
+  }, [vaultPresence]);
 
   // Resolve lock rows (server resource ids) to tree paths for the badges.
   const lockByPath = useMemo(
@@ -832,6 +849,7 @@ export function FileTree() {
               {...props}
               selectedPath={openNote?.path ?? null}
               lock={lockByPath.get(props.node.data.path) ?? null}
+              presenceByDoc={presenceByDoc}
               color={itemColors[props.node.data.path]}
               onMenu={(x, y, node) => setMenu({ x, y, node })}
               selectMode={selectMode}
@@ -929,6 +947,8 @@ export function FileTree() {
 interface NodeExtra {
   selectedPath: string | null;
   lock: LockScope | null;
+  /** docId -> teammates currently viewing that note (drives presence dots). */
+  presenceByDoc: Map<string, VaultPeer[]>;
   /** Item color id (vault-local preference) — tints the type glyph. */
   color: string | undefined;
   onMenu: (x: number, y: number, node: NodeApi<TreeNode>) => void;
@@ -996,12 +1016,94 @@ const ICON_LOCK = (
   </TreeSvg>
 );
 
+/** Max faces in a sidebar row's presence cluster before the rest roll into +N. */
+const MAX_ROW_AVATARS = 3;
+
+/** Collect the docIds of every note under a folder (recursively), so a collapsed
+ *  folder can roll up the presence of the notes hidden inside it. */
+function descendantDocIds(node: TreeNode, out: string[]): void {
+  for (const child of node.children ?? []) {
+    if (child.isDir) {
+      descendantDocIds(child, out);
+    } else {
+      const mapping = syncManager.registry.getMapping(child.path);
+      if (mapping) out.push(mapping.docId);
+    }
+  }
+}
+
+/** Resolve the teammates to show on a row: the note's own viewers, or — for a
+ *  collapsed folder — the union of everyone viewing a note inside it (deduped by
+ *  user). An expanded folder shows nothing; its avatars live on the child rows. */
+function peersForNode(
+  node: NodeApi<TreeNode>,
+  presenceByDoc: Map<string, VaultPeer[]>,
+): VaultPeer[] {
+  if (presenceByDoc.size === 0) return [];
+  if (node.data.isDir) {
+    if (node.isOpen) return [];
+    const ids: string[] = [];
+    descendantDocIds(node.data, ids);
+    const seen = new Set<string>();
+    const rolled: VaultPeer[] = [];
+    for (const id of ids) {
+      for (const peer of presenceByDoc.get(id) ?? []) {
+        if (seen.has(peer.userId)) continue;
+        seen.add(peer.userId);
+        rolled.push(peer);
+      }
+    }
+    return rolled;
+  }
+  const mapping = syncManager.registry.getMapping(node.data.path);
+  return mapping ? (presenceByDoc.get(mapping.docId) ?? []) : [];
+}
+
+/** One presence face: the teammate's illustrated character ringed in their
+ *  colour — the same treatment as the editor's PresenceAvatar, sized for a row. */
+function SidebarAvatar({ peer }: { peer: VaultPeer }) {
+  const svg = useMemo(
+    () => characterSvg(peer.name || peer.userId || "?"),
+    [peer.name, peer.userId],
+  );
+  const tone = statusTone(peer.status);
+  const live = ringShowsColor(tone);
+  return (
+    <span
+      className={`tree-presence-avatar tone-${tone}${live ? "" : " offline"}`}
+      style={{ "--user-color": live ? peer.color : PRESENCE_OFFLINE } as CSSProperties}
+      title={peer.name}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}
+
+/** The overlapping avatar cluster shown at the right edge of a row. */
+function SidebarPresence({ peers }: { peers: VaultPeer[] }) {
+  if (peers.length === 0) return null;
+  const shown =
+    peers.length > MAX_ROW_AVATARS ? peers.slice(0, MAX_ROW_AVATARS - 1) : peers;
+  const overflow = peers.length - shown.length;
+  const names = peers.map((p) => p.name).join(", ");
+  return (
+    <span className="tree-presence" title={names} aria-label={`Viewing: ${names}`}>
+      {shown.map((p) => (
+        <SidebarAvatar key={p.userId} peer={p} />
+      ))}
+      {overflow > 0 && (
+        <span className="tree-presence-avatar tree-presence-overflow">+{overflow}</span>
+      )}
+    </span>
+  );
+}
+
 function Node({
   node,
   style,
   dragHandle,
   selectedPath,
   lock,
+  presenceByDoc,
   color,
   onMenu,
   selectMode,
@@ -1012,6 +1114,7 @@ function Node({
   const isEmpty = isDir && (node.data.children?.length ?? 0) === 0;
   const isSelected = !isDir && node.data.path === selectedPath;
   const colorValue = itemColorValue(color);
+  const peers = peersForNode(node, presenceByDoc);
   // Compose arborist's per-level indent with the row's base inset so every
   // glyph on a level shares one left edge (no chevron column to misalign).
   // 20 = 12 base + 8 compensating the tree's full-bleed negative margin.
@@ -1107,6 +1210,7 @@ function Node({
               {ICON_LOCK}
             </span>
           )}
+          <SidebarPresence peers={peers} />
           {!selectMode && (
           <button
             className="tree-more"

--- a/app/apps/desktop/src/components/SidebarHeader.tsx
+++ b/app/apps/desktop/src/components/SidebarHeader.tsx
@@ -80,23 +80,22 @@ export function SidebarHeader() {
     }
   };
 
-  // Signed out or no workspace yet: there's no workspace to lead with, so we
-  // say so plainly and show the local folder as what it actually is — the
-  // folder you're editing, not a workspace. "Switch" here changes the folder.
+  // A local (unsynced) folder is still a workspace — it just isn't syncing yet.
+  // Lead with its name and mark the state; "Switch" opens a different folder.
   if (!activeOrg) {
     return (
       <div className="sidebar-header">
         <div className="sidebar-header-main">
-          <span className="vault-name none">No workspace</span>
-        </div>
-        <div className="vault-line">
-          {FOLDER_ICON}
-          <span className="vault-line-name" title={vault.path}>
+          <span className="vault-name" title={vault.path}>
             {vault.name}
           </span>
           <button className="link-btn" onClick={() => void switchVault()}>
             Switch
           </button>
+        </div>
+        <div className="vault-line">
+          <span className="ws-badge local">Local</span>
+          <span className="vault-line-name">Not synced</span>
         </div>
       </div>
     );

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import type { VaultInfo, RecentVault } from "../lib/ipc";
 import * as ipc from "../lib/ipc";
@@ -72,6 +72,12 @@ export function VaultPicker() {
   // When "New vault" lands on a folder that's already a vault, hold its path so
   // we can offer to open it instead of nesting a new empty vault inside it.
   const [alreadyVault, setAlreadyVault] = useState<string | null>(null);
+  // Recents are collapsed to the 3 most recent; "Load more" reveals the rest
+  // inside a scroll area locked to the collapsed height so the logo/buttons
+  // above never shift (the vault-picker card is vertically centered).
+  const [showAllRecents, setShowAllRecents] = useState(false);
+  const recentScrollRef = useRef<HTMLDivElement>(null);
+  const [lockedHeight, setLockedHeight] = useState<number | null>(null);
   const reduceMotion = useReducedMotion();
 
   // Surface recently opened vaults as one-tap "reopen" affordances.
@@ -155,7 +161,7 @@ export function VaultPicker() {
   function createInsideAnyway() {
     if (!alreadyVault) return;
     setNewParent(alreadyVault);
-    setNewName("Untitled Vault");
+    setNewName("Untitled Workspace");
     setAlreadyVault(null);
   }
 
@@ -207,11 +213,27 @@ export function VaultPicker() {
     }
   }
 
+  // Freeze the scroll box at the collapsed 3-card height before revealing the
+  // rest, so the list scrolls internally instead of growing the (centered) card.
+  function expandRecents() {
+    setLockedHeight(recentScrollRef.current?.offsetHeight ?? null);
+    setShowAllRecents(true);
+  }
+  function collapseRecents() {
+    setShowAllRecents(false);
+    setLockedHeight(null);
+  }
+
   const naming = newParent !== null;
   const deciding = alreadyVault !== null;
   // Whether either multi-step flow (naming a new vault, or deciding what to do
   // with an already-a-vault folder) is showing — hides the recents/hint.
   const inFlow = naming || deciding;
+
+  // Show the 3 most recent by default; the rest hide behind "Load more".
+  const RECENT_LIMIT = 3;
+  const shownRecents = showAllRecents ? recents : recents.slice(0, RECENT_LIMIT);
+  const hiddenRecents = recents.length - RECENT_LIMIT;
 
   return (
     <div className="vault-picker">
@@ -253,10 +275,10 @@ export function VaultPicker() {
                 exit={reduceMotion ? undefined : { opacity: 0, y: -8 }}
                 transition={SPRING}
               >
-                <label className="new-vault-label">This folder is already a vault</label>
+                <label className="new-vault-label">This folder is already a workspace</label>
                 <p className="new-vault-loc" title={alreadyVault ?? undefined}>
                   <code>{tidyPath(alreadyVault ?? "")}</code> already contains notes — open
-                  it instead of creating a new vault inside?
+                  it instead of creating a new workspace inside?
                 </p>
                 <div className="new-vault-buttons">
                   <button
@@ -281,7 +303,7 @@ export function VaultPicker() {
                     disabled={busy}
                     onClick={() => void openDetectedVault()}
                   >
-                    {busy ? "Opening…" : "Open vault"}
+                    {busy ? "Opening…" : "Open workspace"}
                   </button>
                 </div>
               </motion.div>
@@ -302,7 +324,7 @@ export function VaultPicker() {
                   void confirmNewVault();
                 }}
               >
-                <label className="new-vault-label">Name your vault</label>
+                <label className="new-vault-label">Name your workspace</label>
                 {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
                 <input
                   className="new-vault-input"
@@ -313,7 +335,7 @@ export function VaultPicker() {
                   onKeyDown={(e) => {
                     if (e.key === "Escape") cancelNewVault();
                   }}
-                  placeholder="Untitled Vault"
+                  placeholder="Untitled Workspace"
                   spellCheck={false}
                 />
                 <p className="new-vault-loc" title={newParent ?? undefined}>
@@ -333,7 +355,7 @@ export function VaultPicker() {
                     className="primary sm"
                     disabled={busy || !newName.trim()}
                   >
-                    {busy ? "Creating…" : "Create vault"}
+                    {busy ? "Creating…" : "Create workspace"}
                   </button>
                 </div>
               </motion.form>
@@ -355,7 +377,7 @@ export function VaultPicker() {
                   whileTap={reduceMotion ? undefined : { scale: 0.96 }}
                   transition={SPRING}
                 >
-                  New vault
+                  New workspace
                 </motion.button>
                 <motion.button
                   className="ghost-pill lg"
@@ -383,32 +405,49 @@ export function VaultPicker() {
               reduceMotion ? undefined : revealTransition(REVEAL_DELAY + 0.15)
             }
           >
-            <p className="recent-heading">Recent vaults</p>
-            {recents.map((r) => (
-              <div className="recent-card" key={r.path}>
-                <button
-                  className="recent-open"
-                  disabled={busy}
-                  onClick={() => reopen(r)}
-                  title={r.path}
-                >
-                  <span className="recent-name">{r.name}</span>
-                  <span className="recent-path">{tidyPath(r.path)}</span>
-                  {r.openedAt > 0 && (
-                    <span className="recent-time">{relativeTime(r.openedAt)}</span>
-                  )}
-                </button>
-                <button
-                  className="recent-remove"
-                  aria-label={`Remove ${r.name} from recents`}
-                  title="Remove from recents"
-                  disabled={busy}
-                  onClick={() => forget(r.path)}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
+            <p className="recent-heading">Recent workspaces</p>
+            <div
+              ref={recentScrollRef}
+              className={`recent-scroll${showAllRecents ? " expanded" : ""}`}
+              style={
+                showAllRecents && lockedHeight ? { height: lockedHeight } : undefined
+              }
+            >
+              {shownRecents.map((r) => (
+                <div className="recent-card" key={r.path}>
+                  <button
+                    className="recent-open"
+                    disabled={busy}
+                    onClick={() => reopen(r)}
+                    title={r.path}
+                  >
+                    <span className="recent-name">{r.name}</span>
+                    <span className="recent-path">{tidyPath(r.path)}</span>
+                    {r.openedAt > 0 && (
+                      <span className="recent-time">{relativeTime(r.openedAt)}</span>
+                    )}
+                  </button>
+                  <button
+                    className="recent-remove"
+                    aria-label={`Remove ${r.name} from recents`}
+                    title="Remove from recents"
+                    disabled={busy}
+                    onClick={() => forget(r.path)}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+            {hiddenRecents > 0 && (
+              <button
+                className="recent-more"
+                disabled={busy}
+                onClick={showAllRecents ? collapseRecents : expandRecents}
+              >
+                {showAllRecents ? "Show less" : `Load more (${hiddenRecents})`}
+              </button>
+            )}
           </motion.div>
         )}
 
@@ -421,7 +460,7 @@ export function VaultPicker() {
               reduceMotion ? undefined : revealTransition(REVEAL_DELAY + 0.3)
             }
           >
-            A vault is any folder of <code>.md</code> files.
+            A workspace is any folder of <code>.md</code> files.
           </motion.p>
         )}
       </div>

--- a/app/apps/desktop/src/components/editor.css
+++ b/app/apps/desktop/src/components/editor.css
@@ -239,6 +239,18 @@
   background: var(--success);
   box-shadow: 0 0 6px -1px var(--success);
 }
+/* Availability tones mirror the account avatar's presence light and the
+   Settings status dots: away → amber, busy → red, offline/invisible → gray. */
+.peer-dot.tone-away {
+  background: #f59e0b;
+}
+.peer-dot.tone-busy {
+  background: var(--danger);
+  box-shadow: 0 0 6px -1px var(--danger);
+}
+.peer-dot.tone-offline {
+  background: var(--text-tertiary);
+}
 .peer-ping {
   flex: 0 0 auto;
   font-size: var(--fs-xs);

--- a/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
@@ -130,6 +130,25 @@ describe("VaultSyncEngine", () => {
     expect(status).toBe("synced");
   });
 
+  it("fires onMemberJoined with the name on a member control frame", async () => {
+    const sink = new MemSink();
+    let ws: FakeWs | null = null;
+    const joined: string[] = [];
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => (ws = new FakeWs()),
+      onMemberJoined: (name) => joined.push(name),
+    });
+    engine.start();
+    ws!.onopen?.(null);
+    await tick();
+
+    ws!.onmessage?.({ data: JSON.stringify({ t: "member", name: "Ada" }) });
+    expect(joined).toEqual(["Ada"]);
+  });
+
   it("drops a doc on a drop control frame", async () => {
     const sink = new MemSink();
     let ws: FakeWs | null = null;

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -409,11 +409,20 @@ export class ApiClient {
         user: AuthUser;
         session: { activeOrganizationId?: string | null };
       } | null>("GET", "/api/auth/get-session");
-      if (!data || !data.user) return null;
-      return {
-        user: data.user,
-        activeOrganizationId: data.session?.activeOrganizationId ?? null,
-      };
+      // Better Auth signals "no active session" with a literal `null` body — the
+      // only response that should drop the stored token. A well-formed session
+      // has a `user`. Anything else (an empty body, a proxy's HTML error page
+      // that happened to return 200, an API contract drift) is NOT a trustworthy
+      // "signed out" signal: throwing keeps the token so the caller can retry,
+      // instead of logging the user out over a transient hiccup.
+      if (data == null) return null;
+      if (typeof data === "object" && (data as { user?: unknown }).user) {
+        return {
+          user: data.user,
+          activeOrganizationId: data.session?.activeOrganizationId ?? null,
+        };
+      }
+      throw new ApiError(0, "Unexpected get-session response shape");
     } catch (e) {
       if (e instanceof ApiError && (e.status === 401 || e.status === 403)) return null;
       throw e;

--- a/app/apps/desktop/src/lib/celebrate/celebrate.ts
+++ b/app/apps/desktop/src/lib/celebrate/celebrate.ts
@@ -1,0 +1,128 @@
+// Join celebration: a warm chime + a lightweight confetti burst. Both are
+// self-contained (WebAudio synth, hand-rolled canvas) so there's no asset to
+// ship and no dependency — matching the graph view's no-deps canvas approach.
+
+let ctx: AudioContext | null = null;
+
+function audioContext(): AudioContext | null {
+  try {
+    ctx ??= new AudioContext();
+    if (ctx.state === "suspended") void ctx.resume();
+    return ctx;
+  } catch {
+    return null; // no audio device / autoplay blocked — celebration stays visual
+  }
+}
+
+/** A short, bright ascending arpeggio (C6–E6–G6–C7) — celebratory but polite. */
+export function playJoinChime(): void {
+  const ac = audioContext();
+  if (!ac) return;
+  const t0 = ac.currentTime;
+  for (const [freq, at] of [
+    [1046.5, 0], // C6
+    [1318.5, 0.09], // E6
+    [1568.0, 0.18], // G6
+    [2093.0, 0.27], // C7
+  ] as const) {
+    const osc = ac.createOscillator();
+    const gain = ac.createGain();
+    osc.type = "triangle";
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0, t0 + at);
+    gain.gain.linearRampToValueAtTime(0.16, t0 + at + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + at + 0.5);
+    osc.connect(gain).connect(ac.destination);
+    osc.start(t0 + at);
+    osc.stop(t0 + at + 0.55);
+  }
+}
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  rot: number;
+  vr: number;
+  size: number;
+  color: string;
+}
+
+const CONFETTI_COLORS = [
+  "#f97316",
+  "#facc15",
+  "#4ade80",
+  "#38bdf8",
+  "#a78bfa",
+  "#fb7185",
+];
+
+/**
+ * Fire a brief confetti burst onto `canvas` (sized to its client box). Returns a
+ * cancel function that stops the animation early. Auto-stops once every particle
+ * has fallen past the bottom, so it never spins forever.
+ */
+export function runConfetti(
+  canvas: HTMLCanvasElement,
+  opts: { count?: number; random?: () => number } = {},
+): () => void {
+  const rand = opts.random ?? Math.random;
+  const g = canvas.getContext("2d");
+  if (!g) return () => {};
+
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  canvas.width = Math.max(1, Math.floor(w * dpr));
+  canvas.height = Math.max(1, Math.floor(h * dpr));
+  g.scale(dpr, dpr);
+
+  const count = opts.count ?? 120;
+  const particles: Particle[] = Array.from({ length: count }, () => ({
+    // Rain in from just above the top edge, spread across the width.
+    x: rand() * w,
+    y: -20 - rand() * h * 0.4,
+    vx: (rand() - 0.5) * 3,
+    vy: 2 + rand() * 4,
+    rot: rand() * Math.PI * 2,
+    vr: (rand() - 0.5) * 0.3,
+    size: 5 + rand() * 6,
+    color: CONFETTI_COLORS[Math.floor(rand() * CONFETTI_COLORS.length)],
+  }));
+
+  let raf = 0;
+  let stopped = false;
+  const gravity = 0.08;
+
+  const frame = () => {
+    if (stopped) return;
+    g.clearRect(0, 0, w, h);
+    let alive = 0;
+    for (const p of particles) {
+      p.vy += gravity;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rot += p.vr;
+      if (p.y < h + 20) alive++;
+      g.save();
+      g.translate(p.x, p.y);
+      g.rotate(p.rot);
+      g.fillStyle = p.color;
+      g.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.6);
+      g.restore();
+    }
+    if (alive === 0) {
+      g.clearRect(0, 0, w, h);
+      return;
+    }
+    raf = requestAnimationFrame(frame);
+  };
+  raf = requestAnimationFrame(frame);
+
+  return () => {
+    stopped = true;
+    cancelAnimationFrame(raf);
+    g.clearRect(0, 0, w, h);
+  };
+}

--- a/app/apps/desktop/src/lib/editor/htmlToMarkdown.test.ts
+++ b/app/apps/desktop/src/lib/editor/htmlToMarkdown.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+//
+// The paste path converts a rich `text/html` clipboard (Notion, Google Docs, the
+// web) to clean Markdown so raw HTML never lands in the buffer — where it would
+// parse into a document-spanning HTMLBlock that live-preview renders as a single
+// un-editable widget and traps the caret. These tests pin the conversion.
+
+import { describe, expect, it } from "vitest";
+import { htmlClipboardToMarkdown } from "./htmlToMarkdown";
+
+describe("htmlClipboardToMarkdown", () => {
+  it("converts headings and paragraphs", () => {
+    const md = htmlClipboardToMarkdown(
+      "<h1>Title</h1><p>First para.</p><h2>Sub</h2><p>Second para.</p>"
+    );
+    expect(md).toBe("# Title\n\nFirst para.\n\n## Sub\n\nSecond para.");
+  });
+
+  it("converts inline emphasis, code, and links", () => {
+    const md = htmlClipboardToMarkdown(
+      "<p>Some <strong>bold</strong>, <em>italic</em>, <code>code</code> and a <a href=\"https://ex.com\">link</a>.</p>"
+    );
+    expect(md).toBe(
+      "Some **bold**, *italic*, `code` and a [link](https://ex.com)."
+    );
+  });
+
+  it("keeps trailing spaces outside emphasis markers", () => {
+    const md = htmlClipboardToMarkdown("<p>a <strong>bold </strong>b</p>");
+    expect(md).toBe("a **bold** b");
+  });
+
+  it("converts nested bullet lists with indentation", () => {
+    const md = htmlClipboardToMarkdown(
+      "<ul><li>one<ul><li>one-a</li><li>one-b</li></ul></li><li>two</li></ul>"
+    );
+    expect(md).toBe("- one\n  - one-a\n  - one-b\n- two");
+  });
+
+  it("converts ordered lists honoring start", () => {
+    const md = htmlClipboardToMarkdown(
+      "<ol start=\"3\"><li>third</li><li>fourth</li></ol>"
+    );
+    expect(md).toBe("3. third\n4. fourth");
+  });
+
+  it("converts a table to GFM pipes", () => {
+    const md = htmlClipboardToMarkdown(
+      "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+    );
+    expect(md).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
+  });
+
+  it("converts blockquotes", () => {
+    const md = htmlClipboardToMarkdown("<blockquote><p>quoted</p></blockquote>");
+    expect(md).toBe("> quoted");
+  });
+
+  it("preserves code blocks with language", () => {
+    const md = htmlClipboardToMarkdown(
+      "<pre><code class=\"language-js\">const x = 1;\n</code></pre>"
+    );
+    expect(md).toBe("```js\nconst x = 1;\n```");
+  });
+
+  it("NEVER emits raw HTML tags — the whole point (no cursor-trap)", () => {
+    const notion =
+      "<div class=\"notion-page\"><h1>Doc</h1><div><p>Hello <b>world</b></p>" +
+      "<ul><li>item</li></ul></div><figure><img src=\"x.png\" alt=\"pic\"></figure></div>";
+    const md = htmlClipboardToMarkdown(notion);
+    expect(md).not.toMatch(/<[a-z]/i);
+    expect(md).toContain("# Doc");
+    expect(md).toContain("Hello **world**");
+    expect(md).toContain("- item");
+    expect(md).toContain("![pic](x.png)");
+  });
+
+  it("strips script/style content entirely", () => {
+    const md = htmlClipboardToMarkdown(
+      "<p>safe</p><script>alert(1)</script><style>.x{}</style>"
+    );
+    expect(md).toBe("safe");
+  });
+
+  it("returns empty string for content-free HTML (caller falls back to plain text)", () => {
+    expect(htmlClipboardToMarkdown("<meta charset=\"utf-8\">")).toBe("");
+    expect(htmlClipboardToMarkdown("")).toBe("");
+  });
+
+  it("flattens plain wrapped text to just the text", () => {
+    expect(htmlClipboardToMarkdown("<meta charset=\"utf-8\">just text")).toBe(
+      "just text"
+    );
+  });
+});

--- a/app/apps/desktop/src/lib/editor/htmlToMarkdown.ts
+++ b/app/apps/desktop/src/lib/editor/htmlToMarkdown.ts
@@ -1,0 +1,284 @@
+// HTML → Markdown, for paste.
+//
+// When you copy from Notion, Google Docs, a webpage, etc., the clipboard carries
+// a rich `text/html` flavor. Pasting that verbatim would dump `<div>`/`<table>`
+// soup into the buffer, which the Markdown parser turns into a document-spanning
+// `HTMLBlock` — and the live-preview renders that as one un-editable block
+// widget, trapping the caret (arrows / select-all / mouse selection all die).
+//
+// So on paste we convert the HTML to clean Markdown ourselves and insert *that*.
+// The buffer stays real Markdown, round-trips losslessly, and Notion formatting
+// (headings, bold, lists, links, tables) survives as its Markdown equivalent.
+// It's a *convert, never embed*: we only read text + known structural tags and
+// emit Markdown, so no raw HTML (and no script) ever reaches the document.
+
+/** Block-level tags that break the inline flow and start their own line/para. */
+const BLOCK_TAGS = new Set([
+  "ADDRESS", "ARTICLE", "ASIDE", "BLOCKQUOTE", "DETAILS", "DIV", "DL", "DD", "DT",
+  "FIELDSET", "FIGCAPTION", "FIGURE", "FOOTER", "FORM", "H1", "H2", "H3", "H4",
+  "H5", "H6", "HEADER", "HR", "LI", "MAIN", "NAV", "OL", "P", "PRE", "SECTION",
+  "TABLE", "UL",
+]);
+
+function isElement(n: Node): n is Element {
+  return n.nodeType === 1;
+}
+function isText(n: Node): n is Text {
+  return n.nodeType === 3;
+}
+
+/** Collapse HTML whitespace runs to single spaces, the way rendering would. */
+function collapse(s: string): string {
+  return s.replace(/[\t\r\n ]+/g, " ");
+}
+
+/** Wrap inline text in `marker` (e.g. `**`), keeping surrounding spaces outside
+ *  the markers so we never emit invalid `** bold **`. Empty content → "". */
+function emphasize(inner: string, marker: string): string {
+  const m = /^(\s*)([\s\S]*?)(\s*)$/.exec(inner);
+  if (!m || !m[2]) return inner;
+  return `${m[1]}${marker}${m[2]}${marker}${m[3]}`;
+}
+
+/** Render the inline (character-level) content of a node to Markdown. */
+function inline(node: Node): string {
+  if (isText(node)) return collapse(node.data);
+  if (!isElement(node)) return "";
+
+  const tag = node.tagName;
+  const kids = childrenInline(node);
+
+  switch (tag) {
+    case "STRONG":
+    case "B":
+      return emphasize(kids, "**");
+    case "EM":
+    case "I":
+      return emphasize(kids, "*");
+    case "S":
+    case "DEL":
+    case "STRIKE":
+      return emphasize(kids, "~~");
+    case "CODE":
+    case "KBD":
+    case "SAMP":
+      // Inline code: raw text, never re-processed (so `**` inside stays literal).
+      return `\`${(node.textContent ?? "").replace(/\s+/g, " ").trim()}\``;
+    case "BR":
+      return "  \n";
+    case "A": {
+      const href = (node.getAttribute("href") ?? "").trim();
+      const text = kids.trim() || href;
+      return href && !href.startsWith("javascript:") ? `[${text}](${href})` : text;
+    }
+    case "IMG": {
+      const src = (node.getAttribute("src") ?? "").trim();
+      const alt = (node.getAttribute("alt") ?? "").trim();
+      return src ? `![${alt}](${src})` : "";
+    }
+    default:
+      return kids;
+  }
+}
+
+/** Concatenate the inline rendering of a node's children. */
+function childrenInline(el: Element): string {
+  let out = "";
+  el.childNodes.forEach((c) => {
+    out += inline(c);
+  });
+  return out;
+}
+
+/** Are any of this node's children block-level? (drives para grouping). */
+function hasBlockChild(el: Element): boolean {
+  return Array.from(el.childNodes).some((c) => isElement(c) && BLOCK_TAGS.has(c.tagName));
+}
+
+/** Prefix every line of `text` with `prefix` (first line included). */
+function prefixLines(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((l) => prefix + l)
+    .join("\n");
+}
+
+/** Render a `<ul>`/`<ol>` (recursing for nested lists) into Markdown list lines. */
+function renderList(list: Element, depth: number): string {
+  const ordered = list.tagName === "OL";
+  const indent = "  ".repeat(depth);
+  const items: string[] = [];
+  let n = Number(list.getAttribute("start") ?? "1") || 1;
+
+  Array.from(list.children).forEach((li) => {
+    if (li.tagName !== "LI") return;
+    const marker = ordered ? `${n++}. ` : "- ";
+
+    // An <li> mixes its own inline text with nested lists / block children.
+    // Pull nested lists out so they indent under the item; the rest is the
+    // item's own content.
+    const nested: string[] = [];
+    const ownParts: string[] = [];
+    Array.from(li.childNodes).forEach((c) => {
+      if (isElement(c) && (c.tagName === "UL" || c.tagName === "OL")) {
+        nested.push(renderList(c, depth + 1));
+      } else if (isElement(c) && BLOCK_TAGS.has(c.tagName)) {
+        ownParts.push(...renderBlock(c, depth));
+      } else {
+        ownParts.push(inline(c));
+      }
+    });
+
+    const own = ownParts.join("").replace(/\n{2,}/g, "\n").trim();
+    const pad = "  ".repeat(depth + 1);
+    // First line carries the marker; wrapped continuation lines align under it.
+    const body = own
+      .split("\n")
+      .map((l, i) => (i === 0 ? `${indent}${marker}${l}` : `${pad}${l}`))
+      .join("\n");
+    items.push(body + (nested.length ? "\n" + nested.join("\n") : ""));
+  });
+
+  return items.join("\n");
+}
+
+/** Render a `<table>` as a GFM pipe table (best-effort; falls back to rows). */
+function renderTable(table: Element): string {
+  const rows = Array.from(table.querySelectorAll("tr"));
+  if (!rows.length) return "";
+  const cellsOf = (tr: Element) =>
+    Array.from(tr.querySelectorAll("th,td")).map((c) =>
+      childrenInline(c).replace(/\|/g, "\\|").replace(/\n/g, " ").trim()
+    );
+
+  const grid = rows.map(cellsOf).filter((r) => r.length);
+  if (!grid.length) return "";
+  const width = Math.max(...grid.map((r) => r.length));
+  const pad = (r: string[]) => r.concat(Array(width - r.length).fill(""));
+
+  const header = pad(grid[0]);
+  const bodyRows = grid.slice(1).map(pad);
+  const lines = [
+    `| ${header.join(" | ")} |`,
+    `| ${header.map(() => "---").join(" | ")} |`,
+    ...bodyRows.map((r) => `| ${r.join(" | ")} |`),
+  ];
+  return lines.join("\n");
+}
+
+/** Render one block-level element to zero or more Markdown blocks. */
+function renderBlock(el: Element, depth: number): string[] {
+  const tag = el.tagName;
+
+  switch (tag) {
+    case "H1":
+    case "H2":
+    case "H3":
+    case "H4":
+    case "H5":
+    case "H6": {
+      const level = Number(tag[1]);
+      const text = childrenInline(el).trim();
+      return text ? [`${"#".repeat(level)} ${text}`] : [];
+    }
+    case "HR":
+      return ["---"];
+    case "PRE": {
+      // Preserve code verbatim inside a fence; keep the language if tagged.
+      const code = el.querySelector("code");
+      const lang = code
+        ? (code.className.match(/language-([\w-]+)/)?.[1] ?? "")
+        : "";
+      const text = (el.textContent ?? "").replace(/\n$/, "");
+      return ["```" + lang + "\n" + text + "\n```"];
+    }
+    case "BLOCKQUOTE": {
+      const inner = renderChildren(el, depth).join("\n\n");
+      return inner ? [prefixLines(inner, "> ")] : [];
+    }
+    case "UL":
+    case "OL": {
+      const list = renderList(el, depth);
+      return list ? [list] : [];
+    }
+    case "TABLE": {
+      const t = renderTable(el);
+      return t ? [t] : [];
+    }
+    case "P":
+    case "FIGCAPTION": {
+      const text = childrenInline(el).trim();
+      return text ? [text] : [];
+    }
+    case "FIGURE":
+    case "DIV":
+    case "SECTION":
+    case "ARTICLE":
+    case "HEADER":
+    case "FOOTER":
+    case "MAIN":
+    case "ASIDE":
+    case "NAV":
+    case "DETAILS":
+    case "DL":
+    case "DD":
+    case "DT":
+    case "ADDRESS":
+    case "FIELDSET":
+    case "FORM":
+      // Structural wrapper: flatten to whatever its children render to.
+      return renderChildren(el, depth);
+    default:
+      return renderChildren(el, depth);
+  }
+}
+
+/** Walk a container's children, grouping runs of inline nodes into paragraphs
+ *  and rendering block children on their own. Returns a list of Markdown blocks. */
+function renderChildren(parent: Element, depth: number): string[] {
+  const out: string[] = [];
+  let buf = "";
+  const flush = () => {
+    const s = buf.trim();
+    if (s) out.push(s);
+    buf = "";
+  };
+  parent.childNodes.forEach((c) => {
+    if (isElement(c) && BLOCK_TAGS.has(c.tagName)) {
+      flush();
+      out.push(...renderBlock(c, depth));
+    } else {
+      buf += inline(c);
+    }
+  });
+  flush();
+  return out;
+}
+
+/**
+ * Convert a parsed HTML body (or any container element) to Markdown. Exposed for
+ * unit tests; the paste path uses {@link htmlClipboardToMarkdown}.
+ */
+export function htmlElementToMarkdown(root: Element): string {
+  const blocks = hasBlockChild(root)
+    ? renderChildren(root, 0)
+    : [childrenInline(root).trim()].filter(Boolean);
+  return blocks.join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
+ * Convert an HTML clipboard string to Markdown. Returns "" when the input has no
+ * usable content (caller then falls back to plain-text paste). Never returns raw
+ * HTML. Uses DOMParser, so it runs in the webview (and jsdom under test).
+ */
+export function htmlClipboardToMarkdown(html: string): string {
+  let doc: Document;
+  try {
+    doc = new DOMParser().parseFromString(html, "text/html");
+  } catch {
+    return "";
+  }
+  // Drop anything that could carry script/style noise before walking.
+  doc.querySelectorAll("script,style,noscript,head").forEach((n) => n.remove());
+  return htmlElementToMarkdown(doc.body);
+}

--- a/app/apps/desktop/src/lib/editor/livePreview.ts
+++ b/app/apps/desktop/src/lib/editor/livePreview.ts
@@ -282,6 +282,33 @@ function buildDecorations(view: EditorView, resolveAsset: ResolveAsset): Decorat
           return false;
         }
 
+        // A ```html fenced block → render its HTML as an inline preview (the
+        // same sanitized render as a bare HTML block). The fence is what a
+        // pasted HTML snippet lands in (see paste.ts): it survives blank lines
+        // inside the markup, and shows raw source for editing when the cursor
+        // is inside it.
+        if (node.name === "FencedCode") {
+          const info = node.node.getChild("CodeInfo");
+          const lang = info
+            ? doc.sliceString(info.from, info.to).trim().toLowerCase()
+            : "";
+          if ((lang === "html" || lang === "htm") && !isActive(node.from, node.to)) {
+            const codeNode = node.node.getChild("CodeText");
+            const html = codeNode ? doc.sliceString(codeNode.from, codeNode.to) : "";
+            if (html.trim()) {
+              decos.push(
+                Decoration.replace({
+                  widget: new HtmlEmbedWidget(html, resolveAsset),
+                  block: true,
+                }).range(node.from, node.to)
+              );
+            }
+            return false;
+          }
+          // Non-HTML fences (and the active HTML fence) keep their raw source.
+          return;
+        }
+
         // GFM table → render as a real table off the active line; show the raw
         // pipe source (and descend for inline styling) while it's being edited.
         if (node.name === "Table") {

--- a/app/apps/desktop/src/lib/editor/paste.test.ts
+++ b/app/apps/desktop/src/lib/editor/paste.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+//
+// Paste routing helpers: distinguishing raw HTML *source* (→ a ```html preview
+// fence) from prose, and building a safe fence around it.
+
+import { describe, expect, it } from "vitest";
+import { fenceHtml, looksLikeHtmlSource } from "./paste";
+
+describe("looksLikeHtmlSource", () => {
+  it("detects a full HTML document", () => {
+    expect(
+      looksLikeHtmlSource("<!DOCTYPE html>\n<html><body><h1>Hi</h1></body></html>")
+    ).toBe(true);
+  });
+
+  it("detects an HTML fragment", () => {
+    expect(looksLikeHtmlSource("<div class=\"x\">hello</div>")).toBe(true);
+    expect(looksLikeHtmlSource("  <p>indented</p>")).toBe(true);
+    expect(looksLikeHtmlSource("<br>")).toBe(true);
+    expect(looksLikeHtmlSource("<!-- a comment -->")).toBe(true);
+  });
+
+  it("does NOT flag prose that merely contains angle brackets", () => {
+    expect(looksLikeHtmlSource("a < b and c > d")).toBe(false);
+    expect(looksLikeHtmlSource("email me <at> nowhere")).toBe(false);
+    expect(looksLikeHtmlSource("just some text")).toBe(false);
+    expect(looksLikeHtmlSource("")).toBe(false);
+  });
+
+  it("does NOT flag Markdown that starts with a wikilink or heading", () => {
+    expect(looksLikeHtmlSource("[[Welcome]]")).toBe(false);
+    expect(looksLikeHtmlSource("# Heading")).toBe(false);
+  });
+});
+
+describe("fenceHtml", () => {
+  it("wraps HTML in a ```html fence", () => {
+    expect(fenceHtml("<h1>Hi</h1>")).toBe("```html\n<h1>Hi</h1>\n```");
+  });
+
+  it("trims a single trailing newline before closing the fence", () => {
+    expect(fenceHtml("<h1>Hi</h1>\n")).toBe("```html\n<h1>Hi</h1>\n```");
+  });
+
+  it("uses a longer fence when the source itself contains backticks", () => {
+    const src = "<p>```</p>";
+    const out = fenceHtml(src);
+    expect(out.startsWith("````html\n")).toBe(true);
+    expect(out.endsWith("\n````")).toBe(true);
+    expect(out).toContain(src);
+  });
+});

--- a/app/apps/desktop/src/lib/editor/paste.ts
+++ b/app/apps/desktop/src/lib/editor/paste.ts
@@ -10,11 +10,42 @@
 
 import { EditorSelection } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
+import { htmlClipboardToMarkdown } from "./htmlToMarkdown";
 
 /** Persist image bytes and return the markdown `src` to embed (e.g. `/attachments/ab12.png`). */
 export type SaveAttachment = (bytes: Uint8Array, ext: string) => Promise<string>;
 
 const URL_RE = /^(https?:\/\/|mailto:)\S+$/i;
+
+/**
+ * Does the pasted *plain text* look like raw HTML source (a document or a
+ * fragment), rather than prose? We treat these two paste sources differently:
+ *
+ *   • HTML *source* the user deliberately copied (from a code editor, View
+ *     Source, a snippet) → wrap it in a ```html fence so it renders as a live
+ *     preview block and stays editable (a blank line inside can't split it).
+ *   • Rich content whose *plain* flavor is prose but which also carries a
+ *     `text/html` flavor (Notion, Google Docs, a web selection) → convert that
+ *     HTML to Markdown ({@link htmlClipboardToMarkdown}).
+ *
+ * Must start with a tag (`<tag`, `</tag`, `<!doctype`, `<!--`) and contain a
+ * matching `>`, so a sentence that merely mentions `a < b` isn't mistaken for
+ * markup.
+ */
+export function looksLikeHtmlSource(plain: string): boolean {
+  const s = plain.trim();
+  // Must open with `<!doctype`, `<!--`, or a real (possibly closing) tag whose
+  // name is followed by whitespace, `/`, or `>` — and there must be a closing
+  // `>` somewhere. A sentence like "a < b" fails the start anchor.
+  return /^<(!doctype\b|!--|\/?[a-z][\w-]*[\s/>])/i.test(s) && s.includes(">");
+}
+
+/** Wrap raw HTML in a ```html fence, guarding against fences inside the source. */
+export function fenceHtml(source: string): string {
+  const longest = source.match(/`{3,}/g)?.reduce((a, b) => (b.length > a ? b.length : a), 0) ?? 0;
+  const fence = "`".repeat(Math.max(3, longest + 1));
+  return `${fence}html\n${source.replace(/\n$/, "")}\n${fence}`;
+}
 
 /** Map an image MIME type to a file extension. */
 function extFor(type: string): string {
@@ -87,6 +118,37 @@ export function smartPaste(save: SaveAttachment | undefined) {
           userEvent: "input.paste",
         });
         return true;
+      }
+
+      // 3) Raw HTML *source* → wrap in a ```html fence so live-preview renders
+      //    it as an editable preview block. The fence keeps the whole snippet as
+      //    one node even with blank lines inside (unfenced HTML splits at blank
+      //    lines into several HTMLBlocks that render piecemeal), and stops the
+      //    parser folding `<div>` soup into a caret-trapping block widget.
+      if (looksLikeHtmlSource(text)) {
+        event.preventDefault();
+        const insert = fenceHtml(text);
+        view.dispatch(view.state.replaceSelection(insert), {
+          userEvent: "input.paste",
+        });
+        return true;
+      }
+
+      // 4) Rich content whose plain flavor is prose but that also carries a
+      //    `text/html` flavor (Notion, Google Docs, a web selection) → convert
+      //    that HTML to clean Markdown. Only intervene when it actually yields
+      //    Markdown that differs from the plain text; otherwise fall through to
+      //    CodeMirror's plain-text paste.
+      const html = data?.getData("text/html") ?? "";
+      if (html.trim()) {
+        const md = htmlClipboardToMarkdown(html);
+        if (md && md !== text) {
+          event.preventDefault();
+          view.dispatch(view.state.replaceSelection(md), {
+            userEvent: "input.paste",
+          });
+          return true;
+        }
       }
       return false;
     },

--- a/app/apps/desktop/src/lib/presence/__tests__/color.test.ts
+++ b/app/apps/desktop/src/lib/presence/__tests__/color.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { PRESENCE_PALETTE, colorForUser, hashString, presenceUser } from "../color";
+import {
+  PRESENCE_PALETTE,
+  colorForUser,
+  hashString,
+  presenceUser,
+  ringShowsColor,
+  statusTone,
+} from "../color";
 
 describe("presence color mapping (spec 04 §5)", () => {
   it("is deterministic for a given user id", () => {
@@ -30,5 +37,31 @@ describe("presence color mapping (spec 04 §5)", () => {
   it("presenceUser bundles id, name, and a deterministic color", () => {
     const u = presenceUser("user-abc", "Ada");
     expect(u).toEqual({ id: "user-abc", name: "Ada", color: colorForUser("user-abc") });
+  });
+
+  it("presenceUser carries the chosen status when one is set", () => {
+    expect(presenceUser("u", "Ada", "away").status).toBe("away");
+    expect(presenceUser("u", "Ada").status).toBeUndefined();
+  });
+});
+
+describe("availability tone mapping", () => {
+  it("folds each activity status to a tone", () => {
+    expect(statusTone("online")).toBe("online");
+    expect(statusTone("away")).toBe("away");
+    expect(statusTone("busy")).toBe("busy");
+    // Invisible reads as offline to teammates.
+    expect(statusTone("invisible")).toBe("offline");
+  });
+
+  it("treats an absent status as present", () => {
+    expect(statusTone(undefined)).toBe("online");
+  });
+
+  it("shows a coloured ring only for present tones", () => {
+    expect(ringShowsColor("online")).toBe(true);
+    expect(ringShowsColor("busy")).toBe(true);
+    expect(ringShowsColor("away")).toBe(false);
+    expect(ringShowsColor("offline")).toBe(false);
   });
 });

--- a/app/apps/desktop/src/lib/presence/color.ts
+++ b/app/apps/desktop/src/lib/presence/color.ts
@@ -62,3 +62,33 @@ export function presenceUser(
 ): PresenceUser {
   return { id: userId, name, color: colorForUser(userId), ...(status ? { status } : {}) };
 }
+
+/**
+ * The visual tone of a presence indicator — the shared vocabulary the account
+ * avatar light and the note-roster rings both speak. It folds the four chosen
+ * availability states down to how *present* someone reads: `online`/`busy` are
+ * live (their unique ring colour shows), while `away`/`invisible` read as
+ * not-at-the-keyboard (a muted, neutral ring). This is what "the status depends
+ * on whether the user is active" means in practice.
+ */
+export type PresenceTone = "online" | "away" | "busy" | "offline";
+
+/** Fold a chosen availability status into a presence tone. */
+export function statusTone(status: ActivityStatus | undefined): PresenceTone {
+  switch (status) {
+    case "away":
+      return "away";
+    case "busy":
+      return "busy";
+    // "Invisible" is meant to read as offline to teammates.
+    case "invisible":
+      return "offline";
+    default:
+      return "online";
+  }
+}
+
+/** Whether a ring should show the user's unique colour (vs. neutral gray). */
+export function ringShowsColor(tone: PresenceTone): boolean {
+  return tone === "online" || tone === "busy";
+}

--- a/app/apps/desktop/src/lib/sync/__tests__/multiuser.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/multiuser.test.ts
@@ -137,6 +137,17 @@ describe.skipIf(!RUN)("multi-user collaboration (live server)", () => {
       folderId: folder.id,
     });
     teamDocId = noteDocId(teamNote);
+
+    // New workspaces are PRIVATE by default (no org-wide grant). These tests
+    // exercise team collaboration, so the owner shares the whole workspace with
+    // the team ("Open" = org-wide edit) — the same action AccessPanel performs
+    // via setWorkspacePosture. Without this, members correctly resolve to "none".
+    await owner.createShare({
+      resourceType: "workspace",
+      resourceId: orgId,
+      principalType: "org",
+      permission: "edit",
+    });
   }, 30_000);
 
   // ── 1. Invite → accept ────────────────────────────────────────────────────
@@ -194,7 +205,8 @@ describe.skipIf(!RUN)("multi-user collaboration (live server)", () => {
     const vaults = await owner.listVaults();
     expect(vaults.filter((v) => (v.organizationId ?? v.organization_id) === orgId)).toHaveLength(1);
 
-    // A plain member has edit access by default (workspace defaults to Open).
+    // The workspace was shared with the team (Open) in setup, so a plain member
+    // inherits edit access.
     const tok = await member.syncToken(welcomeDocId);
     expect(tok.readOnly).toBe(false);
   }, 30_000);
@@ -404,7 +416,7 @@ describe.skipIf(!RUN)("multi-user collaboration (live server)", () => {
     const res = await owner.resolveAccess("file", welcomeDocId);
     const byId = new Map(res.members.map((m) => [m.userId, m]));
     expect(byId.get(ownerId)?.permission).toBe("edit"); // owner/admin
-    expect(byId.get(memberId)?.permission).toBe("edit"); // via workspace Open
+    expect(byId.get(memberId)?.permission).toBe("edit"); // via the workspace-wide team grant
   }, 30_000);
 
   // ── 8. Outsiders stay out ─────────────────────────────────────────────────

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -16,14 +16,18 @@ import type { SessionInfo } from "../api";
 import type { TreeNode } from "../ipc";
 import * as ipc from "../ipc";
 import { api } from "../auth/authManager";
-import { presenceUser } from "../presence/color";
+import { colorForUser, presenceUser } from "../presence/color";
 import type { ActivityStatus } from "../prefs";
 import { AttachmentSync } from "./attachments";
 import { decideSeed } from "./startup";
 import { DocSync, type SyncStatus } from "./syncManager";
 import { VaultRegistry } from "./registry";
 import { VaultDocStore } from "./vaultDocStore";
-import { VaultSyncEngine, type VaultSyncStatus } from "./vaultSyncEngine";
+import {
+  VaultSyncEngine,
+  type VaultPeer,
+  type VaultSyncStatus,
+} from "./vaultSyncEngine";
 
 /** Basename of a vault-relative path (for the upload's x-file-name hint). */
 function baseName(relPath: string): string {
@@ -51,6 +55,7 @@ export class SyncManager {
   private onPending?: (pending: boolean) => void;
   private onFlushed?: () => void;
   private onRegistryChanged?: () => void;
+  private onMemberJoined?: (name: string) => void;
   private registryPullTimer: ReturnType<typeof setTimeout> | null = null;
   private attachments: AttachmentSync | null = null;
 
@@ -60,6 +65,13 @@ export class SyncManager {
   private docStore: VaultDocStore | null = null;
   private vaultEngine: VaultSyncEngine | null = null;
   private onVaultStatus?: (status: VaultSyncStatus) => void;
+
+  // Vault-wide presence: which teammate is viewing which note. Keyed by userId
+  // (last-write-wins across a user's devices), fed by the engine's presence
+  // frames, surfaced to the sidebar. `viewingDocId` is our own current note.
+  private vaultPresence = new Map<string, VaultPeer>();
+  private viewingDocId: string | null = null;
+  private onVaultPresence?: (peers: VaultPeer[]) => void;
 
   /** UI subscribes here to render the per-note sync indicator. */
   setStatusListener(cb: ((status: SyncStatus) => void) | undefined): void {
@@ -85,6 +97,14 @@ export class SyncManager {
    */
   setRegistryListener(cb: (() => void) | undefined): void {
     this.onRegistryChanged = cb;
+  }
+
+  /**
+   * UI subscribes here to react when a new teammate joins the workspace: refresh
+   * the roster (so the member list updates without a reload) and celebrate.
+   */
+  setMemberJoinedListener(cb: ((name: string) => void) | undefined): void {
+    this.onMemberJoined = cb;
   }
 
   /**
@@ -149,6 +169,8 @@ export class SyncManager {
     this.enabled = false;
     this.presence = null;
     this.attachments = null;
+    this.viewingDocId = null;
+    this.clearVaultPresence();
     this.stopVaultEngine();
     this.closeCurrent();
   }
@@ -156,6 +178,49 @@ export class SyncManager {
   /** UI subscribes here for the vault-wide background-sync indicator. */
   setVaultStatusListener(cb: ((status: VaultSyncStatus) => void) | undefined): void {
     this.onVaultStatus = cb;
+  }
+
+  /**
+   * UI subscribes here for the live "who's viewing what" roster that drives the
+   * sidebar presence dots. Fires with the full peer list on every change.
+   */
+  setVaultPresenceListener(cb: ((peers: VaultPeer[]) => void) | undefined): void {
+    this.onVaultPresence = cb;
+  }
+
+  /** Record which note this client is now viewing (null = none) and broadcast it. */
+  setViewing(docId: string | null): void {
+    this.viewingDocId = docId;
+    this.pushLocalPresence();
+  }
+
+  /** Send our current viewing state over the vault channel. Invisible users
+   *  broadcast a null doc so they don't appear on teammates' sidebars. */
+  private pushLocalPresence(): void {
+    if (!this.vaultEngine || !this.presence) return;
+    const docId = this.status === "invisible" ? null : this.viewingDocId;
+    this.vaultEngine.setPresence({
+      docId,
+      name: this.presence.name,
+      color: colorForUser(this.presence.id),
+      status: this.status,
+    });
+  }
+
+  /** Fold an incoming teammate presence update into the roster and notify the UI. */
+  private handleVaultPresence(peer: VaultPeer): void {
+    // Never show ourselves in the sidebar — you know where you are.
+    if (this.presence && peer.userId === this.presence.id) return;
+    if (peer.docId === null) this.vaultPresence.delete(peer.userId);
+    else this.vaultPresence.set(peer.userId, peer);
+    this.onVaultPresence?.([...this.vaultPresence.values()]);
+  }
+
+  /** Drop the whole roster (on disconnect/disable) so no stale dots linger. */
+  private clearVaultPresence(): void {
+    if (this.vaultPresence.size === 0) return;
+    this.vaultPresence.clear();
+    this.onVaultPresence?.([]);
   }
 
   /** Start the always-on background feed for the reconciled vault (spec 05). */
@@ -171,15 +236,27 @@ export class SyncManager {
       api,
       vaultId,
       sink: store,
-      onStatus: (s) => this.onVaultStatus?.(s),
+      onStatus: (s) => {
+        // A dropped/reconnecting channel means we no longer have a live roster —
+        // clear it so the sidebar doesn't show ghosts (the engine re-announces
+        // everyone on the next `synced`).
+        if (s !== "synced") this.clearVaultPresence();
+        this.onVaultStatus?.(s);
+      },
       // An ACL change in this vault may have flipped the open note's grant
       // (view↔edit, lock/unlock). Re-mint its token so the editor becomes
       // read-only/editable live — no reopen (spec 04 §4).
       onAclChanged: () => this.current?.refreshAccess(),
       // A teammate changed the folder/note structure — re-pull + refresh tree.
       onRegistryChanged: () => this.handleRegistryChanged(),
+      // A new teammate joined the workspace — refresh roster + celebrate.
+      onMemberJoined: (name) => this.onMemberJoined?.(name),
+      // A teammate's viewing state changed — update the sidebar presence roster.
+      onPresence: (peer) => this.handleVaultPresence(peer),
     });
     this.vaultEngine.start();
+    // Seed our own presence into the fresh engine (it flushes on `ready`).
+    this.pushLocalPresence();
   }
 
   private stopVaultEngine(): void {
@@ -309,6 +386,9 @@ export class SyncManager {
     this.status = status;
     if (this.current) this.applyPresence(this.current.awareness);
     if (this.currentLocalAwareness) this.applyPresence(this.currentLocalAwareness);
+    // Reflect the new availability on the vault-wide sidebar presence too
+    // (also hides/shows us when toggling invisible).
+    this.pushLocalPresence();
   }
 
   private applyPresence(awareness: Awareness): void {

--- a/app/apps/desktop/src/lib/sync/vaultProtocol.ts
+++ b/app/apps/desktop/src/lib/sync/vaultProtocol.ts
@@ -15,15 +15,38 @@ export interface HelloFrame {
   priority?: string[];
 }
 
+/** A teammate's live "who's viewing what" state (mirror of the server type).
+ *  `docId` null means the user isn't viewing anything (or left) — clear them. */
+export interface PresenceState {
+  userId: string;
+  docId: string | null;
+  name: string;
+  color: string;
+  status: string;
+}
+
 export type ServerControl =
   | { t: "ready" }
   | { t: "drop"; docId: string }
   | { t: "reauth" }
   | { t: "registry" }
+  | { t: "member"; name: string }
+  | ({ t: "presence" } & PresenceState)
   | { t: "err"; message: string };
 
 export function encodeHello(frame: Omit<HelloFrame, "t">): string {
   return JSON.stringify({ t: "hello", ...frame });
+}
+
+/** Encode this client's presence frame (which note we're currently viewing).
+ *  `userId` is omitted — the server stamps it from our authenticated token. */
+export function encodePresence(frame: {
+  docId: string | null;
+  name: string;
+  color: string;
+  status: string;
+}): string {
+  return JSON.stringify({ t: "presence", ...frame });
 }
 
 /** Parse a server text control frame; null if it isn't one we recognise. */
@@ -39,6 +62,29 @@ export function parseServerControl(text: string): ServerControl | null {
   if (t === "ready") return { t: "ready" };
   if (t === "reauth") return { t: "reauth" };
   if (t === "registry") return { t: "registry" };
+  if (t === "member" && typeof (v as { name?: unknown }).name === "string") {
+    return { t: "member", name: (v as { name: string }).name };
+  }
+  if (t === "presence") {
+    const o = v as Record<string, unknown>;
+    if (
+      typeof o.userId === "string" &&
+      (o.docId === null || typeof o.docId === "string") &&
+      typeof o.name === "string" &&
+      typeof o.color === "string" &&
+      typeof o.status === "string"
+    ) {
+      return {
+        t: "presence",
+        userId: o.userId,
+        docId: (o.docId as string | null) ?? null,
+        name: o.name,
+        color: o.color,
+        status: o.status,
+      };
+    }
+    return null;
+  }
   if (t === "drop" && typeof (v as { docId?: unknown }).docId === "string") {
     return { t: "drop", docId: (v as { docId: string }).docId };
   }

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -11,12 +11,32 @@
 // CodeMirror — it moves opaque Yjs updates to the sink.
 
 import { ApiClient, ApiError } from "../api";
+import type { ActivityStatus } from "../prefs";
 import {
   bytesToBase64,
   decodeUpdateFrame,
   encodeHello,
+  encodePresence,
   parseServerControl,
 } from "./vaultProtocol";
+
+/** A teammate's live viewing state, surfaced to the UI for sidebar presence. */
+export interface VaultPeer {
+  userId: string;
+  /** The note they're currently viewing, or null when not on any note. */
+  docId: string | null;
+  name: string;
+  color: string;
+  status: ActivityStatus;
+}
+
+/** What this client broadcasts about itself over the vault channel. */
+export interface LocalPresence {
+  docId: string | null;
+  name: string;
+  color: string;
+  status: ActivityStatus;
+}
 
 export type VaultSyncStatus =
   | "idle" // not started / stopped
@@ -70,6 +90,13 @@ export interface VaultSyncEngineOptions {
    *  a teammate created/renamed/moved/deleted a folder or note. The client
    *  re-pulls the registry so its local tree reflects the change live. */
   onRegistryChanged?: () => void;
+  /** Fired when a new teammate joined the workspace (`member`): the client
+   *  refreshes its roster and shows a join celebration. */
+  onMemberJoined?: (name: string) => void;
+  /** Fired for each teammate presence update (`presence`): who is now viewing
+   *  which note (docId null = they left / closed the note). The sink aggregates
+   *  these into the sidebar roster. */
+  onPresence?: (peer: VaultPeer) => void;
   /** Injected in tests. Defaults to the global WebSocket. */
   wsFactory?: WsFactory;
   /** Backoff bounds (ms). */
@@ -106,6 +133,8 @@ export class VaultSyncEngine {
   private readonly onStatus?: (s: VaultSyncStatus) => void;
   private readonly onAclChanged?: () => void;
   private readonly onRegistryChanged?: () => void;
+  private readonly onMemberJoined?: (name: string) => void;
+  private readonly onPresence?: (peer: VaultPeer) => void;
   private readonly wsFactory: WsFactory;
   private readonly baseMs: number;
   private readonly maxMs: number;
@@ -118,6 +147,10 @@ export class VaultSyncEngine {
   private stopped = false;
   private attempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Our own presence (which note we're viewing). Held so we can (re)announce it
+  // the moment the channel is ready — including after a reconnect.
+  private localPresence: LocalPresence | null = null;
+  private ready = false;
 
   constructor(opts: VaultSyncEngineOptions) {
     this.api = opts.api;
@@ -127,6 +160,8 @@ export class VaultSyncEngine {
     this.onStatus = opts.onStatus;
     this.onAclChanged = opts.onAclChanged;
     this.onRegistryChanged = opts.onRegistryChanged;
+    this.onMemberJoined = opts.onMemberJoined;
+    this.onPresence = opts.onPresence;
     this.wsFactory =
       opts.wsFactory ?? ((url) => new WebSocket(url) as unknown as WebSocketLike);
     this.baseMs = opts.reconnect?.baseMs ?? 500;
@@ -140,6 +175,21 @@ export class VaultSyncEngine {
     return this.status;
   }
 
+  /**
+   * Broadcast which note this client is now viewing (null = none). Stored so it
+   * survives reconnects — the engine re-announces on every `ready`. Sent live
+   * only once the channel is ready; otherwise it goes out on the next ready.
+   */
+  setPresence(presence: LocalPresence | null): void {
+    this.localPresence = presence;
+    if (this.ready) this.sendPresence();
+  }
+
+  private sendPresence(): void {
+    if (!this.ws || !this.localPresence) return;
+    this.ws.send(encodePresence(this.localPresence));
+  }
+
   /** Open the connection (idempotent). */
   start(): void {
     if (this.stopped || this.ws) return;
@@ -149,6 +199,7 @@ export class VaultSyncEngine {
   /** Tear down permanently; no further reconnects. */
   stop(): void {
     this.stopped = true;
+    this.ready = false;
     if (this.reconnectTimer) {
       this.clearTimeoutImpl(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -228,7 +279,11 @@ export class VaultSyncEngine {
       if (!control) return;
       if (control.t === "ready") {
         this.attempt = 0; // a clean sync resets backoff
+        this.ready = true;
         this.setStatus("synced");
+        // (Re)announce our presence now the channel is live — covers first
+        // connect and every reconnect so teammates never see us go stale.
+        this.sendPresence();
       } else if (control.t === "drop") {
         this.sink.drop(control.docId);
       } else if (control.t === "reauth") {
@@ -238,6 +293,18 @@ export class VaultSyncEngine {
       } else if (control.t === "registry") {
         // Folder/note structure changed — re-pull the registry + refresh tree.
         this.onRegistryChanged?.();
+      } else if (control.t === "member") {
+        // A new teammate joined — refresh the roster + celebrate.
+        this.onMemberJoined?.(control.name);
+      } else if (control.t === "presence") {
+        // A teammate's viewing state changed — feed the sidebar roster.
+        this.onPresence?.({
+          userId: control.userId,
+          docId: control.docId,
+          name: control.name,
+          color: control.color,
+          status: control.status as ActivityStatus,
+        });
       } else if (control.t === "err") {
         // Server refused us mid-session (e.g. bad token) — reconnect fresh.
         this.onDisconnect();
@@ -256,6 +323,7 @@ export class VaultSyncEngine {
 
   private onDisconnect(): void {
     if (this.stopped) return;
+    this.ready = false; // must re-announce presence after we reconnect
     this.closeSocket();
     this.setStatus("error");
     this.scheduleReconnect();

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -21,6 +21,7 @@ import {
 import { authManager } from "./lib/auth/authManager";
 import { syncManager } from "./lib/sync/docSession";
 import type { SyncStatus } from "./lib/sync/syncManager";
+import type { VaultPeer } from "./lib/sync/vaultSyncEngine";
 import { createWithUniqueSlug, slugifyName } from "./lib/orgSlug";
 import {
   type ActivityStatus,
@@ -30,6 +31,7 @@ import {
   writeMentionSound,
 } from "./lib/prefs";
 import { seedWelcomeContent, vaultIsEmpty, WELCOME_NOTE_PATH } from "./lib/vault/seed";
+import { playJoinChime } from "./lib/celebrate/celebrate";
 
 export interface OpenNote {
   path: string;
@@ -80,6 +82,9 @@ interface AppStore {
   syncPending: boolean;
   /** Locks (read-only overlays) in the synced vault — drives tree badges. */
   locks: Share[];
+  /** Live "who's viewing what" roster (teammates only) — drives the sidebar
+   *  presence dots on notes/folders. Empty when sync is off or disconnected. */
+  vaultPresence: VaultPeer[];
   /** Per-item accent colors (vault-local preference), path → color id. */
   itemColors: Record<string, string>;
   /** Custom sidebar arrangement (vault-local preference), parent → child order. */
@@ -99,6 +104,9 @@ interface AppStore {
   activityStatus: ActivityStatus;
   /** Whether the mention chime plays when someone pings you. */
   mentionSound: boolean;
+  /** Set briefly when a teammate joins the workspace, to drive the celebration
+   *  banner + confetti. `at` changes each time so a repeat join re-triggers it. */
+  memberJoined: { name: string; at: number } | null;
 
   setVault: (v: ipc.VaultInfo | null) => void;
   setItemColor: (path: string, colorId: string | null) => void;
@@ -128,10 +136,17 @@ interface AppStore {
   updateProfile: (input: { name?: string; image?: string | null }) => Promise<void>;
   setActivityStatus: (status: ActivityStatus) => void;
   setMentionSound: (enabled: boolean) => void;
+  /** A teammate joined — show the celebration (banner + confetti + chime). */
+  celebrateMemberJoined: (name: string) => void;
+  /** Dismiss the join celebration (auto-fires after a few seconds). */
+  dismissMemberJoined: () => void;
 
   // Workspace actions
   refreshWorkspace: () => Promise<void>;
   createOrganization: (name: string) => Promise<void>;
+  /** Promote the currently-open local folder into a synced workspace, adopting
+   *  the files already in it (no new empty folder). This is "Turn on sync". */
+  turnOnSyncForCurrentVault: (name?: string) => Promise<void>;
   setActiveOrganization: (organizationId: string) => Promise<void>;
   inviteMember: (email: string, role: "member" | "admin") => Promise<void>;
   acceptInvitation: (invitationId: string) => Promise<void>;
@@ -141,6 +156,11 @@ interface AppStore {
   removeWorkspaceLocally: (organizationId: string) => Promise<void>;
   /** Permanently delete a workspace everywhere (owner only), then detach it. */
   deleteWorkspace: (organizationId: string) => Promise<void>;
+
+  /** Open a plain local folder as the current (unsynced) workspace — leaving any
+   *  synced workspace's sync context behind. Used by the switcher's local rows
+   *  and "Open a folder…". */
+  openLocalWorkspace: (path: string) => Promise<void>;
 
   // Resolving a workspace's local folder (when none is bound yet)
   /** Bind `path` to `orgId`, open it, and enable sync. */
@@ -240,6 +260,85 @@ function forgetOrgVault(orgId: string): void {
   }
 }
 
+// The workspace the user was last actually working in (folder + org resolved
+// together). The server session carries an `activeOrganizationId`, but it can be
+// null (fresh session, 2+ orgs) and it doesn't know which *folder* to open — so
+// we persist the last opened workspace locally and reopen it on launch instead
+// of dumping the user on the picker every time.
+const LAST_WORKSPACE_KEY = "context.lastWorkspace";
+
+export function readLastWorkspace(): string | null {
+  try {
+    return localStorage.getItem(LAST_WORKSPACE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function rememberLastWorkspace(orgId: string): void {
+  try {
+    localStorage.setItem(LAST_WORKSPACE_KEY, orgId);
+  } catch {
+    /* quota/unavailable — convenience only */
+  }
+}
+
+function forgetLastWorkspace(orgId?: string): void {
+  try {
+    // With no id, clear unconditionally; with one, only clear if it still points
+    // at the workspace being removed (don't clobber a newer pointer).
+    if (orgId && readLastWorkspace() !== orgId) return;
+    localStorage.removeItem(LAST_WORKSPACE_KEY);
+  } catch {
+    /* quota/unavailable — convenience only */
+  }
+}
+
+/**
+ * After a session is (re)established, land the user in the workspace they were
+ * last using — preferring the session's active org, then the last workspace we
+ * opened on this device — instead of leaving them on whatever local folder
+ * happened to be open. Restores only workspaces we're still a member of; falls
+ * back to syncing the open local vault when there's nothing to restore.
+ */
+async function landInLastWorkspace(get: () => AppStore): Promise<void> {
+  const orgs = get().organizations;
+  // The folder that's already open (App.tsx reopens the last one at launch) is
+  // the strongest signal for "the workspace I was last in" — it unifies local
+  // and synced workspaces under one recency signal.
+  const openPath = get().vault?.path ?? null;
+  const boundOrgOfOpen = openPath
+    ? (Object.entries(readOrgVaults()).find(([, p]) => p === openPath)?.[0] ?? null)
+    : null;
+
+  // 1) The open folder belongs to a synced workspace → make it active + sync.
+  if (openPath && boundOrgOfOpen && orgs.some((o) => o.id === boundOrgOfOpen)) {
+    if (get().session?.activeOrganizationId === boundOrgOfOpen) {
+      await get().enableSyncForVault();
+    } else {
+      await get().setActiveOrganization(boundOrgOfOpen);
+    }
+    return;
+  }
+
+  // 2) A local (unsynced) folder is open → keep it local. Don't pull the user
+  //    into a different workspace just because they happen to be signed in.
+  if (openPath && !boundOrgOfOpen) return;
+
+  // 3) Nothing open → restore the session's active org, else the last workspace
+  //    we used on this device (only if we're still a member).
+  const active = get().session?.activeOrganizationId ?? null;
+  const remembered = readLastWorkspace();
+  const target =
+    (active && orgs.some((o) => o.id === active) ? active : null) ??
+    (remembered && orgs.some((o) => o.id === remembered) ? remembered : null);
+  if (target) await get().setActiveOrganization(target);
+}
+
+/** Auto-dismiss timer for the member-joined celebration (module-scoped so a
+ *  repeat join resets it rather than stacking). */
+let memberJoinedTimer: ReturnType<typeof setTimeout> | null = null;
+
 export const useStore = create<AppStore>((set, get) => ({
   vault: null,
   tree: null,
@@ -261,6 +360,7 @@ export const useStore = create<AppStore>((set, get) => ({
   lastSyncedAt: null,
   syncPending: false,
   locks: [],
+  vaultPresence: [],
   itemColors: {},
   itemOrder: {},
   pendingWorkspaceFolder: null,
@@ -268,6 +368,7 @@ export const useStore = create<AppStore>((set, get) => ({
   orgBilling: null,
   activityStatus: readActivityStatus(),
   mentionSound: readMentionSound(),
+  memberJoined: null,
 
   setVault: (v) =>
     set({
@@ -344,6 +445,8 @@ export const useStore = create<AppStore>((set, get) => ({
       openNote: { path, id: meta?.id ?? null, title },
       noteRemoved: false,
     });
+    // Tell teammates which note we're now viewing (drives their sidebar dots).
+    syncManager.setViewing(meta?.id ?? null);
     await get().refreshBacklinks();
   },
 
@@ -363,7 +466,10 @@ export const useStore = create<AppStore>((set, get) => ({
 
   setNoteRemoved: (removed) => set({ noteRemoved: removed }),
 
-  closeNote: () => set({ openNote: null, backlinks: [], noteRemoved: false }),
+  closeNote: () => {
+    syncManager.setViewing(null);
+    set({ openNote: null, backlinks: [], noteRemoved: false });
+  },
 
   // ---- Auth ----
 
@@ -379,6 +485,16 @@ export const useStore = create<AppStore>((set, get) => ({
       void get().refreshTree();
       void get().refreshTitles();
     });
+    // A teammate joined the workspace — refresh the roster live (no reload) and
+    // celebrate. Fires for everyone already connected; the joiner celebrates
+    // locally in joinWorkspace/acceptInvitation (they connect after the push).
+    syncManager.setMemberJoinedListener((name) => {
+      void get().refreshWorkspace();
+      get().celebrateMemberJoined(name);
+    });
+    // Live sidebar presence — the vault channel tells us which teammate is
+    // viewing which note; mirror the roster into the store for FileTree.
+    syncManager.setVaultPresenceListener((peers) => set({ vaultPresence: peers }));
     try {
       const session = await authManager.init();
       set({ serverUrl: authManager.getServerUrl() });
@@ -386,8 +502,8 @@ export const useStore = create<AppStore>((set, get) => ({
         set({ session, authStatus: "signed-in", authError: null });
         await get().refreshWorkspace();
         await get().refreshBillingConfig();
+        await landInLastWorkspace(get);
         await get().refreshOrgBilling();
-        await get().enableSyncForVault();
       } else {
         set({ session: null, authStatus: "signed-out" });
       }
@@ -405,8 +521,9 @@ export const useStore = create<AppStore>((set, get) => ({
       if (session) {
         await get().refreshWorkspace();
         await get().refreshBillingConfig();
+        // Open the workspace they last used, rather than making them pick one.
+        await landInLastWorkspace(get);
         await get().refreshOrgBilling();
-        await get().enableSyncForVault();
         await get().openWelcomeIfPresent();
       }
     } catch (e) {
@@ -424,8 +541,9 @@ export const useStore = create<AppStore>((set, get) => ({
       if (session) {
         await get().refreshWorkspace();
         await get().refreshBillingConfig();
+        // Open the workspace they last used, rather than making them pick one.
+        await landInLastWorkspace(get);
         await get().refreshOrgBilling();
-        await get().enableSyncForVault();
         await get().openWelcomeIfPresent();
       }
     } catch (e) {
@@ -527,6 +645,26 @@ export const useStore = create<AppStore>((set, get) => ({
     set({ mentionSound: enabled });
   },
 
+  celebrateMemberJoined: (name) => {
+    const who = name?.trim() || "A new teammate";
+    set({ memberJoined: { name: who, at: Date.now() } });
+    // Reuse the app's sound preference so a muted user stays muted.
+    if (get().mentionSound) playJoinChime();
+    if (memberJoinedTimer) clearTimeout(memberJoinedTimer);
+    memberJoinedTimer = setTimeout(() => {
+      memberJoinedTimer = null;
+      set({ memberJoined: null });
+    }, 6000);
+  },
+
+  dismissMemberJoined: () => {
+    if (memberJoinedTimer) {
+      clearTimeout(memberJoinedTimer);
+      memberJoinedTimer = null;
+    }
+    set({ memberJoined: null });
+  },
+
   // ---- Workspace ----
 
   refreshWorkspace: async () => {
@@ -568,6 +706,26 @@ export const useStore = create<AppStore>((set, get) => ({
     // Route through the switch path so a brand-new workspace prompts for its
     // own folder instead of adopting whatever folder is currently open.
     await get().setActiveOrganization(org.id);
+  },
+
+  turnOnSyncForCurrentVault: async (name) => {
+    const vault = get().vault;
+    if (!vault) throw new Error("Open a workspace first.");
+    // Unlike createOrganization (which prompts for a fresh folder), this binds
+    // the folder you're already in and syncs its existing files up. Create the
+    // org directly, bind THIS folder, then let enableSyncForVault reconcile the
+    // current tree into the new server vault.
+    const org = await createWithUniqueSlug(name?.trim() || vault.name, (input) =>
+      authManager.api.createOrganization(input),
+    );
+    await authManager.api.setActiveOrganization(org.id);
+    const session = await authManager.currentSession();
+    set({ session });
+    await get().refreshWorkspace();
+    rememberOrgVault(org.id, vault.path);
+    rememberLastWorkspace(org.id);
+    await get().enableSyncForVault();
+    await get().refreshOrgBilling();
   },
 
   setActiveOrganization: async (organizationId) => {
@@ -638,16 +796,26 @@ export const useStore = create<AppStore>((set, get) => ({
       set({ session });
       await get().refreshWorkspace();
     }
+    // The joiner celebrates locally too (they connect after the server push).
+    const me = get().session?.user;
+    get().celebrateMemberJoined(me?.name || me?.email || "You");
   },
 
   joinWorkspace: async (code) => {
     const joined = await authManager.api.joinWorkspace(code.trim());
     await get().setActiveOrganization(joined.organizationId);
+    // The joiner sees the celebration too (their vault channel connects after
+    // the server broadcast, so they'd otherwise miss the live push).
+    if (!joined.alreadyMember) {
+      const me = get().session?.user;
+      get().celebrateMemberJoined(me?.name || me?.email || "You");
+    }
   },
 
   removeWorkspaceLocally: async (organizationId) => {
     // Forget this workspace's local folder so it won't auto-open here again.
     forgetOrgVault(organizationId);
+    forgetLastWorkspace(organizationId);
     // If we're removing the workspace that's currently open, move off it: swap
     // to another workspace if one exists, otherwise close the vault and stop
     // syncing (the workspace itself stays on the server — this device just
@@ -681,6 +849,29 @@ export const useStore = create<AppStore>((set, get) => ({
 
   // ---- Workspace folder resolution ----
 
+  openLocalWorkspace: async (path) => {
+    // A local workspace is a plain folder that isn't syncing to an org. Opening
+    // one tears down any active workspace sync (we're no longer in that org's
+    // folder) and leaves sync off until the user explicitly turns it on.
+    const info = await ipc.openVault(path);
+    syncManager.disable();
+    get().closeNote();
+    set({
+      vault: info,
+      locks: [],
+      syncEnabled: false,
+      syncStatus: "offline",
+      syncPending: false,
+      itemColors: readItemColors(info.path),
+      itemOrder: readItemOrder(info.path),
+      pendingWorkspaceFolder: null,
+    });
+    await get().refreshTree();
+    await get().refreshTitles();
+    // Give a brand-new empty folder its first-run welcome content.
+    await get().seedLocalVaultIfEmpty();
+  },
+
   applyWorkspaceFolder: async (orgId, path) => {
     const v = await ipc.openWorkspaceFolder(path);
     get().closeNote();
@@ -692,6 +883,7 @@ export const useStore = create<AppStore>((set, get) => ({
       pendingWorkspaceFolder: null,
     });
     rememberOrgVault(orgId, v.path);
+    rememberLastWorkspace(orgId);
     await get().refreshTree();
     await get().refreshTitles();
     await get().enableSyncForVault();
@@ -823,6 +1015,7 @@ export const useStore = create<AppStore>((set, get) => ({
       // This folder is now the one this workspace opens with.
       if (session.activeOrganizationId) {
         rememberOrgVault(session.activeOrganizationId, vault.path);
+        rememberLastWorkspace(session.activeOrganizationId);
       }
       // Reconcile may have materialized server-only notes onto disk; refresh so
       // the sidebar reflects the full workspace, not just what was already local.

--- a/app/apps/server/src/auth/auth.ts
+++ b/app/apps/server/src/auth/auth.ts
@@ -6,6 +6,7 @@ import pg from "pg";
 import { config } from "../config.js";
 import { BRAND_NAME } from "../brand.js";
 import { canAddMember, canCreateOrganization } from "../billing/entitlements.js";
+import { announceMemberJoined } from "../sync/member-events.js";
 
 /**
  * Better Auth (spec 04 §1/§2).
@@ -57,6 +58,15 @@ export const auth = betterAuth({
     "http://tauri.localhost",
     "http://localhost:1420",
   ],
+  // Desktop clients authenticate with a bearer token kept in the OS keychain,
+  // so the session's sliding refresh only advances when the app actually calls
+  // the server. Better Auth's 7-day default therefore logs people out if they
+  // don't open the app for a week. Give sessions a 30-day life, refreshed
+  // whenever they're a day old, so a returning user stays signed in.
+  session: {
+    expiresIn: 60 * 60 * 24 * 30, // 30 days
+    updateAge: 60 * 60 * 24, // refresh once the session is a day old
+  },
   emailAndPassword: {
     enabled: true,
     // MVP: no email round-trip required to sign in (email verification deferred).
@@ -117,6 +127,15 @@ export const auth = betterAuth({
               limit,
             });
           }
+        },
+        // A teammate accepted an invitation → announce to everyone live in the
+        // workspace so their roster refreshes and the join celebration fires.
+        // (The join-code path bypasses Better Auth and announces itself; org
+        // creation adds the owner via `afterAddMember`, which we deliberately
+        // don't hook — no one should be "welcomed" to their own new workspace.)
+        afterAcceptInvitation: async (data) => {
+          const name = data.user.name?.trim() || data.user.email;
+          await announceMemberJoined(data.organization.id, name);
         },
       },
     }),

--- a/app/apps/server/src/http/routes/orgs.ts
+++ b/app/apps/server/src/http/routes/orgs.ts
@@ -4,6 +4,7 @@ import { pool } from "../../db/pool.js";
 import { orgRole } from "../../permissions/lookup.js";
 import { getSession } from "../session.js";
 import { canAddMember } from "../../billing/entitlements.js";
+import { announceMemberJoined } from "../../sync/member-events.js";
 import { billingEnabled } from "../../config.js";
 import type { BillingProvider } from "../../billing/provider.js";
 
@@ -142,6 +143,16 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
        VALUES ($1, $2, $3, 'member', now())`,
       [randomUUID(), organizationId, session.userId],
     );
+
+    // Announce to teammates already live in the workspace (this path bypasses
+    // Better Auth, so its hooks never fire — we do it explicitly here).
+    const who = await pool.query<{ name: string | null }>(
+      'SELECT name FROM "user" WHERE id = $1',
+      [session.userId],
+    );
+    const displayName = who.rows[0]?.name?.trim() || session.email;
+    void announceMemberJoined(organizationId, displayName);
+
     return c.json({ organizationId, name: target.name, alreadyMember: false });
   });
 

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -6,6 +6,7 @@ import { createSyncServer, disconnectDoc } from "./sync/hocuspocus.js";
 import { attachSyncUpgrade } from "./sync/http-upgrade.js";
 import { createPubSub } from "./sync/pubsub.js";
 import { VaultChannel } from "./sync/vault-channel.js";
+import { setMemberJoinedPublisher } from "./sync/member-events.js";
 import { backfillIndex } from "./index/indexer.js";
 import { createDocWriter } from "./mcp/doc-writer.js";
 
@@ -23,6 +24,12 @@ async function main() {
   // is set, in which case fanout spans instances (HA / rolling deploys).
   const pubsub = await createPubSub(config.redisUrl);
   const vaultChannel = new VaultChannel({ pubsub });
+
+  // Let the HTTP/auth layer announce member joins onto the vault channel, so
+  // connected teammates refresh their roster + celebrate without a reload.
+  setMemberJoinedPublisher((vaultId, name) => {
+    void vaultChannel.publishMemberJoined(vaultId, name);
+  });
 
   // Every persisted doc change is fanned out to background vault subscribers.
   const sync = createSyncServer(config.hocuspocusPort, (vaultId, docId, update) => {

--- a/app/apps/server/src/sync/member-events.ts
+++ b/app/apps/server/src/sync/member-events.ts
@@ -1,0 +1,37 @@
+import { pool } from "../db/pool.js";
+
+/**
+ * Bridge between the HTTP/auth layer (where a member join happens) and the vault
+ * replication channel (which fans events out to connected teammates). The channel
+ * is created in the process entrypoint, long after routes/auth are wired, so the
+ * publisher is injected there via `setMemberJoinedPublisher`. Until then — and in
+ * unit tests that never start the channel — announcing is a no-op.
+ */
+type MemberJoinedPublisher = (vaultId: string, name: string) => void;
+
+let publish: MemberJoinedPublisher | null = null;
+
+export function setMemberJoinedPublisher(fn: MemberJoinedPublisher): void {
+  publish = fn;
+}
+
+/**
+ * Tell everyone live in a workspace that `name` just joined. Fans out to every
+ * vault the org owns (currently one). Best-effort: swallows its own errors so a
+ * failed announce can never fail the join that triggered it.
+ */
+export async function announceMemberJoined(
+  organizationId: string,
+  name: string,
+): Promise<void> {
+  if (!publish) return;
+  try {
+    const { rows } = await pool.query<{ id: string }>(
+      "SELECT id FROM vaults WHERE organization_id = $1",
+      [organizationId],
+    );
+    for (const { id } of rows) publish(id, name);
+  } catch (err) {
+    console.error("announceMemberJoined failed:", err);
+  }
+}

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -8,12 +8,17 @@ import { listReadableDocsInVault } from "../permissions/vault-docs.js";
 import { loadDocDiff } from "../yjs/persistence.js";
 import {
   parseHello,
+  parsePresence,
   encodeWsUpdate,
   encodePubsubUpdate,
   encodePubsubAclChanged,
   encodePubsubRegistryChanged,
+  encodePubsubMemberJoined,
+  encodePubsubPresence,
+  encodePubsubPresenceQuery,
   decodePubsub,
   type ServerControl,
+  type PresenceFrame,
 } from "./vault-protocol.js";
 
 /**
@@ -68,6 +73,12 @@ export class VaultChannel {
     await this.pubsub.publish(vaultTopic(vaultId), encodePubsubRegistryChanged());
   }
 
+  /** Announce that a new member joined the workspace this vault belongs to;
+   *  subscribers refresh their roster and show a join celebration. */
+  async publishMemberJoined(vaultId: string, name: string): Promise<void> {
+    await this.pubsub.publish(vaultTopic(vaultId), encodePubsubMemberJoined(name));
+  }
+
   /** Wire the channel onto the HTTP server's upgrade at `config.vaultSyncPath`. */
   attachUpgrade(httpServer: HttpServer): WebSocketServer {
     const wss = new WebSocketServer({ noServer: true });
@@ -106,6 +117,11 @@ class VaultConnection {
   private unsubscribe: (() => void) | null = null;
   private helloSeen = false;
   private readonly helloTimer: ReturnType<typeof setTimeout>;
+  // This connection's last-announced presence (which note the user is viewing),
+  // kept so we can re-broadcast it when a newcomer asks, and clear it on close.
+  private myPresence: { docId: string | null; name: string; color: string; status: string } | null =
+    null;
+  private announced = false;
 
   constructor(
     private readonly ws: WebSocket,
@@ -129,7 +145,12 @@ class VaultConnection {
   }
 
   private async onText(text: string): Promise<void> {
-    if (this.helloSeen) return; // hello is the only client->server message
+    if (this.helloSeen) {
+      // Post-hello, the only client message we accept is a presence update.
+      const presence = parsePresence(text);
+      if (presence) this.handlePresence(presence);
+      return;
+    }
     const hello = parseHello(text);
     if (!hello) return this.fail("expected hello");
     this.helloSeen = true;
@@ -160,6 +181,28 @@ class VaultConnection {
 
     await this.backfill(hello.manifest, hello.priority ?? []);
     this.send({ t: "ready" });
+  }
+
+  /** A client announced which note it's now viewing. Stamp the authenticated
+   *  userId (never trust the client's), fan it out to the vault, and — on the
+   *  first announce — ask everyone else to re-announce so this newcomer learns
+   *  the current roster (the channel holds no shared presence state). */
+  private handlePresence(frame: PresenceFrame): void {
+    if (!this.userId || !this.vaultId) return;
+    this.myPresence = {
+      docId: frame.docId,
+      name: frame.name,
+      color: frame.color,
+      status: frame.status,
+    };
+    void this.pubsub.publish(
+      vaultTopic(this.vaultId),
+      encodePubsubPresence({ userId: this.userId, ...this.myPresence }),
+    );
+    if (!this.announced) {
+      this.announced = true;
+      void this.pubsub.publish(vaultTopic(this.vaultId), encodePubsubPresenceQuery());
+    }
   }
 
   /** Stream missing ops for every readable doc, priority docs first. */
@@ -204,6 +247,32 @@ class VaultConnection {
       this.send({ t: "registry" });
       return;
     }
+    if (msg.type === "member-joined") {
+      // Org-wide news, not doc-scoped — forward to every subscriber of this
+      // vault so their roster refreshes and the join celebration fires live.
+      this.send({ t: "member", name: msg.name });
+      return;
+    }
+    if (msg.type === "presence") {
+      // Forward a teammate's viewing state — but only for docs this client may
+      // read (ACL-safe). A null docId ("not viewing"/gone) always passes so the
+      // client can clear that user from wherever it last showed them.
+      const { presence } = msg;
+      if (presence.docId === null || this.readable.has(presence.docId)) {
+        this.send({ t: "presence", ...presence });
+      }
+      return;
+    }
+    if (msg.type === "presence-query") {
+      // A newcomer joined — re-announce our current presence so they see us.
+      if (this.myPresence && this.userId && this.vaultId) {
+        void this.pubsub.publish(
+          vaultTopic(this.vaultId),
+          encodePubsubPresence({ userId: this.userId, ...this.myPresence }),
+        );
+      }
+      return;
+    }
     // acl-changed: re-evaluate; drop revoked docs, backfill newly-granted ones.
     void this.refreshAcl();
   }
@@ -230,6 +299,11 @@ class VaultConnection {
     // unlocks both reach open editors in realtime without a reopen (spec 04 §4).
     this.send({ t: "reauth" });
     const added = [...next].filter((d) => !prev.has(d));
+    if (added.length > 0 && this.vaultId) {
+      // We can now see docs we couldn't before — ask the vault to re-announce
+      // presence so viewers of the newly-readable docs light up for us.
+      void this.pubsub.publish(vaultTopic(this.vaultId), encodePubsubPresenceQuery());
+    }
     // Newly-readable docs: full backfill (client holds no state vector for them).
     await runPool(added, this.deps.concurrency, (docId) => this.sendDocBackfill(docId, undefined));
   }
@@ -250,6 +324,16 @@ class VaultConnection {
 
   private cleanup(): void {
     clearTimeout(this.helloTimer);
+    // Tell the vault this user is gone so teammates clear their presence dot.
+    // Guard on `announced` so we only emit for connections that ever appeared.
+    if (this.announced && this.userId && this.vaultId) {
+      const { name = "", color = "", status = "" } = this.myPresence ?? {};
+      void this.pubsub.publish(
+        vaultTopic(this.vaultId),
+        encodePubsubPresence({ userId: this.userId, docId: null, name, color, status }),
+      );
+      this.announced = false;
+    }
     if (this.unsubscribe) {
       this.unsubscribe();
       this.unsubscribe = null;

--- a/app/apps/server/src/sync/vault-protocol.ts
+++ b/app/apps/server/src/sync/vault-protocol.ts
@@ -27,12 +27,62 @@ export interface HelloFrame {
   priority?: string[];
 }
 
+/** A teammate's live "who's viewing what" state, forwarded to every subscriber
+ *  of the vault so the sidebar can show presence dots on notes/folders. `docId`
+ *  null means "not viewing anything" (or gone) — clients clear that user. The
+ *  `userId` is stamped by the server from the token, never trusted from the
+ *  client, so presence can't be spoofed. */
+export interface PresenceState {
+  userId: string;
+  docId: string | null;
+  name: string;
+  color: string;
+  status: string;
+}
+
 export type ServerControl =
   | { t: "ready" } // initial backfill drained
   | { t: "drop"; docId: string } // access lost / doc removed -> client evicts
   | { t: "reauth" } // ACL changed in this vault -> client re-mints its open doc's token
   | { t: "registry" } // folders/notes structure changed -> client re-pulls the registry
+  | { t: "member"; name: string } // a new teammate joined the workspace -> refresh + celebrate
+  | ({ t: "presence" } & PresenceState) // a teammate's live viewing state changed
   | { t: "err"; message: string };
+
+/** Client's post-hello presence frame: declares what note it's currently on.
+ *  `docId` is null when the client has no note open. `userId` is intentionally
+ *  absent — the server derives it from the authenticated token. */
+export interface PresenceFrame {
+  t: "presence";
+  docId: string | null;
+  name: string;
+  color: string;
+  status: string;
+}
+
+/** Parse a client presence text frame; null if it isn't one. */
+export function parsePresence(text: string): PresenceFrame | null {
+  let v: unknown;
+  try {
+    v = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!v || typeof v !== "object") return null;
+  const o = v as Record<string, unknown>;
+  if (o.t !== "presence") return null;
+  if (o.docId !== null && typeof o.docId !== "string") return null;
+  if (typeof o.name !== "string" || typeof o.color !== "string" || typeof o.status !== "string") {
+    return null;
+  }
+  return {
+    t: "presence",
+    docId: (o.docId as string | null) ?? null,
+    name: o.name,
+    color: o.color,
+    status: o.status,
+  };
+}
 
 export function parseHello(text: string): HelloFrame | null {
   let v: unknown;
@@ -77,6 +127,9 @@ export function decodeWsUpdate(
 export const PS_UPDATE = 0x01;
 export const PS_ACL_CHANGED = 0x02;
 export const PS_REGISTRY_CHANGED = 0x03;
+export const PS_MEMBER_JOINED = 0x04;
+export const PS_PRESENCE = 0x05;
+export const PS_PRESENCE_QUERY = 0x06;
 
 export function encodePubsubUpdate(docId: string, update: Uint8Array): Uint8Array {
   const body = frameDocPayload(docId, update);
@@ -94,10 +147,37 @@ export function encodePubsubRegistryChanged(): Uint8Array {
   return new Uint8Array([PS_REGISTRY_CHANGED]);
 }
 
+export function encodePubsubMemberJoined(name: string): Uint8Array {
+  const n = enc.encode(name);
+  const out = new Uint8Array(1 + n.length);
+  out[0] = PS_MEMBER_JOINED;
+  out.set(n, 1);
+  return out;
+}
+
+/** Fan a teammate's viewing state out to the vault (JSON body after the type). */
+export function encodePubsubPresence(p: PresenceState): Uint8Array {
+  const body = enc.encode(JSON.stringify(p));
+  const out = new Uint8Array(1 + body.length);
+  out[0] = PS_PRESENCE;
+  out.set(body, 1);
+  return out;
+}
+
+/** Ask every connection in the vault to re-announce its presence — sent when a
+ *  client joins so it learns who's already viewing what (stateless: no instance
+ *  holds the whole roster, so newcomers pull it via a re-announce round). */
+export function encodePubsubPresenceQuery(): Uint8Array {
+  return new Uint8Array([PS_PRESENCE_QUERY]);
+}
+
 export type PubsubMessage =
   | { type: "update"; docId: string; update: Uint8Array }
   | { type: "acl-changed" }
-  | { type: "registry-changed" };
+  | { type: "registry-changed" }
+  | { type: "member-joined"; name: string }
+  | { type: "presence"; presence: PresenceState }
+  | { type: "presence-query" };
 
 export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
   if (bytes.length < 1) return null;
@@ -110,6 +190,19 @@ export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
       return { type: "acl-changed" };
     case PS_REGISTRY_CHANGED:
       return { type: "registry-changed" };
+    case PS_MEMBER_JOINED:
+      return { type: "member-joined", name: dec.decode(bytes.subarray(1)) };
+    case PS_PRESENCE: {
+      try {
+        const p = JSON.parse(dec.decode(bytes.subarray(1))) as PresenceState;
+        if (typeof p?.userId !== "string") return null;
+        return { type: "presence", presence: p };
+      } catch {
+        return null;
+      }
+    }
+    case PS_PRESENCE_QUERY:
+      return { type: "presence-query" };
     default:
       return null;
   }

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -25,6 +25,13 @@ class FakeWs extends EventEmitter {
   hello(token: string, manifest: Record<string, string> = {}, priority?: string[]): void {
     this.emit("message", Buffer.from(JSON.stringify({ t: "hello", token, manifest, priority })), false);
   }
+  presence(docId: string | null, name = "Ada", color = "#6366f1", status = "online"): void {
+    this.emit(
+      "message",
+      Buffer.from(JSON.stringify({ t: "presence", docId, name, color, status })),
+      false,
+    );
+  }
   controls(): Array<Record<string, unknown>> {
     return this.sent.filter((s) => s.kind === "text").map((s) => (s as { value: Record<string, unknown> }).value);
   }
@@ -123,6 +130,72 @@ describe("VaultChannel relay (spec 05 §3.1)", () => {
     expect(ws.controls().filter((c) => c.t === "registry")).toEqual([{ t: "registry" }]);
     // Newly-readable "B" is backfilled off the same signal.
     await waitFor(() => ws.updates().some((u) => u.docId === "B"));
+  });
+
+  it("forwards a member-joined announcement to every subscriber (not doc-scoped)", async () => {
+    const { channel } = channelWith(() => new Set(["A"]));
+    const ws = new FakeWs();
+    channel.handleConnection(ws as never);
+    ws.hello("good");
+    await waitFor(() => ws.controls().some((c) => c.t === "ready"));
+
+    await channel.publishMemberJoined("v1", "Ada");
+    await waitFor(() => ws.controls().some((c) => c.t === "member"));
+
+    expect(ws.controls().filter((c) => c.t === "member")).toEqual([
+      { t: "member", name: "Ada" },
+    ]);
+  });
+
+  it("forwards a teammate's presence to subscribers that can read the doc (gone always passes)", async () => {
+    const { channel } = channelWith(() => new Set(["A"]));
+    const a = new FakeWs();
+    const b = new FakeWs();
+    channel.handleConnection(a as never);
+    channel.handleConnection(b as never);
+    a.hello("good");
+    b.hello("good");
+    await waitFor(() => a.controls().some((c) => c.t === "ready"));
+    await waitFor(() => b.controls().some((c) => c.t === "ready"));
+
+    // A is viewing note "A" (readable by B) → B sees it.
+    a.presence("A");
+    await waitFor(() => b.controls().some((c) => c.t === "presence" && c.docId === "A"));
+    const seen = b.controls().find((c) => c.t === "presence" && c.docId === "A");
+    expect(seen).toEqual({
+      t: "presence",
+      userId: "u1",
+      docId: "A",
+      name: "Ada",
+      color: "#6366f1",
+      status: "online",
+    });
+
+    // A moves to note "Z" (NOT in B's readable set) → B never sees "Z".
+    a.presence("Z");
+    // A closes the note (docId null = gone) → always forwarded so B can clear.
+    a.presence(null);
+    await waitFor(() => b.controls().some((c) => c.t === "presence" && c.docId === null));
+    expect(b.controls().some((c) => c.t === "presence" && c.docId === "Z")).toBe(false);
+  });
+
+  it("re-announces presence so a newcomer learns who's already viewing what", async () => {
+    const { channel } = channelWith(() => new Set(["A"]));
+    const a = new FakeWs();
+    channel.handleConnection(a as never);
+    a.hello("good");
+    await waitFor(() => a.controls().some((c) => c.t === "ready"));
+    a.presence("A"); // A is already here before B joins
+
+    // B joins afterward and announces itself; its first announce triggers a
+    // presence-query, prompting A to re-announce so B learns A is on "A".
+    const b = new FakeWs();
+    channel.handleConnection(b as never);
+    b.hello("good");
+    await waitFor(() => b.controls().some((c) => c.t === "ready"));
+    b.presence(null);
+
+    await waitFor(() => b.controls().some((c) => c.t === "presence" && c.docId === "A"));
   });
 
   it("drops a doc when an acl change removes it from the readable set", async () => {

--- a/app/apps/server/tests/vault-protocol.test.ts
+++ b/app/apps/server/tests/vault-protocol.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   parseHello,
+  parsePresence,
   encodeWsUpdate,
   decodeWsUpdate,
   encodePubsubUpdate,
   encodePubsubAclChanged,
   encodePubsubRegistryChanged,
+  encodePubsubMemberJoined,
+  encodePubsubPresence,
+  encodePubsubPresenceQuery,
   decodePubsub,
 } from "../src/sync/vault-protocol.js";
 
@@ -32,6 +36,43 @@ describe("vault channel framing", () => {
 
   it("decodes the registry-changed control payload", () => {
     expect(decodePubsub(encodePubsubRegistryChanged())).toEqual({ type: "registry-changed" });
+  });
+
+  it("round-trips a member-joined payload with the member's name (incl. unicode)", () => {
+    expect(decodePubsub(encodePubsubMemberJoined("Ada Lovelace"))).toEqual({
+      type: "member-joined",
+      name: "Ada Lovelace",
+    });
+    expect(decodePubsub(encodePubsubMemberJoined("François 🎉"))).toEqual({
+      type: "member-joined",
+      name: "François 🎉",
+    });
+  });
+
+  it("round-trips a presence pubsub payload (incl. a null docId = gone)", () => {
+    const p = { userId: "u1", docId: "note-9", name: "Ada 🎉", color: "#6366f1", status: "online" };
+    expect(decodePubsub(encodePubsubPresence(p))).toEqual({ type: "presence", presence: p });
+    const gone = { userId: "u1", docId: null, name: "", color: "", status: "" };
+    expect(decodePubsub(encodePubsubPresence(gone))).toEqual({ type: "presence", presence: gone });
+  });
+
+  it("decodes the presence-query control payload", () => {
+    expect(decodePubsub(encodePubsubPresenceQuery())).toEqual({ type: "presence-query" });
+  });
+
+  it("parses a valid presence frame and rejects malformed ones", () => {
+    const ok = parsePresence(
+      JSON.stringify({ t: "presence", docId: "d1", name: "Ada", color: "#fff", status: "busy" }),
+    );
+    expect(ok).toEqual({ t: "presence", docId: "d1", name: "Ada", color: "#fff", status: "busy" });
+    // null docId is valid ("not viewing anything")
+    expect(
+      parsePresence(JSON.stringify({ t: "presence", docId: null, name: "A", color: "c", status: "s" }))
+        ?.docId,
+    ).toBeNull();
+    expect(parsePresence(JSON.stringify({ t: "hello", token: "x", manifest: {} }))).toBeNull();
+    expect(parsePresence(JSON.stringify({ t: "presence", name: "A", color: "c" }))).toBeNull(); // no status
+    expect(parsePresence("not json")).toBeNull();
   });
 
   it("returns null for a truncated frame and an unknown pubsub type", () => {

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -88,9 +88,15 @@ shares (
 
 **Effective permission** for a user on a file:
 1. Workspace `owner`/`admin` → `edit` on everything in the workspace.
-2. Else take the **max** of: any `share` on the file itself, any `share` on a containing folder
-   (walk `parent_id` up), and any team share the user belongs to (later).
-3. `edit > view > none`. No matching grant → **no sync access**.
+2. A note's **creator** → `edit` on their own note.
+3. Else take the **max** of: any `share` on the file itself, any `share` on a containing folder
+   (walk `parent_id` up), and any workspace-wide grant — each either **per-user** or an org-wide
+   **"share with team"** grant.
+4. `edit > view > none`. No matching grant → **no sync access**.
+
+**Private by default:** a new workspace grants nothing org-wide, so members see only what they create
+or what's shared with them / the team. (Owner sets the whole workspace to Shared/Read-only, or shares
+individual folders, in the Access panel; workspaces created before this stay Open.)
 
 Folder grants are **inherited by descendants**; a file-level `share` can only *raise* permission
 (Outline's "read-only collection + writable document" pattern).


### PR DESCRIPTION
## Summary
- **Workspace switcher (`AccountMenu`)**: the account popover now caps at 2 synced + 2 local workspaces with a "View all" that opens the full Workspaces settings page (which now lists local *and* synced workspaces together). Keeps the modal from growing unbounded.
- **Fixed the double "Current" badge**: "Current" now tracks the workspace whose folder is actually open (keyed off the open vault path) instead of the account's active org and `!syncEnabled` independently — so exactly one row can read "Current". `switchTo` was relaxed so you can enter the active org even when its folder isn't the one currently open.
- Bundles concurrent work: paste / HTML-to-markdown editor handling, celebrate module, sync (`vault-channel`, `vault-protocol`, `member-events`) and presence updates, plus doc/spec touch-ups.

## Test
- `tsc --noEmit` passes for the desktop app.