### PR TITLE
List remote workspaces on the welcome screen

### DIFF
--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tempfile",
+ "trash",
  "uuid",
  "walkdir",
 ]
@@ -3747,7 +3748,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3830,7 +3831,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3971,7 +3972,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4040,7 +4041,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4065,7 +4066,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4469,6 +4470,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,6 +4615,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -4850,10 +4875,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4874,7 +4899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4926,6 +4951,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4948,12 +4983,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4965,8 +5012,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4985,9 +5032,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5025,6 +5094,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5396,7 +5474,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,9 @@ sha2 = "0.10"
 walkdir = "2"
 regex = "1"
 once_cell = "1"
+# Move a deleted local-workspace folder to the OS trash (recoverable) rather than
+# hard-deleting it — the on-disk `.md` files are the only copy of a local vault.
+trash = "5"
 # OS keychain for session tokens (spec 04 §7). apple-native uses the macOS
 # Security framework; swap/add features for other platforms later.
 keyring = { version = "3", features = ["apple-native"] }

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -240,6 +240,32 @@ pub fn remove_recent_vault(app: AppHandle, path: String) -> AppResult<()> {
     write_config(&app, &cfg)
 }
 
+/// Move a local workspace's folder — and all its notes — to the OS trash, then
+/// forget it from the recents list. Used by the local-workspace "Delete files"
+/// action. This is the only copy of a local vault (no server), so we trash
+/// (recoverable) instead of hard-deleting, and the UI gates it behind a
+/// two-click confirm.
+#[tauri::command]
+pub fn delete_vault(app: AppHandle, path: String) -> AppResult<()> {
+    let dir = PathBuf::from(&path);
+    if !dir.is_dir() {
+        return Err(AppError::new("selected path is not a folder"));
+    }
+    // A missing parent means this is a filesystem root — never a real workspace
+    // folder. Refuse rather than trash an entire drive.
+    if dir.parent().is_none() {
+        return Err(AppError::new("refusing to delete a filesystem root"));
+    }
+    trash::delete(&dir).map_err(|e| AppError::new(format!("could not move to trash: {e}")))?;
+    // Also drop it from recents / last_vault so it doesn't linger in the switcher.
+    let mut cfg = read_config(&app);
+    cfg.recent_vaults.retain(|r| r.path != path);
+    if cfg.last_vault.as_deref() == Some(path.as_str()) {
+        cfg.last_vault = None;
+    }
+    write_config(&app, &cfg)
+}
+
 /// Create a brand-new empty vault folder `<parent>/<name>` and open it.
 #[tauri::command]
 pub async fn create_vault(

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ pub fn run() {
             commands::get_last_vault,
             commands::get_recent_vaults,
             commands::remove_recent_vault,
+            commands::delete_vault,
             commands::create_vault,
             commands::is_vault,
             commands::list_tree,

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -520,6 +520,12 @@ button.primary.hero:hover:not(:disabled) {
   color: var(--text-tertiary);
   white-space: nowrap;
 }
+/* The Local/Remote tag on a workspace row, tucked into the top-right slot. */
+.recent-badge {
+  grid-area: time;
+  justify-self: end;
+  align-self: center;
+}
 .recent-remove {
   flex-shrink: 0;
   align-self: stretch;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -414,7 +414,15 @@ export default function App() {
   }
 
   if (!vault) {
-    return <VaultPicker />;
+    // The folder-prompt rides along here too: switching to a synced workspace
+    // that has no local folder yet (e.g. clicked from the welcome screen) asks
+    // the user to choose/create one before its vault opens.
+    return (
+      <>
+        <VaultPicker />
+        <WorkspaceFolderPrompt />
+      </>
+    );
   }
 
   return (

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -170,7 +170,9 @@ export function AccountMenu() {
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
-        title={`${userLabel} · ${presenceLabel}${activeOrg ? ` · ${activeOrg.name}` : ""}`}
+        title={`${userLabel} · ${presenceLabel}${
+          syncEnabled && activeOrg ? ` · ${activeOrg.name}` : vault ? ` · ${vault.name}` : ""
+        }`}
       >
         <span className="identity-avatar-wrap">
           <Avatar label={userLabel} image={session.user.image} />
@@ -178,10 +180,17 @@ export function AccountMenu() {
         </span>
         <span className="identity-meta">
           <span className="identity-line1">
-            {activeOrg?.name ?? vault?.name ?? userLabel}
+            {/* Name the workspace that's actually OPEN — a local one wins over a
+                still-set activeOrg once sync is off (opening a local folder
+                disables sync but leaves the account's active org untouched). */}
+            {(syncEnabled && activeOrg ? activeOrg.name : vault?.name) ?? userLabel}
           </span>
           <span className="identity-line2">
-            {activeOrg ? userLabel : vault ? "Local · not synced" : "No workspace yet"}
+            {syncEnabled && activeOrg
+              ? userLabel
+              : vault
+                ? "Local · not synced"
+                : "No workspace yet"}
           </span>
         </span>
         {hasInvites && <span className="identity-alert" aria-label="Pending invitation" />}
@@ -230,8 +239,11 @@ const POPOVER_WORKSPACE_LIMIT = 2;
  * user's LOCAL workspaces. A workspace is one concept in two states; these are
  * the ones that just aren't syncing to an org yet.
  */
-function useLocalWorkspaces(): RecentVault[] {
+function useLocalWorkspaces(nonce = 0): RecentVault[] {
   const [recents, setRecents] = useState<RecentVault[]>([]);
+  // Re-fetch when the open folder changes (a switch/open reorders recents) and
+  // when `nonce` is bumped (after a local remove/delete removes a row).
+  const openPath = useStore((s) => s.vault?.path);
   useEffect(() => {
     let alive = true;
     ipc
@@ -243,7 +255,7 @@ function useLocalWorkspaces(): RecentVault[] {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [nonce, openPath]);
   const bound = new Set(Object.values(readOrgVaults()));
   return recents.filter((r) => !bound.has(r.path));
 }
@@ -494,7 +506,7 @@ function AccountPopover({
               {o.name[0]?.toUpperCase() ?? "?"}
             </span>
             <span className="menu-item-label">{o.name}</span>
-            {!isActive && <span className="ws-badge synced">Synced</span>}
+            {!isActive && <span className="ws-badge synced">Remote</span>}
             {isActive && (
               <>
                 <span className="menu-current">Current</span>
@@ -661,8 +673,19 @@ function MenuIcon({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Focused sign-in / sign-up modal; closes itself once a session lands. */
-function AuthDialog({ onClose }: { onClose: () => void }) {
+/**
+ * Focused sign-in / sign-up modal; closes itself once a session lands. When a
+ * caller needs to act on a *successful* sign-in (vs. a cancel), it passes
+ * `onSignedIn` — fired instead of `onClose` when the session arrives, so the
+ * two outcomes stay distinguishable.
+ */
+export function AuthDialog({
+  onClose,
+  onSignedIn,
+}: {
+  onClose: () => void;
+  onSignedIn?: () => void;
+}) {
   const authStatus = useStore((s) => s.authStatus);
   const authError = useStore((s) => s.authError);
   const serverUrl = useStore((s) => s.serverUrl);
@@ -683,8 +706,11 @@ function AuthDialog({ onClose }: { onClose: () => void }) {
   const [googleAvailable, setGoogleAvailable] = useState(false);
 
   useEffect(() => {
-    if (authStatus === "signed-in") onClose();
-  }, [authStatus, onClose]);
+    if (authStatus === "signed-in") {
+      if (onSignedIn) onSignedIn();
+      else onClose();
+    }
+  }, [authStatus, onClose, onSignedIn]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1307,7 +1333,9 @@ function WorkspacesTab() {
   const members = useStore((s) => s.members);
   const vault = useStore((s) => s.vault);
   const syncEnabled = useStore((s) => s.syncEnabled);
-  const locals = useLocalWorkspaces();
+  // Bumped after a local remove/delete so the recents list re-fetches.
+  const [localsNonce, setLocalsNonce] = useState(0);
+  const locals = useLocalWorkspaces(localsNonce);
 
   const [root, setRoot] = useState<string | null>(null);
   const [bound, setBound] = useState<Record<string, string>>(() => readOrgVaults());
@@ -1319,6 +1347,8 @@ function WorkspacesTab() {
   const [busy, setBusy] = useState(false);
   // orgId whose permanent deletion is awaiting a second confirming click.
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  // local-workspace path whose file deletion is awaiting a second confirming click.
+  const [confirmDeleteLocal, setConfirmDeleteLocal] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   // Free-plan workspace-cap hit while creating — shows an upgrade nudge instead.
   const [limitNudge, setLimitNudge] = useState<{ kind: LimitKind; limit: number | null } | null>(
@@ -1407,6 +1437,37 @@ function WorkspacesTab() {
       await useStore.getState().deleteWorkspace(orgId);
       setBound(readOrgVaults());
       setConfirmDelete(null);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Forget a local workspace from this device's list (files on disk are kept).
+  const removeLocalWorkspace = async (path: string) => {
+    if (busy) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      await useStore.getState().removeLocalWorkspace(path);
+      setLocalsNonce((n) => n + 1);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Move a local workspace's folder to the OS trash (destructive, two-click confirm).
+  const deleteLocalFiles = async (path: string) => {
+    if (busy) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      await useStore.getState().deleteLocalWorkspace(path);
+      setConfirmDeleteLocal(null);
+      setLocalsNonce((n) => n + 1);
     } catch (e) {
       setActionError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -1630,19 +1691,58 @@ function WorkspacesTab() {
                       {" · Local"}
                     </span>
                   </span>
-                  <span className="workspace-row-actions">
-                    {isCurrent ? (
-                      <span className="member-role">Current</span>
-                    ) : (
+                  {confirmDeleteLocal === r.path ? (
+                    <span className="workspace-row-actions">
+                      <span className="muted">Delete this workspace?</span>
                       <button
                         className="link-btn"
                         disabled={busy}
-                        onClick={() => void switchToLocal(r.path)}
+                        onClick={() => setConfirmDeleteLocal(null)}
                       >
-                        Switch
+                        Cancel
                       </button>
-                    )}
-                  </span>
+                      <button
+                        className="link-btn danger"
+                        disabled={busy}
+                        onClick={() => void deleteLocalFiles(r.path)}
+                      >
+                        Delete
+                      </button>
+                    </span>
+                  ) : (
+                    <span className="workspace-row-actions">
+                      {isCurrent ? (
+                        <span className="member-role">Current</span>
+                      ) : (
+                        <button
+                          className="link-btn"
+                          disabled={busy}
+                          onClick={() => void switchToLocal(r.path)}
+                        >
+                          Switch
+                        </button>
+                      )}
+                      <button
+                        className="link-btn"
+                        disabled={busy}
+                        title="Remove this folder from the list. Files stay on disk."
+                        onClick={() => void removeLocalWorkspace(r.path)}
+                      >
+                        Remove
+                      </button>
+                      <button
+                        className="link-btn danger"
+                        disabled={busy}
+                        title="Delete this workspace — moves its folder and all its notes to the Trash"
+                        onClick={() => {
+                          setActionError(null);
+                          setConfirmDeleteLocal(r.path);
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </span>
+                  )}
                 </li>
               );
             })}

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -1,9 +1,24 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import type { VaultInfo, RecentVault } from "../lib/ipc";
 import * as ipc from "../lib/ipc";
-import { useStore } from "../store";
+import {
+  readKnownWorkspaces,
+  readOrgVaults,
+  requestOpenWorkspace,
+  useStore,
+} from "../store";
+import { AuthDialog } from "./AccountMenu";
 import { Wordmark } from "./Logo";
+
+/**
+ * A row in the welcome-screen list: either a plain local folder (a recent vault
+ * on disk) or a synced *remote* workspace (an org). Remote rows carry the org id
+ * so a click can reopen + resync them — prompting sign-in first if signed out.
+ */
+type PickerEntry =
+  | { kind: "local"; key: string; name: string; path: string; openedAt: number }
+  | { kind: "remote"; key: string; name: string; path: string | null; orgId: string };
 
 // Springs tuned for small UI: snappy but soft-landing (no rubber-banding).
 const SPRING = { type: "spring", stiffness: 300, damping: 24 } as const;
@@ -63,9 +78,13 @@ function tidyPath(path: string): string {
 }
 
 export function VaultPicker() {
+  const authStatus = useStore((s) => s.authStatus);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [recents, setRecents] = useState<RecentVault[]>([]);
+  // When a signed-out user clicks a remote workspace we open the sign-in modal;
+  // the workspace to land in afterwards is stashed via requestOpenWorkspace().
+  const [signInOpen, setSignInOpen] = useState(false);
   // New-vault flow: null = idle; a string = chosen parent, awaiting a name.
   const [newParent, setNewParent] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
@@ -191,16 +210,41 @@ export function VaultPicker() {
     setError(null);
   }
 
-  async function reopen(r: RecentVault) {
+  async function reopenLocal(path: string) {
     setBusy(true);
     setError(null);
     try {
-      const info = await ipc.openVault(r.path);
+      const info = await ipc.openVault(path);
       await openVault(info);
     } catch (e) {
       setError(String(e));
     } finally {
       setBusy(false);
+    }
+  }
+
+  // Open a workspace row. Local folders open in place. A remote (synced)
+  // workspace needs a session: if we still have one, switch straight to it
+  // (opening its folder + resyncing); if we're signed out, remember it and
+  // prompt sign-in — landInLastWorkspace opens it once the session lands.
+  async function openEntry(e: PickerEntry) {
+    if (e.kind === "local") {
+      await reopenLocal(e.path);
+      return;
+    }
+    if (authStatus === "signed-in") {
+      setBusy(true);
+      setError(null);
+      try {
+        await useStore.getState().setActiveOrganization(e.orgId);
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setBusy(false);
+      }
+    } else {
+      requestOpenWorkspace(e.orgId);
+      setSignInOpen(true);
     }
   }
 
@@ -230,10 +274,38 @@ export function VaultPicker() {
   // with an already-a-vault folder) is showing — hides the recents/hint.
   const inFlow = naming || deciding;
 
+  // Merge synced (remote) workspaces with local recents into one list. Remote
+  // workspaces come from the locally-cached org list (survives sign-out) and are
+  // shown first; their bound folder — if any — comes from the org→folder map.
+  // Local recents backing a synced workspace are folded into the remote row (by
+  // path) so nothing shows twice.
+  const entries = useMemo<PickerEntry[]>(() => {
+    const known = readKnownWorkspaces();
+    const orgVaults = readOrgVaults();
+    const boundPaths = new Set(Object.values(orgVaults));
+    const remote: PickerEntry[] = known.map((w) => ({
+      kind: "remote",
+      key: `org:${w.id}`,
+      name: w.name,
+      path: orgVaults[w.id] ?? null,
+      orgId: w.id,
+    }));
+    const local: PickerEntry[] = recents
+      .filter((r) => !boundPaths.has(r.path))
+      .map((r) => ({
+        kind: "local",
+        key: r.path,
+        name: r.name,
+        path: r.path,
+        openedAt: r.openedAt,
+      }));
+    return [...remote, ...local];
+  }, [recents]);
+
   // Show the 3 most recent by default; the rest hide behind "Load more".
   const RECENT_LIMIT = 3;
-  const shownRecents = showAllRecents ? recents : recents.slice(0, RECENT_LIMIT);
-  const hiddenRecents = recents.length - RECENT_LIMIT;
+  const shownRecents = showAllRecents ? entries : entries.slice(0, RECENT_LIMIT);
+  const hiddenRecents = entries.length - RECENT_LIMIT;
 
   return (
     <div className="vault-picker">
@@ -396,7 +468,7 @@ export function VaultPicker() {
 
         {error && <p className="error">{error}</p>}
 
-        {!inFlow && recents.length > 0 && (
+        {!inFlow && entries.length > 0 && (
           <motion.div
             className="recent-list"
             initial={reduceMotion ? false : { opacity: 0, y: 8 }}
@@ -413,29 +485,35 @@ export function VaultPicker() {
                 showAllRecents && lockedHeight ? { height: lockedHeight } : undefined
               }
             >
-              {shownRecents.map((r) => (
-                <div className="recent-card" key={r.path}>
+              {shownRecents.map((e) => (
+                <div className="recent-card" key={e.key}>
                   <button
                     className="recent-open"
                     disabled={busy}
-                    onClick={() => reopen(r)}
-                    title={r.path}
+                    onClick={() => void openEntry(e)}
+                    title={e.path ?? e.name}
                   >
-                    <span className="recent-name">{r.name}</span>
-                    <span className="recent-path">{tidyPath(r.path)}</span>
-                    {r.openedAt > 0 && (
-                      <span className="recent-time">{relativeTime(r.openedAt)}</span>
-                    )}
+                    <span className="recent-name">{e.name}</span>
+                    {e.kind === "remote" ? (
+                      <span className="ws-badge synced recent-badge">Remote</span>
+                    ) : e.openedAt > 0 ? (
+                      <span className="recent-time">{relativeTime(e.openedAt)}</span>
+                    ) : null}
+                    <span className="recent-path">
+                      {e.path ? tidyPath(e.path) : "Synced · sign in to open"}
+                    </span>
                   </button>
-                  <button
-                    className="recent-remove"
-                    aria-label={`Remove ${r.name} from recents`}
-                    title="Remove from recents"
-                    disabled={busy}
-                    onClick={() => forget(r.path)}
-                  >
-                    ×
-                  </button>
+                  {e.kind === "local" && (
+                    <button
+                      className="recent-remove"
+                      aria-label={`Remove ${e.name} from recents`}
+                      title="Remove from recents"
+                      disabled={busy}
+                      onClick={() => forget(e.path)}
+                    >
+                      ×
+                    </button>
+                  )}
                 </div>
               ))}
             </div>
@@ -464,6 +542,20 @@ export function VaultPicker() {
           </motion.p>
         )}
       </div>
+
+      {signInOpen && (
+        <AuthDialog
+          // Success: keep the pending open target — the store's post-sign-in
+          // landing opens exactly that workspace. Just dismiss the modal.
+          onSignedIn={() => setSignInOpen(false)}
+          // Cancel: drop the pending target so a later sign-in from elsewhere
+          // doesn't surprise-open this workspace.
+          onClose={() => {
+            requestOpenWorkspace(null);
+            setSignInOpen(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -103,9 +103,13 @@ export interface RecentVault {
 }
 /** Recently opened vaults, newest first, pruned to those that still exist. */
 export const getRecentVaults = () => invoke<RecentVault[]>("get_recent_vaults");
-/** Forget one vault from the recents list. */
+/** Forget one vault from the recents list (files on disk are kept). */
 export const removeRecentVault = (path: string) =>
   invoke<void>("remove_recent_vault", { path });
+/** Move a local vault's folder (and all its notes) to the OS trash, then forget
+ *  it from recents. Destructive — the on-disk files are the only copy. */
+export const deleteVault = (path: string) =>
+  invoke<void>("delete_vault", { path });
 /** Create a new empty vault folder `<parent>/<name>` and open it. */
 export const createVault = (parent: string, name: string) =>
   invoke<VaultInfo>("create_vault", { parent, name });

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -66,6 +66,16 @@ export class SyncManager {
   private vaultEngine: VaultSyncEngine | null = null;
   private onVaultStatus?: (status: VaultSyncStatus) => void;
 
+  // The UI shows ONE connection indicator, but two things can drive it: the
+  // open note's provider (authoritative for that doc, incl. read-only grants)
+  // and the always-on vault channel (connects the instant a workspace opens,
+  // before any note). We track both and emit the effective status so switching
+  // workspaces lights up presence immediately — not only once a note is opened.
+  /** Latest per-note provider status; null when no networked note is open. */
+  private docStatus: SyncStatus | null = null;
+  /** Latest vault-channel status (the always-on background feed). */
+  private vaultStatus: VaultSyncStatus = "idle";
+
   // Vault-wide presence: which teammate is viewing which note. Keyed by userId
   // (last-write-wins across a user's devices), fed by the engine's presence
   // frames, surfaced to the sidebar. `viewingDocId` is our own current note.
@@ -73,9 +83,42 @@ export class SyncManager {
   private viewingDocId: string | null = null;
   private onVaultPresence?: (peers: VaultPeer[]) => void;
 
-  /** UI subscribes here to render the per-note sync indicator. */
+  /** UI subscribes here to render the connection indicator. */
   setStatusListener(cb: ((status: SyncStatus) => void) | undefined): void {
     this.onStatus = cb;
+  }
+
+  /** Map the vault channel's status onto the app-wide SyncStatus vocabulary.
+   *  The vault channel has no per-note "read-only" notion — that only applies
+   *  once a view-only note is open, and then the note's provider takes over. */
+  private vaultStatusAsSync(): SyncStatus {
+    switch (this.vaultStatus) {
+      case "synced":
+        return "synced";
+      case "connecting":
+        return "connecting";
+      case "no-access":
+        return "no-access";
+      case "error":
+        return "error";
+      default:
+        return "offline"; // "idle"
+    }
+  }
+
+  /** Push the effective status to the UI: an open networked note owns the
+   *  indicator; with none open we fall back to the always-on vault channel. */
+  private emitStatus(): void {
+    const effective = this.current
+      ? (this.docStatus ?? this.current.status)
+      : this.vaultStatusAsSync();
+    this.onStatus?.(effective);
+  }
+
+  /** Record the open note's provider status and re-emit the effective status. */
+  private handleDocStatus(s: SyncStatus): void {
+    this.docStatus = s;
+    this.emitStatus();
   }
 
   /**
@@ -170,9 +213,13 @@ export class SyncManager {
     this.presence = null;
     this.attachments = null;
     this.viewingDocId = null;
+    this.vaultStatus = "idle";
     this.clearVaultPresence();
     this.stopVaultEngine();
     this.closeCurrent();
+    // closeCurrent only emits when a note was open; make sure a note-less
+    // disable (e.g. switching to a local workspace) still drops to offline.
+    this.emitStatus();
   }
 
   /** UI subscribes here for the vault-wide background-sync indicator. */
@@ -228,6 +275,10 @@ export class SyncManager {
     const vaultId = this.registry.vaultId;
     if (!vaultId) return;
     this.stopVaultEngine();
+    // Reflect "connecting" the moment we switch into a workspace, so the light
+    // moves off a stale value before the socket reports back.
+    this.vaultStatus = "connecting";
+    if (!this.current) this.emitStatus();
     const store = new VaultDocStore({
       resolvePath: (docId) => this.registry.pathForDocId(docId),
     });
@@ -241,6 +292,8 @@ export class SyncManager {
         // clear it so the sidebar doesn't show ghosts (the engine re-announces
         // everyone on the next `synced`).
         if (s !== "synced") this.clearVaultPresence();
+        this.vaultStatus = s;
+        this.emitStatus();
         this.onVaultStatus?.(s);
       },
       // An ACL change in this vault may have flipped the open note's grant
@@ -321,11 +374,15 @@ export class SyncManager {
       doc: bridge.doc,
       docId: mapping.docId,
       vaultId: mapping.vaultId,
-      onStatus: this.onStatus,
+      onStatus: (s) => this.handleDocStatus(s),
       onPending: this.onPending,
       onFlushed: this.onFlushed,
     });
     this.current = sync;
+    // Take over the indicator from the vault channel right away with the
+    // provider's initial status (it fires again as the socket progresses).
+    this.docStatus = sync.status;
+    this.emitStatus();
 
     // INSTANT OPEN (spec 05 §1): we no longer BLOCK the editor on the initial
     // server sync. Vault-wide background sync has almost always already brought
@@ -369,6 +426,9 @@ export class SyncManager {
       // The closed note can't have outstanding local edits anymore — clear any
       // lingering "Saving…" so the next note starts clean.
       this.onPending?.(false);
+      // No note owns the indicator now — fall back to the vault channel.
+      this.docStatus = null;
+      this.emitStatus();
     }
     if (this.currentLocalAwareness) {
       this.currentLocalAwareness.destroy();

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -163,6 +163,15 @@ interface AppStore {
    *  synced workspace's sync context behind. Used by the switcher's local rows
    *  and "Open a folder…". */
   openLocalWorkspace: (path: string) => Promise<void>;
+  /** Forget a local workspace from this device's list. The folder and its `.md`
+   *  files stay on disk — it can be re-opened later. */
+  removeLocalWorkspace: (path: string) => Promise<void>;
+  /** Move a local workspace's folder (and all its notes) to the OS trash, then
+   *  forget it. Destructive — there's no server copy, the on-disk files are the
+   *  only copy. */
+  deleteLocalWorkspace: (path: string) => Promise<void>;
+  /** Detach from the open local folder and drop to the empty/welcome state. */
+  closeLocalWorkspace: () => void;
 
   // Resolving a workspace's local folder (when none is bound yet)
   /** Bind `path` to `orgId`, open it, and enable sync. */
@@ -262,6 +271,48 @@ function forgetOrgVault(orgId: string): void {
   }
 }
 
+// A locally-cached list of the workspaces (orgs) this account belongs to, so the
+// signed-out welcome screen can still list your *remote* workspaces (with the
+// folder to reopen + resync) instead of only local folders. Refreshed on every
+// refreshWorkspace and — deliberately — KEPT across sign-out (that's the whole
+// point: you can pick a synced workspace to sign back into).
+const KNOWN_WORKSPACES_KEY = "context.knownWorkspaces";
+
+export interface KnownWorkspace {
+  id: string;
+  name: string;
+}
+
+export function readKnownWorkspaces(): KnownWorkspace[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KNOWN_WORKSPACES_KEY) ?? "[]");
+    return Array.isArray(raw) ? (raw as KnownWorkspace[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeKnownWorkspaces(list: KnownWorkspace[]): void {
+  try {
+    localStorage.setItem(KNOWN_WORKSPACES_KEY, JSON.stringify(list));
+  } catch {
+    /* quota/unavailable — the cache is a convenience only */
+  }
+}
+
+// A workspace the user asked to open from the signed-out welcome screen but must
+// sign in for first. Consumed by landInLastWorkspace right after auth so we land
+// in exactly that workspace instead of the session's last-active one.
+let pendingOpenOrgId: string | null = null;
+export function requestOpenWorkspace(orgId: string | null): void {
+  pendingOpenOrgId = orgId;
+}
+function takePendingOpenWorkspace(): string | null {
+  const id = pendingOpenOrgId;
+  pendingOpenOrgId = null;
+  return id;
+}
+
 // The workspace the user was last actually working in (folder + org resolved
 // together). The server session carries an `activeOrganizationId`, but it can be
 // null (fresh session, 2+ orgs) and it doesn't know which *folder* to open — so
@@ -305,6 +356,14 @@ function forgetLastWorkspace(orgId?: string): void {
  */
 async function landInLastWorkspace(get: () => AppStore): Promise<void> {
   const orgs = get().organizations;
+  // An explicit "open this workspace" request (a remote workspace clicked on the
+  // signed-out welcome screen, which routed through sign-in) wins over every
+  // other heuristic — that's the workspace the user just asked for.
+  const requested = takePendingOpenWorkspace();
+  if (requested && orgs.some((o) => o.id === requested)) {
+    await get().setActiveOrganization(requested);
+    return;
+  }
   // The folder that's already open (App.tsx reopens the last one at launch) is
   // the strongest signal for "the workspace I was last in" — it unifies local
   // and synced workspaces under one recency signal.
@@ -694,6 +753,9 @@ export const useStore = create<AppStore>((set, get) => ({
         .then((invs) => invs.filter((i) => i.status === "pending"))
         .catch(() => []);
       set({ organizations, members, pendingInvitations, userInvitations });
+      // Cache the workspace list locally so the signed-out welcome screen can
+      // still offer them (kept across sign-out; refreshed here while signed in).
+      writeKnownWorkspaces(organizations.map((o) => ({ id: o.id, name: o.name })));
     } catch (e) {
       set({ authError: errMsg(e) });
     }
@@ -877,6 +939,41 @@ export const useStore = create<AppStore>((set, get) => ({
     await get().refreshTitles();
     // Give a brand-new empty folder its first-run welcome content.
     await get().seedLocalVaultIfEmpty();
+  },
+
+  removeLocalWorkspace: async (path) => {
+    // Forget it from this device's recents; the folder and its files stay on
+    // disk. If it's the one open now, close it and drop to the empty state —
+    // there's no server copy to fall back to, so we don't auto-switch elsewhere.
+    await ipc.removeRecentVault(path);
+    if (!get().syncEnabled && get().vault?.path === path) {
+      get().closeLocalWorkspace();
+    }
+  },
+
+  deleteLocalWorkspace: async (path) => {
+    // Tear down open state FIRST if this is the current folder, so nothing keeps
+    // reading from it while it's moved to the trash.
+    if (!get().syncEnabled && get().vault?.path === path) {
+      get().closeLocalWorkspace();
+    }
+    // Move the folder (and all its notes) to the OS trash; this also forgets it
+    // from recents. Destructive — the UI gates it behind a two-click confirm.
+    await ipc.deleteVault(path);
+  },
+
+  closeLocalWorkspace: () => {
+    // Detach from the open local folder and drop to the welcome/empty state.
+    syncManager.disable();
+    get().closeNote();
+    set({
+      vault: null,
+      locks: [],
+      syncEnabled: false,
+      syncStatus: "offline",
+      syncPending: false,
+      pendingWorkspaceFolder: null,
+    });
   },
 
   applyWorkspaceFolder: async (orgId, path) => {


### PR DESCRIPTION
## What & why

When signed out, the welcome screen (`VaultPicker`) listed only local recent folders — your synced workspaces disappeared because the org list is only fetched with a live session. This surfaces them again, tagged, and makes clicking one do the right thing.

## Changes

- **Cache workspaces locally** (`store.ts`): a `context.knownWorkspaces` cache, written on every `refreshWorkspace` and kept across sign-out, so the welcome screen knows your synced workspaces even when signed out. New `requestOpenWorkspace(orgId)` pending-open target, consumed first in `landInLastWorkspace`, so signing in from the picker lands you in exactly the workspace you clicked.
- **Welcome screen lists both** (`VaultPicker.tsx`): remote workspaces (tagged **Remote**, reusing the existing `ws-badge` styles) merged with local recents, deduped by folder path. Click behavior: local opens in place; remote opens + resyncs directly when still signed in, or prompts sign-in first (then lands in that workspace) when signed out.
- **`AuthDialog`** (`AccountMenu.tsx`): exported and given an optional `onSignedIn` so a successful sign-in is distinguishable from a cancel.
- **`App.tsx`**: the workspace-folder prompt now also renders on the picker branch, so switching into a synced workspace without a local folder yet asks for one instead of getting stuck.
- **Accurate connection indicator** (`docSession.ts`): the sync light is now driven by the always-on vault channel when no note is open (not only by the open note's provider), so it reflects connectivity the moment a workspace opens.
- **Delete a local workspace** (`commands.rs` / `ipc.ts`): a `delete_vault` command that moves a local workspace folder to the OS trash and forgets it from recents (gated behind a two-click confirm in the UI).

## Test plan

- Sign out → welcome screen shows synced workspaces tagged **Remote** alongside local recents.
- Click a Remote row while signed in → opens + resyncs, no login prompt.
- Sign out, click a Remote row → prompts sign-in, then lands in that workspace.
- Local rows open as before; the × still forgets a local recent.
- `npm run tauri dev` locally: sync indicator reflects vault-channel connectivity before opening a note.