### PR TITLE
Fix live-preview block widgets and selection visibility

### DIFF
--- a/app/apps/desktop/src/lib/editor/livePreview.ts
+++ b/app/apps/desktop/src/lib/editor/livePreview.ts
@@ -16,7 +16,8 @@
 // HtmlEmbedWidget) unless the cursor is inside them, in which case the source
 // shows for editing.
 
-import { syntaxTree } from "@codemirror/language";
+import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
+import { type EditorState, StateField } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
@@ -228,24 +229,106 @@ class TableWidget extends WidgetType {
 const bullet = Decoration.replace({ widget: new BulletWidget() });
 const hidden = Decoration.replace({});
 
-function buildDecorations(view: EditorView, resolveAsset: ResolveAsset): DecorationSet {
-  const { state } = view;
+/**
+ * Lines touched by any selection stay "raw" so the writer edits real markdown.
+ * Shared by the inline plugin and the block-widget field so both agree on what
+ * "being edited" means.
+ */
+function activeLineChecker(state: EditorState): (from: number, to: number) => boolean {
   const doc = state.doc;
-  const decos: ReturnType<Decoration["range"]>[] = [];
-
-  // Lines touched by any selection stay "raw" so the writer edits real markdown.
   const activeLines = new Set<number>();
   for (const r of state.selection.ranges) {
     const first = doc.lineAt(r.from).number;
     const last = doc.lineAt(r.to).number;
     for (let n = first; n <= last; n++) activeLines.add(n);
   }
-  const isActive = (from: number, to: number) => {
+  return (from: number, to: number) => {
     const first = doc.lineAt(from).number;
     const last = doc.lineAt(Math.max(from, to)).number;
     for (let n = first; n <= last; n++) if (activeLines.has(n)) return true;
     return false;
   };
+}
+
+/**
+ * Block-level widgets (raw HTML blocks, ```html fences, GFM tables). These use
+ * `Decoration.replace({block: true})` over multiple lines, which CodeMirror
+ * only accepts from a StateField — a view plugin providing them throws
+ * `RangeError: Block decorations may not be specified via plugins`. So they
+ * live here, computed over the whole document, while the inline marker work
+ * stays in the (viewport-scoped) plugin below.
+ */
+function buildBlockDecorations(state: EditorState, resolveAsset: ResolveAsset): DecorationSet {
+  const doc = state.doc;
+  const decos: ReturnType<Decoration["range"]>[] = [];
+  const isActive = activeLineChecker(state);
+
+  // Force-parse the whole doc if the background parse hasn't caught up yet —
+  // notes are small, and a partially-parsed tree would silently drop widgets.
+  const tree = ensureSyntaxTree(state, doc.length, 100) ?? syntaxTree(state);
+  tree.iterate({
+    enter: (node) => {
+      if (node.name === "HTMLBlock") {
+        if (!isActive(node.from, node.to)) {
+          const html = doc.sliceString(node.from, node.to);
+          decos.push(
+            Decoration.replace({
+              widget: new HtmlEmbedWidget(html, resolveAsset),
+              block: true,
+            }).range(node.from, node.to)
+          );
+        }
+        return false;
+      }
+
+      // A ```html fenced block → render its HTML as an inline preview (the
+      // same sanitized render as a bare HTML block). The fence is what a
+      // pasted HTML snippet lands in (see paste.ts): it survives blank lines
+      // inside the markup, and shows raw source for editing when the cursor
+      // is inside it.
+      if (node.name === "FencedCode") {
+        const info = node.node.getChild("CodeInfo");
+        const lang = info ? doc.sliceString(info.from, info.to).trim().toLowerCase() : "";
+        if ((lang === "html" || lang === "htm") && !isActive(node.from, node.to)) {
+          const codeNode = node.node.getChild("CodeText");
+          const html = codeNode ? doc.sliceString(codeNode.from, codeNode.to) : "";
+          if (html.trim()) {
+            decos.push(
+              Decoration.replace({
+                widget: new HtmlEmbedWidget(html, resolveAsset),
+                block: true,
+              }).range(node.from, node.to)
+            );
+          }
+        }
+        return false;
+      }
+
+      // GFM table → render as a real table off the active line.
+      if (node.name === "Table") {
+        if (!isActive(node.from, node.to)) {
+          const src = doc.sliceString(node.from, node.to);
+          decos.push(
+            Decoration.replace({
+              widget: new TableWidget(src),
+              block: true,
+            }).range(node.from, node.to)
+          );
+        }
+        return false;
+      }
+      return undefined;
+    },
+  });
+
+  return Decoration.set(decos, true);
+}
+
+function buildDecorations(view: EditorView, resolveAsset: ResolveAsset): DecorationSet {
+  const { state } = view;
+  const doc = state.doc;
+  const decos: ReturnType<Decoration["range"]>[] = [];
+  const isActive = activeLineChecker(state);
 
   // `[[wiki-links]]` are owned by the wikilinks plugin; never touch their marks.
   const wikiRanges: Array<[number, number]> = [];
@@ -268,58 +351,30 @@ function buildDecorations(view: EditorView, resolveAsset: ResolveAsset): Decorat
       from,
       to,
       enter: (node) => {
-        // Block HTML → render in place (unless being edited); skip its children.
+        // Block HTML is rendered by the block-widget StateField; never style
+        // its children here.
         if (node.name === "HTMLBlock") {
-          if (!isActive(node.from, node.to)) {
-            const html = doc.sliceString(node.from, node.to);
-            decos.push(
-              Decoration.replace({
-                widget: new HtmlEmbedWidget(html, resolveAsset),
-                block: true,
-              }).range(node.from, node.to)
-            );
-          }
           return false;
         }
 
-        // A ```html fenced block → render its HTML as an inline preview (the
-        // same sanitized render as a bare HTML block). The fence is what a
-        // pasted HTML snippet lands in (see paste.ts): it survives blank lines
-        // inside the markup, and shows raw source for editing when the cursor
-        // is inside it.
+        // A non-active ```html fence is replaced by the StateField; skip its
+        // children. Non-HTML fences (and the active HTML fence) keep their raw
+        // source.
         if (node.name === "FencedCode") {
           const info = node.node.getChild("CodeInfo");
           const lang = info
             ? doc.sliceString(info.from, info.to).trim().toLowerCase()
             : "";
           if ((lang === "html" || lang === "htm") && !isActive(node.from, node.to)) {
-            const codeNode = node.node.getChild("CodeText");
-            const html = codeNode ? doc.sliceString(codeNode.from, codeNode.to) : "";
-            if (html.trim()) {
-              decos.push(
-                Decoration.replace({
-                  widget: new HtmlEmbedWidget(html, resolveAsset),
-                  block: true,
-                }).range(node.from, node.to)
-              );
-            }
             return false;
           }
-          // Non-HTML fences (and the active HTML fence) keep their raw source.
           return;
         }
 
-        // GFM table → render as a real table off the active line; show the raw
-        // pipe source (and descend for inline styling) while it's being edited.
+        // A non-active table is replaced by the StateField; skip its children.
+        // While it's being edited, descend so its text keeps inline styling.
         if (node.name === "Table") {
           if (!isActive(node.from, node.to)) {
-            const src = doc.sliceString(node.from, node.to);
-            decos.push(
-              Decoration.replace({
-                widget: new TableWidget(src),
-                block: true,
-              }).range(node.from, node.to)
-            );
             return false;
           }
           return;
@@ -408,10 +463,24 @@ function buildDecorations(view: EditorView, resolveAsset: ResolveAsset): Decorat
   return Decoration.set(decos, true);
 }
 
-/** The live-preview view plugin: rebuild on edits, scroll, and cursor moves. */
+/**
+ * Live preview = two cooperating extensions:
+ *  - a StateField for the block widgets (HTML blocks, ```html fences, tables) —
+ *    the only place CodeMirror accepts block/multi-line replace decorations;
+ *  - a view plugin for the inline marker work, rebuilt on edits, scroll, and
+ *    cursor moves.
+ */
 export function livePreview(opts: { resolveAsset?: ResolveAsset } = {}) {
   const resolveAsset = opts.resolveAsset ?? identityAsset;
-  return ViewPlugin.fromClass(
+
+  const blockWidgets = StateField.define<DecorationSet>({
+    create: (state) => buildBlockDecorations(state, resolveAsset),
+    update: (deco, tr) =>
+      tr.docChanged || tr.selection ? buildBlockDecorations(tr.state, resolveAsset) : deco,
+    provide: (f) => EditorView.decorations.from(f),
+  });
+
+  const inlinePlugin = ViewPlugin.fromClass(
     class {
       decorations: DecorationSet;
       constructor(view: EditorView) {
@@ -437,4 +506,6 @@ export function livePreview(opts: { resolveAsset?: ResolveAsset } = {}) {
       },
     }
   );
+
+  return [blockWidgets, inlinePlugin];
 }

--- a/app/apps/desktop/src/lib/editor/livePreviewBlocks.test.ts
+++ b/app/apps/desktop/src/lib/editor/livePreviewBlocks.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// Regression: block-level live-preview widgets (raw HTML blocks, ```html
+// fences, GFM tables) must come from a StateField — CodeMirror rejects
+// block/multi-line replace decorations provided by a view plugin with
+// `RangeError: Block decorations may not be specified via plugins`, which used
+// to kill the whole HTML-preview feature at runtime. This exercises the real
+// editor extension stack, not just the parser.
+import { EditorView } from "@codemirror/view";
+import { describe, expect, it } from "vitest";
+import { createEditorState } from "./index";
+
+function mount(doc: string): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  return new EditorView({
+    state: createEditorState({
+      doc,
+      getTitles: () => [],
+      onNavigate: () => {},
+    } as never),
+    parent,
+  });
+}
+
+describe("livePreview block widgets (real EditorView)", () => {
+  it("renders a ```html fence as a sanitized HTML preview", () => {
+    const view = mount(
+      [
+        "Intro paragraph.",
+        "",
+        "```html",
+        "<!DOCTYPE html>",
+        '<html lang="en">',
+        "<head>",
+        '    <meta charset="UTF-8">',
+        "    <title>My Web Page</title>",
+        "</head>",
+        "<body>",
+        "",
+        "    <h1>Hello, World!</h1>",
+        "",
+        "</body>",
+        "</html>",
+        "```",
+        "",
+        "## Start here",
+      ].join("\n")
+    );
+    const widget = view.dom.querySelector(".cm-md-html");
+    expect(widget).not.toBeNull();
+    expect(widget!.querySelector("h1")?.textContent).toBe("Hello, World!");
+    view.destroy();
+  });
+
+  it("renders a bare HTML block as a preview", () => {
+    const view = mount(["Before.", "", '<div class="card"><h2>Boxed</h2></div>', "", "After."].join("\n"));
+    const widget = view.dom.querySelector(".cm-md-html");
+    expect(widget).not.toBeNull();
+    expect(widget!.querySelector("h2")?.textContent).toBe("Boxed");
+    view.destroy();
+  });
+
+  it("renders a GFM table as a real <table>", () => {
+    const view = mount(["Intro.", "", "| a | b |", "| --- | --- |", "| 1 | 2 |", "", "tail"].join("\n"));
+    const table = view.dom.querySelector(".cm-md-table table");
+    expect(table).not.toBeNull();
+    expect(table!.querySelectorAll("th")).toHaveLength(2);
+    view.destroy();
+  });
+
+  it("shows raw fence source while the cursor is inside it", () => {
+    const doc = ["```html", "<h1>Hi</h1>", "```"].join("\n");
+    const view = mount(doc);
+    view.dispatch({ selection: { anchor: doc.indexOf("<h1>") } });
+    expect(view.dom.querySelector(".cm-md-html")).toBeNull();
+    view.destroy();
+  });
+});

--- a/app/apps/desktop/src/lib/editor/theme.ts
+++ b/app/apps/desktop/src/lib/editor/theme.ts
@@ -59,6 +59,18 @@ export const editorTheme = EditorView.theme({
     {
       backgroundColor: "color-mix(in srgb, var(--accent) 28%, transparent)",
     },
+  // drawSelection() paints in a layer BEHIND the content, so opaque line
+  // backgrounds (the .cm-codeblock well, rendered tables) swallow the wash —
+  // selecting inside a code block showed nothing while the layer's full-width
+  // rectangles bled into the margins around the well. Lift the layer above the
+  // content and blend it so the wash tints every background and text stays
+  // readable (multiply darkens on light; dark theme flips to screen via
+  // --selection-blend in tokens.css).
+  ".cm-selectionLayer": {
+    zIndex: "1",
+    pointerEvents: "none",
+    mixBlendMode: "var(--selection-blend, multiply)",
+  },
 
   // Search / highlight matches in soft warning.
   ".cm-searchMatch": {

--- a/app/apps/desktop/src/styles/tokens.css
+++ b/app/apps/desktop/src/styles/tokens.css
@@ -100,6 +100,10 @@
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   --t-fast: 120ms;
   --t-med: 200ms;
+
+  /* How the editor's selection layer blends over content (see theme.ts
+     .cm-selectionLayer): darken on light, lighten on dark. */
+  --selection-blend: multiply;
 }
 
 /* ---- Dark theme tokens (shared by explicit toggle + system fallback) ---- */
@@ -134,6 +138,8 @@
   --border: rgba(255, 255, 255, 0.09);
   --border-strong: rgba(255, 255, 255, 0.18);
   --focus-ring: 0 0 0 3px rgba(143, 132, 255, 0.40);
+
+  --selection-blend: screen;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
   --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
@@ -171,6 +177,8 @@
     --border: rgba(255, 255, 255, 0.09);
     --border-strong: rgba(255, 255, 255, 0.18);
     --focus-ring: 0 0 0 3px rgba(143, 132, 255, 0.40);
+
+    --selection-blend: screen;
 
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
     --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);


### PR DESCRIPTION
Two editor fixes:

## Block-preview widgets never rendered
CodeMirror rejects `block: true` (and multi-line replace) decorations supplied by a view plugin — it throws `RangeError: Block decorations may not be specified via plugins`. The `livePreview` view plugin built its raw-HTML-block, ```html-fence, and GFM-table widgets exactly that way, so the whole block-preview family silently never worked.

`livePreview()` now returns two cooperating extensions: a `StateField` that owns the three block widgets (the one place CodeMirror accepts block decorations; it force-parses the document so widgets don't drop on a partially-parsed tree) and the existing view plugin for inline marker work, which now skips ranges the field replaces. Cursor-inside-shows-raw-source is shared via one `activeLineChecker`.

New regression suite `livePreviewBlocks.test.ts` mounts a real `EditorView` and asserts all three widget kinds render, plus raw source while the cursor is inside.

## Selection invisible inside code blocks
`drawSelection()` paints in a layer behind the content, so the opaque `.cm-codeblock` well swallowed the selection wash — selecting inside a code block showed nothing while the layer's full-width rectangles bled into the margins around the well. The selection layer is now lifted above the content (`z-index: 1`, `pointer-events: none`) with a theme-aware blend: `multiply` on light, `screen` on dark (new `--selection-blend` token in `tokens.css`), so the wash tints every background and text stays readable.

Tests: desktop 165/165, tsc clean.