### PR TITLE
Fix Vaults tab actions stacking

### DIFF
--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -3404,7 +3404,7 @@ button.primary.hero:hover:not(:disabled) {
   flex-shrink: 0;
   white-space: nowrap;
 }
-.vault-actions {
+.vault-tab-actions {
   gap: var(--sp-4);
   margin-top: var(--sp-2);
 }

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1612,7 +1612,7 @@ function VaultsTab() {
         })}
       </ul>
 
-      <div className="row vault-actions">
+      <div className="row vault-tab-actions">
         {creating ? (
           <div className="menu-create-org">
             <input


### PR DESCRIPTION
The workspace→vault rename collapsed the settings dialog's `.workspace-actions` class into the VaultPicker's pre-existing `.vault-actions`, which sets `flex-direction: column` — so "+ New vault" and "# Join with code" in the Vaults tab rendered stacked instead of inline. The settings row now has its own `.vault-tab-actions` class.

Swept the other renamed CSS classes (`vault-list`, `vault-popover`, `vault-folder-*`, `vault-row-actions`, `vault-root-path`) for the same collision pattern — none existed pre-rename, so this was the only one.