### PR TITLE
Merge sidebar collapse/expand into one animated fold toggle

### DIFF
--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -855,6 +855,33 @@ button.primary.hero:hover:not(:disabled) {
   width: 16px;
   height: 16px;
 }
+/* The fold toggle holds both icons stacked; the inactive one fades + spins
+   away so a click reads as the button flipping into its opposite. */
+.filetree-actions .tree-fold-toggle {
+  position: relative;
+}
+.tree-fold-toggle .fold-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    opacity var(--t-med) var(--ease),
+    transform var(--t-med) var(--ease);
+}
+.tree-fold-toggle .fold-expand {
+  opacity: 0;
+  transform: scale(0.5) rotate(90deg);
+}
+.tree-fold-toggle.collapsed .fold-collapse {
+  opacity: 0;
+  transform: scale(0.5) rotate(-90deg);
+}
+.tree-fold-toggle.collapsed .fold-expand {
+  opacity: 1;
+  transform: none;
+}
 /* Hairline splitting the "create" pair from the "fold/unfold" pair. */
 .filetree-actions .tool-divider {
   width: 1px;

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -148,6 +148,8 @@ export function FileTree() {
   const treeRef = useRef<TreeApi<TreeNode> | null>(null);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [shareTarget, setShareTarget] = useState<ShareTarget | null>(null);
+  // Which way the fold toggle points: false → "collapse all", true → "expand all".
+  const [treeCollapsed, setTreeCollapsed] = useState(false);
   // True while an OS drag hovers the tree, for the drop-target highlight.
   const [dropActive, setDropActive] = useState(false);
   // Transient status pill shown after an import (from the menu or a drop).
@@ -728,21 +730,24 @@ export function FileTree() {
             {ICON_NEW_FOLDER}
           </button>
           <span className="tool-divider" aria-hidden="true" />
+          {/* One fold toggle instead of a collapse/expand pair: each click runs
+              the shown action and cross-fades to its opposite. */}
           <button
-            className="tree-tool"
-            title="Collapse all folders"
-            aria-label="Collapse all folders"
-            onClick={() => treeRef.current?.closeAll()}
+            className={`tree-tool tree-fold-toggle${treeCollapsed ? " collapsed" : ""}`}
+            title={treeCollapsed ? "Expand all folders" : "Collapse all folders"}
+            aria-label={treeCollapsed ? "Expand all folders" : "Collapse all folders"}
+            onClick={() => {
+              if (treeCollapsed) treeRef.current?.openAll();
+              else treeRef.current?.closeAll();
+              setTreeCollapsed(!treeCollapsed);
+            }}
           >
-            {ICON_COLLAPSE_ALL}
-          </button>
-          <button
-            className="tree-tool"
-            title="Expand all folders"
-            aria-label="Expand all folders"
-            onClick={() => treeRef.current?.openAll()}
-          >
-            {ICON_EXPAND_ALL}
+            <span className="fold-icon fold-collapse" aria-hidden="true">
+              {ICON_COLLAPSE_ALL}
+            </span>
+            <span className="fold-icon fold-expand" aria-hidden="true">
+              {ICON_EXPAND_ALL}
+            </span>
           </button>
           <span className="tool-divider" aria-hidden="true" />
           <button


### PR DESCRIPTION
The NOTES header had separate collapse-all and expand-all buttons. They're now a single toggle: clicking runs the shown action (collapse or expand all folders) and cross-fades — opacity + a small rotation — into its opposite. Tooltip/aria-label follow the state.