### PR TITLE
Fix stale npm-era vite path in relaunch skill pgrep check

### DIFF
--- a/.claude/skills/relaunch/SKILL.md
+++ b/.claude/skills/relaunch/SKILL.md
@@ -31,7 +31,7 @@ pkill -f "tsx.*src/index.ts"           # the Node/tsx server
 pkill -f "apps/server"                 # server pnpm wrapper
 sleep 1
 # Confirm nothing survived:
-pgrep -fl "tauri dev|node_modules/.bin/vite|target/debug/desktop|tsx.*src/index.ts" || echo "all stopped"
+pgrep -fl "tauri dev|node_modules/.*vite.*bin|target/debug/desktop|tsx.*src/index.ts" || echo "all stopped"
 ```
 
 If `pgrep` still lists survivors, `kill -9` them by PID.


### PR DESCRIPTION
The relaunch skill's kill-confirmation pgrep still matched the old npm bin path (node_modules/.bin/vite). Under pnpm, vite runs via a resolved bin path, so the check could report vite as stopped while it was still running. Aligns the pgrep pattern with the pkill pattern above it.