### PR TITLE
Fix Railway preDeployCommand format

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "app/apps/server/Dockerfile"
   },
   "deploy": {
-    "preDeployCommand": ["node", "dist/db/migrate.js"],
+    "preDeployCommand": ["node dist/db/migrate.js"],
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
The pnpm migration changed preDeployCommand to ["node", "dist/db/migrate.js"], but Railway treats each array element as a separate shell command (their docs example is a single element containing the whole command). Railway ran bare node, then tried to execute dist/db/migrate.js as its own command, failing the pre-deploy step before the container started — that's the failed deployment on main. The Docker build itself succeeded. Rejoined into one element.