### PR TITLE
Security hardening: authorization, secrets, and input limits

### DIFF
--- a/app/apps/desktop/src-tauri/src/attachments.rs
+++ b/app/apps/desktop/src-tauri/src/attachments.rs
@@ -38,9 +38,34 @@ pub fn read_binary_file(vault: &Path, rel: &str) -> AppResult<Vec<u8>> {
     Ok(std::fs::read(&abs)?)
 }
 
+/// A binary write may only target the `attachments/` subtree — never a note
+/// path, the hidden `.context/` store, or any ignored/dotfile segment.
+/// Server-supplied blob `rel_path`s flow into `write_binary_file`, so this
+/// bounds an attacker-chosen path. Defence in depth behind the TS
+/// `isSafeAttachmentRelPath` download filter and `resolve_in_vault`'s traversal
+/// check.
+fn ensure_attachment_rel(rel: &str) -> AppResult<()> {
+    let mut segs = rel.split('/');
+    if segs.next() != Some("attachments") {
+        return Err(AppError::new("attachment path must be under attachments/"));
+    }
+    let mut named = false;
+    for seg in segs {
+        named = true;
+        if seg.is_empty() || seg == "." || seg == ".." || is_ignored_name(seg) {
+            return Err(AppError::new("invalid attachment path segment"));
+        }
+    }
+    if !named {
+        return Err(AppError::new("attachment path must name a file"));
+    }
+    Ok(())
+}
+
 /// Atomic write of raw bytes: temp file in the same dir, then rename over the
 /// target so readers never observe a half-written file. Creates parent dirs.
 pub fn write_binary_file(vault: &Path, rel: &str, bytes: &[u8]) -> AppResult<()> {
+    ensure_attachment_rel(rel)?;
     let abs = resolve_in_vault(vault, rel)?;
     let parent = abs
         .parent()
@@ -138,6 +163,21 @@ mod tests {
         assert!(write_binary_file(tmp.path(), "../escape.bin", &[1]).is_err());
         assert!(read_binary_file(tmp.path(), "../../etc/passwd").is_err());
         assert!(write_binary_file(tmp.path(), "attachments/../../x.bin", &[1]).is_err());
+    }
+
+    #[test]
+    fn write_confined_to_attachments_subtree() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A server-supplied rel_path targeting a note or the hidden .context
+        // store must be refused even though it does not escape the vault.
+        assert!(write_binary_file(tmp.path(), ".context/index.sqlite", &[1]).is_err());
+        assert!(write_binary_file(tmp.path(), "Team Plans.md", &[1]).is_err());
+        assert!(write_binary_file(tmp.path(), "attachments/.context/x", &[1]).is_err());
+        assert!(write_binary_file(tmp.path(), "attachments/.hidden", &[1]).is_err());
+        assert!(write_binary_file(tmp.path(), "attachments", &[1]).is_err());
+        // Legitimate attachment paths still work.
+        assert!(write_binary_file(tmp.path(), "attachments/ok.png", &[1]).is_ok());
+        assert!(write_binary_file(tmp.path(), "attachments/sub/ok.pdf", &[1]).is_ok());
     }
 
     #[test]

--- a/app/apps/desktop/src-tauri/src/oauth.rs
+++ b/app/apps/desktop/src-tauri/src/oauth.rs
@@ -17,11 +17,13 @@
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
+use serde::Serialize;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::{Duration, Instant};
 use tauri::State;
+use uuid::Uuid;
 
 /// Ok(code) on a successful redirect, Err(message) on an OAuth error or a
 /// malformed/absent redirect.
@@ -30,16 +32,34 @@ pub type OauthResult = Result<String, String>;
 /// How long the browser flow may take before we give up waiting.
 const FLOW_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// Returned by `google_oauth_listen`: the loopback port plus a single-use
+/// `state` nonce the caller must embed in the callback URL. The redirect the
+/// browser lands on must echo this exact value or the callback is rejected —
+/// this is what stops a co-resident local process from injecting its own
+/// authorization code (login CSRF) by racing to the ephemeral port.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OauthListen {
+    pub port: u16,
+    pub state: String,
+}
+
 /// Bind a loopback listener and start waiting for the OAuth redirect in the
-/// background. Returns the chosen port for the caller to build the callback URL.
+/// background. Returns the chosen port + the `state` nonce the caller must put
+/// in the callback URL (see {@link OauthListen}).
 #[tauri::command]
-pub fn google_oauth_listen(state: State<AppState>) -> AppResult<u16> {
+pub fn google_oauth_listen(state: State<AppState>) -> AppResult<OauthListen> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .map_err(|e| AppError::new(format!("oauth: bind loopback: {e}")))?;
     let port = listener
         .local_addr()
         .map_err(|e| AppError::new(format!("oauth: local addr: {e}")))?
         .port();
+
+    // High-entropy single-use nonce (122 random bits) — unguessable, so a local
+    // attacker cannot forge a matching callback.
+    let nonce = Uuid::new_v4().to_string();
+    let expected = nonce.clone();
 
     let (tx, rx) = mpsc::channel::<OauthResult>();
     *state
@@ -59,7 +79,7 @@ pub fn google_oauth_listen(state: State<AppState>) -> AppResult<u16> {
             match listener.accept() {
                 Ok((stream, _)) => {
                     let _ = stream.set_nonblocking(false);
-                    let _ = tx.send(handle_connection(stream));
+                    let _ = tx.send(handle_connection(stream, &expected));
                     return;
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -77,7 +97,7 @@ pub fn google_oauth_listen(state: State<AppState>) -> AppResult<u16> {
         }
     });
 
-    Ok(port)
+    Ok(OauthListen { port, state: nonce })
 }
 
 /// Wait for the redirect and return the one-time code. Errors if the flow
@@ -174,9 +194,15 @@ fn render_page(ok: bool, title: &str, body: &str) -> String {
     )
 }
 
-/// Read the request line, extract `code`/`error` from the query, and reply with
-/// a small "you can close this" page.
-fn handle_connection(mut stream: std::net::TcpStream) -> OauthResult {
+/// Read the request line, extract `code`/`error`/`state` from the query,
+/// verify the `state` matches the nonce this sign-in was started with, and
+/// reply with a small "you can close this" page.
+///
+/// The `state` check is the CSRF guard: only the callback carrying our
+/// single-use nonce is trusted. A local process that races to the loopback
+/// port with its own `?code=` (and no/foreign `state`) is refused, so it cannot
+/// sign the user into the attacker's account.
+fn handle_connection(mut stream: std::net::TcpStream, expected_state: &str) -> OauthResult {
     let mut reader = BufReader::new(
         stream
             .try_clone()
@@ -187,18 +213,39 @@ fn handle_connection(mut stream: std::net::TcpStream) -> OauthResult {
         .read_line(&mut request_line)
         .map_err(|e| format!("read request: {e}"))?;
 
-    // "GET /cb?code=… HTTP/1.1"
+    // "GET /cb?code=…&state=… HTTP/1.1"
     let target = request_line.split_whitespace().nth(1).unwrap_or("");
     let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
 
     let mut code: Option<String> = None;
     let mut error: Option<String> = None;
+    let mut state: Option<String> = None;
     for pair in query.split('&') {
         match pair.split_once('=') {
             Some(("code", v)) => code = Some(v.to_string()),
             Some(("error", v)) => error = Some(v.to_string()),
+            Some(("state", v)) => state = Some(v.to_string()),
             _ => {}
         }
+    }
+
+    // Reject any callback whose state does not match the nonce we issued —
+    // before trusting its code. Constant work either way; the nonce is a UUIDv4.
+    if state.as_deref() != Some(expected_state) {
+        let html = render_page(
+            false,
+            "Sign-in failed",
+            "That didn't go through. Close this tab and try again from the app.",
+        );
+        let response = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html; charset=utf-8\r\n\
+             Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+            html.len(),
+            html
+        );
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+        return Err("unexpected sign-in callback (state mismatch)".to_string());
     }
 
     let (ok, title, body, result) = match (&code, &error) {
@@ -241,20 +288,25 @@ mod tests {
     use std::io::Read;
     use std::net::TcpStream;
 
-    /// Drive a full listen → browser-redirect → await cycle over a real socket.
-    #[test]
-    fn round_trips_the_code() {
+    /// Serve one connection with a fixed expected nonce, returning the result.
+    fn serve_once(expected: &'static str) -> (u16, mpsc::Receiver<OauthResult>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let (tx, rx) = mpsc::channel::<OauthResult>();
         std::thread::spawn(move || {
             let (stream, _) = listener.accept().unwrap();
-            let _ = tx.send(handle_connection(stream));
+            let _ = tx.send(handle_connection(stream, expected));
         });
+        (port, rx)
+    }
 
+    /// Drive a full listen → browser-redirect → await cycle over a real socket.
+    #[test]
+    fn round_trips_the_code() {
+        let (port, rx) = serve_once("nonce-1");
         let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
         stream
-            .write_all(b"GET /cb?code=abc123&scope=email HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET /cb?code=abc123&state=nonce-1&scope=email HTTP/1.1\r\nHost: localhost\r\n\r\n")
             .unwrap();
         // Drain the response so the server-side write doesn't error.
         let mut buf = String::new();
@@ -266,17 +318,10 @@ mod tests {
 
     #[test]
     fn surfaces_oauth_error() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let (tx, rx) = mpsc::channel::<OauthResult>();
-        std::thread::spawn(move || {
-            let (stream, _) = listener.accept().unwrap();
-            let _ = tx.send(handle_connection(stream));
-        });
-
+        let (port, rx) = serve_once("nonce-1");
         let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
         stream
-            .write_all(b"GET /cb?error=access_denied HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET /cb?error=access_denied&state=nonce-1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
             .unwrap();
         let mut buf = String::new();
         let _ = stream.read_to_string(&mut buf);
@@ -285,5 +330,34 @@ mod tests {
             rx.recv_timeout(Duration::from_secs(2)).unwrap(),
             Err("access_denied".into())
         );
+    }
+
+    #[test]
+    fn rejects_callback_with_wrong_state() {
+        // An attacker racing the loopback with their own code but no/foreign
+        // state must be refused — the code is never surfaced.
+        let (port, rx) = serve_once("real-nonce");
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .write_all(b"GET /cb?code=attacker_code&state=guessed HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+        let mut buf = String::new();
+        let _ = stream.read_to_string(&mut buf);
+
+        assert!(matches!(rx.recv_timeout(Duration::from_secs(2)).unwrap(), Err(_)));
+        assert!(!buf.contains("Signed in"));
+    }
+
+    #[test]
+    fn rejects_callback_with_no_state() {
+        let (port, rx) = serve_once("real-nonce");
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .write_all(b"GET /cb?code=attacker_code HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+        let mut buf = String::new();
+        let _ = stream.read_to_string(&mut buf);
+
+        assert!(matches!(rx.recv_timeout(Duration::from_secs(2)).unwrap(), Err(_)));
     }
 }

--- a/app/apps/desktop/src-tauri/src/parse.rs
+++ b/app/apps/desktop/src-tauri/src/parse.rs
@@ -68,9 +68,29 @@ fn split_frontmatter(content: &str) -> (Option<&str>, &str) {
     (None, content)
 }
 
+/// Frontmatter above this size is ignored — real metadata is tiny, and a large
+/// blob is either junk or an attack. Bounds the bytes serde_yaml ever sees.
+const MAX_FRONTMATTER_BYTES: usize = 64 * 1024;
+/// Max YAML anchor/alias sigils (`&`/`*`) tolerated before we refuse to parse.
+/// serde_yaml (unsafe-libyaml) materializes every alias into an owned Value
+/// with no expansion limit, so nested anchors/aliases are a billion-laughs DoS
+/// (a few KB → billions of nodes → OOM/crash). Legitimate frontmatter uses no
+/// anchors, so a small cap here defeats the bomb while leaving real notes
+/// untouched; even at the cap, alias doubling stays bounded to a few thousand
+/// nodes.
+const MAX_FRONTMATTER_SIGILS: usize = 32;
+
 /// Convert parsed YAML frontmatter into a compact JSON string.
 fn frontmatter_to_json(yaml: &str) -> Option<(String, serde_json::Value)> {
     if yaml.trim().is_empty() {
+        return None;
+    }
+    // Guard against YAML alias bombs before deserializing (see the consts).
+    if yaml.len() > MAX_FRONTMATTER_BYTES {
+        return None;
+    }
+    let sigils = yaml.bytes().filter(|&b| b == b'&' || b == b'*').count();
+    if sigils > MAX_FRONTMATTER_SIGILS {
         return None;
     }
     match serde_yaml::from_str::<serde_json::Value>(yaml) {
@@ -234,5 +254,24 @@ mod tests {
         let p = parse_note("---\ntags: one two three\n---\nbody", "s");
         assert!(p.tags.contains(&"one".to_string()));
         assert!(p.tags.contains(&"three".to_string()));
+    }
+
+    #[test]
+    fn yaml_alias_bomb_is_refused_not_expanded() {
+        // A billion-laughs frontmatter must be skipped (returns quickly, no
+        // frontmatter, no OOM) rather than deserialized. Nested anchor/alias
+        // chains push the sigil count over the cap, so parsing is refused.
+        let anchors = ['a', 'b', 'c', 'd', 'e', 'f'];
+        let mut yaml = String::from("a: &a [x,x,x,x,x,x,x,x,x,x]\n");
+        for w in anchors.windows(2) {
+            let (prev, cur) = (w[0], w[1]);
+            let refs = vec![format!("*{prev}"); 10].join(",");
+            yaml.push_str(&format!("{cur}: &{cur} [{refs}]\n"));
+        }
+        let content = format!("---\n{yaml}---\nbody");
+        let p = parse_note(&content, "s");
+        // Refused: no frontmatter materialized, body still intact.
+        assert!(p.frontmatter_json.is_none());
+        assert_eq!(p.body.trim(), "body");
     }
 }

--- a/app/apps/desktop/src/lib/auth/__tests__/authManager.test.ts
+++ b/app/apps/desktop/src/lib/auth/__tests__/authManager.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 // `@tauri-apps/api` (unavailable in the Node test env). These fakes stand in for
 // the Rust loopback + keychain + browser-opener.
 vi.mock("../../ipc", () => ({
-  googleOauthListen: vi.fn(async () => 5123),
+  googleOauthListen: vi.fn(async () => ({ port: 5123, state: "test-nonce" })),
   googleOauthAwait: vi.fn(async () => "code-xyz"),
   openExternal: vi.fn(async () => {}),
   keychainSet: vi.fn(async () => {}),
@@ -44,6 +44,12 @@ describe("AuthManager.signInWithGoogle", () => {
     expect(api.socialSignInUrl).toHaveBeenCalledWith(
       "google",
       expect.stringContaining("127.0.0.1%3A5123%2Fcb"),
+    );
+    // …and carries the listener's CSRF state nonce (URL-encoded in the nested
+    // redirect), so a foreign callback is rejected by the Rust listener.
+    expect(api.socialSignInUrl).toHaveBeenCalledWith(
+      "google",
+      expect.stringContaining("state%3Dtest-nonce"),
     );
     // The authorize URL is opened in the system browser.
     expect(ipc.openExternal).toHaveBeenCalledWith("https://accounts.google.com/authorize?x=1");

--- a/app/apps/desktop/src/lib/auth/authManager.ts
+++ b/app/apps/desktop/src/lib/auth/authManager.ts
@@ -97,8 +97,12 @@ export class AuthManager {
    * like an email/password sign-in.
    */
   async signInWithGoogle(): Promise<AuthUser> {
-    const port = await ipc.googleOauthListen();
-    const redirect = `http://127.0.0.1:${port}/cb`;
+    const { port, state } = await ipc.googleOauthListen();
+    // Embed the loopback listener's single-use nonce in the callback URL. The
+    // server's `finish` only sets `code`/`error`, so this `state` survives the
+    // round-trip and the Rust listener rejects any callback that doesn't echo
+    // it — blocking a local process from injecting its own auth code.
+    const redirect = `http://127.0.0.1:${port}/cb?state=${encodeURIComponent(state)}`;
     const callbackURL = `${this.serverUrl}/api/desktop-auth/finish?redirect=${encodeURIComponent(
       redirect,
     )}`;

--- a/app/apps/desktop/src/lib/editor/livePreview.ts
+++ b/app/apps/desktop/src/lib/editor/livePreview.ts
@@ -69,20 +69,37 @@ const BLOCKED_HTML_TAGS = new Set([
  * whole app away). `DOMParser` splits head/body even for a full-document paste,
  * so `<!DOCTYPE html>…<body>…` renders just its body content.
  */
+/**
+ * Is a URL attribute value dangerous to keep? Browsers ignore ASCII whitespace
+ * and control chars inside a scheme, so `java\tscript:` executes — strip those
+ * before checking, then block script-y schemes and non-image `data:` (which can
+ * carry `data:text/html`). A tab/newline no longer defeats the check.
+ */
+function isDangerousUrl(raw: string): boolean {
+  const v = raw.replace(/[\u0000-\u0020]+/g, "").toLowerCase();
+  if (v.startsWith("data:")) return !v.startsWith("data:image/");
+  return v.startsWith("javascript:") || v.startsWith("vbscript:");
+}
+
 function renderEmbeddedHtml(target: HTMLElement, html: string, resolveAsset: ResolveAsset) {
   const parsed = new DOMParser().parseFromString(html, "text/html");
   parsed.querySelectorAll("*").forEach((el) => {
-    if (BLOCKED_HTML_TAGS.has(el.tagName)) {
+    // Uppercase so a foreign-content (SVG/MathML) <script> — whose tagName is
+    // lowercase — is caught by the same blocklist as an HTML one.
+    if (BLOCKED_HTML_TAGS.has(el.tagName.toUpperCase())) {
       el.remove();
       return;
     }
     for (const attr of Array.from(el.attributes)) {
       const name = attr.name.toLowerCase();
-      const value = attr.value.trim().toLowerCase();
       const isUrlAttr = name === "href" || name === "src" || name === "xlink:href";
       if (name.startsWith("on")) {
+        // Inline event handlers.
         el.removeAttribute(attr.name);
-      } else if (isUrlAttr && value.startsWith("javascript:")) {
+      } else if (name === "style") {
+        // Inline styles enable full-screen fixed overlays / UI spoofing.
+        el.removeAttribute(attr.name);
+      } else if (isUrlAttr && isDangerousUrl(attr.value)) {
         el.removeAttribute(attr.name);
       }
     }

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -226,7 +226,12 @@ export const keychainDelete = (serviceKey: string) =>
 // (so the caller can build the callback URL); `await` blocks until the redirect
 // lands and resolves with the one-time handoff code.
 
-export const googleOauthListen = () => invoke<number>("google_oauth_listen");
+/** Loopback port + the single-use `state` nonce to embed in the callback URL. */
+export interface OauthListen {
+  port: number;
+  state: string;
+}
+export const googleOauthListen = () => invoke<OauthListen>("google_oauth_listen");
 export const googleOauthAwait = () => invoke<string>("google_oauth_await");
 
 // ---- Sync server URL (app config, next to last-vault) ----------------------

--- a/app/apps/desktop/src/lib/sync/__tests__/attachments.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AttachmentSync,
   diffAttachments,
+  isSafeAttachmentRelPath,
   mimeForPath,
   type AttachmentSyncDeps,
   type LocalAttachment,
@@ -39,6 +40,35 @@ describe("diffAttachments (content-hash diff)", () => {
     ];
     const { toDownload } = diffAttachments([], server);
     expect(toDownload.map((b) => b.id)).toEqual(["3"]);
+  });
+
+  it("refuses server blobs whose relPath escapes attachments/ (path-traversal ACL bypass)", () => {
+    const server: ServerBlob[] = [
+      { id: "evil-ctx", relPath: ".context/index.sqlite", sha256: "1" },
+      { id: "evil-note", relPath: "Team Plans.md", sha256: "2" },
+      { id: "evil-dot", relPath: "attachments/.context/x", sha256: "3" },
+      { id: "evil-up", relPath: "attachments/../secret", sha256: "4" },
+      { id: "ok", relPath: "attachments/img.png", sha256: "5" },
+      { id: "ok-sub", relPath: "attachments/sub/doc.pdf", sha256: "6" },
+    ];
+    const { toDownload } = diffAttachments([], server);
+    // Only the two legitimate attachment paths survive; the rest are dropped.
+    expect(toDownload.map((b) => b.id).sort()).toEqual(["ok", "ok-sub"]);
+  });
+});
+
+describe("isSafeAttachmentRelPath", () => {
+  it("accepts only non-traversing paths under attachments/", () => {
+    expect(isSafeAttachmentRelPath("attachments/a.png")).toBe(true);
+    expect(isSafeAttachmentRelPath("attachments/sub/deep/b.pdf")).toBe(true);
+    // Rejected: root files, dotfiles/.context, traversal, wrong root, bare dir.
+    expect(isSafeAttachmentRelPath("note.md")).toBe(false);
+    expect(isSafeAttachmentRelPath(".context/index.sqlite")).toBe(false);
+    expect(isSafeAttachmentRelPath("attachments/.hidden")).toBe(false);
+    expect(isSafeAttachmentRelPath("attachments/../x")).toBe(false);
+    expect(isSafeAttachmentRelPath("attachments")).toBe(false);
+    expect(isSafeAttachmentRelPath("attachments\\..\\x")).toBe(false);
+    expect(isSafeAttachmentRelPath("")).toBe(false);
   });
 });
 

--- a/app/apps/desktop/src/lib/sync/attachments.ts
+++ b/app/apps/desktop/src/lib/sync/attachments.ts
@@ -32,10 +32,29 @@ export interface AttachmentDiff {
 }
 
 /**
+ * Whether a server-supplied `relPath` is a safe attachment target to write to
+ * disk. The server stores the uploader's `x-rel-path` header verbatim, so a
+ * malicious member could set it to `.context/index.sqlite` or a note path and
+ * have every teammate's client overwrite that file. We accept ONLY paths under
+ * `attachments/`, with no traversal or dotfile/ignored segments — attachments
+ * are the only thing this sync channel is allowed to place.
+ */
+export function isSafeAttachmentRelPath(relPath: string): boolean {
+  if (!relPath) return false;
+  // Normalize separators; reject Windows-style just in case.
+  const parts = relPath.split(/[\\/]/);
+  if (parts[0] !== "attachments" || parts.length < 2) return false;
+  return parts.every(
+    (seg) => seg !== "" && seg !== "." && seg !== ".." && !seg.startsWith("."),
+  );
+}
+
+/**
  * Pure content-hash diff. A file is "the same" iff its sha256 matches; rel_path
  * is not part of identity (dedupe is by content), so a rename with unchanged
- * bytes is a no-op. Server blobs without a sha or a rel_path can't be placed on
- * disk, so they're skipped from the download set.
+ * bytes is a no-op. Server blobs without a sha or a rel_path — or with a
+ * relPath outside `attachments/` (see {@link isSafeAttachmentRelPath}) — can't
+ * be placed on disk, so they're skipped from the download set.
  */
 export function diffAttachments(
   local: LocalAttachment[],
@@ -46,7 +65,11 @@ export function diffAttachments(
 
   const toUpload = local.filter((a) => !serverShas.has(a.sha256));
   const toDownload = server.filter(
-    (b) => !!b.sha256 && !!b.relPath && !localShas.has(b.sha256),
+    (b) =>
+      !!b.sha256 &&
+      !!b.relPath &&
+      isSafeAttachmentRelPath(b.relPath) &&
+      !localShas.has(b.sha256),
   );
   return { toUpload, toDownload };
 }

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -3,7 +3,11 @@
 # Postgres. docker-compose maps host 5439 -> container 5432.
 DATABASE_URL=postgres://context:context@localhost:5439/context
 
-# Better Auth session/crypto secret. Generate with: openssl rand -base64 32
+# Shared signing secret: Better Auth crypto + HS256 sync/vault JWTs.
+# REQUIRED. Generate a real one — do NOT ship this placeholder:
+#   openssl rand -base64 32
+# In production (NODE_ENV=production) the server REFUSES to start if this is
+# unset or left at the placeholder below. Locally it warns and runs.
 JWT_SECRET=dev-only-insecure-change-me-please-32bytes
 
 # Public base URL Better Auth uses to build links (email verify / invitations).

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -8,6 +8,44 @@ function required(name: string, fallback?: string): string {
   return v;
 }
 
+/** The insecure example secret shipped in .env.example. Never allowed in prod. */
+const INSECURE_JWT_SECRET = "dev-only-insecure-change-me-please-32bytes";
+
+/**
+ * The shared signing secret (Better Auth crypto + HS256 sync/vault JWTs), read
+ * fail-closed. In production (NODE_ENV=production, set by the Dockerfile) an
+ * unset secret OR the known example placeholder is a FATAL startup error, so a
+ * deploy can never silently sign real tokens with a globally-known key
+ * (`cp .env.example .env` and forget). Outside production the placeholder is
+ * tolerated with a loud warning, so local dev / tests keep working unchanged.
+ */
+function jwtSecret(): string {
+  const v = process.env.JWT_SECRET;
+  const prod = process.env.NODE_ENV === "production";
+  if (v === undefined || v === "") {
+    if (prod) {
+      throw new Error(
+        "JWT_SECRET is required in production. Generate one with: openssl rand -base64 32",
+      );
+    }
+    console.warn(
+      "[config] JWT_SECRET is unset — falling back to an INSECURE development secret. Never run production this way.",
+    );
+    return INSECURE_JWT_SECRET;
+  }
+  if (v === INSECURE_JWT_SECRET) {
+    if (prod) {
+      throw new Error(
+        "JWT_SECRET is the insecure .env.example placeholder. Generate a real secret with: openssl rand -base64 32",
+      );
+    }
+    console.warn(
+      "[config] JWT_SECRET is the insecure .env.example placeholder — fine for local dev only, FATAL in production.",
+    );
+  }
+  return v;
+}
+
 function int(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === "") return fallback;
@@ -27,8 +65,9 @@ export const config = {
     "DATABASE_URL",
     "postgres://context:context@localhost:5439/context",
   ),
-  /** Shared secret: Better Auth crypto + HS256 per-doc sync JWTs. */
-  jwtSecret: required("JWT_SECRET", "dev-only-insecure-change-me-please-32bytes"),
+  /** Shared secret: Better Auth crypto + HS256 per-doc sync JWTs. Fail-closed
+   *  in production (see {@link jwtSecret}). */
+  jwtSecret: jwtSecret(),
   betterAuthUrl: required("BETTER_AUTH_URL", "http://localhost:3010"),
   port: int("PORT", 3010),
   hocuspocusPort: int("HOCUSPOCUS_PORT", 3011),

--- a/app/apps/server/src/http/routes/billing.ts
+++ b/app/apps/server/src/http/routes/billing.ts
@@ -63,8 +63,21 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
   billing.post("/billing/webhook", async (c) => {
     if (!billingEnabled()) return c.json({ error: "Not found" }, 404);
 
+    // This route is unauthenticated (signature is checked below), so bound the
+    // body BEFORE buffering it — a Polar event is a few KB; 256 KB is ample.
+    // Without this an attacker who knows the path could OOM the shared process
+    // with a huge payload before the signature check ever runs.
+    const MAX_WEBHOOK_BYTES = 256 * 1024;
+    const declaredLen = Number(c.req.header("content-length"));
+    if (Number.isFinite(declaredLen) && declaredLen > MAX_WEBHOOK_BYTES) {
+      return c.json({ error: "payload too large" }, 413);
+    }
+
     // MUST read the raw body before any JSON parsing so the signature matches.
     const raw = await c.req.text();
+    if (Buffer.byteLength(raw, "utf8") > MAX_WEBHOOK_BYTES) {
+      return c.json({ error: "payload too large" }, 413);
+    }
     const headers: Record<string, string> = {};
     c.req.raw.headers.forEach((v, k) => {
       headers[k] = v;

--- a/app/apps/server/src/http/routes/blobs.ts
+++ b/app/apps/server/src/http/routes/blobs.ts
@@ -19,6 +19,11 @@ import { getSession } from "../session.js";
  */
 export const blobRoutes = new Hono();
 
+/** Max attachment upload size. Generous for real attachments (images, PDFs)
+ *  while stopping a single member from OOM-crashing the shared HTTP+sync
+ *  process with a multi-gigabyte body. */
+const MAX_BLOB_BYTES = 100 * 1024 * 1024; // 100 MB
+
 interface BlobRow {
   id: string;
   sha256: string;
@@ -51,9 +56,20 @@ blobRoutes.post("/vaults/:vaultId/blobs", async (c) => {
     return c.json({ error: "Not a member of this vault" }, 403);
   }
 
+  // Reject oversized uploads before buffering the whole body into memory. A
+  // truthful Content-Length is short-circuited here; the post-read guard below
+  // catches a lying/absent one.
+  const declaredLen = Number(c.req.header("content-length"));
+  if (Number.isFinite(declaredLen) && declaredLen > MAX_BLOB_BYTES) {
+    return c.json({ error: "Attachment too large" }, 413);
+  }
+
   const body = new Uint8Array(await c.req.arrayBuffer());
   if (body.byteLength === 0) {
     return c.json({ error: "empty body" }, 400);
+  }
+  if (body.byteLength > MAX_BLOB_BYTES) {
+    return c.json({ error: "Attachment too large" }, 413);
   }
   const buf = Buffer.from(body);
 
@@ -124,8 +140,16 @@ blobRoutes.get("/blobs/:id", async (c) => {
     return c.json({ error: "Not a member of this vault" }, 403);
   }
 
+  // The stored MIME is attacker-controlled (taken verbatim from the uploader's
+  // content-type). Serve every blob as a non-rendering download: `nosniff`
+  // stops the browser MIME-sniffing it into an active document, and
+  // `Content-Disposition: attachment` forces a download rather than inline
+  // rendering — so a stored text/html blob can't execute as script in the API
+  // origin. The desktop reads the raw bytes regardless of these headers.
   return c.body(blob.data, 200, {
     "Content-Type": blob.mime || "application/octet-stream",
     "Content-Length": String(blob.data.byteLength),
+    "X-Content-Type-Options": "nosniff",
+    "Content-Disposition": "attachment",
   });
 });

--- a/app/apps/server/src/http/routes/blobs.ts
+++ b/app/apps/server/src/http/routes/blobs.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
+import { canReadAttachment, filterReadableBlobs } from "../../permissions/http-gates.js";
 import { getSession } from "../session.js";
 
 /**
@@ -115,7 +116,10 @@ blobRoutes.get("/vaults/:vaultId/blobs", async (c) => {
        FROM blobs WHERE vault_id = $1 ORDER BY rel_path`,
     [vaultId],
   );
-  return c.json({ blobs: rows.map(toMeta) });
+  // Private-by-default: a scoped member only sees blobs referenced by notes
+  // they can read (owner/admin + Open vaults see all). Mirrors the download gate.
+  const visible = await filterReadableBlobs(session.userId, vaultId, rows);
+  return c.json({ blobs: visible.map(toMeta) });
 });
 
 // ── download ────────────────────────────────────────────────────────────────
@@ -128,16 +132,23 @@ blobRoutes.get("/blobs/:id", async (c) => {
     vault_id: string | null;
     org_id: string | null;
     mime: string | null;
+    rel_path: string | null;
     data: Buffer | null;
-  }>("SELECT vault_id, org_id, mime, data FROM blobs WHERE id = $1", [id]);
+  }>("SELECT vault_id, org_id, mime, rel_path, data FROM blobs WHERE id = $1", [id]);
   const blob = rows[0];
   if (!blob || !blob.data) return c.json({ error: "Blob not found" }, 404);
 
-  // View requires vault membership (via the blob's note collection, or its
-  // org_id fallback for legacy rows without vault_id).
+  // Membership is necessary but not sufficient (via the blob's note collection,
+  // or its org_id fallback for legacy rows without vault_id).
   const org = blob.vault_id ? await vaultOrg(blob.vault_id) : blob.org_id;
   if (!org || !(await orgRole(org, session.userId))) {
     return c.json({ error: "Not a member of this vault" }, 403);
+  }
+  // Per-attachment ACL: a scoped member may only download a blob referenced by
+  // a note they can read (owner/admin + Open vaults are allowed everything).
+  // Legacy rows without a vault_id keep membership-only access (no note to gate on).
+  if (blob.vault_id && !(await canReadAttachment(session.userId, blob.vault_id, blob.rel_path))) {
+    return c.json({ error: "You do not have access to this attachment" }, 403);
   }
 
   // The stored MIME is attacker-controlled (taken verbatim from the uploader's

--- a/app/apps/server/src/http/routes/graph.ts
+++ b/app/apps/server/src/http/routes/graph.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
+import { listReadableDocsInVault } from "../../permissions/vault-docs.js";
 import { getSession } from "../session.js";
 import { cosineSimilarity, embed, tokenize } from "../../index/embedder.js";
 
@@ -45,7 +46,7 @@ graphRoutes.get("/vaults/:vaultId/graph", async (c) => {
   const gate = await gateVaultMember(vaultId, session.userId);
   if (!gate.ok) return c.json({ error: gate.error }, gate.status);
 
-  const { rows: noteRows } = await pool.query<{
+  const { rows: allNoteRows } = await pool.query<{
     id: string;
     title: string | null;
     rel_path: string;
@@ -54,6 +55,12 @@ graphRoutes.get("/vaults/:vaultId/graph", async (c) => {
       WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path`,
     [vaultId],
   );
+
+  // Private-by-default: restrict the graph to notes the caller may read, so a
+  // member can't harvest every private note's id/title/path. Owner/admin and
+  // Open vaults get the full set from the resolver. Mirrors GET /notes.
+  const readable = await listReadableDocsInVault(session.userId, vaultId);
+  const noteRows = allNoteRows.filter((n) => readable.has(n.id));
 
   const nodes = noteRows.map((n) => ({
     docId: n.id,
@@ -74,11 +81,15 @@ graphRoutes.get("/vaults/:vaultId/graph", async (c) => {
     "SELECT from_doc, to_title FROM note_links WHERE vault_id = $1",
     [vaultId],
   );
-  const links = linkRows.map((l) => ({
-    fromDoc: l.from_doc,
-    toTitle: l.to_title,
-    toDocId: byTitle.get(l.to_title.toLowerCase()) ?? null,
-  }));
+  // Only edges out of a readable note; targets already resolve within the
+  // readable node set (byTitle is built from noteRows).
+  const links = linkRows
+    .filter((l) => readable.has(l.from_doc))
+    .map((l) => ({
+      fromDoc: l.from_doc,
+      toTitle: l.to_title,
+      toDocId: byTitle.get(l.to_title.toLowerCase()) ?? null,
+    }));
 
   return c.json({ nodes, links });
 });
@@ -98,7 +109,7 @@ graphRoutes.get("/vaults/:vaultId/search", async (c) => {
   const kRaw = Number.parseInt(c.req.query("k") ?? "10", 10);
   const k = Number.isNaN(kRaw) || kRaw <= 0 ? 10 : Math.min(kRaw, 100);
 
-  const { rows } = await pool.query<{
+  const { rows: allRows } = await pool.query<{
     doc_id: string;
     title: string | null;
     rel_path: string;
@@ -111,6 +122,12 @@ graphRoutes.get("/vaults/:vaultId/search", async (c) => {
       WHERE ni.vault_id = $1`,
     [vaultId],
   );
+
+  // Restrict the candidate set to readable notes: the score is computed over
+  // note content, so scoring unreadable notes would be a content oracle.
+  // Mirrors the MCP search tool. Owner/admin + Open vaults see everything.
+  const readable = await listReadableDocsInVault(session.userId, vaultId);
+  const rows = allRows.filter((r) => readable.has(r.doc_id));
 
   const qVec = embed(q);
   const qTokens = Array.from(new Set(tokenize(q)));

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
+import { canEditDoc, canEditFolder } from "../../permissions/http-gates.js";
 import { listReadableDocsInVault, listVisibleFolders } from "../../permissions/vault-docs.js";
 import { getSession } from "../session.js";
 
@@ -136,13 +137,21 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     );
     const row = rows[0];
     if (!row) return c.json({ error: "Unknown folder" }, 404);
-    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
-      return c.json({ error: "Not a member of this vault" }, 403);
+    // Edit permission on the folder itself (not bare membership): owner/admin,
+    // the folder's creator, or an edit share. Blocks renaming/moving folders a
+    // member has no rights on.
+    if (!(await canEditFolder(session.userId, id))) {
+      return c.json({ error: "You cannot modify this folder" }, 403);
     }
     const oldPath: string = row.path;
     const newPath = typeof body.path === "string" ? body.path : oldPath;
     const newName = typeof body.name === "string" ? body.name : basename(newPath);
     const newParentId = body.parentId === undefined ? undefined : (body.parentId ?? null);
+    // Re-parenting under another folder must not be a way to change inherited
+    // access: require edit on the destination parent too (root/null is fine).
+    if (newParentId != null && !(await canEditFolder(session.userId, newParentId))) {
+      return c.json({ error: "You cannot move this folder there" }, 403);
+    }
 
     await pool.query(
       `UPDATE folders SET path = $1, name = $2${newParentId === undefined ? "" : ", parent_id = $4"}
@@ -169,14 +178,16 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     );
     const row = rows[0];
     if (!row) return c.json({ error: "Unknown folder" }, 404);
-    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
-      return c.json({ error: "Not a member of this vault" }, 403);
+    if (!(await canEditFolder(session.userId, id))) {
+      return c.json({ error: "You cannot delete this folder" }, 403);
     }
+    // $2 is an exact match; $3 is the LIKE prefix with %/_ escaped so a folder
+    // path containing wildcards cannot widen the soft-delete beyond its subtree.
     await pool.query(
       `UPDATE notes SET deleted_at = now()
         WHERE vault_id = $1 AND deleted_at IS NULL
-          AND (rel_path = $2 OR rel_path LIKE $2 || '/%')`,
-      [row.vault_id, row.path],
+          AND (rel_path = $2 OR rel_path LIKE $3 || '/%' ESCAPE '\\')`,
+      [row.vault_id, row.path, likeEscape(row.path)],
     );
     await pool.query("DELETE FROM folders WHERE id = $1", [id]);
     changed(row.vault_id);
@@ -247,8 +258,11 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     );
     const row = rows[0];
     if (!row) return c.json({ error: "Unknown note" }, 404);
-    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
-      return c.json({ error: "Not a member of this vault" }, 403);
+    // Edit permission on the note itself (owner/admin, creator, or edit share),
+    // not bare membership. This also closes the relocate-to-escalate path: a
+    // member with no access to the note can't rename/move it at all.
+    if (!(await canEditDoc(session.userId, id))) {
+      return c.json({ error: "You cannot modify this note" }, 403);
     }
     const relPath = typeof body.relPath === "string" ? body.relPath : row.rel_path;
     const title = body.title === undefined ? row.title : body.title;
@@ -272,8 +286,9 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     );
     const row = rows[0];
     if (!row) return c.json({ error: "Unknown note" }, 404);
-    if (!(await orgRole((await vaultOrg(row.vault_id))!, session.userId))) {
-      return c.json({ error: "Not a member of this vault" }, 403);
+    // Edit permission required to destroy a note — not bare membership.
+    if (!(await canEditDoc(session.userId, id))) {
+      return c.json({ error: "You cannot delete this note" }, 403);
     }
     await pool.query("UPDATE notes SET deleted_at = now() WHERE id = $1", [id]);
     changed(row.vault_id);
@@ -317,21 +332,31 @@ async function rewriteDescendantPaths(
   // $4::int cast is load-bearing: a bare text param would select substring's
   // REGEX overload (substring(text FROM text)) and silently return NULL.
   const from = oldPath.length + 1;
+  // $3 is the LIKE prefix with %/_ escaped so a folder path containing SQL
+  // wildcards cannot match (and rewrite) unrelated notes/folders. The substring
+  // offset ($4) is the true prefix length, unaffected by escaping.
+  const prefix = likeEscape(oldPath);
   await pool.query(
     `UPDATE folders
         SET path = $2 || substring(path FROM $4::int)
-      WHERE vault_id = $1 AND path LIKE $3 || '/%'`,
-    [vaultId, newPath, oldPath, from],
+      WHERE vault_id = $1 AND path LIKE $3 || '/%' ESCAPE '\\'`,
+    [vaultId, newPath, prefix, from],
   );
   await pool.query(
     `UPDATE notes
         SET rel_path = $2 || substring(rel_path FROM $4::int), updated_at = now()
-      WHERE vault_id = $1 AND rel_path LIKE $3 || '/%'`,
-    [vaultId, newPath, oldPath, from],
+      WHERE vault_id = $1 AND rel_path LIKE $3 || '/%' ESCAPE '\\'`,
+    [vaultId, newPath, prefix, from],
   );
 }
 
 function basename(path: string): string {
   const i = path.lastIndexOf("/");
   return i === -1 ? path : path.slice(i + 1);
+}
+
+/** Escape SQL LIKE metacharacters (\ % _) so a value is matched literally under
+ *  `LIKE … ESCAPE '\'`. */
+function likeEscape(s: string): string {
+  return s.replace(/[\\%_]/g, (ch) => `\\${ch}`);
 }

--- a/app/apps/server/src/permissions/http-gates.ts
+++ b/app/apps/server/src/permissions/http-gates.ts
@@ -1,0 +1,76 @@
+import type pg from "pg";
+import { pool as defaultPool } from "../db/pool.js";
+import { orgRole } from "./lookup.js";
+import {
+  ancestorFolderIds,
+  buildAccessContext,
+  effectivePermission,
+  isLocked,
+  resolveAccessForUser,
+} from "./resolver.js";
+
+type Queryable = Pick<pg.Pool, "query">;
+
+/**
+ * Authorization gates for the session-authenticated HTTP registry/blob routes.
+ *
+ * These exist so the HTTP layer stops authorizing structural mutations on bare
+ * vault membership and instead uses the SAME per-doc/per-folder ACL the MCP
+ * layer already enforces (`effectivePermission` / `folderWritePermission`).
+ * Owner/admin, a note's creator, and edit-share holders keep their access; a
+ * plain member with no grant no longer can mutate content they cannot read.
+ */
+
+/** May `userId` edit (rename/move/delete) note or file `docId`? Mirrors the
+ *  MCP `requireEditableNote` gate: owner/admin, the note's creator, or an
+ *  edit share — with a lock capping to view (→ false). */
+export async function canEditDoc(
+  userId: string,
+  docId: string,
+  db: Queryable = defaultPool,
+): Promise<boolean> {
+  return (await effectivePermission(userId, docId, db)) === "edit";
+}
+
+/**
+ * May `userId` modify folder `folderId` (rename / re-parent / delete)?
+ *
+ * Allowed for the vault owner/admin, the folder's creator (mirrors the note
+ * creator rule so a member can still manage their own private folders), or a
+ * user/team edit share on the folder or any ancestor. A lock on the folder or
+ * any ancestor makes it read-only for everyone (owners/admins included),
+ * matching `folderWritePermission` in the MCP service.
+ */
+export async function canEditFolder(
+  userId: string,
+  folderId: string,
+  db: Queryable = defaultPool,
+): Promise<boolean> {
+  const { rows } = await db.query<{
+    created_by: string | null;
+    organization_id: string;
+  }>(
+    `SELECT f.created_by, v.organization_id
+       FROM folders f JOIN vaults v ON v.id = f.vault_id
+      WHERE f.id = $1`,
+    [folderId],
+  );
+  const row = rows[0];
+  if (!row) return false;
+
+  const role = await orgRole(row.organization_id, userId, db);
+  if (role === null) return false; // not a member of the vault
+
+  // Deny overlay first: a lock caps everyone at view (no edits at all).
+  const chain = await ancestorFolderIds(db, folderId);
+  if (await isLocked(db, userId, null, chain)) return false;
+
+  if (role === "owner" || role === "admin") return true;
+  if (row.created_by && row.created_by === userId) return true;
+
+  // Else: an explicit user/team edit share on the folder or an ancestor.
+  const ctx = await buildAccessContext("folder", folderId, db);
+  if (!ctx) return false;
+  const resolved = await resolveAccessForUser(ctx, userId, role, db);
+  return resolved.permission === "edit";
+}

--- a/app/apps/server/src/permissions/http-gates.ts
+++ b/app/apps/server/src/permissions/http-gates.ts
@@ -8,8 +8,15 @@ import {
   isLocked,
   resolveAccessForUser,
 } from "./resolver.js";
+import { listReadableDocsInVault, vaultAccess } from "./vault-docs.js";
 
 type Queryable = Pick<pg.Pool, "query">;
+
+/** Escape SQL LIKE metacharacters so a value is matched literally under
+ *  `LIKE … ESCAPE '\'`. */
+function likeEscape(s: string): string {
+  return s.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
 
 /**
  * Authorization gates for the session-authenticated HTTP registry/blob routes.
@@ -73,4 +80,67 @@ export async function canEditFolder(
   if (!ctx) return false;
   const resolved = await resolveAccessForUser(ctx, userId, role, db);
   return resolved.permission === "edit";
+}
+
+/**
+ * May `userId` read attachment blob `relPath` in vault `vaultId`?
+ *
+ * Attachments have no per-blob ACL row, so their access derives from the notes
+ * that embed them: a caller with vault-wide read (owner/admin, or an
+ * Open/Read-only grant) sees every blob — including orphaned ones — while a
+ * scoped member may fetch a blob only if some note they can READ references it.
+ * This closes the IDOR where any member could download every attachment
+ * (including those in private notes) while keeping attachment sync working for
+ * legitimately-shared notes.
+ *
+ * Best-effort by design: the reference check reads `note_index.content`, so a
+ * just-embedded attachment becomes fetchable to other readers once its note is
+ * indexed (attachment sync is already eventually-consistent).
+ */
+export async function canReadAttachment(
+  userId: string,
+  vaultId: string,
+  relPath: string | null,
+  db: Queryable = defaultPool,
+): Promise<boolean> {
+  const access = await vaultAccess(db, userId, vaultId);
+  if (!access) return false; // unknown vault or not a member
+  if (access.vaultWide) return true; // owner/admin or vault-wide grant
+  if (!relPath) return false; // legacy blob w/o a path — no readable note to tie it to
+
+  const readable = await listReadableDocsInVault(userId, vaultId, db);
+  if (readable.size === 0) return false;
+  const { rows } = await db.query<{ ok: number }>(
+    `SELECT 1 AS ok FROM note_index
+      WHERE vault_id = $1 AND doc_id = ANY($2::text[])
+        AND content LIKE '%' || $3 || '%' ESCAPE '\\'
+      LIMIT 1`,
+    [vaultId, [...readable], likeEscape(relPath)],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Filter a vault's blob list to the ones `userId` may read (see
+ * {@link canReadAttachment}). Vault-wide readers get everything; a scoped
+ * member gets only blobs referenced by a note they can read.
+ */
+export async function filterReadableBlobs<T extends { rel_path: string | null }>(
+  userId: string,
+  vaultId: string,
+  blobs: T[],
+  db: Queryable = defaultPool,
+): Promise<T[]> {
+  const access = await vaultAccess(db, userId, vaultId);
+  if (!access) return [];
+  if (access.vaultWide) return blobs;
+
+  const readable = await listReadableDocsInVault(userId, vaultId, db);
+  if (readable.size === 0) return [];
+  const { rows } = await db.query<{ content: string | null }>(
+    `SELECT content FROM note_index WHERE vault_id = $1 AND doc_id = ANY($2::text[])`,
+    [vaultId, [...readable]],
+  );
+  const haystack = rows.map((r) => r.content ?? "").join("\n");
+  return blobs.filter((b) => !!b.rel_path && haystack.includes(b.rel_path));
 }

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -208,9 +208,12 @@ export async function effectivePermission(
   let granted: Permission;
   if (role === "owner" || role === "admin") {
     granted = "edit";
-  } else if (loc.createdBy && loc.createdBy === userId) {
+  } else if (role !== null && loc.createdBy && loc.createdBy === userId) {
     // Private-by-default: a member always has edit on a note they created, even
-    // with no explicit share (that's what makes "my private notes" work).
+    // with no explicit share (that's what makes "my private notes" work). The
+    // `role !== null` gate is load-bearing: a user REMOVED from the vault must
+    // lose this grant (their session outlives removal), else they keep edit on
+    // notes they authored and can re-mint sync tokens indefinitely.
     granted = "edit";
   } else {
     granted = await sharePermission(

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -25,7 +25,7 @@ type Queryable = Pick<pg.Pool, "query">;
  */
 /** Resolve a user's vault-level posture: their org, role, and whether they have
  *  vault-wide read (owner/admin, or a vault-scoped Open/Read-only grant). */
-async function vaultAccess(
+export async function vaultAccess(
   db: Queryable,
   userId: string,
   vaultId: string,

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -100,12 +100,13 @@ export async function listReadableDocsInVault(
   }
 
   // Non-privileged (private-by-default): readable docs are the union of
-  //   - notes the user created (created_by);
+  //   - notes the user created (created_by) — ONLY while still a member;
   //   - docs under a folder shared to the user OR the team (org grant), walking
   //     the subtree since folder grants inherit down;
   //   - files/notes shared directly to the user or the team.
-  // The org ($3) branches are gated by membership ($4) so a non-member with a
-  // stray doc id gets nothing. Mirrors resolver.sharePermission + creator rule.
+  // Both the creator branch and the org ($3) branches are gated by membership
+  // ($4) so a REMOVED member (session outlives removal) loses read on notes
+  // they authored — matching resolver.effectivePermission's creator rule.
   const isMember = row.role !== null;
   const { rows } = await db.query<{ id: string }>(
     `WITH RECURSIVE shared_folders AS (
@@ -132,7 +133,7 @@ export async function listReadableDocsInVault(
      SELECT n.id FROM notes n
        WHERE n.vault_id = $2 AND n.deleted_at IS NULL
          AND (
-           n.created_by = $1
+           ($4 AND n.created_by = $1)
            OR n.folder_id IN (SELECT id FROM subtree)
            OR n.id IN (SELECT id FROM shared_files)
          )

--- a/app/apps/server/tests/blobs.test.ts
+++ b/app/apps/server/tests/blobs.test.ts
@@ -5,7 +5,17 @@ import { testAppDeps } from "./helpers/app.js";
 import { pool } from "../src/db/pool.js";
 import { resetDb } from "./helpers/db.js";
 import { authHeaders, signUp } from "./helpers/auth.js";
-import { seedMember, seedOrg, seedVault } from "./helpers/seed.js";
+import { seedMember, seedNote, seedOrg, seedVault } from "./helpers/seed.js";
+
+/** Insert a note_index row so an attachment reference is discoverable by the
+ *  per-attachment ACL (which scans indexed note content). */
+async function indexNote(docId: string, vaultId: string, content: string) {
+  await pool.query(
+    `INSERT INTO note_index (doc_id, vault_id, title, content, vector, updated_at)
+     VALUES ($1, $2, $3, $4, $5::jsonb, now())`,
+    [docId, vaultId, "t", content, JSON.stringify([])],
+  );
+}
 
 const app = createApp(testAppDeps());
 
@@ -146,5 +156,49 @@ describe("attachment blob store (spec 02 §2/§5A)", () => {
     expect((await uploadBlob(null, vault, new Uint8Array([1]))).status).toBe(401);
     expect((await uploadBlob(owner.token, "no-such-vault", new Uint8Array([1]))).status).toBe(404);
     expect((await downloadBlob(owner.token, "no-such-blob")).status).toBe(404);
+  });
+
+  // F13: a scoped member must not be able to list/download attachments of notes
+  // they cannot read, while still getting attachments of notes they can.
+  it("scopes a member's blob access to attachments of readable notes", async () => {
+    const owner = await signUp("owner@blob5.com");
+    const org = await seedOrg("Acme", "acme-blob5");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    // Private-by-default vault: a plain member with no shares.
+    const member = await signUp("member@blob5.com");
+    await seedMember(org, member.userId, "member");
+
+    // Owner's private note references secret.png; member's own note references mine.png.
+    const secretNote = await seedNote(vault, null, "Secret.md", owner.userId);
+    await indexNote(secretNote, vault, "see ![x](/attachments/secret.png)");
+    const myNote = await seedNote(vault, null, "Mine.md", member.userId);
+    await indexNote(myNote, vault, "mine ![y](/attachments/mine.png)");
+
+    const secretBlob = (await (
+      await uploadBlob(owner.token, vault, new Uint8Array([1, 1]), {
+        relPath: "attachments/secret.png",
+      })
+    ).json()) as { id: string };
+    const mineBlob = (await (
+      await uploadBlob(owner.token, vault, new Uint8Array([2, 2]), {
+        relPath: "attachments/mine.png",
+      })
+    ).json()) as { id: string };
+
+    // Owner (vault-wide) sees and downloads both.
+    const ownerList = (await (await listBlobs(owner.token, vault)).json()) as {
+      blobs: unknown[];
+    };
+    expect(ownerList.blobs).toHaveLength(2);
+    expect((await downloadBlob(owner.token, secretBlob.id)).status).toBe(200);
+
+    // Member: only the attachment of their own readable note.
+    expect((await downloadBlob(member.token, secretBlob.id)).status).toBe(403);
+    expect((await downloadBlob(member.token, mineBlob.id)).status).toBe(200);
+    const memberList = (await (await listBlobs(member.token, vault)).json()) as {
+      blobs: Array<{ relPath: string | null }>;
+    };
+    expect(memberList.blobs.map((b) => b.relPath)).toEqual(["attachments/mine.png"]);
   });
 });

--- a/app/apps/server/tests/http-authz-gates.test.ts
+++ b/app/apps/server/tests/http-authz-gates.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { seedFolder, seedMember, seedNote, seedVault } from "./helpers/seed.js";
+
+/**
+ * Regression tests for the security fix that moved the session-authenticated
+ * HTTP registry/graph routes off bare vault-membership onto the per-doc/folder
+ * ACL (findings F2, F3, F6, F11). A plain member of a private-by-default vault
+ * must NOT be able to read, mutate, or destroy content they were never granted
+ * — while owner/admin and a note's own creator keep their access.
+ */
+
+const app = createApp({
+  disconnectDoc: () => {},
+  docWriter: {
+    async setContent() {},
+    async appendContent() {},
+    async readContent() {
+      return "";
+    },
+  },
+});
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+describe("HTTP authz gates (per-doc ACL, not bare membership)", () => {
+  let owner: TestUser;
+  let member: TestUser;
+  let vault: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    owner = await signUp("owner@authz.test");
+    const org = (await createOrg(owner, "Authz Co", "authz-co")).id;
+    // A plain member with NO shares — the vault is private by default.
+    member = await signUp("member@authz.test");
+    await seedMember(org, member.userId, "member");
+    vault = await seedVault(org);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("F2: member cannot delete a note they have no access to; owner can", async () => {
+    const note = await seedNote(vault, null, "Secret.md", owner.userId);
+    expect((await req(member, "DELETE", `/api/notes/${note}`)).status).toBe(403);
+    // Still present, and the owner can delete it.
+    expect((await req(owner, "DELETE", `/api/notes/${note}`)).status).toBe(200);
+  });
+
+  it("F3: member cannot rename/move a note they have no access to", async () => {
+    const note = await seedNote(vault, null, "Secret.md", owner.userId);
+    const res = await req(member, "PATCH", `/api/notes/${note}`, { title: "hijacked" });
+    expect(res.status).toBe(403);
+  });
+
+  it("creator (a plain member) keeps edit on their own note", async () => {
+    const mine = await seedNote(vault, null, "Mine.md", member.userId);
+    const res = await req(member, "PATCH", `/api/notes/${mine}`, { title: "renamed" });
+    expect(res.status).toBe(200);
+  });
+
+  it("F6: graph excludes notes the member cannot read, includes their own", async () => {
+    const secret = await seedNote(vault, null, "Secret.md", owner.userId);
+    const mine = await seedNote(vault, null, "Mine.md", member.userId);
+    const res = await req(member, "GET", `/api/vaults/${vault}/graph`);
+    expect(res.status).toBe(200);
+    const { nodes } = (await res.json()) as { nodes: Array<{ docId: string }> };
+    const ids = nodes.map((n) => n.docId);
+    expect(ids).toContain(mine);
+    expect(ids).not.toContain(secret);
+  });
+
+  it("F11: member cannot delete a folder they don't own; owner can", async () => {
+    const folder = await seedFolder(vault, null, "Docs", "Docs");
+    expect((await req(member, "DELETE", `/api/folders/${folder}`)).status).toBe(403);
+    expect((await req(owner, "DELETE", `/api/folders/${folder}`)).status).toBe(200);
+  });
+});


### PR DESCRIPTION
Hardens the server and desktop against a set of authorization, secret-handling, and resource-exhaustion issues. All existing tests pass and new regression tests were added.

## Server
- Session-authenticated registry/graph/blob routes now enforce the per-doc/folder ACL (via `effectivePermission` / a new `http-gates` helper) instead of bare vault membership, so a plain member can no longer read, mutate, or delete content they were not granted. Owner/admin and a note's creator retain access.
- `JWT_SECRET` is read fail-closed: production refuses to start when it is unset or left at the example placeholder (dev keeps working with a warning).
- Attachment (blob) access is scoped to notes the caller can read; downloads are served non-renderable (`nosniff` + `Content-Disposition: attachment`).
- Removed vault members lose the implicit "creator" edit grant.
- Body-size caps on blob upload and the billing webhook; LIKE-pattern escaping on folder path queries.

## Desktop
- OAuth loopback callback now carries and verifies a single-use `state` nonce, rejecting unsolicited local callbacks.
- Attachment sync writes are confined to `attachments/` (TS filter + Rust guard).
- YAML frontmatter parsing is bounded to defeat alias-expansion bombs.
- Embedded-HTML preview sanitizer strips inline styles and hardens URL-scheme checks.

## Tests
- Server: 153 passing (new `http-authz-gates` suite + per-attachment ACL cases).
- Desktop: 167 passing; Rust: 60 passing (new OAuth-state, attachment-path, and YAML-bomb cases).