### PR TITLE
Bound server memory so idle RSS stops growing to GBs

### DIFF
--- a/app/apps/server/Dockerfile
+++ b/app/apps/server/Dockerfile
@@ -49,4 +49,13 @@ COPY --from=build /out ./
 ENV PORT=3010
 EXPOSE 3010
 
+# Bound V8's heap so it garbage-collects aggressively instead of letting RSS
+# ratchet toward the host's total RAM. On a container with no memory limit,
+# Node otherwise sizes its old space against the (large) host and lets memory
+# creep into the gigabytes over days of allocation churn — which bills as
+# continuous memory usage even with no traffic. 512 MB is ~3x the idle
+# footprint (~160 MB), ample for backfill/compaction of a single note while
+# keeping resident memory low. Pair with a container memory limit for a hard cap.
+ENV NODE_OPTIONS="--max-old-space-size=512"
+
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
The deployed server's memory climbs from ~160 MB to multiple GB over days with no traffic, then resets only on redeploy — a classic unbounded-container RSS ratchet, not a code object leak (the Y.Doc lifecycle in persistence/doc-writer is clean and destroys everything).

Caps V8's old-space heap at 512 MB via `NODE_OPTIONS` so Node garbage-collects aggressively instead of sizing its heap against the host's total RAM. 512 MB is ~3x the idle footprint — ample for note backfill/compaction while keeping resident memory low.

Pair with a container memory limit (Railway service settings) for a hard cap.