### PR TITLE
Codify server memory limit in railway.json

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -9,6 +9,11 @@
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 5
+    "restartPolicyMaxRetries": 5,
+    "limitOverride": {
+      "containers": {
+        "memoryBytes": 1073741824
+      }
+    }
   }
 }


### PR DESCRIPTION
Pins the server container to a 1 GiB memory limit via config-as-code (`deploy.limitOverride.containers.memoryBytes`), so any Railway deploy of this server is memory-bounded by default rather than relying on a dashboard setting someone has to know to apply.

Pairs with the V8 heap cap already in the server Dockerfile (`NODE_OPTIONS=--max-old-space-size=512`). Together they keep resident memory low and prevent a one-off activity burst from pinning RSS at multiple GB (which bills as continuous memory usage). The server runs comfortably under ~300 MB even under sustained sync/MCP load, so the cap has ample headroom.

No secrets or environment-specific identifiers are added — just a generic resource limit.