### PR TITLE
Stop rejected sync tokens from hot-reconnecting, and smooth graph reheat

### DIFF
--- a/app/apps/desktop/src/components/GraphView.tsx
+++ b/app/apps/desktop/src/components/GraphView.tsx
@@ -38,9 +38,22 @@ const LABEL_FADE_END = 2.4; // camera.k at which labels are fully opaque (labelS
 const DEFAULT_FONT_FAMILY = "sans-serif";
 const FALLBACK_ACCENT = "#7f73ff";
 
-// Startup "come to life" burst.
-const INTRO_MS = 1200; // duration of the light flare + settle
-const INTRO_KICK = 28; // initial random velocity magnitude — the quick shake
+// Startup "come to life" burst. Deliberately gentle: the graph should ease open,
+// not explode. A big random kick reads as chaos rather than life, because every
+// node scatters in an unrelated direction at once — the settle that follows is
+// then large enough to look like a glitch. A small nudge over a slightly longer
+// window gives the same "it's alive" impression while staying legible.
+const INTRO_MS = 1600; // duration of the light flare + settle
+const INTRO_KICK = 7; // initial random velocity magnitude — a nudge, not a shake
+
+// How hard a *data refresh* re-energizes the layout. The first build needs real
+// energy to find a shape from seeded positions; later rebuilds already have a
+// settled layout and only need to absorb what changed, so they get a small warm
+// nudge. Reheating those to 1 was what made the graph appear to "reset": every
+// `file-changed` event (a whole storm of them while a vault syncs) threw the
+// entire layout back to maximum energy and it visibly flew apart and re-settled.
+const REHEAT_FIRST = 1;
+const REHEAT_REFRESH = 0.22;
 
 // Matte-sphere lighting. A single soft key light from the upper-left, tilted
 // toward the viewer, is baked once into grayscale alpha sprites (makeShadeSprites)
@@ -343,11 +356,15 @@ export function GraphView({ onClose }: { onClose: () => void }) {
     // {source,target} ids against the current node array.
     sim.nodes(visNodes);
     (sim.force("link") as ForceLink<SimNode, SimLink>).links(links);
-    sim.alpha(1);
 
-    // First time real data lands: light the graph up. Give every node a random
-    // velocity impulse (the "quick shake") and start the intro clock so the
-    // draw loop paints the light flare from all nodes, then it all settles.
+    // Only the first build gets a full reheat. After that, warm the layout just
+    // enough to absorb the change (and never *cool* one that's already hotter).
+    const first = !S.introKicked;
+    sim.alpha(first ? REHEAT_FIRST : Math.max(sim.alpha(), REHEAT_REFRESH));
+
+    // First time real data lands: light the graph up. Give every node a small
+    // random velocity impulse and start the intro clock so the draw loop paints
+    // the light flare from all nodes, then it all settles.
     if (!S.introKicked && visNodes.length > 0) {
       for (const node of visNodes) {
         const a = Math.random() * Math.PI * 2;
@@ -593,7 +610,9 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       const introT =
         S.introStart > 0 ? clamp((nowT - S.introStart) / INTRO_MS, 0, 1) : 1;
       const introEase = 1 - Math.pow(1 - introT, 3); // easeOutCubic
-      const glowBoost = 1 + (1 - introEase) * 2.4; // nodes are brightest at birth
+      // Nodes are brightest at birth, but only modestly so — a 3.4× flare blew
+      // out to near-white and read as a flash rather than a fade-in.
+      const glowBoost = 1 + (1 - introEase) * 1.1;
 
       const nodeScale = s.nodeSize;
       const time = nowT / 1000;

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -13,6 +13,7 @@
 
 import {
   ApiClient,
+  ApiError,
   noteDocId,
   noteRelPath,
   vaultOrgId,
@@ -261,6 +262,18 @@ export class VaultRegistry {
         });
         docIdByPath.set(rp, noteDocId(created));
       } catch (e) {
+        // 409 = this note's local doc_id is already a note in a DIFFERENT vault
+        // (e.g. this folder was previously synced to another vault whose ids the
+        // local index still carries). Deliberately leave it UNMAPPED: the note
+        // keeps working locally, whereas mapping it would point sync at a doc the
+        // user has no grant on, which only yields a permanent 403. Rotating the
+        // local doc_id to rejoin such a note to this vault is not implemented.
+        if (e instanceof ApiError && e.status === 409) {
+          console.warn(
+            `[registry] ${rp}: local doc_id belongs to another vault — staying local-only`,
+          );
+          continue;
+        }
         console.error("[registry] createNote failed", rp, e);
       }
     }

--- a/app/apps/desktop/src/lib/sync/syncManager.ts
+++ b/app/apps/desktop/src/lib/sync/syncManager.ts
@@ -128,6 +128,13 @@ export class DocSync {
   private settleTimer: ReturnType<typeof setTimeout> | null = null;
   private destroyed = false;
   private reconnectPending = false;
+  /**
+   * Consecutive auth rejections, driving the backoff below. Reset the moment a
+   * connection authenticates (onSynced/connected), so a single expiry still
+   * reconnects instantly and only a genuinely stuck token backs off.
+   */
+  private authFailures = 0;
+  private authRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(opts: DocSyncOptions) {
     this.api = opts.api;
@@ -154,9 +161,16 @@ export class DocSync {
       onAuthenticationFailed: () => {
         // Token rejected/expired. If we still have access, a reconnect re-mints;
         // if the mint itself 403s, mintToken() sets 'no-access' and we stop.
+        //
+        // This MUST back off. Reconnecting immediately makes rejection
+        // self-sustaining whenever the re-mint can't produce a usable token
+        // (mintToken() returning null yields the empty-string token below, which
+        // the server always rejects): reject → reconnect → reject, as fast as the
+        // socket can cycle. That spins the CPU, floods the server log, and — since
+        // each lap flips status error→connecting→error — strobes the sync badge.
         if (!this.destroyed && this._status !== "no-access") {
           this.setStatus("error");
-          this.reconnectWithFreshToken();
+          this.scheduleAuthRetry();
         }
       },
       onClose: ({ event }) => {
@@ -177,8 +191,16 @@ export class DocSync {
       onStatus: ({ status }) => {
         if (this.destroyed) return;
         if (status === "connected") {
+          // Connected means the server accepted our token, so the streak is over.
+          this.noteAuthSuccess();
           this.setStatus(this._readOnly ? "read-only" : "synced");
         } else if (status === "connecting") {
+          // `no-access` is TERMINAL and must survive this. The provider runs its
+          // own reconnect loop, and each lap emits "connecting" — which used to
+          // overwrite no-access, reopening the guard on every other handler here.
+          // A doc we've been refused then retried forever: 403 → no-access →
+          // "connecting" clears it → empty token → rejected → repeat, ~4×/second.
+          if (this._status === "no-access") return;
           this.setStatus("connecting");
         } else if (status === "disconnected") {
           if (this._status !== "no-access") this.setStatus("offline");
@@ -186,6 +208,7 @@ export class DocSync {
       },
       onSynced: () => {
         if (!this.destroyed && this._status !== "no-access") {
+          this.noteAuthSuccess();
           this.setStatus(this._readOnly ? "read-only" : "synced");
         }
       },
@@ -253,23 +276,72 @@ export class DocSync {
     });
   }
 
+  /**
+   * Reconnect after an auth rejection, with exponential backoff + jitter.
+   *
+   * 500ms → 1s → 2s … capped at 30s, jittered 50–100% so many open docs don't
+   * retry in lockstep. The first retry is quick because the common cause is a
+   * token that expired a moment ago and a fresh mint just works; the cap is what
+   * stops a persistently-unusable session (expired login, revoked account) from
+   * turning into an unbounded reconnect storm.
+   */
+  private scheduleAuthRetry(): void {
+    if (this.destroyed || this.authRetryTimer) return;
+    const backoff = Math.min(30_000, 500 * 2 ** this.authFailures);
+    const delay = backoff * (0.5 + 0.5 * Math.random());
+    this.authFailures++;
+    this.authRetryTimer = setTimeout(() => {
+      this.authRetryTimer = null;
+      if (this.destroyed || this._status === "no-access") return;
+      this.reconnectWithFreshToken();
+    }, delay);
+  }
+
+  /** A connection authenticated: forget the failure streak. */
+  private noteAuthSuccess(): void {
+    this.authFailures = 0;
+    if (this.authRetryTimer) {
+      clearTimeout(this.authRetryTimer);
+      this.authRetryTimer = null;
+    }
+  }
+
   private async mintToken(): Promise<string | null> {
     try {
       const res = await this.api.syncToken(this.docId);
       this._readOnly = res.readOnly;
       // (Re)arm refresh based on the real token TTL.
       this.refresher.schedule(ttlFromToken(res.token));
-      if (this._status !== "no-access") {
-        this.setStatus(res.readOnly ? "read-only" : "synced");
+      // A minted token is NOT a connected socket. Claiming "synced" here (and,
+      // via setSyncStatus, stamping lastSyncedAt) painted a green "Synced · just
+      // now" before the server had even seen the token — so a token the server
+      // then rejected still flashed success first. Read-only is a property of the
+      // grant rather than the connection, so it's safe to reflect immediately;
+      // "synced" now waits for onStatus/onSynced.
+      if (this._status !== "no-access" && res.readOnly) {
+        this.setStatus("read-only");
       }
       return res.token;
     } catch (e) {
       if (e instanceof ApiError && e.status === 403) {
         this.setStatus("no-access");
         this.refresher.cancel();
+        // Guards alone can't stop this: HocuspocusProvider reconnects on its own
+        // schedule, so a refused doc would keep opening sockets (and keep getting
+        // rejected) for as long as the note stayed open. Refusal is terminal until
+        // something re-opens the note or an ACL change calls refreshAccess(), so
+        // take the socket down instead of leaving it to cycle.
+        try {
+          this.provider.configuration.websocketProvider?.disconnect();
+        } catch {
+          /* provider already torn down */
+        }
         return null;
       }
-      this.setStatus("error");
+      // A 401 means the stored session is no longer valid (expired, or the user
+      // no longer exists on this server). Re-minting cannot fix that, so treat it
+      // as offline and let the backoff stretch out instead of retrying hard.
+      this.setStatus(e instanceof ApiError && e.status === 401 ? "offline" : "error");
       return null;
     }
   }
@@ -339,6 +411,12 @@ export class DocSync {
     if (this.settleTimer) {
       clearTimeout(this.settleTimer);
       this.settleTimer = null;
+    }
+    // A pending auth retry outlives the provider otherwise, reconnecting a doc
+    // the user already closed.
+    if (this.authRetryTimer) {
+      clearTimeout(this.authRetryTimer);
+      this.authRetryTimer = null;
     }
     this.refresher.cancel();
     try {

--- a/app/apps/server/src/billing/polar.ts
+++ b/app/apps/server/src/billing/polar.ts
@@ -30,6 +30,48 @@ import {
 const META_ORG = "organization_id";
 const META_USER = "user_id";
 
+/**
+ * Run one Polar SDK call, converting its errors into something diagnosable.
+ *
+ * The SDK's `ResponseValidationError` carries a `message` of exactly
+ * "Response validation failed" — the Zod cause, the HTTP status and the body
+ * that failed to parse live on the error object and are NOT in `message`. Since
+ * the routes surface `err.message` to the client, an unhandled one of these
+ * reaches the UI as a bare "Response validation failed" with every clue
+ * dropped. So log the detail server-side (that's the only place it can go — it
+ * may quote a provider payload, which must not travel to the client) and
+ * rethrow a neutral Error that at least names the operation and status.
+ *
+ * Note this fires on error responses too, not just success ones: the SDK
+ * validates a 4xx/5xx body against its declared error schema with the same
+ * message, so a wrong token/server/product — whose error body doesn't match —
+ * shows up here rather than as the actual "not found"/"unauthorized".
+ */
+async function polarCall<T>(op: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    const e = err as {
+      name?: string;
+      statusCode?: number;
+      body?: string;
+      rawValue?: unknown;
+      pretty?: () => string;
+    };
+    if (typeof e.pretty === "function") {
+      const body = typeof e.body === "string" ? e.body.slice(0, 2000) : "";
+      console.error(
+        `[billing] Polar ${op} failed: ${e.name} status=${e.statusCode ?? "?"}\n` +
+          `${e.pretty()}\nbody: ${body}`,
+      );
+      throw new Error(
+        `Polar ${op} returned a response this SDK could not parse (HTTP ${e.statusCode ?? "?"}) — see server logs`,
+      );
+    }
+    throw err;
+  }
+}
+
 function client(): Polar {
   if (!config.polarAccessToken) {
     throw new Error("Polar access token not configured");
@@ -84,27 +126,33 @@ export class PolarBillingProvider implements BillingProvider {
         `No Polar product configured for interval "${args.interval}"`,
       );
     }
-    const checkout = await client().checkouts.create({
-      products: [productId],
-      successUrl: args.successUrl,
-      customerEmail: args.email,
-      metadata: {
-        [META_ORG]: args.orgId,
-        [META_USER]: args.userId,
-      },
-    });
+    const checkout = await polarCall("checkouts.create", () =>
+      client().checkouts.create({
+        products: [productId],
+        successUrl: args.successUrl,
+        customerEmail: args.email,
+        metadata: {
+          [META_ORG]: args.orgId,
+          [META_USER]: args.userId,
+        },
+      }),
+    );
     return { url: checkout.url };
   }
 
   async getPortalUrl(args: { customerId: string }): Promise<{ url: string }> {
-    const session = await client().customerSessions.create({
-      customerId: args.customerId,
-    });
+    const session = await polarCall("customerSessions.create", () =>
+      client().customerSessions.create({
+        customerId: args.customerId,
+      }),
+    );
     return { url: session.customerPortalUrl };
   }
 
   async cancelSubscription(providerSubscriptionId: string): Promise<void> {
-    await client().subscriptions.revoke({ id: providerSubscriptionId });
+    await polarCall("subscriptions.revoke", () =>
+      client().subscriptions.revoke({ id: providerSubscriptionId }),
+    );
   }
 
   verifyAndNormalizeWebhook(

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -212,12 +212,39 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
 
     // Client may supply a stable doc_id (generated locally); else we mint one.
     const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
-    await pool.query(
+    // RETURNING tells us whether the row is actually ours. `DO NOTHING` alone is
+    // silent about *why* nothing happened, and answering 201 regardless told the
+    // client "doc `id` now belongs to `vaultId`" even when that id was already a
+    // note in a DIFFERENT vault. The client persisted that mapping and then synced
+    // against a doc it has no grant on: /api/sync-token 403s forever, the provider
+    // reconnects on every rejection, and the note never loads. A doc_id is global,
+    // so a collision across vaults has to be reported, not swallowed.
+    const inserted = await pool.query(
       `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by)
        VALUES ($1, $2, $3, $4, $5, $1, $6)
-       ON CONFLICT (id) DO NOTHING`,
+       ON CONFLICT (id) DO NOTHING
+       RETURNING id`,
       [id, vaultId, folderId ?? null, title ?? null, relPath, session.userId],
     );
+    if (inserted.rowCount === 0) {
+      const { rows: existing } = await pool.query<{ vault_id: string; rel_path: string }>(
+        "SELECT vault_id, rel_path FROM notes WHERE id = $1",
+        [id],
+      );
+      const row = existing[0];
+      // Re-registering the same note in the same vault is the ordinary adopt
+      // path (a second device, or a repeat reconcile) — still a success.
+      if (row && row.vault_id !== vaultId) {
+        return c.json(
+          {
+            error: "doc_id already belongs to another vault",
+            code: "doc_id_conflict",
+            docId: id,
+          },
+          409,
+        );
+      }
+    }
     changed(vaultId);
     return c.json(
       { id, docId: id, vaultId, folderId: folderId ?? null, title: title ?? null, relPath },

--- a/app/apps/server/src/sync/hocuspocus.ts
+++ b/app/apps/server/src/sync/hocuspocus.ts
@@ -60,7 +60,17 @@ export function createSyncServer(
       let claims;
       try {
         claims = await verifySyncToken(data.token);
-      } catch {
+      } catch (err) {
+        // Log WHY, not just that it failed: an empty token (the client couldn't
+        // mint one) and an expired or wrong-secret token are completely different
+        // faults, and "Invalid or expired sync token" alone can't tell them apart
+        // — which turned a client-side retry storm into thousands of identical,
+        // undiagnosable log lines.
+        const len = typeof data.token === "string" ? data.token.length : -1;
+        const code = (err as { code?: string })?.code ?? (err as Error)?.name;
+        console.warn(
+          `[onAuthenticate] rejected token for ${data.documentName}: ${code} (token length ${len})`,
+        );
         throw new Error("Invalid or expired sync token");
       }
 


### PR DESCRIPTION
A rejected per-doc sync token made the desktop reconnect immediately, forever. On a note whose `doc_id` belongs to a vault the user has no grant on, `POST /api/sync-token` 403s, `mintToken()` returns `null`, and the token function hands the server `""` — which is always rejected. `onAuthenticationFailed` then reconnected with no delay, so the cycle ran ~4×/second and produced 25k+ identical server log lines in one session.

Three things kept it alive:

- **No backoff.** `onAuthenticationFailed` reconnected instantly. Now 500ms→30s exponential with 50–100% jitter, reset on any successful auth.
- **`no-access` wasn't terminal.** `onStatus("connecting")` overwrote it unconditionally, and HocuspocusProvider emits that on every lap of its own reconnect loop — reopening the guard on every other handler. Now preserved, and a 403 disconnects the socket instead of leaving it to cycle (guards alone can't stop the provider's internal retry).
- **Premature success.** `mintToken()` called `setStatus("synced")` on mint, before the socket had authenticated — so a token the server went on to reject still stamped `lastSyncedAt` and painted a green "Synced · just now" first. Combined with the loop and the pill's 260ms tint transition, that strobed the sync badge amber↔green.

### Root cause of the bad state

`POST /api/notes` did `ON CONFLICT (id) DO NOTHING` and then returned `201 { docId, vaultId }` regardless — telling the client a doc belonged to the requested vault even when that id was already a note in a *different* one. Clients persisted those mappings and synced against docs they can't read. It now returns `409 doc_id_conflict`, and the desktop leaves such notes local-only rather than writing a mapping that can only ever 403.

Rotating a local `doc_id` so an affected note can rejoin a new vault is still not implemented; local-only is the safe fallback.

### Also

- `onAuthenticate` logs *why* a token was rejected (empty vs expired vs wrong secret) — previously indistinguishable.
- The Polar adapter logs `ResponseValidationError`'s Zod cause, status and body server-side. Its `.message` is exactly `"Response validation failed"` with the cause on the error object, so the checkout route was surfacing that bare string to the UI with every clue dropped.
- Graph: `rebuild()` called `sim.alpha(1)` on **every** data refresh, so each `file-changed` event threw the whole layout back to maximum energy and it visibly flew apart — a storm of them during a vault sync read as a constant reset. Only the first build fully reheats now; refreshes warm to 0.22. Intro kick 28→7 over 1600ms, birth flare 3.4×→2.1×.

### Testing

Desktop: 172 pass, 0 fail. Typecheck clean in both workspaces. Verified live against a reproducing vault: sustained ~4 rejections/second → 0.

Server suite not run — it wipes the shared dev database.