### PR TITLE
Bound unbounded memory growth across vault sync, blob uploads, search, and undo

### DIFF
--- a/app/apps/desktop/src/lib/bridge/__tests__/undo.test.ts
+++ b/app/apps/desktop/src/lib/bridge/__tests__/undo.test.ts
@@ -1,0 +1,168 @@
+// F4 — the per-note UndoManager must be bounded.
+//
+// Every tracked local edit pushes a StackItem AND makes Yjs pin the structs that
+// edit deleted (`keepItem(item, true)`) so undo can restore them. Unbounded,
+// one long session in a single note grows both forever. These tests run the same
+// workload twice — with trimming disabled (the old behaviour) and enabled — so
+// the difference is the fix, not the harness.
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { NoteBridge } from "../noteBridge";
+import { ORIGIN_EDITOR } from "../types";
+import { makeHarness } from "./helpers";
+
+/**
+ * How many characters of *deleted* content the doc is still holding onto.
+ * Collecting a deleted struct swaps its content for `ContentDeleted` (a bare
+ * length) — anything else means the text itself is still in memory, pinned by
+ * the UndoManager so it could be restored.
+ */
+function pinnedDeletedChars(doc: Y.Doc): number {
+  let n = 0;
+  for (const structs of doc.store.clients.values()) {
+    for (const s of structs) {
+      if (s instanceof Y.Item && s.deleted && !(s.content instanceof Y.ContentDeleted)) {
+        n += s.length;
+      }
+    }
+  }
+  return n;
+}
+
+const CHUNK_LEN = 24;
+
+/** `cycles` independent edit steps, each inserting then deleting a chunk. */
+async function churn(bridge: NoteBridge, cycles: number): Promise<void> {
+  for (let i = 0; i < cycles; i++) {
+    const chunk = `chunk-${String(i).padStart(4, "0")}-${"x".repeat(12)}\n`;
+    if (chunk.length !== CHUNK_LEN) throw new Error(`chunk len ${chunk.length}`);
+    bridge.doc.transact(() => bridge.text.insert(0, chunk), ORIGIN_EDITOR);
+    bridge.doc.transact(() => bridge.text.delete(0, chunk.length), ORIGIN_EDITOR);
+  }
+}
+
+async function openWith(limit: number): Promise<NoteBridge> {
+  const { io } = makeHarness({ "n.md": "seed\n" });
+  return NoteBridge.open(io, {
+    docId: `d-${limit}`,
+    path: "n.md",
+    // captureTimeout 0 ⇒ every transaction is its own step, so "cycles" maps
+    // 1:1 onto stack depth and the test doesn't depend on wall-clock timing.
+    config: { undoCaptureTimeoutMs: 0, undoStackLimit: limit },
+  });
+}
+
+const CYCLES = 60;
+const LIMIT = 5;
+
+describe("undo history is bounded", () => {
+  it("without trimming, the stack and its GC pins grow with every edit", async () => {
+    const bridge = await openWith(0); // 0 disables trimming = pre-fix behaviour
+    await churn(bridge, CYCLES);
+
+    // Two steps per cycle (insert, delete) — nothing is ever released.
+    expect(bridge.undoDepth).toBe(CYCLES * 2);
+    // Every character ever deleted is still pinned (CHUNK chars per cycle).
+    expect(pinnedDeletedChars(bridge.doc)).toBeGreaterThanOrEqual(
+      CYCLES * CHUNK_LEN,
+    );
+    bridge.destroy();
+  });
+
+  it("caps the stack depth and releases the dropped steps' GC pins", async () => {
+    const bridge = await openWith(LIMIT);
+    await churn(bridge, CYCLES);
+
+    expect(bridge.undoDepth).toBe(LIMIT);
+    // Only the retained steps may still pin deleted content: O(limit), not
+    // O(edits). Pre-fix this was >= CYCLES * CHUNK_LEN (~1500 chars).
+    expect(pinnedDeletedChars(bridge.doc)).toBeLessThanOrEqual(LIMIT * CHUNK_LEN);
+    bridge.destroy();
+  });
+
+  it("trimming keeps recent undo working (oldest steps go, newest stay)", async () => {
+    const bridge = await openWith(LIMIT);
+    await churn(bridge, CYCLES);
+    const settled = bridge.serialize(); // every chunk was inserted then deleted
+
+    // The newest step was the delete of the last chunk. Undoing it must bring
+    // that text BACK — only possible if the retained steps kept their pins, so
+    // this is the assertion that the trim didn't over-release.
+    const last = `chunk-${String(CYCLES - 1).padStart(4, "0")}-${"x".repeat(12)}\n`;
+    bridge.undoManager.undo();
+    expect(bridge.serialize()).toBe(last + settled);
+    bridge.undoManager.redo();
+    expect(bridge.serialize()).toBe(settled);
+
+    // The remaining retained steps are still undoable — no wall at depth 1.
+    let undos = 0;
+    while (bridge.undoManager.canUndo()) {
+      bridge.undoManager.undo();
+      undos++;
+      if (undos > LIMIT + 2) break; // guard against an infinite loop
+    }
+    expect(undos).toBe(LIMIT);
+    // ...and the deepest retained step's chunk came back intact too, so the pins
+    // that survived really do still carry content.
+    //
+    // Which chunk that is falls out of the churn shape: the retained steps
+    // alternate insert/delete, so each *pair* of undos restores a chunk and then
+    // removes it again, netting back to `settled`. With an odd LIMIT the final
+    // undo is the leftover delete-undo, leaving that cycle's chunk in place.
+    // LIMIT=5 therefore lands on cycle 57, not 58. Computed, not hardcoded, so
+    // it tracks LIMIT/CYCLES instead of silently rotting if either changes.
+    if (LIMIT % 2 === 0) throw new Error("this assertion assumes an odd LIMIT");
+    const deepest = CYCLES - 1 - (LIMIT - 1) / 2;
+    const prev = `chunk-${String(deepest).padStart(4, "0")}-${"x".repeat(12)}\n`;
+    expect(bridge.serialize()).toContain(prev);
+    bridge.destroy();
+  });
+
+  it("the default bound is generous: hundreds of steps stay undoable", async () => {
+    const { io } = makeHarness({ "big.md": "" });
+    const bridge = await NoteBridge.open(io, {
+      docId: "big",
+      path: "big.md",
+      config: { undoCaptureTimeoutMs: 0 }, // default undoStackLimit
+    });
+    await churn(bridge, 150); // 300 steps
+    expect(bridge.undoDepth).toBe(300);
+    bridge.destroy();
+  });
+
+  it("trimming does not append phantom updates to the CRDT log", async () => {
+    const { io, persistence } = makeHarness({ "q.md": "" });
+    const bridge = await NoteBridge.open(io, {
+      docId: "q",
+      path: "q.md",
+      config: { undoCaptureTimeoutMs: 0, undoStackLimit: 2, compactThreshold: 10_000 },
+    });
+    await churn(bridge, 20);
+    await Promise.resolve();
+    // 40 content transactions ⇒ 40 logged updates; the trim's own (empty)
+    // transaction must not add any.
+    expect(persistence.logLength("q")).toBe(40);
+    expect(bridge.updatesObserved).toBe(40);
+    bridge.destroy();
+  });
+
+  it("the trimmed doc still serializes and round-trips its state", async () => {
+    const { io } = makeHarness({ "r.md": "" });
+    const bridge = await NoteBridge.open(io, {
+      docId: "r",
+      path: "r.md",
+      config: { undoCaptureTimeoutMs: 0, undoStackLimit: 3 },
+    });
+    await churn(bridge, 30);
+    bridge.doc.transact(() => bridge.text.insert(0, "final content"), ORIGIN_EDITOR);
+
+    // A peer applying the doc's full state must see exactly the same text —
+    // releasing GC pins must not lose live content.
+    const peer = new Y.Doc();
+    Y.applyUpdate(peer, Y.encodeStateAsUpdate(bridge.doc));
+    expect(peer.getText("content").toString()).toBe(bridge.serialize());
+    peer.destroy();
+    bridge.destroy();
+  });
+});

--- a/app/apps/desktop/src/lib/bridge/adapter.ts
+++ b/app/apps/desktop/src/lib/bridge/adapter.ts
@@ -49,8 +49,35 @@ export class BridgeManager {
   private current: { path: string; docId: string; bridge: NoteBridge } | null =
     null;
 
+  /**
+   * Serialises open/close so the slot has exactly one writer at a time.
+   *
+   * A fast note switch calls `openNote(B)` while `openNote(A)` is still awaiting
+   * `NoteBridge.open` (React runs the old effect's cleanup — which only fires
+   * `closeCurrent()` — before the new effect body). Without a queue the two
+   * opens interleave and the later assignment silently overwrites the earlier
+   * one, dropping a fully-wired bridge without `destroy()`. Worse, two
+   * concurrent opens of the SAME doc_id both see an empty CRDT log and both
+   * seed from the file, so the note's persisted history ends up containing the
+   * file's text twice (two client ids ⇒ the inserts merge instead of dedupe).
+   */
+  private chain: Promise<unknown> = Promise.resolve();
+  /** Bumped per `openNote` call: only the newest request may install a bridge. */
+  private generation = 0;
+
   constructor(io: BridgeIO = createTauriBridgeIO()) {
     this.io = io;
+  }
+
+  /** Run `fn` after every previously-queued open/close, whatever their outcome. */
+  private enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.chain.then(fn, fn);
+    // Swallow on the chain only — the caller still sees the real outcome.
+    this.chain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   async openNote(
@@ -58,17 +85,28 @@ export class BridgeManager {
     docId: string,
     opts: { seedFromFile?: boolean } = {},
   ): Promise<NoteBridge> {
-    if (this.current?.path === path && this.current.docId === docId) {
-      return this.current.bridge;
-    }
-    await this.closeCurrent();
-    const bridge = await NoteBridge.open(this.io, {
-      docId,
-      path,
-      seedFromFile: opts.seedFromFile,
+    const gen = ++this.generation;
+    return this.enqueue(async () => {
+      if (this.current?.path === path && this.current.docId === docId) {
+        return this.current.bridge;
+      }
+      await this.closeCurrentNow();
+      const bridge = await NoteBridge.open(this.io, {
+        docId,
+        path,
+        seedFromFile: opts.seedFromFile,
+      });
+      if (gen !== this.generation) {
+        // A newer openNote was requested while we were opening. Never install a
+        // stale bridge over the newest slot: retire this one ourselves so it
+        // can't outlive its request. The caller is a React effect that has
+        // already been cleaned up (`cancelled`), so it drops the return value.
+        await this.retire(bridge);
+        return bridge;
+      }
+      this.current = { path, docId, bridge };
+      return bridge;
     });
-    this.current = { path, docId, bridge };
-    return bridge;
   }
 
   /** Route a watcher event: ingest if it targets the open note. */
@@ -84,16 +122,32 @@ export class BridgeManager {
     return this.current?.path ?? null;
   }
 
+  /**
+   * Close the open note. Queued behind any in-flight open, so closing during a
+   * note switch can't no-op on an empty slot and leave that bridge resident.
+   */
   async closeCurrent(): Promise<void> {
+    // A close supersedes any *pending* open (there is nothing to show it in).
+    this.generation++;
+    await this.enqueue(() => this.closeCurrentNow());
+  }
+
+  /** Unqueued close — only call from inside the queue. */
+  private async closeCurrentNow(): Promise<void> {
     const cur = this.current;
     if (!cur) return;
     this.current = null;
+    await this.retire(cur.bridge);
+  }
+
+  /** Flush a bridge's pending write, then tear it down. Never throws. */
+  private async retire(bridge: NoteBridge): Promise<void> {
     try {
-      await cur.bridge.flushEgest();
+      await bridge.flushEgest();
     } catch (e) {
       console.error("[bridge] flush on close failed", e);
     }
-    cur.bridge.destroy();
+    bridge.destroy();
   }
 }
 

--- a/app/apps/desktop/src/lib/bridge/noteBridge.ts
+++ b/app/apps/desktop/src/lib/bridge/noteBridge.ts
@@ -55,6 +55,7 @@ export class NoteBridge {
 
   private readonly onDocUpdate: (update: Uint8Array, origin: unknown) => void;
   private readonly onTextChange: (evt: Y.YTextEvent, tr: Y.Transaction) => void;
+  private readonly onUndoStackItemAdded: () => void;
 
   // UndoManager scoped to local editor edits only — 'disk'/'remote' origins are
   // never undoable. y-codemirror's yCollab additionally registers its own sync
@@ -71,7 +72,15 @@ export class NoteBridge {
     this.text = this.doc.getText("content");
     this.undoManager = new Y.UndoManager(this.text, {
       trackedOrigins: new Set([ORIGIN_EDITOR]),
+      // Group rapid keystrokes into one undo step (Yjs default, made explicit
+      // because the whole bound below is expressed in *steps*).
+      captureTimeout: this.cfg.undoCaptureTimeoutMs,
     });
+    // Bound the history: without this, one long session in a single note grows
+    // the undo stack for every edit AND keeps every deleted struct pinned
+    // against garbage collection (Yjs `keepItem(item, true)`).
+    this.onUndoStackItemAdded = () => this.trimUndoHistory();
+    this.undoManager.on("stack-item-added", this.onUndoStackItemAdded);
 
     this.setT =
       io.setTimeout ??
@@ -334,6 +343,69 @@ export class NoteBridge {
     Y.applyUpdate(this.doc, update, ORIGIN_REMOTE);
   }
 
+  // ---- Undo history bound -----------------------------------------------
+
+  /** Retained undo steps (for tests/observability). */
+  get undoDepth(): number {
+    return this.undoManager.undoStack.length;
+  }
+
+  /**
+   * Drop the oldest undo steps once the stack exceeds `cfg.undoStackLimit`.
+   *
+   * Two things grow per step, and both have to be released:
+   *   1. the `StackItem` itself, and
+   *   2. the GC pin Yjs puts on every struct that step deleted —
+   *      `UndoManager`'s afterTransaction handler calls `keepItem(item, true)`
+   *      so undo can restore the text, which makes the deleted content
+   *      un-collectable for the lifetime of the doc.
+   *
+   * Yjs releases (2) in `clear()` but exposes no "forget the oldest step" API,
+   * so we mirror its `clearUndoManagerStackItem` with the public primitives
+   * (`iterateDeletedStructs` + `Item.keep` + `tryGc`). Steps are dropped from
+   * the FRONT, so recent history — the only history a user actually reaches —
+   * is untouched.
+   */
+  private trimUndoHistory(): void {
+    const limit = this.cfg.undoStackLimit;
+    if (limit <= 0) return;
+    const stack = this.undoManager.undoStack;
+    const excess = stack.length - limit;
+    if (excess <= 0) return;
+    const dropped = stack.splice(0, excess);
+
+    // Un-pin what the dropped steps were holding. A step's `deletions` set is
+    // disjoint from every other step's (a struct can only be deleted once), so
+    // this can never un-pin content a retained step still needs to restore.
+    this.doc.transact((tr) => {
+      for (const item of dropped) {
+        Y.iterateDeletedStructs(tr, item.deletions, (struct) => {
+          // `keepItem` also walks parents, but this doc's scope is a ROOT
+          // Y.Text, so a struct's parent has no `_item` to un-pin.
+          if (struct instanceof Y.Item && this.inUndoScope(tr, struct)) {
+            struct.keep = false;
+          }
+        });
+      }
+    });
+    // The current transaction's own deletions are GC'd by Yjs at cleanup, but
+    // these were deleted long ago — collect them explicitly now that nothing
+    // pins them. (This transaction changes no content, so it emits no update.)
+    if (this.doc.gc) {
+      for (const item of dropped) {
+        Y.tryGc(item.deletions, this.doc.store, this.doc.gcFilter);
+      }
+    }
+  }
+
+  private inUndoScope(tr: Y.Transaction, struct: Y.Item): boolean {
+    return this.undoManager.scope.some(
+      (type) =>
+        type === tr.doc ||
+        (type instanceof Y.AbstractType && Y.isParentOf(type, struct)),
+    );
+  }
+
   // ---- Compaction -------------------------------------------------------
 
   /** Merge the log into one snapshot and truncate it (spec 02 §4). */
@@ -346,6 +418,11 @@ export class NoteBridge {
 
   // ---- Teardown ---------------------------------------------------------
 
+  /** True once `destroy()` has run — a destroyed bridge must not be reused. */
+  get isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
@@ -355,6 +432,7 @@ export class NoteBridge {
     this.egestTimer = null;
     this.text.unobserve(this.onTextChange);
     this.doc.off("update", this.onDocUpdate);
+    this.undoManager.off("stack-item-added", this.onUndoStackItemAdded);
     this.undoManager.destroy();
     this.doc.destroy();
   }

--- a/app/apps/desktop/src/lib/bridge/types.ts
+++ b/app/apps/desktop/src/lib/bridge/types.ts
@@ -62,6 +62,20 @@ export interface BridgeConfig {
   compactThreshold: number;
   /** Take a recovery snapshot before a diff that churns this fraction of the doc. */
   largeDiffRatio: number;
+  /**
+   * Undo grouping window: local edits landing within this many ms of each other
+   * merge into ONE undo step (Yjs `UndoManager.captureTimeout`). This is what
+   * keeps a burst of keystrokes from becoming one stack item per character.
+   */
+  undoCaptureTimeoutMs: number;
+  /**
+   * Hard cap on retained undo steps for one open note. Past this, the OLDEST
+   * steps are dropped and their GC pins released (see
+   * `NoteBridge.trimUndoHistory`) so a long session in one note cannot grow the
+   * undo stack — or the deleted content it keeps un-collectable — without bound.
+   * 0 disables trimming.
+   */
+  undoStackLimit: number;
 }
 
 export const DEFAULT_CONFIG: BridgeConfig = {
@@ -69,6 +83,13 @@ export const DEFAULT_CONFIG: BridgeConfig = {
   egestDebounceMs: 300,
   compactThreshold: 64,
   largeDiffRatio: 0.6,
+  // 500ms matches Yjs' own default and CodeMirror's `newGroupDelay`, so undo
+  // granularity feels the same as the non-collab editor.
+  undoCaptureTimeoutMs: 500,
+  // 500 grouped steps ≈ 500 distinct edit bursts in a single note without
+  // switching away — far past any realistic Ctrl+Z run (CodeMirror's own
+  // history keeps ~100), while still bounding the stack.
+  undoStackLimit: 500,
 };
 
 export interface NoteBridgeOptions {

--- a/app/apps/desktop/src/lib/sync/vaultDocStore.ts
+++ b/app/apps/desktop/src/lib/sync/vaultDocStore.ts
@@ -48,7 +48,11 @@ export class VaultDocStore implements DocUpdateSink {
   private readonly svCache = new Map<string, Uint8Array>();
   /** Most-recently-touched docIds (tail = newest) for backfill prioritisation. */
   private readonly recent: string[] = [];
-  /** Per-doc promise chain so concurrent cold applies for one doc serialise. */
+  /** Per-doc promise chain so concurrent cold applies for one doc serialise.
+   *  Self-clearing: a chain removes its own entry when it settles, so this map
+   *  only ever holds *in-flight* work (see `enqueueCold`). That's why `drop()`
+   *  leaves it alone — deleting a live entry would let the next update for that
+   *  doc run in parallel with the one still writing. */
   private readonly coldChains = new Map<string, Promise<void>>();
 
   private touchSeq = 0;
@@ -101,11 +105,14 @@ export class VaultDocStore implements DocUpdateSink {
     if (entry) {
       this.hot.delete(docId);
       // Flush any pending write, then tear down — access is gone, so stop syncing.
-      void entry.bridge.flushEgest().finally(() => entry.bridge.destroy());
+      void this.retire(entry.bridge);
     }
     this.svCache.delete(docId);
     const i = this.recent.indexOf(docId);
     if (i !== -1) this.recent.splice(i, 1);
+    // coldChains is deliberately untouched: it only holds in-flight work, which
+    // must be allowed to finish (and clears itself). A later update for a dropped
+    // doc is skipped by `coldApply` once the registry stops resolving its path.
   }
 
   // ---- Public tier controls (used by the open-note path, Phase E) -------
@@ -145,29 +152,45 @@ export class VaultDocStore implements DocUpdateSink {
     if (this.recent.length > RECENT_CAP) this.recent.shift();
   }
 
-  /** Tear everything down (app shutdown / sign-out). */
+  /**
+   * Tear everything down (app shutdown / sign-out). Drops ALL state the store
+   * holds — hot bridges, the manifest cache, the recency list and the suppressed
+   * doc — and waits for any in-flight cold apply so no transient bridge is left
+   * mid-write.
+   */
   async destroyAll(): Promise<void> {
     const entries = [...this.hot.values()];
+    const cold = [...this.coldChains.values()];
     this.hot.clear();
-    await Promise.all(
-      entries.map((e) => e.bridge.flushEgest().finally(() => e.bridge.destroy())),
-    );
+    this.coldChains.clear();
+    this.svCache.clear();
+    this.recent.length = 0;
+    this.suppressed = null;
+    await Promise.all([
+      ...entries.map((e) => this.retire(e.bridge)),
+      ...cold.map((c) => c.catch(() => {})),
+    ]);
   }
 
   // ---- internals --------------------------------------------------------
 
   private enqueueCold(docId: string, update: Uint8Array): Promise<void> {
     const prev = this.coldChains.get(docId) ?? Promise.resolve();
-    const next = prev
-      .catch(() => {})
-      .then(() => this.coldApply(docId, update));
-    this.coldChains.set(
-      docId,
-      next.finally(() => {
-        if (this.coldChains.get(docId) === next) this.coldChains.delete(docId);
-      }),
-    );
-    return next;
+    const run = prev.catch(() => {}).then(() => this.coldApply(docId, update));
+    // The map must hold the SAME promise the guard compares against, otherwise
+    // the self-delete never fires and the entry is never reclaimed. The identity
+    // check is what keeps an older chain from deleting a newer one enqueued for
+    // the same doc while it was still running.
+    const chain: Promise<void> = run.finally(() => {
+      if (this.coldChains.get(docId) === chain) this.coldChains.delete(docId);
+    });
+    this.coldChains.set(docId, chain);
+    return chain;
+  }
+
+  /** In-flight cold applies, for tests/observability. */
+  pendingColdDocs(): string[] {
+    return [...this.coldChains.keys()];
   }
 
   private async coldApply(docId: string, update: Uint8Array): Promise<void> {
@@ -199,7 +222,18 @@ export class VaultDocStore implements DocUpdateSink {
       const e = this.hot.get(lruId)!;
       this.hot.delete(lruId);
       // Keep the svCache entry so the manifest stays cheap after eviction.
-      void e.bridge.flushEgest().finally(() => e.bridge.destroy());
+      void this.retire(e.bridge);
     }
+  }
+
+  /** Flush a bridge's pending write, then tear it down. Never throws, and always
+   *  destroys — a failed flush must not leak the bridge's observers. */
+  private async retire(bridge: NoteBridge): Promise<void> {
+    try {
+      await bridge.flushEgest();
+    } catch (e) {
+      console.error("[vaultDocStore] flush on retire failed", e);
+    }
+    bridge.destroy();
   }
 }

--- a/app/apps/server/migrations/014_purge_deleted_note_index.sql
+++ b/app/apps/server/migrations/014_purge_deleted_note_index.sql
@@ -1,0 +1,36 @@
+-- Purge derived index rows stranded by deleted notes, and index note_index for
+-- the batched search scan.
+--
+-- note_index / note_links are a rebuildable cache derived from the canonical
+-- Yjs state (see migration 005). Soft-deleting a note (notes.deleted_at) never
+-- dropped them: registry.ts flipped deleted_at, the folder cascade did the same
+-- for a whole subtree, and indexer.indexDoc early-returned before its own
+-- DELETE because the note was already gone. So every deleted note kept a FULL
+-- plain-text copy of its body in note_index forever, plus wikilink edges in
+-- note_links. That is unbounded table growth and a privacy problem ("deleted"
+-- content still readable server-side).
+--
+-- The write paths now purge on delete (src/http/routes/registry.ts,
+-- src/mcp/service.ts) and indexer.indexDoc self-heals when it finds no live
+-- note row. This clears the backlog. Nothing here is destructive to any source
+-- of truth: every row deleted below belongs to a doc with no live `notes` row,
+-- and a live note's rows can always be re-derived by re-indexing.
+
+DELETE FROM note_index ni
+ WHERE NOT EXISTS (
+   SELECT 1 FROM notes n WHERE n.id = ni.doc_id AND n.deleted_at IS NULL
+ );
+
+DELETE FROM note_links nl
+ WHERE NOT EXISTS (
+   SELECT 1 FROM notes n WHERE n.id = nl.from_doc AND n.deleted_at IS NULL
+ );
+
+-- Semantic search now walks a vault's note_index in keyset-paginated batches
+-- (WHERE vault_id = $1 AND doc_id > $2 ORDER BY doc_id LIMIT n) instead of
+-- selecting every row's body + vector at once. This composite index serves that
+-- scan directly, so each batch is an ordered index range rather than a sort of
+-- the whole vault. The existing single-column note_index_vault_idx becomes
+-- redundant with it, but is left in place — dropping it is not worth a rewrite
+-- of anything that may already depend on the name.
+CREATE INDEX IF NOT EXISTS note_index_vault_doc_idx ON note_index (vault_id, doc_id);

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -82,6 +82,49 @@ export const config = {
   backfillConcurrency: int("BACKFILL_CONCURRENCY", 6),
   /** WebSocket path for the vault replication channel. */
   vaultSyncPath: required("VAULT_SYNC_PATH", "/vault-sync"),
+  /**
+   * Outbound bound for ONE vault-channel connection: how many bytes may sit in
+   * its socket queue before the server stops producing frames for it (backfill
+   * parks *before* its Postgres read; live updates fold into a pending
+   * full-state resend). The channel keeps no second userland queue, so
+   * `ws.bufferedAmount` is the connection's whole outbound footprint and this is
+   * a real bound, not a watermark on part of it. Peak per connection is this cap
+   * plus the frames the concurrently-admitted backfill loads hand over (at most
+   * `backfillConcurrency` of them — a WebSocket frame is indivisible, so it is
+   * always enqueued whole once its doc has been read).
+   *
+   * 4 MiB is ~320 ms of a 100 Mbit/s link, so producing never becomes the
+   * throughput limit for a healthy client; 32 connections backfilling at once
+   * total 128 MiB, which fits the headroom the 512 MB heap cap (Dockerfile
+   * NODE_OPTIONS) leaves above the ~160 MB idle footprint.
+   */
+  vaultSendCapBytes: int("VAULT_SEND_CAP_BYTES", 4 * 1024 * 1024),
+  /**
+   * How long a connection may sit AT `vaultSendCapBytes` with **zero** bytes
+   * leaving its socket before it is terminated. Any drain progress at all resets
+   * the window, so a peer draining even a trickle is paced indefinitely and is
+   * never closed for being slow; this fires only on a peer that has stopped
+   * reading. 60 s matches the idle deadline `@hocuspocus/server` applies to its
+   * own sockets in this same process.
+   */
+  vaultSendStallMs: int("VAULT_SEND_STALL_MS", 60_000),
+  /**
+   * Sampling period for a **blocked** connection — no timer runs for a
+   * connection that is under its cap. This is how often it re-reads
+   * `ws.bufferedAmount` to release parked producers and to check drain progress.
+   * At 25 ms the cap can be refilled ~40×/s (≈160 MB/s at the 4 MiB default),
+   * well above any real link, so sampling latency is never the bottleneck.
+   */
+  vaultSendPollMs: int("VAULT_SEND_POLL_MS", 25),
+  /**
+   * Vault-channel heartbeat period. One shared interval pings every connection
+   * and terminates any that did not answer the previous tick, so a peer that
+   * vanished without FIN/RST is reaped after one to two ticks (30–60 s) instead
+   * of keeping its PubSub subscription — and its presence dot in every
+   * teammate's sidebar — forever. Comparable to `@hocuspocus/server`'s 60 s
+   * `timeout` default.
+   */
+  vaultHeartbeatMs: int("VAULT_HEARTBEAT_MS", 30_000),
   // ---- Google OAuth (spec 04 §7 — social sign-in) ----
   /** Google OAuth client id/secret. Both unset ⇒ Google sign-in is simply
    *  disabled and the desktop hides the button; self-host stays fully usable

--- a/app/apps/server/src/http/routes/blobs.ts
+++ b/app/apps/server/src/http/routes/blobs.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
 import { canReadAttachment, filterReadableBlobs } from "../../permissions/http-gates.js";
@@ -20,10 +21,133 @@ import { getSession } from "../session.js";
  */
 export const blobRoutes = new Hono();
 
-/** Max attachment upload size. Generous for real attachments (images, PDFs)
- *  while stopping a single member from OOM-crashing the shared HTTP+sync
- *  process with a multi-gigabyte body. */
-const MAX_BLOB_BYTES = 100 * 1024 * 1024; // 100 MB
+/**
+ * Max attachment upload size, and the admission budget that bounds how many
+ * uploads may be in flight at once.
+ *
+ * Sizing rationale (this process runs with V8 capped at 512 MB inside a 1 GiB
+ * container, see Dockerfile / railway.json): storing an N-byte blob costs
+ * several multiples of N on the heap at peak, because node-postgres has no
+ * binary parameter protocol — the bytes must be rendered into a text-encodable
+ * form and then serialized into the outgoing wire buffer. With the base64
+ * encoding used below that is roughly N (body) + 1.33N (base64) + 1.33N (pg's
+ * write buffer) ≈ 3.7N. A 100 MB cap therefore put a SINGLE legal upload at
+ * ~370 MB of a 512 MB heap, and two concurrent ones over the container.
+ *
+ * So: a cap that is generous for real attachments (images, PDFs, short clips)
+ * but survivable at ~3.7x, plus a global byte budget so concurrency cannot
+ * stack peaks. Both are env-overridable for operators who have sized their
+ * container differently. Deliberately local to this file rather than added to
+ * config.ts.
+ */
+const MAX_BLOB_BYTES = positiveEnvInt("MAX_BLOB_BYTES", 25 * 1024 * 1024); // 25 MB
+
+/**
+ * Total upload-body bytes admitted concurrently. Must be >= MAX_BLOB_BYTES or a
+ * single max-size upload could never be admitted; the budget is what stops N
+ * simultaneous uploads from summing past the heap. At the default 50 MB the
+ * worst case is ~185 MB of peak heap for uploads.
+ */
+const MAX_INFLIGHT_UPLOAD_BYTES = Math.max(
+  MAX_BLOB_BYTES,
+  positiveEnvInt("MAX_INFLIGHT_UPLOAD_BYTES", 2 * MAX_BLOB_BYTES),
+);
+
+/** Requests allowed to WAIT for budget before we start shedding with 503. */
+const MAX_UPLOAD_QUEUE = 16;
+
+/** How long a queued upload waits for budget before giving up with 503. */
+const UPLOAD_WAIT_MS = 30_000;
+
+function positiveEnvInt(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : fallback;
+}
+
+/**
+ * FIFO admission control over a byte budget.
+ *
+ * Peak memory on the upload path is proportional to the size of the bodies
+ * being handled, and nothing else bounded it: the size cap limited one request
+ * while any number of compliant requests could run at once. Callers reserve
+ * their (declared, clamped) body size before touching the body and release it
+ * when done.
+ *
+ * Exported so it can be unit-tested without a database or an HTTP server.
+ */
+export class ByteBudget {
+  private inflight = 0;
+  private readonly waiters: Array<{
+    bytes: number;
+    resolve: (ok: boolean) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+
+  constructor(
+    private readonly budget: number,
+    private readonly maxQueue: number = MAX_UPLOAD_QUEUE,
+    private readonly waitMs: number = UPLOAD_WAIT_MS,
+  ) {}
+
+  /** Bytes currently reserved. Test/observability helper. */
+  get reserved(): number {
+    return this.inflight;
+  }
+
+  /** Requests currently waiting for budget. Test/observability helper. */
+  get waiting(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * Reserve `bytes`. Resolves true once admitted, false if the queue is
+   * saturated or the wait timed out (caller should shed the request).
+   *
+   * `inflight === 0` always admits, so a request larger than the whole budget
+   * still makes progress instead of deadlocking. Admission is strictly FIFO —
+   * a newcomer never jumps a queue — so a large upload can't be starved by a
+   * stream of small ones.
+   */
+  acquire(bytes: number): Promise<boolean> {
+    if (this.waiters.length === 0 && this.fits(bytes)) {
+      this.inflight += bytes;
+      return Promise.resolve(true);
+    }
+    if (this.waiters.length >= this.maxQueue) return Promise.resolve(false);
+    return new Promise<boolean>((resolve) => {
+      const waiter = {
+        bytes,
+        resolve,
+        timer: setTimeout(() => {
+          const i = this.waiters.indexOf(waiter);
+          if (i >= 0) this.waiters.splice(i, 1);
+          resolve(false);
+        }, this.waitMs),
+      };
+      // Never hold the process open just for a queued upload.
+      if (typeof waiter.timer.unref === "function") waiter.timer.unref();
+      this.waiters.push(waiter);
+    });
+  }
+
+  /** Give back a previous successful reservation. Always call from a `finally`. */
+  release(bytes: number): void {
+    this.inflight -= bytes;
+    if (this.inflight < 0) this.inflight = 0;
+    while (this.waiters.length > 0 && this.fits(this.waiters[0].bytes)) {
+      const waiter = this.waiters.shift() as (typeof this.waiters)[number];
+      clearTimeout(waiter.timer);
+      this.inflight += waiter.bytes;
+      waiter.resolve(true);
+    }
+  }
+
+  private fits(bytes: number): boolean {
+    return this.inflight === 0 || this.inflight + bytes <= this.budget;
+  }
+}
+
+const uploadBudget = new ByteBudget(MAX_INFLIGHT_UPLOAD_BYTES);
 
 interface BlobRow {
   id: string;
@@ -46,58 +170,105 @@ function toMeta(row: BlobRow) {
 }
 
 // ── upload ────────────────────────────────────────────────────────────────
-blobRoutes.post("/vaults/:vaultId/blobs", async (c) => {
-  const session = await getSession(c);
-  if (!session) return c.json({ error: "Authentication required" }, 401);
+blobRoutes.post(
+  "/vaults/:vaultId/blobs",
+  // The size cap has to be enforced BEFORE the body is buffered, otherwise it
+  // protects nothing: `arrayBuffer()` on a 10 GB request kills the process long
+  // before any post-read check could run. Hono's bodyLimit answers 413 straight
+  // from the Content-Length when there is one (no body read at all), and for a
+  // chunked/length-less request it reads incrementally and aborts the moment the
+  // running total passes maxSize — so the limit is not spoofable by omitting or
+  // lying about Content-Length.
+  bodyLimit({
+    maxSize: MAX_BLOB_BYTES,
+    onError: (c) => c.json({ error: "Attachment too large" }, 413),
+  }),
+  async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
 
-  const vaultId = c.req.param("vaultId");
-  const org = await vaultOrg(vaultId);
-  if (!org) return c.json({ error: "Unknown vault" }, 404);
-  if (!(await orgRole(org, session.userId))) {
-    return c.json({ error: "Not a member of this vault" }, 403);
-  }
+    const vaultId = c.req.param("vaultId");
+    const org = await vaultOrg(vaultId);
+    if (!org) return c.json({ error: "Unknown vault" }, 404);
+    if (!(await orgRole(org, session.userId))) {
+      return c.json({ error: "Not a member of this vault" }, 403);
+    }
 
-  // Reject oversized uploads before buffering the whole body into memory. A
-  // truthful Content-Length is short-circuited here; the post-read guard below
-  // catches a lying/absent one.
-  const declaredLen = Number(c.req.header("content-length"));
-  if (Number.isFinite(declaredLen) && declaredLen > MAX_BLOB_BYTES) {
-    return c.json({ error: "Attachment too large" }, 413);
-  }
+    // Admission control, after auth (so anonymous callers can never occupy the
+    // budget) and before the body is materialized. Reserve the declared size,
+    // clamped to the hard cap; an absent/garbage Content-Length reserves the
+    // whole cap, which is the honest worst case for a body we can't size yet.
+    const declared = Number(c.req.header("content-length"));
+    const reserve =
+      Number.isFinite(declared) && declared > 0
+        ? Math.min(Math.trunc(declared), MAX_BLOB_BYTES)
+        : MAX_BLOB_BYTES;
+    if (!(await uploadBudget.acquire(reserve))) {
+      return c.json({ error: "Too many uploads in flight — retry shortly" }, 503, {
+        "Retry-After": "5",
+      });
+    }
+    try {
+      // `Buffer.from(ArrayBuffer)` is a VIEW over the already-allocated body, not
+      // a copy — the previous `Buffer.from(new Uint8Array(ab))` duplicated the
+      // whole payload (Hono also caches the parsed body, so both copies stayed
+      // live for the rest of the request).
+      const ab = await c.req.arrayBuffer();
+      if (ab.byteLength === 0) {
+        return c.json({ error: "empty body" }, 400);
+      }
+      // Belt-and-braces: bodyLimit already enforced this above.
+      if (ab.byteLength > MAX_BLOB_BYTES) {
+        return c.json({ error: "Attachment too large" }, 413);
+      }
+      const buf = Buffer.from(ab);
 
-  const body = new Uint8Array(await c.req.arrayBuffer());
-  if (body.byteLength === 0) {
-    return c.json({ error: "empty body" }, 400);
-  }
-  if (body.byteLength > MAX_BLOB_BYTES) {
-    return c.json({ error: "Attachment too large" }, 413);
-  }
-  const buf = Buffer.from(body);
+      const mime = c.req.header("content-type") || "application/octet-stream";
+      const filename = c.req.header("x-file-name") ?? c.req.query("filename") ?? null;
+      const relPath = c.req.header("x-rel-path") ?? c.req.query("relPath") ?? filename;
+      const sha256 = createHash("sha256").update(buf).digest("hex");
 
-  const mime = c.req.header("content-type") || "application/octet-stream";
-  const filename = c.req.header("x-file-name") ?? c.req.query("filename") ?? null;
-  const relPath = c.req.header("x-rel-path") ?? c.req.query("relPath") ?? filename;
-  const sha256 = createHash("sha256").update(buf).digest("hex");
+      // Dedupe per vault by content hash: return the existing row if present.
+      // Doing this before any encoding means a re-upload of known content never
+      // pays the encode/serialize cost at all.
+      const existing = await pool.query<BlobRow>(
+        `SELECT id, sha256, size, mime, rel_path, filename
+           FROM blobs WHERE vault_id = $1 AND sha256 = $2`,
+        [vaultId, sha256],
+      );
+      if (existing.rows[0]) {
+        return c.json({ ...toMeta(existing.rows[0]), deduped: true }, 200);
+      }
 
-  // Dedupe per vault by content hash: return the existing row if present.
-  const existing = await pool.query<BlobRow>(
-    `SELECT id, sha256, size, mime, rel_path, filename
-       FROM blobs WHERE vault_id = $1 AND sha256 = $2`,
-    [vaultId, sha256],
-  );
-  if (existing.rows[0]) {
-    return c.json({ ...toMeta(existing.rows[0]), deduped: true }, 200);
-  }
-
-  const id = randomUUID();
-  const { rows } = await pool.query<BlobRow>(
-    `INSERT INTO blobs (id, vault_id, org_id, sha256, size, mime, data, rel_path, filename)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-     RETURNING id, sha256, size, mime, rel_path, filename`,
-    [id, vaultId, org, sha256, buf.byteLength, mime, buf, relPath, filename],
-  );
-  return c.json({ ...toMeta(rows[0]), deduped: false }, 201);
-});
+      const id = randomUUID();
+      // base64 + server-side `decode`, not a raw Buffer parameter. node-postgres
+      // has no binary parameter protocol: handed a Buffer it renders it as a
+      // `\x…` HEX string, i.e. 2 bytes of JS string per payload byte, and then
+      // serializes that into the outgoing buffer — ~4N on top of the body.
+      // base64 is 1.33 bytes per payload byte, so this cuts the dominant
+      // allocation on the upload path by a third. Bytes stored are identical.
+      const { rows } = await pool.query<BlobRow>(
+        `INSERT INTO blobs (id, vault_id, org_id, sha256, size, mime, data, rel_path, filename)
+         VALUES ($1, $2, $3, $4, $5, $6, decode($7::text, 'base64'), $8, $9)
+         RETURNING id, sha256, size, mime, rel_path, filename`,
+        [
+          id,
+          vaultId,
+          org,
+          sha256,
+          buf.byteLength,
+          mime,
+          buf.toString("base64"),
+          relPath,
+          filename,
+        ],
+      );
+      return c.json({ ...toMeta(rows[0]), deduped: false }, 201);
+    } finally {
+      uploadBudget.release(reserve);
+    }
+  },
+);
 
 // ── list ──────────────────────────────────────────────────────────────────
 blobRoutes.get("/vaults/:vaultId/blobs", async (c) => {
@@ -128,15 +299,19 @@ blobRoutes.get("/blobs/:id", async (c) => {
   if (!session) return c.json({ error: "Authentication required" }, 401);
 
   const id = c.req.param("id");
+  // Metadata FIRST, deliberately without `data`. Selecting the bytes up front
+  // meant every request — including the ones about to be rejected with 403 —
+  // materialized the whole blob several times over (pg renders BYTEA as a hex
+  // string twice the blob's size before decoding it to a Buffer). Now only a
+  // caller who passes both gates can make the process allocate anything large.
   const { rows } = await pool.query<{
     vault_id: string | null;
     org_id: string | null;
     mime: string | null;
     rel_path: string | null;
-    data: Buffer | null;
-  }>("SELECT vault_id, org_id, mime, rel_path, data FROM blobs WHERE id = $1", [id]);
+  }>("SELECT vault_id, org_id, mime, rel_path FROM blobs WHERE id = $1", [id]);
   const blob = rows[0];
-  if (!blob || !blob.data) return c.json({ error: "Blob not found" }, 404);
+  if (!blob) return c.json({ error: "Blob not found" }, 404);
 
   // Membership is necessary but not sufficient (via the blob's note collection,
   // or its org_id fallback for legacy rows without vault_id).
@@ -151,15 +326,34 @@ blobRoutes.get("/blobs/:id", async (c) => {
     return c.json({ error: "You do not have access to this attachment" }, 403);
   }
 
+  // Authorized: now fetch the bytes.
+  //
+  // KNOWN LIMITATION (not fixed here, on purpose): this is still a single
+  // whole-blob read, so peak heap is a few multiples of the blob size and there
+  // is no streaming. node-postgres cannot stream a BYTEA column, so fixing it
+  // properly means either large-object support or chunked reads
+  // (`substring(data from $2 for $3)`), and the chunked route only performs if
+  // the column is also switched to uncompressed storage (`ALTER TABLE blobs
+  // ALTER COLUMN data SET STORAGE EXTERNAL`) — otherwise every chunk detoasts
+  // the entire value. That is a restructuring of the pg access path with its own
+  // correctness surface, so it is written up as a recommendation rather than
+  // attempted. The lowered MAX_BLOB_BYTES bounds the damage meanwhile.
+  const { rows: dataRows } = await pool.query<{ data: Buffer | null }>(
+    "SELECT data FROM blobs WHERE id = $1",
+    [id],
+  );
+  const data = dataRows[0]?.data;
+  if (!data) return c.json({ error: "Blob not found" }, 404);
+
   // The stored MIME is attacker-controlled (taken verbatim from the uploader's
   // content-type). Serve every blob as a non-rendering download: `nosniff`
   // stops the browser MIME-sniffing it into an active document, and
   // `Content-Disposition: attachment` forces a download rather than inline
   // rendering — so a stored text/html blob can't execute as script in the API
   // origin. The desktop reads the raw bytes regardless of these headers.
-  return c.body(blob.data, 200, {
+  return c.body(data, 200, {
     "Content-Type": blob.mime || "application/octet-stream",
-    "Content-Length": String(blob.data.byteLength),
+    "Content-Length": String(data.byteLength),
     "X-Content-Type-Options": "nosniff",
     "Content-Disposition": "attachment",
   });

--- a/app/apps/server/src/http/routes/graph.ts
+++ b/app/apps/server/src/http/routes/graph.ts
@@ -3,7 +3,7 @@ import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
 import { listReadableDocsInVault } from "../../permissions/vault-docs.js";
 import { getSession } from "../session.js";
-import { cosineSimilarity, embed, tokenize } from "../../index/embedder.js";
+import { searchNoteIndex } from "../../index/indexer.js";
 
 /**
  * Read-only views over the note index (spec: links + vectors).
@@ -77,8 +77,15 @@ graphRoutes.get("/vaults/:vaultId/graph", async (c) => {
     if (!byTitle.has(stem)) byTitle.set(stem, n.id);
   }
 
+  // The JOIN keeps edges of soft-deleted notes out of the graph. The delete
+  // paths now purge note_links (registry.ts / indexer.ts), so this is a
+  // belt-and-braces guard against any row that outlives its note — and it means
+  // the rows never reach the heap in the first place.
   const { rows: linkRows } = await pool.query<{ from_doc: string; to_title: string }>(
-    "SELECT from_doc, to_title FROM note_links WHERE vault_id = $1",
+    `SELECT l.from_doc, l.to_title
+       FROM note_links l
+       JOIN notes n ON n.id = l.from_doc AND n.deleted_at IS NULL
+      WHERE l.vault_id = $1`,
     [vaultId],
   );
   // Only edges out of a readable note; targets already resolve within the
@@ -109,46 +116,21 @@ graphRoutes.get("/vaults/:vaultId/search", async (c) => {
   const kRaw = Number.parseInt(c.req.query("k") ?? "10", 10);
   const k = Number.isNaN(kRaw) || kRaw <= 0 ? 10 : Math.min(kRaw, 100);
 
-  const { rows: allRows } = await pool.query<{
-    doc_id: string;
-    title: string | null;
-    rel_path: string;
-    content: string;
-    vector: number[] | null;
-  }>(
-    `SELECT ni.doc_id, ni.title, n.rel_path, ni.content, ni.vector
-       FROM note_index ni
-       JOIN notes n ON n.id = ni.doc_id AND n.deleted_at IS NULL
-      WHERE ni.vault_id = $1`,
-    [vaultId],
-  );
-
   // Restrict the candidate set to readable notes: the score is computed over
   // note content, so scoring unreadable notes would be a content oracle.
   // Mirrors the MCP search tool. Owner/admin + Open vaults see everything.
   const readable = await listReadableDocsInVault(session.userId, vaultId);
-  const rows = allRows.filter((r) => readable.has(r.doc_id));
 
-  const qVec = embed(q);
-  const qTokens = Array.from(new Set(tokenize(q)));
-
-  const results = rows
-    .map((r) => {
-      const sim = r.vector ? cosineSimilarity(qVec, r.vector) : 0;
-      // Keyword boost: fraction of distinct query tokens present in the
-      // title/body, scaled small so it only breaks near-ties.
-      const haystack = `${r.title ?? ""} ${r.content}`.toLowerCase();
-      const matched = qTokens.filter((t) => haystack.includes(t)).length;
-      const boost = qTokens.length > 0 ? 0.1 * (matched / qTokens.length) : 0;
-      return {
-        docId: r.doc_id,
-        title: r.title ?? relPathStem(r.rel_path),
-        relPath: r.rel_path,
-        score: sim + boost,
-      };
-    })
-    .sort((a, b) => b.score - a.score)
-    .slice(0, k);
+  // Scoring lives in index/indexer.ts, which walks the vault in keyset batches
+  // and keeps only {docId, score} per note — note bodies and embedding vectors
+  // are no longer all pulled into the heap just to slice off the top k.
+  // Identical ranking + response shape.
+  const results = await searchNoteIndex({
+    vaultId,
+    query: q,
+    k,
+    readableDocIds: readable,
+  });
 
   return c.json({ results });
 });

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -4,6 +4,7 @@ import { pool } from "../../db/pool.js";
 import { orgRole, vaultOrg } from "../../permissions/lookup.js";
 import { canEditDoc, canEditFolder } from "../../permissions/http-gates.js";
 import { listReadableDocsInVault, listVisibleFolders } from "../../permissions/vault-docs.js";
+import { purgeNoteIndex } from "../../index/indexer.js";
 import { getSession } from "../session.js";
 
 export interface RegistryDeps {
@@ -183,13 +184,17 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
     // $2 is an exact match; $3 is the LIKE prefix with %/_ escaped so a folder
     // path containing wildcards cannot widen the soft-delete beyond its subtree.
-    await pool.query(
+    // RETURNING id gives us exactly the cascade's victims, so their derived
+    // index rows go with them (see the single-note delete below).
+    const { rows: cascaded } = await pool.query<{ id: string }>(
       `UPDATE notes SET deleted_at = now()
         WHERE vault_id = $1 AND deleted_at IS NULL
-          AND (rel_path = $2 OR rel_path LIKE $3 || '/%' ESCAPE '\\')`,
+          AND (rel_path = $2 OR rel_path LIKE $3 || '/%' ESCAPE '\\')
+        RETURNING id`,
       [row.vault_id, row.path, likeEscape(row.path)],
     );
     await pool.query("DELETE FROM folders WHERE id = $1", [id]);
+    await purgeNoteIndex(cascaded.map((n) => n.id));
     changed(row.vault_id);
     return c.json({ ok: true }, 200);
   });
@@ -318,6 +323,13 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "You cannot delete this note" }, 403);
     }
     await pool.query("UPDATE notes SET deleted_at = now() WHERE id = $1", [id]);
+    // Drop the DERIVED search/graph rows with the note. They are a rebuildable
+    // cache of the canonical Yjs state (migration 005), and note_index keeps a
+    // full plain-text copy of the body — leaving it behind grew those tables
+    // without bound and kept "deleted" content readable server-side. The Yjs
+    // doc and the doc_id survive untouched, so re-creating the note re-indexes
+    // it on its next store (indexer.scheduleIndex / backfillIndex).
+    await purgeNoteIndex([id]);
     changed(row.vault_id);
     return c.json({ ok: true }, 200);
   });

--- a/app/apps/server/src/index/indexer.ts
+++ b/app/apps/server/src/index/indexer.ts
@@ -2,7 +2,7 @@ import * as Y from "yjs";
 import type pg from "pg";
 import { pool as defaultPool } from "../db/pool.js";
 import { loadDocState } from "../yjs/persistence.js";
-import { embed } from "./embedder.js";
+import { cosineSimilarity, embed, tokenize } from "./embedder.js";
 
 /**
  * Note indexing engine (spec: links + vectors).
@@ -83,7 +83,16 @@ export async function indexDoc(
     [docId],
   );
   const note = rows[0];
-  if (!note) return false;
+  if (!note) {
+    // No LIVE note row: the note was hard- or soft-deleted (or this doc is a
+    // binary `files` row, which is never indexed). Either way any note_index /
+    // note_links rows for it are stale, and this early return used to strand
+    // them forever — the delete happens in the registry/MCP layer while a
+    // debounced re-index can still fire afterwards. Purge here so the derived
+    // tables self-heal no matter which path deleted the note.
+    await purgeNoteIndex([docId], db);
+    return false;
+  }
 
   const content = await extractDocText(docId, db);
   const title = note.title ?? relPathStem(note.rel_path);
@@ -156,6 +165,156 @@ export async function backfillIndex(db: Queryable = defaultPool): Promise<number
     }
   }
   return count;
+}
+
+/**
+ * Drop the derived index rows for a set of docs.
+ *
+ * note_index / note_links are a rebuildable cache derived from the canonical
+ * Yjs state (migration 005), so deleting them loses nothing that a re-index
+ * can't recompute. Doing so on delete matters twice over: note_index holds a
+ * FULL PLAIN-TEXT COPY of the note body, so keeping it for a "deleted" note is
+ * both unbounded table growth and a privacy problem.
+ */
+export async function purgeNoteIndex(
+  docIds: string[],
+  db: Queryable = defaultPool,
+): Promise<void> {
+  if (docIds.length === 0) return;
+  await db.query("DELETE FROM note_index WHERE doc_id = ANY($1::text[])", [docIds]);
+  await db.query("DELETE FROM note_links WHERE from_doc = ANY($1::text[])", [docIds]);
+}
+
+// ── search ──────────────────────────────────────────────────────────────────
+
+/**
+ * One ranked search hit. This shape is the API contract of BOTH
+ * `GET /api/vaults/:vaultId/search` and the MCP `search_notes` tool — don't
+ * change it without changing them together.
+ */
+export interface NoteSearchHit {
+  docId: string;
+  title: string;
+  relPath: string;
+  score: number;
+}
+
+/**
+ * How many note_index rows to score per round trip. Only a doc id, a 256-float
+ * vector and a small integer cross the wire per row (~2-3 KB), so a batch peaks
+ * around 1 MB regardless of vault size. Note BODIES never leave Postgres.
+ */
+const SEARCH_BATCH = 500;
+
+/**
+ * Rank the notes of one vault against a query, keeping peak memory bounded.
+ *
+ * Ranking is unchanged from the original inline implementations in
+ * http/routes/graph.ts and mcp/service.ts: `cosineSimilarity(embed(q), vector)`
+ * plus a keyword boost of `0.1 * (matched distinct query tokens / total)`, then
+ * sort by score descending and take the top `k`.
+ *
+ * What changed is HOW: those versions selected `ni.content` AND `ni.vector` for
+ * every row in the vault with no LIMIT, so one search materialized every note
+ * body and every embedding on the heap before slicing to k <= 100. Here:
+ *
+ *   1. the keyword-match count is computed in SQL (`position(token IN
+ *      lower(title || ' ' || content))`), so bodies stay in the database;
+ *   2. rows are walked in keyset-paginated batches ordered by doc_id, and only
+ *      a `{docId, score}` pair is retained per note;
+ *   3. titles and rel_paths are fetched afterwards for the <= k winners only.
+ *
+ * `readableDocIds` is pushed into the query rather than filtered afterwards, so
+ * notes the caller may not read are never scored (they'd be a content oracle).
+ *
+ * Note on `lower()`: query tokens are ASCII by construction (`tokenize` yields
+ * `[a-z0-9_]+`), and Postgres `lower()` matches JS `toLowerCase()` on ASCII, so
+ * substring matching is equivalent for every realistic input. Exotic Unicode
+ * that case-folds INTO ASCII (e.g. U+212A KELVIN SIGN) is the only place the two
+ * could disagree, and only in the small keyword-boost term.
+ */
+export async function searchNoteIndex(opts: {
+  vaultId: string;
+  query: string;
+  /** Max hits to return. Callers clamp this (search route <= 100, MCP <= 50). */
+  k: number;
+  /** Doc ids the caller may read — the candidate set. */
+  readableDocIds: Iterable<string>;
+  db?: Queryable;
+}): Promise<NoteSearchHit[]> {
+  const db = opts.db ?? defaultPool;
+  if (opts.k <= 0) return [];
+  const docIds = Array.from(opts.readableDocIds);
+  if (docIds.length === 0) return [];
+
+  const qVec = embed(opts.query);
+  const qTokens = Array.from(new Set(tokenize(opts.query)));
+
+  // Phase 1: score every candidate, retaining only id + score per note.
+  const scored: Array<{ docId: string; score: number }> = [];
+  let after = "";
+  for (;;) {
+    const { rows } = await db.query<{
+      doc_id: string;
+      vector: number[] | null;
+      matched: number;
+    }>(
+      `SELECT ni.doc_id,
+              ni.vector,
+              (
+                SELECT count(*) FROM unnest($4::text[]) AS t(tok)
+                 WHERE position(t.tok IN lower(coalesce(ni.title, '') || ' ' || ni.content)) > 0
+              )::int AS matched
+         FROM note_index ni
+         JOIN notes n ON n.id = ni.doc_id AND n.deleted_at IS NULL
+        WHERE ni.vault_id = $1
+          AND ni.doc_id = ANY($2::text[])
+          AND ni.doc_id > $3
+        ORDER BY ni.doc_id
+        LIMIT $5`,
+      [opts.vaultId, docIds, after, qTokens, SEARCH_BATCH],
+    );
+    if (rows.length === 0) break;
+    for (const r of rows) {
+      const sim = r.vector ? cosineSimilarity(qVec, r.vector) : 0;
+      const boost = qTokens.length > 0 ? 0.1 * (r.matched / qTokens.length) : 0;
+      scored.push({ docId: r.doc_id, score: sim + boost });
+    }
+    after = rows[rows.length - 1].doc_id;
+    if (rows.length < SEARCH_BATCH) break;
+  }
+
+  // Stable sort over doc_id-ordered input, so equal scores keep a deterministic
+  // order (the previous version left ties at the database's arbitrary order).
+  const top = scored.sort((a, b) => b.score - a.score).slice(0, opts.k);
+  if (top.length === 0) return [];
+
+  // Phase 2: fetch the display fields for the winners only.
+  const { rows: metaRows } = await db.query<{
+    doc_id: string;
+    title: string | null;
+    rel_path: string;
+  }>(
+    `SELECT ni.doc_id, ni.title, n.rel_path
+       FROM note_index ni
+       JOIN notes n ON n.id = ni.doc_id AND n.deleted_at IS NULL
+      WHERE ni.doc_id = ANY($1::text[])`,
+    [top.map((t) => t.docId)],
+  );
+  const meta = new Map(metaRows.map((r) => [r.doc_id, r]));
+
+  const hits: NoteSearchHit[] = [];
+  for (const t of top) {
+    const m = meta.get(t.docId);
+    if (!m) continue; // deleted between the two phases
+    hits.push({
+      docId: t.docId,
+      title: m.title ?? relPathStem(m.rel_path),
+      relPath: m.rel_path,
+      score: t.score,
+    });
+  }
+  return hits;
 }
 
 /** Filename stem of a rel_path, used as a fallback title. */

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -7,7 +7,8 @@ import {
   isLocked,
   type Permission,
 } from "../permissions/resolver.js";
-import { cosineSimilarity, embed, tokenize } from "../index/embedder.js";
+import { listReadableDocsInVault } from "../permissions/vault-docs.js";
+import { purgeNoteIndex, searchNoteIndex } from "../index/indexer.js";
 import type { McpAuth } from "./tokens.js";
 import type { DocWriter } from "./doc-writer.js";
 
@@ -321,8 +322,7 @@ export async function deleteNote(ctx: McpContext, docId: string) {
   const note = await requireEditableNote(ctx.auth, docId);
   await pool.query("UPDATE notes SET deleted_at = now() WHERE id = $1", [docId]);
   // Drop derived index rows and kick any live editors off the now-gone doc.
-  await pool.query("DELETE FROM note_index WHERE doc_id = $1", [docId]);
-  await pool.query("DELETE FROM note_links WHERE from_doc = $1", [docId]);
+  await purgeNoteIndex([docId]);
   ctx.disconnectDoc(note.vault_id, docId);
   return { deleted: docId };
 }
@@ -338,39 +338,18 @@ export async function searchNotes(
   await requireVaultInScope(ctx.auth, vaultId);
   const limit = Number.isFinite(k) && k > 0 ? Math.min(Math.trunc(k), 50) : 10;
 
-  const { rows } = await pool.query<{
-    doc_id: string;
-    title: string | null;
-    rel_path: string;
-    content: string;
-    vector: number[] | null;
-  }>(
-    `SELECT ni.doc_id, ni.title, n.rel_path, ni.content, ni.vector
-       FROM note_index ni
-       JOIN notes n ON n.id = ni.doc_id AND n.deleted_at IS NULL
-      WHERE ni.vault_id = $1`,
-    [vaultId],
-  );
-
-  const qVec = embed(query);
-  const qTokens = Array.from(new Set(tokenize(query)));
-  const admin = await isAdmin(ctx.auth);
-
-  const scored: Array<{ docId: string; title: string; relPath: string; score: number }> =
-    [];
-  for (const r of rows) {
-    const perm = admin ? "edit" : await effectivePermission(ctx.auth.userId, r.doc_id);
-    if (perm === "none") continue;
-    const sim = r.vector ? cosineSimilarity(qVec, r.vector) : 0;
-    const haystack = `${r.title ?? ""} ${r.content}`.toLowerCase();
-    const matched = qTokens.filter((t) => haystack.includes(t)).length;
-    const boost = qTokens.length > 0 ? 0.1 * (matched / qTokens.length) : 0;
-    scored.push({
-      docId: r.doc_id,
-      title: r.title ?? relPathStem(r.rel_path),
-      relPath: r.rel_path,
-      score: sim + boost,
-    });
-  }
-  return scored.sort((a, b) => b.score - a.score).slice(0, limit);
+  // Two changes, neither of which alters the result shape or the ranking:
+  //
+  //  - the candidate set comes from `listReadableDocsInVault` (ONE query) rather
+  //    than an O(N) sequential `effectivePermission` loop. That function is the
+  //    documented readable-set dual of the resolver — same owner/admin, creator,
+  //    folder/file/vault-grant and membership rules; `locked` only caps edit
+  //    down to view, so it can't change which notes are readable. It also
+  //    subsumes the old `isAdmin` short-circuit.
+  //  - scoring runs in index/indexer.ts, which walks note_index in keyset
+  //    batches and never pulls note bodies onto the heap. The old version
+  //    selected `ni.content` + `ni.vector` for every row in the vault with no
+  //    LIMIT and then pinned that whole array across the permission loop.
+  const readable = await listReadableDocsInVault(ctx.auth.userId, vaultId);
+  return searchNoteIndex({ vaultId, query, k: limit, readableDocIds: readable });
 }

--- a/app/apps/server/src/sync/hocuspocus.ts
+++ b/app/apps/server/src/sync/hocuspocus.ts
@@ -95,9 +95,36 @@ export function createSyncServer(
     async onLoadDocument(data) {
       const parsed = parseDocName(data.documentName);
       if (!parsed) return data.document;
-      const state = await loadDocState(parsed.docId);
-      if (state) {
-        Y.applyUpdate(data.document, state, LOAD_ORIGIN);
+      try {
+        const state = await loadDocState(parsed.docId);
+        if (state) {
+          Y.applyUpdate(data.document, state, LOAD_ORIGIN);
+        }
+      } catch (err) {
+        // Destroy-then-rethrow is load-bearing; Hocuspocus cannot clean this up
+        // for us. It only inserts the Document into its `documents` map AFTER
+        // this hook resolves (Hocuspocus.createDocument), and its own failure
+        // path calls `unloadDocument(document)`, which early-returns on
+        // `if (!this.documents.has(documentName)) return;` — so `destroy()` is
+        // never reached. Meanwhile `new Document(...)` built a `y-protocols`
+        // Awareness whose constructor arms a plain (non-`unref`'d) 3-second
+        // `setInterval` closing over the doc; `Awareness.destroy()` — reached
+        // only via the Y.Doc `destroy` event — is the sole `clearInterval`.
+        // Without this, one failed load (a dead pooled client, or an in-flight
+        // query during a Postgres restart/failover) permanently leaks the doc
+        // plus a live timer that keeps it reachable.
+        try {
+          data.document.destroy();
+        } catch (destroyErr) {
+          console.error(
+            `Failed to destroy document ${data.documentName} after a failed load:`,
+            destroyErr,
+          );
+        }
+        // Rethrow so Hocuspocus still rejects the connection — a client must
+        // never get an empty doc it would then treat as authoritative and sync
+        // its local state into.
+        throw err;
       }
       return data.document;
     },

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -33,6 +33,22 @@ import {
  * `ready`. After that it's push: every `onChange` publishes to the vault's
  * PubSub topic and the relay forwards it to subscribers whose ACL set contains
  * the doc. Injectable deps keep it unit-testable without a socket.
+ *
+ * **Outbound backpressure.** A client whose `hello` carries an empty manifest
+ * (the desktop's `svCache` is in-memory, so that's every app launch) asks for
+ * the FULL state of every readable doc — far more than any link drains while we
+ * frame it. The server therefore frames only what the socket has room for:
+ * `VaultConnection` keeps NO userland queue, so `ws.bufferedAmount` is the whole
+ * per-connection footprint, and every producer (backfill, ACL top-up, resync)
+ * parks on that number *before* it reads a doc out of Postgres. Nothing is ever
+ * deferred outside the socket, so `ws`'s single per-socket FIFO gives global
+ * ordering for free — a control frame can never overtake a data frame queued
+ * before it, and `ready` can never overtake the backfill it terminates.
+ *
+ * **Liveness.** One shared ping/pong sweep per channel (see `startHeartbeat`)
+ * reaps peers that vanished without FIN/RST; a blocked connection additionally
+ * watches bytes actually leaving its socket and terminates only a peer that
+ * moves none at all for `vaultSendStallMs`.
  */
 export interface VaultChannelDeps {
   pubsub: PubSub;
@@ -40,6 +56,14 @@ export interface VaultChannelDeps {
   loadDiff?: typeof loadDocDiff;
   verifyToken?: typeof verifyVaultToken;
   backfillConcurrency?: number;
+  /** Per-connection outbound cap in bytes (default `config.vaultSendCapBytes`). */
+  sendCapBytes?: number;
+  /** Zero-drain window before a blocked connection is terminated (ms). */
+  sendStallMs?: number;
+  /** Sampling period for a blocked connection (ms). */
+  sendPollMs?: number;
+  /** Heartbeat period for {@link VaultChannel.startHeartbeat} (ms). */
+  heartbeatMs?: number;
 }
 
 export class VaultChannel {
@@ -48,6 +72,14 @@ export class VaultChannel {
   private readonly loadDiff: typeof loadDocDiff;
   private readonly verifyToken: typeof verifyVaultToken;
   private readonly concurrency: number;
+  private readonly sendCapBytes: number;
+  private readonly sendStallMs: number;
+  private readonly sendPollMs: number;
+  private readonly heartbeatMs: number;
+  /** Live connections, so the shared heartbeat has something to sweep. Entries
+   *  remove themselves from `cleanup()`, i.e. on close/terminate/failure. */
+  private readonly connections = new Set<VaultConnection>();
+  private heartbeat: ReturnType<typeof setInterval> | null = null;
 
   constructor(deps: VaultChannelDeps) {
     this.pubsub = deps.pubsub;
@@ -55,6 +87,10 @@ export class VaultChannel {
     this.loadDiff = deps.loadDiff ?? loadDocDiff;
     this.verifyToken = deps.verifyToken ?? verifyVaultToken;
     this.concurrency = deps.backfillConcurrency ?? config.backfillConcurrency;
+    this.sendCapBytes = deps.sendCapBytes ?? config.vaultSendCapBytes;
+    this.sendStallMs = deps.sendStallMs ?? config.vaultSendStallMs;
+    this.sendPollMs = deps.sendPollMs ?? config.vaultSendPollMs;
+    this.heartbeatMs = deps.heartbeatMs ?? config.vaultHeartbeatMs;
   }
 
   /** Fan an incremental doc update out to the vault's subscribers (any instance). */
@@ -90,17 +126,61 @@ export class VaultChannel {
       }
       wss.handleUpgrade(req, socket, head, (ws) => this.handleConnection(ws));
     });
+    // One interval for the whole channel; cleared when the server shuts the
+    // WebSocketServer down (index.ts `vaultWss.close()`), and unref'd so it can
+    // never be the reason the process stays alive.
+    const stopHeartbeat = this.startHeartbeat();
+    wss.on("close", stopHeartbeat);
     return wss;
+  }
+
+  /**
+   * Start the shared liveness sweep: each tick pings every connection and
+   * terminates any that has neither answered the previous ping nor sent us
+   * anything since. A peer that vanished without FIN/RST is therefore reaped
+   * after one to two ticks instead of holding its `VaultConnection`, its PubSub
+   * subscription — and, because `cleanup()` is what publishes the "gone"
+   * presence event, its presence dot in every teammate's sidebar — forever.
+   *
+   * Idempotent; returns a stop function. `attachUpgrade` calls this for you.
+   */
+  startHeartbeat(intervalMs: number = this.heartbeatMs): () => void {
+    if (!this.heartbeat) {
+      const timer = setInterval(() => {
+        // Snapshot: a tick may terminate connections, mutating the set.
+        for (const conn of [...this.connections]) conn.heartbeatTick();
+      }, intervalMs);
+      timer.unref?.();
+      this.heartbeat = timer;
+    }
+    return () => this.stopHeartbeat();
+  }
+
+  stopHeartbeat(): void {
+    if (!this.heartbeat) return;
+    clearInterval(this.heartbeat);
+    this.heartbeat = null;
+  }
+
+  /** Live connection count — the number that grew without bound while ghosts
+   *  accumulated (one `VaultConnection` + subscription each). */
+  connectionCount(): number {
+    return this.connections.size;
   }
 
   /** Drive one connection through hello -> backfill -> live fanout. */
   handleConnection(ws: WebSocket): void {
-    new VaultConnection(ws, this.pubsub, {
+    const conn = new VaultConnection(ws, this.pubsub, {
       listReadableDocs: this.listReadableDocs,
       loadDiff: this.loadDiff,
       verifyToken: this.verifyToken,
       concurrency: this.concurrency,
+      sendCapBytes: this.sendCapBytes,
+      sendStallMs: this.sendStallMs,
+      sendPollMs: this.sendPollMs,
+      onGone: (c) => this.connections.delete(c),
     });
+    this.connections.add(conn);
   }
 }
 
@@ -109,6 +189,10 @@ interface ConnDeps {
   loadDiff: typeof loadDocDiff;
   verifyToken: typeof verifyVaultToken;
   concurrency: number;
+  sendCapBytes: number;
+  sendStallMs: number;
+  sendPollMs: number;
+  onGone: (conn: VaultConnection) => void;
 }
 
 class VaultConnection {
@@ -117,12 +201,39 @@ class VaultConnection {
   private readable = new Set<string>();
   private unsubscribe: (() => void) | null = null;
   private helloSeen = false;
+  // Set once by cleanup(). `close` fires exactly once, so anything that outlives
+  // it (an in-flight hello await) must consult this instead of relying on
+  // cleanup() running again — see the subscribe site in onText().
+  private closed = false;
   private readonly helloTimer: ReturnType<typeof setTimeout>;
   // This connection's last-announced presence (which note the user is viewing),
   // kept so we can re-broadcast it when a newcomer asks, and clear it on close.
   private myPresence: { docId: string | null; name: string; color: string; status: string } | null =
     null;
   private announced = false;
+
+  // ---- outbound accounting (F2) ----
+  /** Cumulative bytes handed to `ws.send()`. Monotonic. */
+  private sentBytes = 0;
+  /** `sentBytes - ws.bufferedAmount` at the last sample: bytes that have
+   *  actually LEFT this connection. Monotonic; the only progress signal the
+   *  stall check trusts. */
+  private drained = 0;
+  private lastProgressAt = 0;
+  /** Producers parked on capacity, woken in FIFO order by the sampler. */
+  private capacityWaiters: Array<() => void> = [];
+  /** Runs only while producers are parked — a healthy connection has no timer. */
+  private sampler: ReturnType<typeof setInterval> | null = null;
+  /** Docs whose live update we withheld and now owe as a full state resend. */
+  private readonly pendingResync = new Set<string>();
+  /** Docs whose resend is being read from Postgres right now. */
+  private readonly resyncing = new Set<string>();
+  private resyncDraining = false;
+  /** Liveness for the channel's shared heartbeat: any pong or inbound frame
+   *  proves the peer is there; each tick clears it before pinging again. */
+  private alive = true;
+  /** Why this connection was force-closed, for tests and post-mortem logging. */
+  lastAbortReason: string | null = null;
 
   constructor(
     private readonly ws: WebSocket,
@@ -135,8 +246,12 @@ class VaultConnection {
     }, 10_000);
 
     ws.on("message", (data, isBinary) => {
+      this.alive = true; // traffic from the peer is proof of life, like a pong
       if (isBinary) return; // clients only send the JSON hello; ignore stray binary
       void this.onText(data.toString());
+    });
+    ws.on("pong", () => {
+      this.alive = true;
     });
     ws.on("close", () => this.cleanup());
     ws.on("error", (err) => {
@@ -145,7 +260,26 @@ class VaultConnection {
     });
   }
 
+  /** One tick of the channel's shared liveness sweep ({@link VaultChannel.startHeartbeat}). */
+  heartbeatTick(): void {
+    if (this.closed) return;
+    if (!this.alive) {
+      // Nothing came back since the previous ping: the peer is gone (or wedged
+      // beyond any hope of reading). `close()` would only queue a close frame
+      // behind whatever is already stuck, so terminate the socket outright.
+      this.abort("liveness timeout");
+      return;
+    }
+    this.alive = false;
+    try {
+      this.ws.ping?.();
+    } catch {
+      /* socket died between the readyState check and the ping */
+    }
+  }
+
   private async onText(text: string): Promise<void> {
+    if (this.closed) return; // socket already gone; don't start any I/O for it
     if (this.helloSeen) {
       // Post-hello, the only client message we accept is a presence update.
       const presence = parsePresence(text);
@@ -165,6 +299,7 @@ class VaultConnection {
     }
     this.userId = claims.userId;
     this.vaultId = claims.vaultId;
+    if (this.closed) return; // closed while verifying — don't run the ACL query
 
     try {
       this.readable = await this.deps.listReadableDocs(this.userId, this.vaultId);
@@ -176,9 +311,19 @@ class VaultConnection {
     // Subscribe BEFORE backfill so no live update is missed during the drain;
     // Yjs updates are idempotent/commutative, so overlap with the snapshot is
     // harmless (both apply, the client converges).
-    this.unsubscribe = await this.pubsub.subscribe(vaultTopic(this.vaultId), (p) =>
-      this.onPubsub(p),
-    );
+    //
+    // Capture into a local, then re-check liveness: the awaits above (token
+    // verify + ACL resolve) are real I/O, so the socket may have closed while we
+    // were in them. `close` fires exactly once, so cleanup() has already run and
+    // seen `unsubscribe === null` — if we stored the handler now nothing would
+    // ever remove it from the PubSub topic, leaking this whole connection (and
+    // its readable set) plus an ACL query per future vault event.
+    const off = await this.pubsub.subscribe(vaultTopic(this.vaultId), (p) => this.onPubsub(p));
+    if (this.closed || this.ws.readyState !== this.ws.OPEN) {
+      off();
+      return;
+    }
+    this.unsubscribe = off;
 
     await this.backfill(hello.manifest, hello.priority ?? []);
     this.send({ t: "ready" });
@@ -219,6 +364,14 @@ class VaultConnection {
 
   private async sendDocBackfill(docId: string, clientSvB64: string | undefined): Promise<void> {
     if (this.ws.readyState !== this.ws.OPEN) return;
+    // Producer-side backpressure. `loadDiff` rebuilds the whole Y.Doc and encodes
+    // its state into memory, so parking BEFORE it is what actually bounds the
+    // heap: we never materialize a doc we have nowhere to put. Parking here (not
+    // after the read) also means no frame is ever held outside the socket, which
+    // is what keeps `ws.bufferedAmount` an honest total.
+    if (!(await this.awaitSendCapacity())) return;
+    // The ACL can be revoked while we're parked — re-check before reading.
+    if (!this.readable.has(docId)) return;
     const clientSv = clientSvB64 ? new Uint8Array(Buffer.from(clientSvB64, "base64")) : null;
     let diff;
     try {
@@ -235,9 +388,7 @@ class VaultConnection {
     const msg = decodePubsub(payload);
     if (!msg) return;
     if (msg.type === "update") {
-      if (this.readable.has(msg.docId)) {
-        this.sendBinary(encodeWsUpdate(msg.docId, msg.update));
-      }
+      if (this.readable.has(msg.docId)) this.forwardLive(msg.docId, msg.update);
       return;
     }
     if (msg.type === "registry-changed") {
@@ -309,12 +460,197 @@ class VaultConnection {
     await runPool(added, this.deps.concurrency, (docId) => this.sendDocBackfill(docId, undefined));
   }
 
+  // ---- live fanout under backpressure (F2) --------------------------------
+
+  /**
+   * Forward one live update, or fold it into a full-state resend when this
+   * connection is at its outbound bound.
+   *
+   * Withholding the raw op and re-sending the doc's FULL state later is not the
+   * same as dropping it: a full state is self-contained, so it subsumes every
+   * withheld op for that doc no matter what order things arrived in, and it
+   * reaches the client as an ordinary binary update frame — the only inbound
+   * shape the desktop implements (`VaultSyncEngine.onMessage` -> `applyUpdate`).
+   * Forwarding the raw op instead, once we've withheld an earlier one, would be
+   * the unsafe choice: `VaultDocStore.coldApply` applies a cold-tier update in a
+   * transient Y.Doc it then destroys, so an op whose causal predecessor is
+   * missing is silently discarded rather than parked.
+   */
+  private forwardLive(docId: string, update: Uint8Array): void {
+    if (this.pendingResync.has(docId) || this.resyncing.has(docId)) {
+      // A resend for this doc is already owed. Re-mark (a resend now in flight
+      // may have read Postgres before this op landed) and forward nothing.
+      this.pendingResync.add(docId);
+      this.kickResync();
+      return;
+    }
+    if (this.bufferedBytes() >= this.deps.sendCapBytes) {
+      this.pendingResync.add(docId);
+      this.kickResync();
+      return;
+    }
+    this.sendBinary(encodeWsUpdate(docId, update));
+  }
+
+  /** Ensure exactly one resend drain loop is running. */
+  private kickResync(): void {
+    if (this.resyncDraining || this.closed) return;
+    this.resyncDraining = true;
+    void this.drainResync().finally(() => {
+      this.resyncDraining = false;
+      // A doc re-marked between the loop's last check and here would otherwise
+      // sit owed forever, so re-arm rather than wait for the next live update.
+      if (!this.closed && this.pendingResync.size > 0) this.kickResync();
+    });
+  }
+
+  private async drainResync(): Promise<void> {
+    while (!this.closed && this.pendingResync.size > 0) {
+      const docId = this.pendingResync.values().next().value;
+      if (docId === undefined) return;
+      // Move to `resyncing` (no await between the two, so nothing can observe
+      // the doc as unowed) — live updates arriving during the read re-mark it.
+      this.pendingResync.delete(docId);
+      this.resyncing.add(docId);
+      try {
+        // No client state vector -> full state. `sendDocBackfill` parks on the
+        // cap before it reads Postgres, exactly like the initial backfill.
+        await this.sendDocBackfill(docId, undefined);
+      } finally {
+        this.resyncing.delete(docId);
+      }
+    }
+  }
+
+  // ---- outbound capacity + stall detection (F2) ---------------------------
+
+  /** Bytes this connection is retaining. Every frame we produce is handed
+   *  straight to `ws.send()` and nothing waits anywhere else, so the socket
+   *  queue IS the whole footprint. Fakes without `bufferedAmount` read as 0. */
+  private bufferedBytes(): number {
+    const n = this.ws.bufferedAmount;
+    return typeof n === "number" && Number.isFinite(n) ? n : 0;
+  }
+
+  /**
+   * Park until the socket is back under the cap. Resolves `true` if the caller
+   * may proceed, `false` if the connection died while parked. Waiters are woken
+   * in FIFO order by a single per-connection sampler, so admissions can't
+   * reorder relative to each other; the frames they produce are for distinct
+   * docs anyway (the pool visits each doc once, and `resyncing` serialises a
+   * doc's resends), so per-doc order is preserved regardless.
+   */
+  private async awaitSendCapacity(): Promise<boolean> {
+    while (!this.closed && this.ws.readyState === this.ws.OPEN) {
+      if (this.bufferedBytes() < this.deps.sendCapBytes) return true;
+      await new Promise<void>((resolve) => {
+        this.capacityWaiters.push(resolve);
+        this.startSampler();
+      });
+    }
+    return false;
+  }
+
+  private startSampler(): void {
+    if (this.sampler) return;
+    this.drained = this.sentBytes - this.bufferedBytes();
+    this.lastProgressAt = Date.now();
+    const timer = setInterval(() => this.sample(), this.deps.sendPollMs);
+    timer.unref?.();
+    this.sampler = timer;
+  }
+
+  private stopSampler(): void {
+    if (!this.sampler) return;
+    clearInterval(this.sampler);
+    this.sampler = null;
+  }
+
+  private sample(): void {
+    if (this.closed || this.ws.readyState !== this.ws.OPEN) {
+      this.stopSampler();
+      this.releaseWaiters();
+      return;
+    }
+    const drained = this.sentBytes - this.bufferedBytes();
+    if (drained > this.drained) {
+      this.drained = drained;
+      this.lastProgressAt = Date.now();
+    }
+    if (this.bufferedBytes() < this.deps.sendCapBytes) {
+      this.releaseWaiters();
+      // Woken producers re-check and re-park (restarting the sampler) if they
+      // refill the queue; nothing to watch until then.
+      if (this.capacityWaiters.length === 0) this.stopSampler();
+      return;
+    }
+    // Still at the bound. The ONLY close criterion is that no byte at all has
+    // left the socket for the whole window — a peer draining even a trickle
+    // keeps moving `drained` and is paced for as long as it takes.
+    if (Date.now() - this.lastProgressAt >= this.deps.sendStallMs) {
+      console.warn(
+        `Vault channel terminating a non-draining connection (user=${this.userId ?? "?"} ` +
+          `vault=${this.vaultId ?? "?"}): ${this.bufferedBytes()} bytes queued, ` +
+          `0 bytes drained in ${this.deps.sendStallMs}ms`,
+      );
+      this.abort("send stall");
+    }
+  }
+
+  private releaseWaiters(): void {
+    if (this.capacityWaiters.length === 0) return;
+    const waiters = this.capacityWaiters;
+    this.capacityWaiters = [];
+    for (const wake of waiters) wake();
+  }
+
+  /**
+   * Hard teardown for a socket we can no longer talk to. `terminate()` destroys
+   * it immediately (a graceful `close()` only queues a close frame behind
+   * whatever is already stuck), then we run the normal close path — which is
+   * what clears this user's presence and releases the PubSub subscription.
+   * `terminate()` emits `close`, so `cleanup()` is reached either way; calling it
+   * directly keeps fakes without `terminate` working too.
+   */
+  private abort(reason: string): void {
+    if (this.closed) return;
+    this.lastAbortReason = reason;
+    try {
+      if (typeof this.ws.terminate === "function") this.ws.terminate();
+      else this.ws.close();
+    } catch {
+      /* already gone */
+    }
+    this.cleanup();
+  }
+
   private send(control: ServerControl): void {
-    if (this.ws.readyState === this.ws.OPEN) this.ws.send(JSON.stringify(control));
+    // Control frames are never withheld: they're tens of bytes and losing one is
+    // a correctness bug (a dropped `drop` leaves revoked content live on the
+    // client; a dropped `ready` leaves it stuck "connecting"). They may therefore
+    // push the socket queue past the cap, by the total size of the control frames
+    // issued while it is blocked — bounded in time by the stall check, which
+    // terminates a peer that is draining none of them.
+    this.write(JSON.stringify(control), false);
   }
 
   private sendBinary(bytes: Uint8Array): void {
-    if (this.ws.readyState === this.ws.OPEN) this.ws.send(bytes, { binary: true });
+    this.write(bytes, true);
+  }
+
+  /**
+   * The one place bytes leave this connection. `ws` owns a single outbound FIFO
+   * per socket and writes in call order, so handing frames straight over is what
+   * preserves global ordering — there is no second queue for a later frame to
+   * jump. A frame is indivisible, so a send may take the queue up to `cap +
+   * frame`; with `backfillConcurrency` producers admitted together the peak is
+   * `cap + concurrency × largest frame` (see `config.vaultSendCapBytes`).
+   */
+  private write(payload: string | Uint8Array, binary: boolean): void {
+    if (this.closed || this.ws.readyState !== this.ws.OPEN) return;
+    this.sentBytes +=
+      typeof payload === "string" ? Buffer.byteLength(payload) : payload.byteLength;
+    this.ws.send(payload, { binary });
   }
 
   private fail(message: string): void {
@@ -324,7 +660,21 @@ class VaultConnection {
   }
 
   private cleanup(): void {
+    if (this.closed) {
+      // Idempotent, but a late abort()/close() still needs the timers gone.
+      this.stopSampler();
+      this.releaseWaiters();
+      return;
+    }
+    this.closed = true;
     clearTimeout(this.helloTimer);
+    this.stopSampler();
+    // Unpark every producer so its `awaitSendCapacity` returns false and the
+    // pool unwinds instead of holding this connection's state alive.
+    this.releaseWaiters();
+    this.pendingResync.clear();
+    this.resyncing.clear();
+    this.deps.onGone(this);
     // Tell the vault this user is gone so teammates clear their presence dot.
     // Guard on `announced` so we only emit for connections that ever appeared.
     if (this.announced && this.userId && this.vaultId) {

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -213,4 +213,45 @@ describe("VaultChannel relay (spec 05 §3.1)", () => {
     const drops = ws.controls().filter((c) => c.t === "drop");
     expect(drops).toEqual([{ t: "drop", docId: "B" }]);
   });
+
+  it("releases the pubsub subscription when the socket dies inside the hello handshake", async () => {
+    // The handshake subscribes only AFTER awaiting the ACL resolve. A socket that
+    // closes inside that window has already had its `close` handler run (ws emits
+    // it once), so the connection must notice and release the subscription itself
+    // — otherwise the handler stays in the topic forever with no owner to remove
+    // it, and every later vault event re-runs the ACL query for a dead client.
+    const pubsub = new InMemoryPubSub();
+    pubsubs.push(pubsub);
+    let aclCalls = 0;
+    let releaseAcl!: () => void;
+    const aclGate = new Promise<void>((r) => {
+      releaseAcl = r;
+    });
+    const channel = new VaultChannel({
+      pubsub,
+      verifyToken: async () => ({ userId: "u1", vaultId: "v1" }),
+      listReadableDocs: async () => {
+        aclCalls += 1;
+        await aclGate; // hold the handshake open inside its await window
+        return new Set(["A"]);
+      },
+      loadDiff: async (docId: string) => diffFor(docId),
+      backfillConcurrency: 4,
+    });
+
+    const ws = new FakeWs();
+    channel.handleConnection(ws as never);
+    ws.hello("good");
+    await waitFor(() => aclCalls === 1); // handshake is now parked mid-await
+
+    ws.close(); // cleanup() runs here — before the subscription is ever assigned
+    releaseAcl(); // handshake resumes and reaches the subscribe
+    await new Promise((r) => setTimeout(r, 20)); // let the continuation finish
+
+    // A leaked handler would answer this by kicking off another ACL resolve.
+    await channel.publishAclChanged("v1");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(aclCalls).toBe(1);
+    expect(ws.controls().some((c) => c.t === "ready")).toBe(false);
+  });
 });


### PR DESCRIPTION
Six places where memory (or a derived table) grew with load rather than staying bounded. The server runs with V8 capped at 512 MB inside a 1 GiB container (`Dockerfile` / `railway.json`), so each of these was a path to RSS ratcheting until the process died.

### Vault channel: outbound backpressure + liveness

A `hello` with an empty manifest — which is every app launch, since the desktop's `svCache` is in-memory — asks for the full state of every readable doc, far more than a link drains while we frame it. `VaultConnection` now keeps **no** userland queue, so `ws.bufferedAmount` is the whole per-connection footprint, and every producer (backfill, ACL top-up, resync) parks on that number *before* reading a doc out of Postgres. Nothing is deferred outside the socket, so `ws`'s single per-socket FIFO gives global ordering for free — `ready` can't overtake the backfill it terminates.

Live updates arriving while a connection is at its cap fold into a **full-state resend** rather than being forwarded or dropped: a full state is self-contained, so it subsumes every withheld op regardless of arrival order. Forwarding the raw op would be the unsafe choice — `VaultDocStore.coldApply` applies cold-tier updates in a transient `Y.Doc`, so an op whose causal predecessor is missing is silently discarded.

Plus one shared ping/pong sweep per channel to reap peers that vanished without FIN/RST. Those previously kept their `VaultConnection`, their PubSub subscription, and their presence dot in every teammate's sidebar forever. A blocked connection separately watches bytes *actually leaving* its socket and is terminated only if none move at all for `vaultSendStallMs` — any drain progress resets the window, so a slow peer is paced indefinitely and never closed for being slow.

New env knobs in `config.ts`: `VAULT_SEND_CAP_BYTES` (4 MiB), `VAULT_SEND_STALL_MS` (60s), `VAULT_SEND_POLL_MS` (25ms), `VAULT_HEARTBEAT_MS` (30s).

### Blob uploads: size cap + admission budget

`node-postgres` has no binary parameter protocol, so storing an N-byte blob costs roughly `N + 1.33N + 1.33N ≈ 3.7N` at peak. The old 100 MB cap put a *single legal upload* at ~370 MB of a 512 MB heap, and two concurrent ones over the container. The size cap now sits at a level that's survivable at 3.7×, and a FIFO admission control over a global byte budget stops N compliant uploads from stacking their peaks — previously the size cap bounded one request while any number could run at once.

### Semantic search: keyset batches

Scoring walked every `note_index` row's body *and* embedding vector into the heap just to slice off the top k. It now scans a vault in keyset-paginated batches keeping only `{docId, score}` per note. Migration 014 adds the composite `note_index (vault_id, doc_id)` index that serves that scan directly. Ranking and response shape are unchanged.

### Deleted notes stopped leaking derived rows

`note_index` / `note_links` are a rebuildable cache of canonical Yjs state (migration 005), but soft-deleting a note never dropped them: `registry.ts` flipped `deleted_at`, the folder cascade did the same for a subtree, and `indexer.indexDoc` early-returned *before* its own DELETE because the note was already gone. Every deleted note kept a full plain-text copy of its body forever — unbounded growth **and** "deleted" content still readable server-side. Write paths now purge on delete (`registry.ts`, `mcp/service.ts`), `indexDoc` self-heals when it finds no live note row, and migration 014 clears the backlog. Nothing there is destructive to a source of truth: every deleted row belongs to a doc with no live `notes` row, and a live note's rows can always be re-derived.

### Hocuspocus: destroy the document when a load fails

Destroy-then-rethrow in `onLoadDocument` is load-bearing. Hocuspocus only inserts the `Document` into its map *after* the hook resolves, and its own failure path calls `unloadDocument`, which early-returns on `if (!this.documents.has(documentName)) return` — so `destroy()` was never reached. Meanwhile `new Document(...)` had already armed a plain, non-`unref`'d 3-second `setInterval` inside `y-protocols` Awareness that closes over the doc. One failed load (a dead pooled client, an in-flight query during a Postgres restart) permanently leaked the doc plus a live timer keeping it reachable.

### Desktop: bounded UndoManager

Every tracked local edit pushes a `StackItem` **and** makes Yjs pin the structs that edit deleted (`keepItem(item, true)`) so undo can restore them. Unbounded, one long session in a single note grew both forever. The stack is now capped and dropped steps release their GC pins. `undo.test.ts` runs the same workload with trimming off and on, so the delta is the fix rather than the harness, and asserts the trim doesn't *over*-release — recent undo still restores real content.

### Testing

- Server: 154 pass across 25 files, including the extended `vault-channel.test.ts` covering the cap, the stall detector, and the heartbeat sweep.
- Desktop: 173 pass.
- Typecheck clean in both workspaces.