### PR TITLE
Sign and notarize macOS builds; release v0.1.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,15 +78,16 @@ jobs:
           # `tauri signer generate`; add both as repo Actions secrets.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # macOS code signing + notarization is intentionally NOT wired here:
-          # with no Apple secrets present, macOS builds are ad-hoc signed (users
-          # right-click → Open once to bypass Gatekeeper). Do NOT add empty
-          # APPLE_* env vars — an empty APPLE_CERTIFICATE makes tauri attempt a
-          # keychain import and fails the whole macOS build. To enable clean,
-          # notarized installs, add these six as repo Actions secrets AND
-          # re-add the matching APPLE_* env lines here:
-          #   APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD, APPLE_SIGNING_IDENTITY,
-          #   APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID  (see docs/RELEASE.md).
+          # macOS Developer ID signing + notarization (see docs/RELEASE.md).
+          # All six must be non-empty: an empty APPLE_CERTIFICATE still makes
+          # tauri attempt a keychain import and fails the whole macOS build, so
+          # comment the block out wholesale rather than blanking a single secret.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: app/apps/desktop
           tagName: v__VERSION__

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.8"
+version = "0.1.9"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -52,8 +52,17 @@ stops the repeated macOS Keychain password prompt during normal use.
 
 Once present, `tauri-action` imports the cert into a temporary keychain, signs
 with the hardened runtime using `entitlements.plist`, and notarizes automatically.
-No workflow changes are needed — the env vars are already wired in `release.yml`
-and stay inert on Windows/Linux and until the secrets exist.
+The env vars are wired in `release.yml`; on Windows/Linux they are ignored.
+
+> ⚠️ It is all six or none. An **empty** `APPLE_CERTIFICATE` still makes tauri
+> attempt a keychain import and fails the macOS build — it does not fall back to
+> ad-hoc signing. If you fork this repo and don't have an Apple account, comment
+> out the whole `APPLE_*` block in `release.yml` rather than leaving the secrets
+> unset. Ad-hoc builds are then what you get (right-click → Open to launch).
+
+`tauri.conf.json` pins `bundle.macOS.signingIdentity` to `"-"` (ad-hoc) so local
+`build:desktop` runs work without a certificate. That is **not** a conflict: the
+`APPLE_SIGNING_IDENTITY` env var takes precedence over the config value in CI.
 
 The entitlements (`app/apps/desktop/src-tauri/entitlements.plist`) grant the two
 JIT/executable-memory keys the WKWebView needs under the hardened runtime. The app


### PR DESCRIPTION
Wires the `APPLE_*` env vars into `release.yml` now that a Developer ID Application certificate exists, so macOS installers are signed and notarized instead of ad-hoc signed. Users no longer have to right-click → Open to get past Gatekeeper.

## Changes

- **`release.yml`** — uncomment the six `APPLE_*` env vars on the `tauri-action` step. The matching repo secrets are set.
- **`docs/RELEASE.md`** — correct a stale claim that the env vars "stay inert until the secrets exist". They don't: an empty `APPLE_CERTIFICATE` still triggers a keychain import and fails the macOS build, so it's all six or comment the block out. Also documents why `signingIdentity: "-"` in `tauri.conf.json` is not a conflict.
- Version bump to **0.1.9** across `tauri.conf.json`, `package.json`, `Cargo.toml`, `Cargo.lock`.

## Verification

- `xcrun notarytool history` authenticates against Apple with the Apple ID / app-specific password / team ID that CI will use.
- The `.p12` was built with the full chain (Developer ID G2 CA + Apple Root CA) and `-legacy` encryption — OpenSSL 3 defaults make `security import` fail on the runner with a misleading "MAC verification failed".
- Signing identity resolves correctly in CI: `APPLE_SIGNING_IDENTITY` takes precedence over the config value in `tauri-cli`, so the ad-hoc `"-"` stays as the local-dev fallback.
- `entitlements.plist` already carried the WKWebView JIT keys and `hardenedRuntime` defaults to `true`, so no `tauri.conf.json` signing changes were needed.

Publishing the drafted release is still a manual step — that's what makes running apps see the update.