### PR TITLE
Publish releases automatically instead of drafting them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,13 @@ name: release
 #   git tag v0.2.0 && git push origin v0.2.0
 #
 # This builds signed bundles for macOS (arm64 + x64), Windows, and Linux, and
-# drafts a GitHub Release with the installers + latest.json (the updater
-# manifest). Review the draft, then click "Publish" — only then does
-# `releases/latest` point at it and do running apps see the update.
+# publishes a GitHub Release with the installers + latest.json (the updater
+# manifest).
+#
+# ⚠️ The release goes live as soon as the build finishes — `releases/latest`
+# moves to it immediately and running apps pick up the update on their next
+# updater poll. There is no review step. Push a `v*` tag only when you mean to
+# ship to everyone; set `releaseDraft: true` below if you want a manual gate.
 on:
   push:
     tags:
@@ -93,6 +97,6 @@ jobs:
           tagName: v__VERSION__
           releaseName: 'Baalda v__VERSION__'
           releaseBody: 'See the assets below to download and install this version.'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,10 @@ edit together in real time. Every OSS competitor does one or the other; the whol
 Three pieces; this open-source repo holds the first two.
 
 - **Desktop app** (`app/apps/desktop`) — the product people install. Released by pushing a
-  `v*` tag: `.github/workflows/release.yml` builds signed installers for macOS/Windows/Linux and
-  drafts a GitHub Release with `latest.json`; publishing the draft is what makes running apps
-  see the update (Tauri updater polls `releases/latest`).
+  `v*` tag: `.github/workflows/release.yml` builds signed (macOS: Developer ID + notarized)
+  installers for macOS/Windows/Linux and **publishes** a GitHub Release with `latest.json`.
+  There is no draft/review gate — pushing a `v*` tag ships to every running app on its next
+  updater poll (Tauri updater polls `releases/latest`).
 - **Backend server** (`app/apps/server`) — open source and self-hostable (Node + Postgres).
   The managed option runs this **same server code**, publicly reachable at
   `https://api.baalda.com`; users choose an instance via the server URL in Settings. There is

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,18 +1,28 @@
 # Releasing the Baalda desktop app
 
-The desktop app ships via a git tag. Bump the version in
-`app/apps/desktop/src-tauri/tauri.conf.json` **and** `app/apps/desktop/package.json`,
-then push a matching `v*` tag:
+The desktop app ships via a git tag. Bump the version in all four places — they
+must agree or the build fails the tag/version check:
+
+- `app/apps/desktop/src-tauri/tauri.conf.json`
+- `app/apps/desktop/package.json`
+- `app/apps/desktop/src-tauri/Cargo.toml`
+- `app/apps/desktop/src-tauri/Cargo.lock` (the `desktop` package entry)
+
+Then push a matching `v*` tag:
 
 ```bash
 git tag v0.2.0 && git push origin v0.2.0
 ```
 
 `.github/workflows/release.yml` builds bundles for macOS (arm64 + x64), Windows,
-and Linux, and drafts a GitHub Release with the installers plus `latest.json`
-(the updater manifest). The release is a **draft** — review it, then click
-**Publish**. Only then does `releases/latest` point at it and do running apps
-see the update (the Tauri updater polls `releases/latest`).
+and Linux, and publishes a GitHub Release with the installers plus `latest.json`
+(the updater manifest).
+
+> ⚠️ **The release goes live automatically.** `releaseDraft` is `false`, so the
+> moment the build finishes `releases/latest` points at the new version and every
+> running app updates on its next updater poll. There is no review gate — pushing
+> a `v*` tag ships to all users. Flip `releaseDraft` back to `true` in
+> `release.yml` if you want to inspect bundles before they go out.
 
 ## Two kinds of signing
 


### PR DESCRIPTION
Flips `releaseDraft` to `false` so a `v*` tag ships straight to users, with no manual Publish step.

## Changes

- **`release.yml`** — `releaseDraft: false`, and the header comment now warns that a tag push ships to everyone rather than describing a review step.
- **`docs/RELEASE.md`** — rewrites the intro for the new behavior. Also fixes a real gap: it listed only `tauri.conf.json` and `package.json` as places to bump the version, but `Cargo.toml` and the `desktop` entry in `Cargo.lock` need it too.
- **`CLAUDE.md`** — the system-landscape bullet said "publishing the draft is what makes running apps see the update", which is no longer true.

## Tradeoff

There is now no gate between pushing a tag and every running app auto-updating. That's the intent, but it means a bad build reaches users immediately — the Tauri updater polls `releases/latest`. Flipping `releaseDraft` back to `true` restores the manual review step.