### PR TITLE
Build releases for macOS only for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ name: release
 #
 #   git tag v0.2.0 && git push origin v0.2.0
 #
-# This builds signed bundles for macOS (arm64 + x64), Windows, and Linux, and
-# publishes a GitHub Release with the installers + latest.json (the updater
-# manifest).
+# This builds signed, notarized bundles for macOS (arm64 + x64) and publishes a
+# GitHub Release with the installers + latest.json (the updater manifest).
+# Windows and Linux are commented out of the matrix below — see the note there.
 #
 # ⚠️ The release goes live as soon as the build finishes — `releases/latest`
 # moves to it immediately and running apps pick up the update on their next
@@ -31,10 +31,14 @@ jobs:
             args: '--target aarch64-apple-darwin'
           - platform: 'macos-latest'
             args: '--target x86_64-apple-darwin'
-          - platform: 'ubuntu-22.04'
-            args: ''
-          - platform: 'windows-latest'
-            args: ''
+          # macOS only for now — macOS is the only platform with real OS signing
+          # wired up (Developer ID + notarization), so it's the only one we ship.
+          # Uncomment to resume Windows/Linux; the Linux dependency step below is
+          # already guarded by an `if` and stays inert until then.
+          # - platform: 'ubuntu-22.04'
+          #   args: ''
+          # - platform: 'windows-latest'
+          #   args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,9 @@ edit together in real time. Every OSS competitor does one or the other; the whol
 Three pieces; this open-source repo holds the first two.
 
 - **Desktop app** (`app/apps/desktop`) — the product people install. Released by pushing a
-  `v*` tag: `.github/workflows/release.yml` builds signed (macOS: Developer ID + notarized)
-  installers for macOS/Windows/Linux and **publishes** a GitHub Release with `latest.json`.
+  `v*` tag: `.github/workflows/release.yml` builds signed, notarized (Developer ID)
+  installers for **macOS only** — Windows/Linux are commented out of the matrix — and
+  **publishes** a GitHub Release with `latest.json`.
   There is no draft/review gate — pushing a `v*` tag ships to every running app on its next
   updater poll (Tauri updater polls `releases/latest`).
 - **Backend server** (`app/apps/server`) — open source and self-hostable (Node + Postgres).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,9 +14,11 @@ Then push a matching `v*` tag:
 git tag v0.2.0 && git push origin v0.2.0
 ```
 
-`.github/workflows/release.yml` builds bundles for macOS (arm64 + x64), Windows,
-and Linux, and publishes a GitHub Release with the installers plus `latest.json`
-(the updater manifest).
+`.github/workflows/release.yml` builds bundles for **macOS only** (arm64 + x64)
+and publishes a GitHub Release with the installers plus `latest.json` (the updater
+manifest). Windows and Linux are commented out of the build matrix — macOS is the
+only platform with OS signing wired up, so it's the only one we ship. Re-enable
+them by uncommenting the two matrix entries.
 
 > ⚠️ **The release goes live automatically.** `releaseDraft` is `false`, so the
 > moment the build finishes `releases/latest` points at the new version and every
@@ -81,11 +83,16 @@ on disk.
 
 ## Windows code signing (optional)
 
+> Not currently built — `windows-latest` is commented out of the release matrix.
+> This section applies whenever it is re-enabled.
+
 Unsigned Windows installers still run but show a SmartScreen
 *"Windows protected your PC"* warning. To remove it, obtain an OV/EV code-signing
 certificate and add Tauri's Windows signing config; this is optional and can be
 deferred.
 
 ## Linux
+
+> Not currently built — `ubuntu-22.04` is commented out of the release matrix.
 
 No OS-level signing gate. Bundles install as-is.


### PR DESCRIPTION
Comments Windows and Linux out of the release build matrix. macOS is the only platform with OS-level signing wired up, so it's the only one worth shipping right now.

## Changes

- **`release.yml`** — matrix drops to the two macOS targets. The entries are commented rather than deleted so re-enabling is a two-line uncomment. The Linux dependency step stays put; it's already guarded by `if: matrix.platform == 'ubuntu-22.04'` and is inert until that entry comes back.
- **`docs/RELEASE.md`** — intro reflects macOS-only; the Windows and Linux sections get a "not currently built" note rather than being removed, since the content is still correct for when they return.
- **`CLAUDE.md`** — the system-landscape bullet claimed installers are built for macOS/Windows/Linux.

## Effect on existing installs

Any Windows or Linux users on v0.1.8 will simply stop being offered updates — `latest.json` won't carry their platform, so the Tauri updater finds nothing and does nothing. Their current install keeps working.