### PR TITLE
Push-to-talk voice broadcast over the vault channel

### DIFF
--- a/app/apps/desktop/src-tauri/Info.plist
+++ b/app/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Extra Info.plist keys merged into the macOS bundle by Tauri.
+
+  NSMicrophoneUsageDescription is what macOS shows the first time push-to-talk
+  opens the mic. It is not optional: without it the system terminates the app
+  the moment getUserMedia asks for audio, rather than showing a prompt. Pairs
+  with com.apple.security.device.audio-input in entitlements.plist.
+-->
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Baalda uses your microphone only while you hold the talk button, to broadcast live audio to your vault. Nothing is recorded or stored.</string>
+</dict>
+</plist>

--- a/app/apps/desktop/src-tauri/entitlements.plist
+++ b/app/apps/desktop/src-tauri/entitlements.plist
@@ -6,12 +6,20 @@
   Tauri UI runs in; without them the hardened runtime kills the web process
   on launch. No App Sandbox key — this app reads/writes the user's vault
   anywhere on disk, which the sandbox would forbid.
+
+  audio-input is required for push-to-talk. Under the hardened runtime the mic is
+  refused even after the user grants permission unless this is present, so
+  getUserMedia fails outright instead of prompting. It pairs with
+  NSMicrophoneUsageDescription in Info.plist, which supplies the text of that
+  prompt — macOS terminates the app outright if that string is missing.
 -->
 <plist version="1.0">
 <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>
 </plist>

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -270,43 +270,33 @@ button.primary.hero:hover:not(:disabled) {
   background: radial-gradient(circle, #4aa3ff 0%, transparent 70%);
   opacity: 0.18;
 }
-/* ---- Welcome-screen account chip ----
-   Top-right corner, above the aurora. Deliberately out of the centered column
-   so it never competes with the wordmark or the two primary actions — an
-   account is optional in a local-first app, but it has to be reachable. */
-.picker-account {
-  position: absolute;
-  top: var(--sp-4);
-  right: var(--sp-4);
-  z-index: 2;
-  display: flex;
-  align-items: center;
+/* ---- Welcome-screen sign-in line ----
+   Sits with the hint text under the primary actions, in the same quiet register
+   — an account is optional in a local-first app, so this informs rather than
+   competes with "New vault" / "Open existing". */
+.picker-signin {
+  margin-top: var(--sp-2);
 }
-.picker-account-id {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-  padding: var(--sp-1) var(--sp-3) var(--sp-1) var(--sp-1);
-  border-radius: var(--radius-pill);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-  font-size: var(--fs-sm);
+/* A button that reads as a link: keyboard- and screen-reader-correct (it
+   performs an action, so it must not be an anchor) while looking inline. */
+.linkish {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
   font-weight: 600;
-  color: var(--text-secondary);
-  max-width: 260px;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color var(--t-fast) var(--ease);
 }
-.picker-account-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.linkish:hover:not(:disabled) {
+  color: var(--accent-hover);
 }
-/* The shared .avatar has no intrinsic size; every caller sets its own. */
-.picker-account-id .avatar {
-  width: 22px;
-  height: 22px;
-  font-size: var(--fs-sm);
-  flex: none;
+.linkish:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .vault-picker-card {

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1853,10 +1853,6 @@ button.primary.hero:hover:not(:disabled) {
   margin-top: auto;
   border-top: 1px solid var(--border);
   padding: var(--sp-2) var(--sp-2) var(--sp-2) var(--sp-1);
-  /* Push-to-talk sits above the account row; keep them from touching. */
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
 }
 .account-menu {
   position: relative;

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -270,6 +270,45 @@ button.primary.hero:hover:not(:disabled) {
   background: radial-gradient(circle, #4aa3ff 0%, transparent 70%);
   opacity: 0.18;
 }
+/* ---- Welcome-screen account chip ----
+   Top-right corner, above the aurora. Deliberately out of the centered column
+   so it never competes with the wordmark or the two primary actions — an
+   account is optional in a local-first app, but it has to be reachable. */
+.picker-account {
+  position: absolute;
+  top: var(--sp-4);
+  right: var(--sp-4);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+}
+.picker-account-id {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-3) var(--sp-1) var(--sp-1);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+  max-width: 260px;
+}
+.picker-account-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* The shared .avatar has no intrinsic size; every caller sets its own. */
+.picker-account-id .avatar {
+  width: 22px;
+  height: 22px;
+  font-size: var(--fs-sm);
+  flex: none;
+}
+
 .vault-picker-card {
   position: relative;
   z-index: 1;
@@ -359,6 +398,12 @@ button.primary.hero:hover:not(:disabled) {
 .ghost-pill.lg {
   padding: var(--sp-3) var(--sp-6);
   font-size: var(--fs-lg);
+}
+/* Compact variant for secondary chrome — sits in a corner without competing
+   with whatever the primary action on the screen is. */
+.ghost-pill.sm {
+  padding: var(--sp-1) var(--sp-3);
+  font-size: var(--fs-sm);
 }
 
 /* ---- New-vault naming step ---- */

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1853,6 +1853,10 @@ button.primary.hero:hover:not(:disabled) {
   margin-top: auto;
   border-top: 1px solid var(--border);
   padding: var(--sp-2) var(--sp-2) var(--sp-2) var(--sp-1);
+  /* Push-to-talk sits above the account row; keep them from touching. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
 }
 .account-menu {
   position: relative;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import "./App.css";
 import { AccountMenu } from "./components/AccountMenu";
+import { TalkButton } from "./components/TalkButton";
 import { BacklinksPanel } from "./components/BacklinksPanel";
 import { Editor } from "./components/Editor";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -457,6 +458,7 @@ export default function App() {
         {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
         <FileTree />
         <div className="sidebar-footer">
+          <TalkButton />
           <AccountMenu />
         </div>
       </aside>

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -458,7 +458,6 @@ export default function App() {
         {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
         <FileTree />
         <div className="sidebar-footer">
-          <TalkButton />
           <AccountMenu />
         </div>
       </aside>
@@ -470,6 +469,8 @@ export default function App() {
           <span className="note-title">{openNote?.title ?? "No note open"}</span>
           {openNote && !isPreview && <SaveIndicator />}
           {openNote && !isPreview && <SyncIndicator />}
+          {/* Vault-wide, so it sits in the header regardless of the open note. */}
+          <TalkButton />
           <button
             className="icon-btn search-btn"
             title="Search notes (⌘F)"

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -274,6 +274,28 @@ async function openFolderAsLocalVault(onDone: () => void): Promise<void> {
 }
 
 /**
+ * Repoint the ACTIVE vault at a different folder on disk. Moved here from the
+ * sidebar header's old "Switch" popover, which was otherwise a duplicate of the
+ * vault switcher above — this was the one thing only it could do.
+ *
+ * Distinct from "Vault folder location" further down, which sets the root that
+ * NEW vaults are created under; this rebinds the vault you're in right now.
+ * Routed through the store so the vault being left is properly retired (scope,
+ * registry maps, debounced pulls) rather than leaking into the new folder.
+ */
+async function changeLocalFolder(onDone: () => void): Promise<void> {
+  try {
+    const v = await ipc.pickVault();
+    if (v) {
+      await useStore.getState().adoptOpenedVault(v, { resync: true });
+      onDone();
+    }
+  } catch {
+    /* picker cancelled/unavailable */
+  }
+}
+
+/**
  * The "On this device" rows: local vaults you can switch to with one click.
  * `limit` caps how many show inline; when there are more, an `onViewAll` link
  * hands off to the full Vaults page (which lists local + synced together).
@@ -556,6 +578,26 @@ function AccountPopover({
         </span>
         <span className="menu-item-label">New vault</span>
       </button>
+
+      {/* Rebind the CURRENT vault to a different folder. Lives here now that the
+          sidebar header is a plain label. */}
+      {openPath && (
+        <button className="menu-item subtle" onClick={() => void changeLocalFolder(onClose)}>
+          <span className="menu-swatch" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+            </svg>
+          </span>
+          <span className="menu-item-label">Change local folder…</span>
+        </button>
+      )}
 
       {/* Teammates join with the code shared from Vault settings. */}
       {joining ? (

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -261,38 +261,76 @@ function useLocalVaults(nonce = 0): RecentVault[] {
 }
 
 /** Native-pick a folder and open it as a local vault, then close the menu. */
-async function openFolderAsLocalVault(onDone: () => void): Promise<void> {
-  try {
-    const picked = await ipc.pickFolder();
-    if (picked) {
-      await useStore.getState().openLocalVault(picked);
-      onDone();
-    }
-  } catch {
-    /* picker cancelled/unavailable */
-  }
-}
-
 /**
- * Repoint the ACTIVE vault at a different folder on disk. Moved here from the
- * sidebar header's old "Switch" popover, which was otherwise a duplicate of the
- * vault switcher above — this was the one thing only it could do.
+ * "New vault": name it, and it's created under the vaults root.
  *
- * Distinct from "Vault folder location" further down, which sets the root that
- * NEW vaults are created under; this rebinds the vault you're in right now.
- * Routed through the store so the vault being left is properly retired (scope,
- * registry maps, debounced pulls) rather than leaking into the new folder.
+ * Name-only, matching the welcome screen. Asking which folder was a question
+ * with one sensible answer — every vault we create lives under the same root,
+ * and a vault's folder is just `slugify(its name)`. Adopting a folder you
+ * already have is "Open existing" on the welcome screen, which keeps that
+ * folder exactly where it is.
+ *
+ * Inline rather than a dialog: it's one field, and the menu is already open.
  */
-async function changeLocalFolder(onDone: () => void): Promise<void> {
-  try {
-    const v = await ipc.pickVault();
-    if (v) {
-      await useStore.getState().adoptOpenedVault(v, { resync: true });
+function NewVaultItem({ onDone }: { onDone: () => void }) {
+  const [naming, setNaming] = useState(false);
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const root = await ipc.getVaultsRoot();
+      const v = await ipc.createVault(root, trimmed);
+      await useStore.getState().adoptOpenedVault(v);
+      setName("");
+      setNaming(false);
       onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
     }
-  } catch {
-    /* picker cancelled/unavailable */
+  };
+
+  if (!naming) {
+    return (
+      <button className="menu-item subtle" onClick={() => setNaming(true)}>
+        <span className="menu-swatch plus" aria-hidden="true">
+          +
+        </span>
+        <span className="menu-item-label">New vault</span>
+      </button>
+    );
   }
+
+  return (
+    <>
+      <div className="menu-create-org">
+        <input
+          autoFocus
+          placeholder="Vault name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void create();
+            if (e.key === "Escape") {
+              setNaming(false);
+              setName("");
+            }
+          }}
+        />
+        <button className="primary sm" disabled={busy || !name.trim()} onClick={() => void create()}>
+          Create
+        </button>
+      </div>
+      {error && <div className="auth-error">{error}</div>}
+    </>
+  );
 }
 
 /**
@@ -388,15 +426,7 @@ function SignedOutPopover({
         onViewAll={onViewAllLocal}
       />
 
-      <button
-        className="menu-item subtle"
-        onClick={() => void openFolderAsLocalVault(onClose)}
-      >
-        <span className="menu-swatch plus" aria-hidden="true">
-          +
-        </span>
-        <span className="menu-item-label">New vault</span>
-      </button>
+      <NewVaultItem onDone={onClose} />
 
       {vault && (
         <button className="menu-item" onClick={onOpenSettings}>
@@ -567,37 +597,7 @@ function AccountPopover({
         onViewAll={onOpenVaults}
       />
 
-      {/* "New vault" = pick a folder; it becomes your (local) vault,
-          then Turn on sync promotes it. Same action as the old "Open a folder". */}
-      <button
-        className="menu-item subtle"
-        onClick={() => void openFolderAsLocalVault(onClose)}
-      >
-        <span className="menu-swatch plus" aria-hidden="true">
-          +
-        </span>
-        <span className="menu-item-label">New vault</span>
-      </button>
-
-      {/* Rebind the CURRENT vault to a different folder. Lives here now that the
-          sidebar header is a plain label. */}
-      {openPath && (
-        <button className="menu-item subtle" onClick={() => void changeLocalFolder(onClose)}>
-          <span className="menu-swatch" aria-hidden="true">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
-            </svg>
-          </span>
-          <span className="menu-item-label">Change local folder…</span>
-        </button>
-      )}
+      <NewVaultItem onDone={onClose} />
 
       {/* Teammates join with the code shared from Vault settings. */}
       {joining ? (

--- a/app/apps/desktop/src/components/SidebarHeader.tsx
+++ b/app/apps/desktop/src/components/SidebarHeader.tsx
@@ -100,7 +100,13 @@ export function SidebarHeader() {
   return (
     <div className="sidebar-header" ref={rootRef}>
       <div className="sidebar-header-main">
-        <span className="vault-name" title={activeOrg.name}>
+        {/* One name, one place. The local folder used to get its own line here,
+            but a vault's folder is created as `slugify(vault name)`, so that
+            line said the same thing twice on every vault anyone actually has —
+            "BenAI OS" over "benai-os". Where the files live is still a fair
+            question, so the path is the tooltip, and changing it lives in the
+            Switch menu next to it. */}
+        <span className="vault-name" title={vault.path}>
           {activeOrg.name}
         </span>
         <button
@@ -112,13 +118,6 @@ export function SidebarHeader() {
           Switch
         </button>
       </div>
-      <div className="vault-line">
-        {FOLDER_ICON}
-        <span className="vault-line-name" title={vault.path}>
-          {vault.name}
-        </span>
-      </div>
-
       {open && (
         <div className="vault-popover" role="menu">
           <div className="menu-label">Switch vault</div>

--- a/app/apps/desktop/src/components/SidebarHeader.tsx
+++ b/app/apps/desktop/src/components/SidebarHeader.tsx
@@ -1,202 +1,45 @@
-import { useEffect, useRef, useState } from "react";
-import * as ipc from "../lib/ipc";
 import { useStore } from "../store";
 
-const FOLDER_ICON = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.8"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
-  </svg>
-);
-
 /**
- * Sidebar header: the vault you're in leads; the local folder backing it
- * is a quiet storage line underneath. "Switch" switches the VAULT (it
- * opens a dropdown of your vaults); changing the local folder is the
- * subtle last item in that same menu. Signed out — no vaults to switch —
- * the folder takes the headline and Switch picks a folder, as before.
+ * Sidebar header: the name of the vault you're in. That's all.
+ *
+ * It used to carry a "Switch" dropdown, which duplicated the vault switcher
+ * already in the account menu at the foot of this same sidebar — two controls
+ * for one job, at opposite ends of one column. The account menu's version is
+ * the better one (it also joins by code, badges remote vaults, and links to
+ * Vault settings for the full list), so this one went rather than being kept in
+ * sync forever. Its one unique action, "Change local folder…", moved there too.
+ *
+ * The header is now a label, not a control: no popover, no outside-click
+ * handling, no state. The full path is the tooltip.
  */
 export function SidebarHeader() {
   const vault = useStore((s) => s.vault);
   const session = useStore((s) => s.session);
   const organizations = useStore((s) => s.organizations);
 
-  const [open, setOpen] = useState(false);
-  const [creating, setCreating] = useState(false);
-  const [orgName, setOrgName] = useState("");
-  const [busy, setBusy] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (e: PointerEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    window.addEventListener("pointerdown", onPointerDown);
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("pointerdown", onPointerDown);
-      window.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
   if (!vault) return null;
 
   const activeOrgId = session?.activeOrganizationId ?? null;
   const activeOrg = organizations.find((o) => o.id === activeOrgId) ?? null;
 
-  const switchVault = async () => {
-    setOpen(false);
-    const v = await ipc.pickVault();
-    // Routed through the store so the vault we're leaving is properly retired
-    // (scope, registry maps, debounced pulls) instead of leaking into this one.
-    if (v) await useStore.getState().adoptOpenedVault(v, { resync: true });
-  };
-
-  const createOrg = async () => {
-    if (!orgName.trim()) return;
-    setBusy(true);
-    try {
-      await useStore.getState().createOrganization(orgName.trim());
-      setOrgName("");
-      setCreating(false);
-      setOpen(false);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  // A local (unsynced) folder is still a vault — it just isn't syncing yet.
-  // Lead with its name and mark the state; "Switch" opens a different folder.
-  if (!activeOrg) {
-    return (
-      <div className="sidebar-header">
-        <div className="sidebar-header-main">
-          <span className="vault-name" title={vault.path}>
-            {vault.name}
-          </span>
-          <button className="link-btn" onClick={() => void switchVault()}>
-            Switch
-          </button>
-        </div>
-        <div className="vault-line">
-          <span className="ws-badge local">Local</span>
-          <span className="vault-line-name">Not synced</span>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="sidebar-header" ref={rootRef}>
+    <div className="sidebar-header">
       <div className="sidebar-header-main">
         {/* One name, one place. The local folder used to get its own line here,
             but a vault's folder is created as `slugify(vault name)`, so that
             line said the same thing twice on every vault anyone actually has —
-            "BenAI OS" over "benai-os". Where the files live is still a fair
-            question, so the path is the tooltip, and changing it lives in the
-            Switch menu next to it. */}
+            "BenAI OS" over "benai-os". */}
         <span className="vault-name" title={vault.path}>
-          {activeOrg.name}
+          {activeOrg ? activeOrg.name : vault.name}
         </span>
-        <button
-          className="link-btn"
-          onClick={() => setOpen((v) => !v)}
-          aria-haspopup="menu"
-          aria-expanded={open}
-        >
-          Switch
-        </button>
       </div>
-      {open && (
-        <div className="vault-popover" role="menu">
-          <div className="menu-label">Switch vault</div>
-          {[
-            ...organizations.filter((o) => o.id === activeOrgId),
-            ...organizations.filter((o) => o.id !== activeOrgId),
-          ].map((o) => {
-            const isActive = o.id === activeOrgId;
-            return (
-              <button
-                key={o.id}
-                className={`menu-item${isActive ? " active" : ""}`}
-                role="menuitemradio"
-                aria-checked={isActive}
-                onClick={() => {
-                  if (!isActive) {
-                    void useStore.getState().setActiveOrganization(o.id);
-                  }
-                  setOpen(false);
-                }}
-              >
-                <span className="menu-swatch" aria-hidden="true">
-                  {o.name[0]?.toUpperCase() ?? "?"}
-                </span>
-                <span className="menu-item-label">{o.name}</span>
-                {isActive && (
-                  <>
-                    <span className="menu-current">Current</span>
-                    <svg
-                      className="menu-check"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <path d="M20 6 9 17l-5-5" />
-                    </svg>
-                  </>
-                )}
-              </button>
-            );
-          })}
-
-          {creating ? (
-            <div className="menu-create-org">
-              <input
-                autoFocus
-                placeholder="Vault name"
-                value={orgName}
-                onChange={(e) => setOrgName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") void createOrg();
-                  if (e.key === "Escape") setCreating(false);
-                }}
-              />
-              <button className="primary sm" disabled={busy} onClick={() => void createOrg()}>
-                Create
-              </button>
-            </div>
-          ) : (
-            <button className="menu-item subtle" onClick={() => setCreating(true)}>
-              <span className="menu-swatch plus" aria-hidden="true">
-                +
-              </span>
-              <span className="menu-item-label">New vault</span>
-            </button>
-          )}
-
-          <div className="menu-sep" />
-          <button className="menu-item subtle" onClick={() => void switchVault()}>
-            <span className="menu-icon">{FOLDER_ICON}</span>
-            <span className="menu-item-label">Change local folder…</span>
-            <span className="menu-hint" title={vault.path}>
-              {vault.name}
-            </span>
-          </button>
+      {/* A local folder is still a vault — it just isn't syncing yet, and that
+          IS worth a second line because nothing else on screen says so. */}
+      {!activeOrg && (
+        <div className="vault-line">
+          <span className="ws-badge local">Local</span>
+          <span className="vault-line-name">Not synced</span>
         </div>
       )}
     </div>

--- a/app/apps/desktop/src/components/TalkButton.tsx
+++ b/app/apps/desktop/src/components/TalkButton.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef } from "react";
+import { useStore } from "../store";
+import "./talk.css";
+
+const MIC_ICON = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+    <path d="M19 10v1a7 7 0 0 1-14 0v-1" />
+    <path d="M12 18v4" />
+  </svg>
+);
+
+/**
+ * Push-to-talk. Hold to broadcast live audio to everyone in the vault; release
+ * and it stops. Nothing is recorded or kept — this is a walkie-talkie, not a
+ * voice-note feature, and there is deliberately nothing to play back.
+ *
+ * Hold, never toggle: a toggle makes "am I live right now?" a thing the user has
+ * to remember, and getting that wrong means an open mic. Holding a key is its
+ * own reminder.
+ */
+export function TalkButton() {
+  const broadcasting = useStore((s) => s.broadcasting);
+  const speakers = useStore((s) => s.voiceSpeakers);
+  const voiceError = useStore((s) => s.voiceError);
+  const voiceReady = useStore((s) => s.voiceReady);
+  const startBroadcast = useStore((s) => s.startBroadcast);
+  const stopBroadcast = useStore((s) => s.stopBroadcast);
+
+  // Tracks whether WE started the current press, so a stray pointerup elsewhere
+  // in the window can't stop a broadcast we never began.
+  const held = useRef(false);
+
+  const start = () => {
+    if (held.current) return;
+    held.current = true;
+    void startBroadcast();
+  };
+  const stop = () => {
+    if (!held.current) return;
+    held.current = false;
+    void stopBroadcast();
+  };
+
+  // A pointer released outside the button, a lost window, or a tab hidden
+  // mid-press must all end the transmission. Without these the mic can stay
+  // open after the user believes they let go.
+  useEffect(() => {
+    const onUp = () => stop();
+    const onHide = () => {
+      if (document.hidden) stop();
+    };
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    window.addEventListener("blur", onUp);
+    document.addEventListener("visibilitychange", onHide);
+    return () => {
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      window.removeEventListener("blur", onUp);
+      document.removeEventListener("visibilitychange", onHide);
+      stop(); // unmounting while live must not leave the mic open
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const offline = !voiceReady;
+  const listening = speakers.length > 0;
+
+  return (
+    <div className="talk">
+      <button
+        type="button"
+        className={`talk-btn${broadcasting ? " live" : ""}`}
+        disabled={offline}
+        aria-pressed={broadcasting}
+        title={
+          offline
+            ? "Connect to a synced vault to use push-to-talk"
+            : "Hold to talk to everyone in this vault"
+        }
+        onPointerDown={(e) => {
+          // Primary button only; a right-click shouldn't open the mic.
+          if (e.button !== 0) return;
+          e.preventDefault(); // don't start a text selection drag
+          start();
+        }}
+        // Keyboard parity: hold Space/Enter while focused. `repeat` is ignored
+        // because key repeat would otherwise fire start() many times a second.
+        onKeyDown={(e) => {
+          if (e.repeat || (e.key !== " " && e.key !== "Enter")) return;
+          e.preventDefault();
+          start();
+        }}
+        onKeyUp={(e) => {
+          if (e.key !== " " && e.key !== "Enter") return;
+          stop();
+        }}
+      >
+        <span className="talk-icon">{MIC_ICON}</span>
+        <span className="talk-label">{broadcasting ? "On air" : "Hold to talk"}</span>
+      </button>
+
+      {listening && (
+        <div className="talk-speakers" role="status" aria-live="polite">
+          {speakers.map((s) => (
+            <span key={s.userId} className="talk-speaker">
+              <span
+                className="talk-speaker-dot"
+                style={{ background: s.color || "var(--accent)" }}
+                aria-hidden="true"
+              />
+              {s.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {voiceError && !broadcasting && (
+        <p className="talk-error" role="status">
+          {voiceError}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/apps/desktop/src/components/TalkButton.tsx
+++ b/app/apps/desktop/src/components/TalkButton.tsx
@@ -2,7 +2,9 @@ import { useEffect, useRef } from "react";
 import { useStore } from "../store";
 import "./talk.css";
 
-const MIC_ICON = (
+// Megaphone — reads as "broadcast to the team" in a way a bare microphone
+// doesn't. A mic glyph says "record me"; this says "everyone hears this".
+const MEGAPHONE_ICON = (
   <svg
     viewBox="0 0 24 24"
     fill="none"
@@ -12,9 +14,8 @@ const MIC_ICON = (
     strokeLinejoin="round"
     aria-hidden="true"
   >
-    <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
-    <path d="M19 10v1a7 7 0 0 1-14 0v-1" />
-    <path d="M12 18v4" />
+    <path d="m3 11 18-5v12L3 14v-3z" />
+    <path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
   </svg>
 );
 
@@ -34,6 +35,7 @@ export function TalkButton() {
   const voiceReady = useStore((s) => s.voiceReady);
   const startBroadcast = useStore((s) => s.startBroadcast);
   const stopBroadcast = useStore((s) => s.stopBroadcast);
+  const clearVoiceError = useStore((s) => s.clearVoiceError);
 
   // Tracks whether WE started the current press, so a stray pointerup elsewhere
   // in the window can't stop a broadcast we never began.
@@ -72,20 +74,46 @@ export function TalkButton() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const offline = !voiceReady;
-  const listening = speakers.length > 0;
+  // The notice is transient, like the mention toast — it says its piece and
+  // leaves rather than sitting in the chrome as a permanent red mark.
+  useEffect(() => {
+    if (!voiceError) return;
+    const t = window.setTimeout(() => clearVoiceError(), 4000);
+    return () => window.clearTimeout(t);
+  }, [voiceError, clearVoiceError]);
+
+  const speaker = speakers[0];
+  const extra = speakers.length - 1;
 
   return (
-    <div className="talk">
+    <>
+      {voiceError && (
+        <span className="talk-note" role="status">
+          {voiceError}
+        </span>
+      )}
+
+      {speaker && (
+        <span className="talk-note talking" role="status" aria-live="polite">
+          <span
+            className="talk-dot"
+            style={{ background: speaker.color || "var(--accent)" }}
+            aria-hidden="true"
+          />
+          {extra > 0 ? `${speaker.name} +${extra} talking` : `${speaker.name} is talking`}
+        </span>
+      )}
+
       <button
         type="button"
-        className={`talk-btn${broadcasting ? " live" : ""}`}
-        disabled={offline}
+        className={`icon-btn talk-btn${broadcasting ? " live" : ""}`}
+        disabled={!voiceReady}
         aria-pressed={broadcasting}
+        aria-label="Push to talk"
         title={
-          offline
-            ? "Connect to a synced vault to use push-to-talk"
-            : "Hold to talk to everyone in this vault"
+          voiceReady
+            ? "Press and hold to talk to everyone in this vault"
+            : "Connect to a synced vault to use push-to-talk"
         }
         onPointerDown={(e) => {
           // Primary button only; a right-click shouldn't open the mic.
@@ -105,30 +133,8 @@ export function TalkButton() {
           stop();
         }}
       >
-        <span className="talk-icon">{MIC_ICON}</span>
-        <span className="talk-label">{broadcasting ? "On air" : "Hold to talk"}</span>
+        {MEGAPHONE_ICON}
       </button>
-
-      {listening && (
-        <div className="talk-speakers" role="status" aria-live="polite">
-          {speakers.map((s) => (
-            <span key={s.userId} className="talk-speaker">
-              <span
-                className="talk-speaker-dot"
-                style={{ background: s.color || "var(--accent)" }}
-                aria-hidden="true"
-              />
-              {s.name}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {voiceError && !broadcasting && (
-        <p className="talk-error" role="status">
-          {voiceError}
-        </p>
-      )}
-    </div>
+    </>
   );
 }

--- a/app/apps/desktop/src/components/TalkButton.tsx
+++ b/app/apps/desktop/src/components/TalkButton.tsx
@@ -32,7 +32,6 @@ export function TalkButton() {
   const broadcasting = useStore((s) => s.broadcasting);
   const speakers = useStore((s) => s.voiceSpeakers);
   const voiceError = useStore((s) => s.voiceError);
-  const voiceReady = useStore((s) => s.voiceReady);
   const startBroadcast = useStore((s) => s.startBroadcast);
   const stopBroadcast = useStore((s) => s.stopBroadcast);
   const clearVoiceError = useStore((s) => s.clearVoiceError);
@@ -107,14 +106,13 @@ export function TalkButton() {
       <button
         type="button"
         className={`icon-btn talk-btn${broadcasting ? " live" : ""}`}
-        disabled={!voiceReady}
         aria-pressed={broadcasting}
         aria-label="Push to talk"
-        title={
-          voiceReady
-            ? "Press and hold to talk to everyone in this vault"
-            : "Connect to a synced vault to use push-to-talk"
-        }
+        // Always available. Talking into an empty vault is harmless — the chunks
+        // simply go nowhere — and gating on "is anyone listening" would make the
+        // control flicker in and out with the connection. If someone IS there,
+        // the talking indicator says so.
+        title="Press and hold to talk"
         onPointerDown={(e) => {
           // Primary button only; a right-click shouldn't open the mic.
           if (e.button !== 0) return;

--- a/app/apps/desktop/src/components/TalkButton.tsx
+++ b/app/apps/desktop/src/components/TalkButton.tsx
@@ -83,6 +83,10 @@ export function TalkButton() {
 
   const speaker = speakers[0];
   const extra = speakers.length - 1;
+  // Someone else is transmitting. The button reacts even though it isn't the
+  // control being used — that shake is what tells a listener audio is incoming
+  // and where to look, before they've parsed any text.
+  const receiving = speakers.length > 0 && !broadcasting;
 
   return (
     <>
@@ -105,9 +109,13 @@ export function TalkButton() {
 
       <button
         type="button"
-        className={`icon-btn talk-btn${broadcasting ? " live" : ""}`}
+        className={`icon-btn talk-btn${broadcasting ? " live" : ""}${receiving ? " receiving" : ""}`}
         aria-pressed={broadcasting}
-        aria-label="Push to talk"
+        aria-label={
+          receiving
+            ? `${speaker.name} is talking. Press and hold to talk`
+            : "Push to talk"
+        }
         // Always available. Talking into an empty vault is harmless — the chunks
         // simply go nowhere — and gating on "is anyone listening" would make the
         // control flicker in and out with the connection. If someone IS there,

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -9,6 +9,7 @@ import {
   useStore,
 } from "../store";
 import { AuthDialog } from "./AccountMenu";
+import { Avatar } from "./Identity";
 import { Wordmark } from "./Logo";
 
 /**
@@ -79,6 +80,7 @@ function tidyPath(path: string): string {
 
 export function VaultPicker() {
   const authStatus = useStore((s) => s.authStatus);
+  const session = useStore((s) => s.session);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [recents, setRecents] = useState<RecentVault[]>([]);
@@ -306,6 +308,43 @@ export function VaultPicker() {
 
   return (
     <div className="vault-picker">
+      {/*
+        Account chip. Until this existed, the ONLY way to sign in from this
+        screen was to click a "Remote" vault card — and those come from a
+        locally-cached org list, so a fresh install had none and therefore no
+        route to an account at all. Signing in required first creating or
+        opening a local vault you didn't want, just to reach the sidebar menu,
+        which is exactly backwards for a teammate whose whole reason for opening
+        the app is to join a shared vault.
+
+        Kept as a quiet corner chip rather than a third button beside "New
+        vault" / "Open existing": an account is optional in a local-first app,
+        so it shouldn't compete with the primary choice. When signed in it shows
+        who you are — this screen previously gave no way to tell.
+      */}
+      <div className="picker-account">
+        {authStatus === "signed-in" && session ? (
+          <span className="picker-account-id" title={session.user.email}>
+            <Avatar label={session.user.name || session.user.email} image={session.user.image} />
+            <span className="picker-account-name">
+              {session.user.name || session.user.email}
+            </span>
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="ghost-pill sm"
+            // "unknown" is the pre-restore state: the session is still being
+            // read from the keychain, so offering sign-in would flash a button
+            // that's about to be replaced by the user's own name.
+            disabled={busy || authStatus === "unknown"}
+            onClick={() => setSignInOpen(true)}
+          >
+            Sign in
+          </button>
+        )}
+      </div>
+
       {/* Ambient aurora — three blurred color fields drifting very slowly. */}
       {!reduceMotion && (
         <div className="aurora" aria-hidden="true">

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -9,7 +9,6 @@ import {
   useStore,
 } from "../store";
 import { AuthDialog } from "./AccountMenu";
-import { Avatar } from "./Identity";
 import { Wordmark } from "./Logo";
 
 /**
@@ -80,7 +79,6 @@ function tidyPath(path: string): string {
 
 export function VaultPicker() {
   const authStatus = useStore((s) => s.authStatus);
-  const session = useStore((s) => s.session);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [recents, setRecents] = useState<RecentVault[]>([]);
@@ -308,43 +306,6 @@ export function VaultPicker() {
 
   return (
     <div className="vault-picker">
-      {/*
-        Account chip. Until this existed, the ONLY way to sign in from this
-        screen was to click a "Remote" vault card — and those come from a
-        locally-cached org list, so a fresh install had none and therefore no
-        route to an account at all. Signing in required first creating or
-        opening a local vault you didn't want, just to reach the sidebar menu,
-        which is exactly backwards for a teammate whose whole reason for opening
-        the app is to join a shared vault.
-
-        Kept as a quiet corner chip rather than a third button beside "New
-        vault" / "Open existing": an account is optional in a local-first app,
-        so it shouldn't compete with the primary choice. When signed in it shows
-        who you are — this screen previously gave no way to tell.
-      */}
-      <div className="picker-account">
-        {authStatus === "signed-in" && session ? (
-          <span className="picker-account-id" title={session.user.email}>
-            <Avatar label={session.user.name || session.user.email} image={session.user.image} />
-            <span className="picker-account-name">
-              {session.user.name || session.user.email}
-            </span>
-          </span>
-        ) : (
-          <button
-            type="button"
-            className="ghost-pill sm"
-            // "unknown" is the pre-restore state: the session is still being
-            // read from the keychain, so offering sign-in would flash a button
-            // that's about to be replaced by the user's own name.
-            disabled={busy || authStatus === "unknown"}
-            onClick={() => setSignInOpen(true)}
-          >
-            Sign in
-          </button>
-        )}
-      </div>
-
       {/* Ambient aurora — three blurred color fields drifting very slowly. */}
       {!reduceMotion && (
         <div className="aurora" aria-hidden="true">
@@ -575,6 +536,47 @@ export function VaultPicker() {
             }
           >
             A vault is any folder of <code>.md</code> files.
+          </motion.p>
+        )}
+
+        {/*
+          Sign-in lives with the hint text, under the primary actions, because
+          that is where someone looks after deciding the two buttons above
+          aren't what they came for.
+
+          Before this existed the ONLY route to an account from this screen was
+          clicking a "Remote" vault card — and those come from a locally-cached
+          org list, so a fresh install had none and therefore no route at all.
+          Signing in meant first creating a local vault you didn't want, purely
+          to reach the sidebar menu: exactly backwards for a teammate whose
+          whole reason for opening the app is to join a shared vault.
+
+          A quiet link rather than a third button beside "New vault" / "Open
+          existing": an account is optional in a local-first app and shouldn't
+          compete with the primary choice.
+        */}
+        {!inFlow && authStatus !== "signed-in" && (
+          <motion.p
+            className="hint picker-signin"
+            initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={
+              reduceMotion ? undefined : revealTransition(REVEAL_DELAY + 0.36)
+            }
+          >
+            Have an account?{" "}
+            <button
+              type="button"
+              className="linkish"
+              // "unknown" is the pre-restore state — the session is still being
+              // read from the keychain, so offering sign-in would flash a
+              // control that's about to become unnecessary.
+              disabled={busy || authStatus === "unknown"}
+              onClick={() => setSignInOpen(true)}
+            >
+              Sign in
+            </button>{" "}
+            to sync and collaborate.
           </motion.p>
         )}
       </div>

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -88,9 +88,6 @@ export function VaultPicker() {
   // New-vault flow: null = idle; a string = chosen parent, awaiting a name.
   const [newParent, setNewParent] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
-  // When "New vault" lands on a folder that's already a vault, hold its path so
-  // we can offer to open it instead of nesting a new empty vault inside it.
-  const [alreadyVault, setAlreadyVault] = useState<string | null>(null);
   // Recents are collapsed to the 3 most recent; "Load more" reveals the rest
   // inside a scroll area locked to the collapsed height so the logo/buttons
   // above never shift (the vault-picker card is vertically centered).
@@ -136,58 +133,24 @@ export function VaultPicker() {
     }
   }
 
-  // "New vault": pick a folder — and that folder *is* the vault. We initialize
-  // it in place (named after the folder), so there's no separate naming step:
-  // choosing the folder is the choice. If the chosen folder is ALREADY a vault,
-  // don't nest a new one inside it — offer to open the existing one instead.
+  // "New vault": ask for a name, nothing else.
+  //
+  // It used to open a folder picker first, which was a question with one
+  // sensible answer — every vault we create lives under the vaults root
+  // anyway, so choosing its parent was ceremony. Adopting a folder you already
+  // have is what "Open existing" is for, and that one keeps the folder exactly
+  // where you picked it.
   async function startNewVault() {
     setError(null);
     try {
-      const picked = await ipc.pickFolder();
-      if (!picked) return;
-      if (await ipc.isVault(picked)) {
-        setAlreadyVault(picked);
-        return;
-      }
-      setBusy(true);
-      // `openLocalVault` opens it for us, and does so AFTER retiring the previous
-      // vault's sync — the ordering `adoptOpenedVault` can't offer.
-      await useStore.getState().openLocalVault(picked);
+      setNewParent(await ipc.getVaultsRoot());
+      setNewName("");
     } catch (e) {
       setError(String(e));
-    } finally {
-      setBusy(false);
     }
   }
 
-  // The picked folder is already a vault → open it directly.
-  async function openDetectedVault() {
-    if (!alreadyVault) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await useStore.getState().openLocalVault(alreadyVault);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  // User insists on creating a fresh vault inside the existing one anyway.
-  function createInsideAnyway() {
-    if (!alreadyVault) return;
-    setNewParent(alreadyVault);
-    setNewName("Untitled Vault");
-    setAlreadyVault(null);
-  }
-
-  function cancelAlreadyVault() {
-    setAlreadyVault(null);
-    setError(null);
-  }
-
-  // "New vault" step 2: create <parent>/<name> and open it.
+  // "New vault" step 2: create <vaults root>/<name> and open it.
   async function confirmNewVault() {
     if (!newParent || !newName.trim()) return;
     setBusy(true);
@@ -266,10 +229,8 @@ export function VaultPicker() {
   }
 
   const naming = newParent !== null;
-  const deciding = alreadyVault !== null;
-  // Whether either multi-step flow (naming a new vault, or deciding what to do
-  // with an already-a-vault folder) is showing — hides the recents/hint.
-  const inFlow = naming || deciding;
+  // The naming step is showing — hide the recents/hint behind it.
+  const inFlow = naming;
 
   // Merge synced (remote) vaults with local recents into one list. Remote
   // vaults come from the locally-cached org list (survives sign-out) and are
@@ -334,49 +295,7 @@ export function VaultPicker() {
           transition={reduceMotion ? undefined : revealTransition(REVEAL_DELAY)}
         >
           <AnimatePresence mode="wait" initial={false}>
-            {deciding ? (
-              // ---- Picked folder is already a vault: open vs nest ----
-              <motion.div
-                key="already"
-                className="new-vault-form"
-                initial={reduceMotion ? false : { opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={reduceMotion ? undefined : { opacity: 0, y: -8 }}
-                transition={SPRING}
-              >
-                <label className="new-vault-label">This folder is already a vault</label>
-                <p className="new-vault-loc" title={alreadyVault ?? undefined}>
-                  <code>{tidyPath(alreadyVault ?? "")}</code> already contains notes — open
-                  it instead of creating a new vault inside?
-                </p>
-                <div className="new-vault-buttons">
-                  <button
-                    type="button"
-                    className="ghost-pill"
-                    disabled={busy}
-                    onClick={cancelAlreadyVault}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    className="ghost-pill"
-                    disabled={busy}
-                    onClick={createInsideAnyway}
-                  >
-                    Create inside
-                  </button>
-                  <button
-                    type="button"
-                    className="primary sm"
-                    disabled={busy}
-                    onClick={() => void openDetectedVault()}
-                  >
-                    {busy ? "Opening…" : "Open vault"}
-                  </button>
-                </div>
-              </motion.div>
-            ) : naming ? (
+            {naming ? (
               // ---- Naming step: only reached via "Create inside" an existing
               //      vault, where a nested vault does need its own folder name.
               //      The normal "New vault" flow skips this — the picked folder

--- a/app/apps/desktop/src/components/talk.css
+++ b/app/apps/desktop/src/components/talk.css
@@ -66,6 +66,44 @@
   }
 }
 
+/* Receiving — a teammate is talking to US. Distinct from `.live` on purpose:
+   sending is a state you chose and must not lose track of (steady fill, ring),
+   receiving is something happening TO you, so it shakes to catch the eye and
+   then stops when they stop. Getting these two confused would be the worst
+   possible outcome, since one of them means your mic is open. */
+.talk-btn.receiving {
+  color: var(--accent);
+}
+
+.talk-btn.receiving svg {
+  transform-origin: 50% 50%;
+  animation: talk-shake 0.6s ease-in-out infinite;
+}
+
+/* A quick side-to-side wobble — a megaphone being rattled, not a slow pulse,
+   which would read as "loading". */
+@keyframes talk-shake {
+  0%,
+  100% {
+    transform: rotate(0) translateX(0);
+  }
+  15% {
+    transform: rotate(-9deg) translateX(-1px);
+  }
+  30% {
+    transform: rotate(8deg) translateX(1px);
+  }
+  45% {
+    transform: rotate(-6deg) translateX(-1px);
+  }
+  60% {
+    transform: rotate(4deg) translateX(1px);
+  }
+  75% {
+    transform: rotate(-2deg) translateX(0);
+  }
+}
+
 /* Transient notices — a mic problem, or who's currently talking. Soft accent
    pill, matching `.ping-toast`; deliberately NOT `--danger`, since neither is
    an error the user must act on and a red mark in the chrome reads as breakage. */
@@ -112,6 +150,7 @@
    entirely rather than leaving a static outline sitting around the button. */
 @media (prefers-reduced-motion: reduce) {
   .talk-btn.live svg,
+  .talk-btn.receiving svg,
   .talk-dot {
     animation: none;
   }

--- a/app/apps/desktop/src/components/talk.css
+++ b/app/apps/desktop/src/components/talk.css
@@ -1,0 +1,113 @@
+/* Push-to-talk control in the sidebar footer. Follows DESIGN-BRIEF: pill
+   button, violet accent for the live state, soft shadows, 4pt grid, tokens
+   only — no hardcoded colors, spacing, radii, or shadows. */
+
+.talk {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.talk-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background var(--t-fast),
+    color var(--t-fast),
+    border-color var(--t-fast);
+  /* Holding the button is a drag-like gesture; text selection fights it. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.talk-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.talk-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+  box-shadow: none;
+}
+
+/* Live. Deliberately the loudest thing in the sidebar: an open mic the user has
+   forgotten about is the failure mode worth designing against. */
+.talk-btn.live {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+  animation: talk-pulse 1.6s ease-in-out infinite;
+}
+
+.talk-icon {
+  display: inline-flex;
+  width: 15px;
+  height: 15px;
+  flex: none;
+}
+
+.talk-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.talk-speakers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1) var(--sp-2);
+  padding: 0 var(--sp-1);
+}
+
+.talk-speaker {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.talk-speaker-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  animation: talk-pulse 1.2s ease-in-out infinite;
+}
+
+.talk-error {
+  margin: 0;
+  padding: 0 var(--sp-1);
+  font-size: 0.75rem;
+  color: var(--danger);
+}
+
+@keyframes talk-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+/* Respect a reduced-motion preference: the pulse is decorative, and the colour
+   change alone still communicates "live". */
+@media (prefers-reduced-motion: reduce) {
+  .talk-btn.live,
+  .talk-speaker-dot {
+    animation: none;
+  }
+}

--- a/app/apps/desktop/src/components/talk.css
+++ b/app/apps/desktop/src/components/talk.css
@@ -1,96 +1,61 @@
-/* Push-to-talk control in the sidebar footer. Follows DESIGN-BRIEF: pill
-   button, violet accent for the live state, soft shadows, 4pt grid, tokens
-   only — no hardcoded colors, spacing, radii, or shadows. */
-
-.talk {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-2);
-}
+/* Push-to-talk in the main header. Builds on the shared `.icon-btn` (28px ghost
+   button, 18px glyph) rather than introducing a second button size, and borrows
+   the mention toast's soft-accent pill for its transient notices. Tokens only —
+   no hardcoded colors, spacing, radii, or shadows. */
 
 .talk-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sp-2);
-  width: 100%;
-  padding: var(--sp-2) var(--sp-3);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
-  background: var(--bg-surface);
-  color: var(--text-primary);
-  font: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  transition:
-    background var(--t-fast),
-    color var(--t-fast),
-    border-color var(--t-fast);
   /* Holding the button is a drag-like gesture; text selection fights it. */
   user-select: none;
   -webkit-user-select: none;
 }
 
-.talk-btn:hover:not(:disabled) {
-  background: var(--bg-hover);
-}
-
 .talk-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: default;
-  box-shadow: none;
 }
 
-/* Live. Deliberately the loudest thing in the sidebar: an open mic the user has
+/* Live. The loudest thing in the header on purpose: an open mic the user has
    forgotten about is the failure mode worth designing against. */
 .talk-btn.live {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--text-on-accent);
+  color: var(--accent);
+  background: var(--accent-soft);
   animation: talk-pulse 1.6s ease-in-out infinite;
 }
 
-.talk-icon {
-  display: inline-flex;
-  width: 15px;
-  height: 15px;
-  flex: none;
+.talk-btn.live:hover {
+  color: var(--accent);
 }
 
-.talk-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
-.talk-speakers {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--sp-1) var(--sp-2);
-  padding: 0 var(--sp-1);
-}
-
-.talk-speaker {
+/* Transient notices — a mic problem, or who's currently talking. Soft accent
+   pill, matching `.ping-toast`; deliberately NOT `--danger`, since neither is
+   an error the user must act on and a red mark in the chrome reads as breakage. */
+.talk-note {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);
-  font-size: 0.75rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
   color: var(--text-secondary);
+  background: var(--bg-subtle);
+  border-radius: var(--radius-pill);
+  padding: 3px var(--sp-3);
+  white-space: nowrap;
+  animation: rise-in var(--t-fast) var(--ease) both;
 }
 
-.talk-speaker-dot {
+/* Someone talking is live status, not a passing note — give it the accent. */
+.talk-note.talking {
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 600;
+}
+
+.talk-dot {
   width: 6px;
   height: 6px;
   border-radius: var(--radius-pill);
+  flex: none;
   animation: talk-pulse 1.2s ease-in-out infinite;
-}
-
-.talk-error {
-  margin: 0;
-  padding: 0 var(--sp-1);
-  font-size: 0.75rem;
-  color: var(--danger);
 }
 
 @keyframes talk-pulse {
@@ -103,11 +68,10 @@
   }
 }
 
-/* Respect a reduced-motion preference: the pulse is decorative, and the colour
-   change alone still communicates "live". */
+/* The pulse is decorative; colour alone still says "live". */
 @media (prefers-reduced-motion: reduce) {
   .talk-btn.live,
-  .talk-speaker-dot {
+  .talk-dot {
     animation: none;
   }
 }

--- a/app/apps/desktop/src/components/talk.css
+++ b/app/apps/desktop/src/components/talk.css
@@ -9,21 +9,61 @@
   -webkit-user-select: none;
 }
 
-.talk-btn:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
 /* Live. The loudest thing in the header on purpose: an open mic the user has
-   forgotten about is the failure mode worth designing against. */
+   forgotten about is the failure mode worth designing against.
+
+   Three layers, all keyed to "broadcasting" rather than mere hover:
+     1. the button holds an accent fill,
+     2. a ring radiates outward and fades — the visual grammar of transmitting,
+     3. the megaphone itself leans and breathes.
+   The ring is a pseudo-element so it can overflow the 28px button without
+   affecting layout in the header row. */
 .talk-btn.live {
   color: var(--accent);
   background: var(--accent-soft);
-  animation: talk-pulse 1.6s ease-in-out infinite;
+  position: relative;
 }
 
 .talk-btn.live:hover {
   color: var(--accent);
+}
+
+.talk-btn.live::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--accent);
+  animation: talk-broadcast 1.4s var(--ease) infinite;
+  pointer-events: none;
+}
+
+.talk-btn.live svg {
+  transform-origin: 60% 60%;
+  animation: talk-shout 1.4s ease-in-out infinite;
+}
+
+/* The ring grows past the button edge and dissolves, so the button reads as
+   emitting rather than merely highlighted. */
+@keyframes talk-broadcast {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1.7);
+    opacity: 0;
+  }
+}
+
+@keyframes talk-shout {
+  0%,
+  100% {
+    transform: rotate(0) scale(1);
+  }
+  50% {
+    transform: rotate(-7deg) scale(1.1);
+  }
 }
 
 /* Transient notices — a mic problem, or who's currently talking. Soft accent
@@ -68,10 +108,14 @@
   }
 }
 
-/* The pulse is decorative; colour alone still says "live". */
+/* Motion is decorative; the accent fill alone still says "live". Drop the ring
+   entirely rather than leaving a static outline sitting around the button. */
 @media (prefers-reduced-motion: reduce) {
-  .talk-btn.live,
+  .talk-btn.live svg,
   .talk-dot {
     animation: none;
+  }
+  .talk-btn.live::after {
+    display: none;
   }
 }

--- a/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
@@ -6,6 +6,12 @@ import {
   type DocUpdateSink,
   type WebSocketLike,
 } from "../sync/vaultSyncEngine";
+import {
+  decodeVoiceFrame,
+  encodeVoiceFrame,
+  VOICE_FRAME,
+  type VoiceFrame,
+} from "../sync/vaultProtocol";
 
 // Drives the engine through a fake WebSocket + a mocked token fetch + an
 // in-memory sink. No real socket, DB, or server (spec 05 §3.3).
@@ -517,5 +523,121 @@ describe("VaultSyncEngine — inbound queue", () => {
 
     expect(sink.ready).toBe(true); // hello never precedes the manifest load
     expect((ws!.helloText()!.manifest as Record<string, string>).A).toBe("BQ==");
+  });
+});
+
+describe("VaultSyncEngine voice", () => {
+  /** Bring an engine up to `ready` with a voice listener attached. */
+  async function readyEngine(): Promise<{
+    engine: VaultSyncEngine;
+    ws: FakeWs;
+    heard: VoiceFrame[];
+    sink: MemSink;
+  }> {
+    const sink = new MemSink();
+    const heard: VoiceFrame[] = [];
+    let ws: FakeWs | null = null;
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => (ws = new FakeWs()),
+      onVoice: (f) => heard.push(f),
+    });
+    engine.start();
+    ws!.onopen?.(null);
+    await awaitHello(ws!);
+    ws!.onmessage?.({ data: JSON.stringify({ t: "ready" }) });
+    await tick();
+    return { engine, ws: ws!, heard, sink };
+  }
+
+  it("advertises the voice capability in hello", async () => {
+    const { ws } = await readyEngine();
+    expect(ws.helloText()!.caps).toContain("voice");
+  });
+
+  it("surfaces an inbound chunk without routing it through the doc sink", async () => {
+    const { ws, heard, sink } = await readyEngine();
+
+    const frame = encodeVoiceFrame(
+      { s: "tx1", n: 0, u: "ada", m: "Ada", c: "#6366f1", fmt: "pcm16", sr: 16000 },
+      new Uint8Array([1, 2, 3]),
+    );
+    ws.onmessage?.({ data: frame.buffer.slice(0) });
+    await tick();
+
+    expect(heard).toHaveLength(1);
+    expect(heard[0].header.u).toBe("ada");
+    expect(heard[0].header.m).toBe("Ada");
+    expect(heard[0].audio).toEqual(new Uint8Array([1, 2, 3]));
+    // Critically: it must NOT be mistaken for a doc update.
+    expect(sink.applied).toHaveLength(0);
+  });
+
+  it("still routes doc updates correctly alongside voice traffic", async () => {
+    const { ws, heard, sink } = await readyEngine();
+
+    ws.onmessage?.({ data: updateFrame("doc-a", [7, 8]) });
+    ws.onmessage?.({
+      data: encodeVoiceFrame({ s: "tx1", n: 0, u: "ada" }, new Uint8Array([1])).buffer.slice(0),
+    });
+    ws.onmessage?.({ data: updateFrame("doc-b", [9]) });
+    for (let i = 0; i < 10 && sink.applied.length < 2; i++) await tick();
+
+    expect(sink.applied.map((a) => a.docId)).toEqual(["doc-a", "doc-b"]);
+    expect(heard).toHaveLength(1);
+  });
+
+  it("ignores an inbound chunk with no speaker stamped on it", async () => {
+    const { ws, heard } = await readyEngine();
+    // `u` absent — unattributable, so it can't be shown or grouped.
+    ws.onmessage?.({
+      data: encodeVoiceFrame({ s: "tx1", n: 0 }, new Uint8Array([1])).buffer.slice(0),
+    });
+    await tick();
+    expect(heard).toHaveLength(0);
+  });
+
+  it("copies audio off the socket buffer so playback can outlive the callback", async () => {
+    const { ws, heard } = await readyEngine();
+    const frame = encodeVoiceFrame({ s: "tx1", n: 0, u: "ada" }, new Uint8Array([42, 43]));
+    const buf = frame.buffer.slice(0) as ArrayBuffer;
+    ws.onmessage?.({ data: buf });
+    await tick();
+
+    // Scribble over the received buffer the way a reused socket buffer would.
+    new Uint8Array(buf).fill(0);
+    expect(heard[0].audio).toEqual(new Uint8Array([42, 43]));
+  });
+
+  it("sends a chunk once ready and refuses before the channel is live", async () => {
+    const sink = new MemSink();
+    let ws: FakeWs | null = null;
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => (ws = new FakeWs()),
+    });
+    engine.start();
+    ws!.onopen?.(null);
+    await awaitHello(ws!);
+
+    // Not ready yet: dropped rather than queued — late audio is worthless.
+    expect(engine.sendVoice({ s: "tx1", n: 0 }, new Uint8Array([1]))).toBe(false);
+
+    ws!.onmessage?.({ data: JSON.stringify({ t: "ready" }) });
+    await tick();
+    expect(engine.sendVoice({ s: "tx1", n: 0, fmt: "pcm16", sr: 16000 }, new Uint8Array([1, 2]))).toBe(
+      true,
+    );
+
+    const binary = ws!.sent.filter((s) => typeof s !== "string") as ArrayBufferView[];
+    expect(binary).toHaveLength(1);
+    const decoded = decodeVoiceFrame(new Uint8Array(binary[0] as Uint8Array));
+    expect(decoded).toBeNull(); // outbound frames carry no `u` — the server stamps it
+    // ...but the raw framing is intact and the server will accept it.
+    expect((binary[0] as Uint8Array)[0]).toBe(VOICE_FRAME);
   });
 });

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -36,6 +36,16 @@ import {
   type VaultPeer,
   type VaultSyncStatus,
 } from "./vaultSyncEngine";
+import type { VoiceFrame } from "./vaultProtocol";
+import { CAPTURE_FORMAT, startCapture } from "../voice/capture";
+import { VoicePlayer } from "../voice/playback";
+
+/** A teammate currently transmitting, for the "talking" indicator. */
+export interface VoiceSpeaker {
+  userId: string;
+  name: string;
+  color: string;
+}
 
 /** Basename of a vault-relative path (for the upload's x-file-name hint). */
 function baseName(relPath: string): string {
@@ -123,6 +133,22 @@ export class SyncManager {
   private docStore: VaultDocStore | null = null;
   private vaultEngine: VaultSyncEngine | null = null;
   private onVaultStatus?: (status: VaultSyncStatus) => void;
+
+  // ---- push-to-talk voice ----
+  //
+  // Entirely ephemeral: the player holds only what is scheduled to play in the
+  // next second or so, and `voiceNames` is a display cache keyed by speaker.
+  // Nothing here is written to disk, the CRDT, or the index.
+  private readonly speakingIds = new Set<string>();
+  private readonly voiceNames = new Map<string, { name: string; color: string }>();
+  private onVoiceSpeakers?: (speaking: VoiceSpeaker[]) => void;
+  private readonly voicePlayer = new VoicePlayer({
+    onSpeakingChange: (userId, speaking) => {
+      if (speaking) this.speakingIds.add(userId);
+      else this.speakingIds.delete(userId);
+      this.emitVoiceSpeakers();
+    },
+  });
 
   // ---- bulk sync run (phase 2) ----
   //
@@ -721,6 +747,79 @@ export class SyncManager {
     this.onVaultPresence = cb;
   }
 
+  // ---- push-to-talk voice ------------------------------------------------
+
+  /**
+   * UI subscribes here to learn who is currently talking. Fires with the set of
+   * speaking user ids on every change, so the sidebar can light them up.
+   */
+  setVoiceListener(cb: ((speaking: VoiceSpeaker[]) => void) | undefined): void {
+    this.onVoiceSpeakers = cb;
+  }
+
+  /** True when the vault channel is live, i.e. talking would reach someone. */
+  canBroadcastVoice(): boolean {
+    return this.vaultEngine !== null && this.vaultStatus === "synced";
+  }
+
+  /**
+   * Open the mic and stream to the vault until the returned handle is stopped.
+   *
+   * One transmission per press. The stream id is minted here so every chunk of
+   * a single press-and-hold groups on the receiving end, and the format rides
+   * the opening chunk only.
+   */
+  async startBroadcast(): Promise<{ stop: () => Promise<void> }> {
+    if (!this.vaultEngine) throw new Error("not connected to a vault");
+    const engine = this.vaultEngine;
+    const streamId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    let lastSeq = -1;
+
+    const capture = await startCapture((audio, seq) => {
+      lastSeq = seq;
+      engine.sendVoice(
+        { s: streamId, n: seq, ...(seq === 0 ? CAPTURE_FORMAT : {}) },
+        audio,
+      );
+    });
+
+    return {
+      stop: async () => {
+        await capture.stop();
+        // Always send a final marker, even with an empty payload: it's what
+        // closes the stream on every listener. Without it a receiver holds the
+        // "talking" indicator until its own timeout.
+        engine.sendVoice({ s: streamId, n: lastSeq + 1, f: 1 }, new Uint8Array());
+      },
+    };
+  }
+
+  /** Route one inbound chunk into the player and keep the speaking roster fresh. */
+  private handleVoice(frame: VoiceFrame): void {
+    const { header, audio } = frame;
+    const userId = header.u;
+    if (!userId) return;
+    if (header.m) this.voiceNames.set(userId, { name: header.m, color: header.c ?? "" });
+    this.voicePlayer.push({
+      streamId: header.s,
+      userId,
+      seq: header.n,
+      audio,
+      sampleRate: header.sr,
+      final: header.f === 1,
+    });
+  }
+
+  private emitVoiceSpeakers(): void {
+    this.onVoiceSpeakers?.(
+      [...this.speakingIds].map((id) => ({
+        userId: id,
+        name: this.voiceNames.get(id)?.name ?? "Someone",
+        color: this.voiceNames.get(id)?.color || colorForUser(id),
+      })),
+    );
+  }
+
   /** Record which note this client is now viewing (null = none) and broadcast it. */
   setViewing(docId: string | null): void {
     this.viewingDocId = docId;
@@ -801,6 +900,8 @@ export class SyncManager {
       onMemberJoined: (name) => this.onMemberJoined?.(name),
       // A teammate's viewing state changed — update the sidebar presence roster.
       onPresence: (peer) => this.handleVaultPresence(peer),
+      // A teammate is talking. Play it as it lands; nothing is kept.
+      onVoice: (frame) => this.handleVoice(frame),
       // Inbound backfill progress — the `downloading` half of the run's progress.
       onInboundProgress: (done, total) => this.handleInboundProgress(done, total, scope),
       // …and the edge that ends it.
@@ -814,6 +915,13 @@ export class SyncManager {
   private stopVaultEngine(): void {
     this.vaultEngine?.stop();
     this.vaultEngine = null;
+    // Cut any audio still playing: it belongs to the vault we're leaving, and
+    // hearing a teammate from the previous vault after switching would be a bug
+    // with an unpleasant privacy flavour.
+    this.voicePlayer.stopAll();
+    this.speakingIds.clear();
+    this.voiceNames.clear();
+    this.emitVoiceSpeakers();
     // Kick the durable manifest write FIRST, while this vault's epoch is still the
     // open one: the store's IPC is epoch-pinned, so a write issued after Rust has
     // swapped vaults is refused (benignly — the manifest just misses its last

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -39,13 +39,9 @@ import {
 import type { VoiceFrame } from "./vaultProtocol";
 import { CAPTURE_FORMAT, startCapture } from "../voice/capture";
 import { VoicePlayer } from "../voice/playback";
+import { VoiceRoster, type VoiceSpeaker } from "../voice/roster";
 
-/** A teammate currently transmitting, for the "talking" indicator. */
-export interface VoiceSpeaker {
-  userId: string;
-  name: string;
-  color: string;
-}
+export type { VoiceSpeaker };
 
 /** Basename of a vault-relative path (for the upload's x-file-name hint). */
 function baseName(relPath: string): string {
@@ -139,14 +135,11 @@ export class SyncManager {
   // Entirely ephemeral: the player holds only what is scheduled to play in the
   // next second or so, and `voiceNames` is a display cache keyed by speaker.
   // Nothing here is written to disk, the CRDT, or the index.
-  private readonly speakingIds = new Set<string>();
-  private readonly voiceNames = new Map<string, { name: string; color: string }>();
+  private readonly voiceRoster = new VoiceRoster((id) => colorForUser(id));
   private onVoiceSpeakers?: (speaking: VoiceSpeaker[]) => void;
   private readonly voicePlayer = new VoicePlayer({
     onSpeakingChange: (userId, speaking) => {
-      if (speaking) this.speakingIds.add(userId);
-      else this.speakingIds.delete(userId);
-      this.emitVoiceSpeakers();
+      if (this.voiceRoster.setSpeaking(userId, speaking)) this.emitVoiceSpeakers();
     },
   });
 
@@ -798,7 +791,7 @@ export class SyncManager {
     const { header, audio } = frame;
     const userId = header.u;
     if (!userId) return;
-    if (header.m) this.voiceNames.set(userId, { name: header.m, color: header.c ?? "" });
+    this.voiceRoster.learn(userId, header.m, header.c);
     this.voicePlayer.push({
       streamId: header.s,
       userId,
@@ -810,13 +803,7 @@ export class SyncManager {
   }
 
   private emitVoiceSpeakers(): void {
-    this.onVoiceSpeakers?.(
-      [...this.speakingIds].map((id) => ({
-        userId: id,
-        name: this.voiceNames.get(id)?.name ?? "Someone",
-        color: this.voiceNames.get(id)?.color || colorForUser(id),
-      })),
-    );
+    this.onVoiceSpeakers?.(this.voiceRoster.list());
   }
 
   /** Record which note this client is now viewing (null = none) and broadcast it. */
@@ -918,8 +905,7 @@ export class SyncManager {
     // hearing a teammate from the previous vault after switching would be a bug
     // with an unpleasant privacy flavour.
     this.voicePlayer.stopAll();
-    this.speakingIds.clear();
-    this.voiceNames.clear();
+    this.voiceRoster.clear();
     this.emitVoiceSpeakers();
     // Kick the durable manifest write FIRST, while this vault's epoch is still the
     // open one: the store's IPC is epoch-pinned, so a write issued after Rust has

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -757,27 +757,26 @@ export class SyncManager {
     this.onVoiceSpeakers = cb;
   }
 
-  /** True when the vault channel is live, i.e. talking would reach someone. */
-  canBroadcastVoice(): boolean {
-    return this.vaultEngine !== null && this.vaultStatus === "synced";
-  }
-
   /**
    * Open the mic and stream to the vault until the returned handle is stopped.
    *
    * One transmission per press. The stream id is minted here so every chunk of
    * a single press-and-hold groups on the receiving end, and the format rides
    * the opening chunk only.
+   *
+   * Works with no channel at all. `this.vaultEngine` is read per chunk rather
+   * than captured up front, so a transmission that starts offline still lands
+   * the moment the channel comes back mid-press, and one that starts online
+   * survives a drop instead of throwing. Chunks with nowhere to go are simply
+   * dropped — which is what "ephemeral" already means everywhere else here.
    */
   async startBroadcast(): Promise<{ stop: () => Promise<void> }> {
-    if (!this.vaultEngine) throw new Error("not connected to a vault");
-    const engine = this.vaultEngine;
     const streamId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     let lastSeq = -1;
 
     const capture = await startCapture((audio, seq) => {
       lastSeq = seq;
-      engine.sendVoice(
+      this.vaultEngine?.sendVoice(
         { s: streamId, n: seq, ...(seq === 0 ? CAPTURE_FORMAT : {}) },
         audio,
       );
@@ -789,7 +788,7 @@ export class SyncManager {
         // Always send a final marker, even with an empty payload: it's what
         // closes the stream on every listener. Without it a receiver holds the
         // "talking" indicator until its own timeout.
-        engine.sendVoice({ s: streamId, n: lastSeq + 1, f: 1 }, new Uint8Array());
+        this.vaultEngine?.sendVoice({ s: streamId, n: lastSeq + 1, f: 1 }, new Uint8Array());
       },
     };
   }

--- a/app/apps/desktop/src/lib/sync/vaultProtocol.ts
+++ b/app/apps/desktop/src/lib/sync/vaultProtocol.ts
@@ -19,7 +19,17 @@ export interface HelloFrame {
    * re-pull a structural change we made ourselves.
    */
   origin?: string;
+  /**
+   * Feature flags this build understands. The server withholds any NEW binary
+   * frame type from a client that didn't list it — without that, an older build
+   * would run a voice chunk through {@link decodeUpdateFrame} and apply the
+   * garbage as a doc update. Releases auto-update, so old builds stay live.
+   */
+  caps?: string[];
 }
+
+/** What this build can handle beyond the original protocol. Sent in `hello`. */
+export const CLIENT_CAPS = ["voice"];
 
 /** A teammate's live "who's viewing what" state (mirror of the server type).
  *  `docId` null means the user isn't viewing anything (or left) — clear them. */
@@ -110,6 +120,95 @@ export function decodeUpdateFrame(
   const docId = dec.decode(bytes.subarray(2, 2 + idLen));
   const update = bytes.subarray(2 + idLen);
   return { docId, update };
+}
+
+// ---- Voice broadcast (mirror of the server's framing) --------------------
+//
+//   [0x01 VOICE][headerLen u16 BE][header JSON utf8][audio bytes]
+//
+// Ephemeral by construction: chunks are played as they arrive and dropped. The
+// client never writes them to disk, the CRDT, or the index.
+
+export const VOICE_FRAME = 0x01;
+
+/** Chunk header. Short keys — this rides on every chunk (~10/s while talking). */
+export interface VoiceHeader {
+  /** Transmission id: groups the chunks of one press-and-hold. */
+  s: string;
+  /** Chunk index within the transmission, from 0. */
+  n: number;
+  /** 1 on the final chunk (button released). */
+  f?: 0 | 1;
+  /** Audio encoding, e.g. `"pcm16"`. First chunk only. */
+  fmt?: string;
+  /** Sample rate in Hz. First chunk only. */
+  sr?: number;
+  /** Speaker's user id — inbound only; the server stamps it from the token. */
+  u?: string;
+  /** Speaker's display name. Inbound, first chunk only. */
+  m?: string;
+  /** Speaker's presence colour. Inbound, first chunk only. */
+  c?: string;
+}
+
+export interface VoiceFrame {
+  header: VoiceHeader;
+  audio: Uint8Array;
+}
+
+export function encodeVoiceFrame(header: VoiceHeader, audio: Uint8Array): Uint8Array {
+  const h = enc.encode(JSON.stringify(header));
+  const out = new Uint8Array(3 + h.length + audio.length);
+  out[0] = VOICE_FRAME;
+  out[1] = (h.length >> 8) & 0xff;
+  out[2] = h.length & 0xff;
+  out.set(h, 3);
+  out.set(audio, 3 + h.length);
+  return out;
+}
+
+/** Decode an inbound voice frame; null if it isn't one. Never throws. */
+export function decodeVoiceFrame(bytes: Uint8Array): VoiceFrame | null {
+  if (bytes.length < 3 || bytes[0] !== VOICE_FRAME) return null;
+  const hLen = (bytes[1] << 8) | bytes[2];
+  if (bytes.length < 3 + hLen) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(dec.decode(bytes.subarray(3, 3 + hLen)));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const h = parsed as Record<string, unknown>;
+  if (typeof h.s !== "string" || !h.s) return null;
+  if (typeof h.n !== "number" || !Number.isInteger(h.n) || h.n < 0) return null;
+  // `u` is required inbound: an unattributed chunk can't be shown or grouped.
+  if (typeof h.u !== "string" || !h.u) return null;
+  return {
+    header: {
+      s: h.s,
+      n: h.n,
+      ...(h.f === 1 ? { f: 1 as const } : {}),
+      ...(typeof h.fmt === "string" ? { fmt: h.fmt } : {}),
+      ...(typeof h.sr === "number" ? { sr: h.sr } : {}),
+      u: h.u,
+      ...(typeof h.m === "string" ? { m: h.m } : {}),
+      ...(typeof h.c === "string" ? { c: h.c } : {}),
+    },
+    audio: bytes.subarray(3 + hLen),
+  };
+}
+
+/**
+ * True when a binary frame from the server is voice rather than a doc update.
+ *
+ * The two share the binary path and only the first byte separates them. That is
+ * unambiguous because a doc-update frame opens with `docIdLen` as u16 BE and the
+ * server caps doc ids at 0xff bytes, so its high byte is always 0x00 — never
+ * {@link VOICE_FRAME}. Don't relax that cap without changing this.
+ */
+export function isVoiceFrame(bytes: Uint8Array): boolean {
+  return bytes.length > 0 && bytes[0] === VOICE_FRAME;
 }
 
 /** base64 <-> bytes helpers (browser `atob`/`btoa`, Node `Buffer` fallback). */

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -15,9 +15,15 @@ import type { ActivityStatus } from "../prefs";
 import {
   bytesToBase64,
   decodeUpdateFrame,
+  decodeVoiceFrame,
   encodeHello,
   encodePresence,
+  encodeVoiceFrame,
+  isVoiceFrame,
   parseServerControl,
+  CLIENT_CAPS,
+  type VoiceFrame,
+  type VoiceHeader,
 } from "./vaultProtocol";
 
 /** A teammate's live viewing state, surfaced to the UI for sidebar presence. */
@@ -103,6 +109,14 @@ export interface VaultSyncEngineOptions {
    *  these into the sidebar roster. */
   onPresence?: (peer: VaultPeer) => void;
   /**
+   * One inbound push-to-talk chunk from a teammate. Fired synchronously, ahead
+   * of the doc-update queue: audio is only useful while it's current, so it must
+   * not sit behind a backfill drain the way a doc update legitimately can.
+   *
+   * Nothing here is persisted. The engine hands the bytes over and forgets them.
+   */
+  onVoice?: (frame: VoiceFrame) => void;
+  /**
    * Progress of the inbound BACKFILL: `done` applied out of `total` received.
    *
    * Backfill frames only — the server sends at most one per document
@@ -175,6 +189,7 @@ export class VaultSyncEngine {
   private readonly onRegistryChanged?: () => void;
   private readonly onMemberJoined?: (name: string) => void;
   private readonly onPresence?: (peer: VaultPeer) => void;
+  private readonly onVoice?: (frame: VoiceFrame) => void;
   private readonly onInboundProgress?: (done: number, total: number) => void;
   private readonly onInboundIdle?: () => void;
   private readonly wsFactory: WsFactory;
@@ -235,6 +250,7 @@ export class VaultSyncEngine {
     this.onRegistryChanged = opts.onRegistryChanged;
     this.onMemberJoined = opts.onMemberJoined;
     this.onPresence = opts.onPresence;
+    this.onVoice = opts.onVoice;
     this.onInboundProgress = opts.onInboundProgress;
     this.onInboundIdle = opts.onInboundIdle;
     this.inboundMaxBytes = opts.inboundQueueMaxBytes ?? INBOUND_QUEUE_MAX_BYTES;
@@ -264,6 +280,20 @@ export class VaultSyncEngine {
   private sendPresence(): void {
     if (!this.ws || !this.localPresence) return;
     this.ws.send(encodePresence(this.localPresence));
+  }
+
+  /**
+   * Push one push-to-talk chunk to the vault. Returns false when the channel
+   * isn't live, so the caller can stop capturing rather than talk into a void.
+   *
+   * Dropped outright when not ready: audio is worthless late, so there is no
+   * queue and no retry. That is the deliberate difference from a doc update,
+   * which must survive a disconnect and does.
+   */
+  sendVoice(header: VoiceHeader, audio: Uint8Array): boolean {
+    if (!this.ws || !this.ready) return false;
+    this.ws.send(encodeVoiceFrame(header, audio));
+    return true;
   }
 
   /** Open the connection (idempotent). */
@@ -382,7 +412,15 @@ export class VaultSyncEngine {
     // backfill, and that window is what the download progress measures.
     this.backfilling = true;
     this.ws.send(
-      encodeHello({ token, manifest, priority, origin: this.api.getClientId() }),
+      encodeHello({
+        token,
+        manifest,
+        priority,
+        origin: this.api.getClientId(),
+        // Opt in to the frame types this build understands. Without it the
+        // server withholds them (see `CLIENT_CAPS`).
+        caps: CLIENT_CAPS,
+      }),
     );
   }
 
@@ -442,10 +480,21 @@ export class VaultSyncEngine {
       }
       return;
     }
-    // Binary: an incremental update frame for one doc. Queue it — never apply it
-    // inline (see the `inbound` field comment).
     const bytes = toUint8Array(data);
     if (!bytes) return;
+    // Voice shares the binary path with doc updates; the leading byte separates
+    // them (see `isVoiceFrame`). Delivered straight through rather than queued:
+    // a chunk that waits behind a backfill drain is already too late to play,
+    // and there is nothing to converge — it's ephemeral either way.
+    if (isVoiceFrame(bytes)) {
+      const voice = decodeVoiceFrame(bytes);
+      // Copy off the socket buffer before handing it on: playback outlives this
+      // callback, and a subarray would pin the whole received ArrayBuffer.
+      if (voice) this.onVoice?.({ header: voice.header, audio: new Uint8Array(voice.audio) });
+      return;
+    }
+    // Binary: an incremental update frame for one doc. Queue it — never apply it
+    // inline (see the `inbound` field comment).
     const frame = decodeUpdateFrame(bytes);
     if (!frame) return;
     this.enqueueInbound(frame);

--- a/app/apps/desktop/src/lib/voice/__tests__/pcm.test.ts
+++ b/app/apps/desktop/src/lib/voice/__tests__/pcm.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  ChunkOrderer,
+  downsampleTo16k,
+  floatToPcm16,
+  pcm16ToFloat,
+  VOICE_CHUNK_SAMPLES,
+  VOICE_SAMPLE_RATE,
+} from "../pcm";
+
+describe("pcm16 conversion", () => {
+  it("round-trips a signal within one quantization step", () => {
+    const input = new Float32Array(256);
+    for (let i = 0; i < input.length; i++) input[i] = Math.sin((i / 256) * Math.PI * 4) * 0.8;
+
+    const back = pcm16ToFloat(floatToPcm16(input));
+    expect(back).toHaveLength(input.length);
+    for (let i = 0; i < input.length; i++) expect(Math.abs(back[i] - input[i])).toBeLessThan(1 / 32767);
+  });
+
+  it("holds the rails exactly at full scale", () => {
+    const bytes = floatToPcm16(new Float32Array([1, -1, 0]));
+    const view = new DataView(bytes.buffer);
+    expect(view.getInt16(0, true)).toBe(32767);
+    expect(view.getInt16(2, true)).toBe(-32768);
+    expect(view.getInt16(4, true)).toBe(0);
+  });
+
+  it("clips out-of-range samples instead of letting them wrap", () => {
+    // Unclamped, +1.5 casts to a NEGATIVE Int16 — a loud syllable would come out
+    // as a burst of noise rather than as distortion.
+    const view = new DataView(floatToPcm16(new Float32Array([1.5, -2.3])).buffer);
+    expect(view.getInt16(0, true)).toBe(32767);
+    expect(view.getInt16(2, true)).toBe(-32768);
+  });
+
+  it("ignores a trailing odd byte rather than reading past the buffer", () => {
+    expect(pcm16ToFloat(new Uint8Array([0, 0, 0]))).toHaveLength(1);
+    expect(pcm16ToFloat(new Uint8Array())).toHaveLength(0);
+  });
+
+  it("decodes correctly when the payload is a view into a larger buffer", () => {
+    // Frames arrive as subarrays of a socket buffer, so a byteOffset-aware
+    // DataView is the difference between audio and garbage.
+    const backing = new Uint8Array([0xff, 0xff, 0x00, 0x40, 0x00, 0x80]);
+    const slice = backing.subarray(2); // Int16 LE: 0x4000 = 16384, 0x8000 = -32768
+    const out = pcm16ToFloat(slice);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBeCloseTo(16384 / 32767, 5);
+    expect(out[1]).toBeCloseTo(-1, 5);
+  });
+});
+
+describe("downsampleTo16k", () => {
+  it("returns the input untouched when already at the target rate", () => {
+    const input = new Float32Array([0.1, 0.2, 0.3]);
+    expect(downsampleTo16k(input, VOICE_SAMPLE_RATE)).toBe(input);
+  });
+
+  it("halves the sample count coming from 32 kHz", () => {
+    const input = new Float32Array(640);
+    expect(downsampleTo16k(input, 32_000)).toHaveLength(320);
+  });
+
+  it("produces one chunk's worth of samples from a 48 kHz render quantum run", () => {
+    // 48 kHz is what WebAudio hands us on most machines.
+    const input = new Float32Array(48_000 * (200 / 1000)); // 200 ms
+    expect(downsampleTo16k(input, 48_000)).toHaveLength(VOICE_CHUNK_SAMPLES);
+  });
+
+  it("preserves a constant signal's amplitude", () => {
+    const input = new Float32Array(480).fill(0.5);
+    for (const s of downsampleTo16k(input, 48_000)) expect(s).toBeCloseTo(0.5, 5);
+  });
+
+  it("leaves audio alone when the source rate is already below the target", () => {
+    const input = new Float32Array([0.1, 0.2]);
+    expect(downsampleTo16k(input, 8_000)).toBe(input);
+  });
+
+  it("handles empty input", () => {
+    expect(downsampleTo16k(new Float32Array(), 48_000)).toHaveLength(0);
+  });
+});
+
+describe("ChunkOrderer", () => {
+  const chunk = (n: number) => new Uint8Array([n]);
+  const seqOf = (out: Uint8Array[]) => out.map((c) => c[0]);
+
+  it("passes in-order chunks straight through", () => {
+    const o = new ChunkOrderer();
+    expect(seqOf(o.push(0, chunk(0)))).toEqual([0]);
+    expect(seqOf(o.push(1, chunk(1)))).toEqual([1]);
+    expect(seqOf(o.push(2, chunk(2)))).toEqual([2]);
+  });
+
+  it("holds an early arrival until its predecessor lands, then releases both", () => {
+    const o = new ChunkOrderer();
+    expect(seqOf(o.push(1, chunk(1)))).toEqual([]); // waiting on 0
+    expect(seqOf(o.push(0, chunk(0)))).toEqual([0, 1]);
+  });
+
+  it("gives up on a lost chunk once enough has stacked up behind it", () => {
+    // Chunk 0 never arrives. Playback must continue rather than stall forever.
+    const o = new ChunkOrderer(3);
+    expect(seqOf(o.push(1, chunk(1)))).toEqual([]);
+    expect(seqOf(o.push(2, chunk(2)))).toEqual([]);
+    expect(seqOf(o.push(3, chunk(3)))).toEqual([]);
+    expect(seqOf(o.push(4, chunk(4)))).toEqual([1, 2, 3, 4]);
+  });
+
+  it("discards a chunk that arrives after playback has moved past it", () => {
+    const o = new ChunkOrderer();
+    o.push(0, chunk(0));
+    o.push(1, chunk(1));
+    expect(seqOf(o.push(0, chunk(9)))).toEqual([]); // stale duplicate
+  });
+
+  it("releases everything still held on flush, in sequence order", () => {
+    const o = new ChunkOrderer();
+    o.push(3, chunk(3));
+    o.push(1, chunk(1));
+    o.push(2, chunk(2));
+    // 0 was lost and the tolerance was never reached — end of transmission
+    // should still play what we have rather than silently bin it.
+    expect(seqOf(o.flush())).toEqual([1, 2, 3]);
+    expect(o.flush()).toEqual([]);
+  });
+});

--- a/app/apps/desktop/src/lib/voice/__tests__/playback.test.ts
+++ b/app/apps/desktop/src/lib/voice/__tests__/playback.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VoicePlayer } from "../playback";
+import { floatToPcm16 } from "../pcm";
+
+// A fake AudioContext just real enough to assert scheduling. What matters here
+// is WHEN each buffer is started relative to the last — that's what makes a
+// stream gapless instead of chopped — so the fake records start times.
+
+interface Started {
+  at: number;
+  duration: number;
+}
+
+class FakeSource {
+  onended: (() => void) | null = null;
+  buffer: { duration: number } | null = null;
+  stopped = false;
+  constructor(private readonly log: Started[]) {}
+  connect(): void {}
+  start(at: number): void {
+    this.log.push({ at, duration: this.buffer?.duration ?? 0 });
+  }
+  stop(): void {
+    this.stopped = true;
+  }
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+  state = "running";
+  currentTime = 0;
+  readonly started: Started[] = [];
+  readonly sources: FakeSource[] = [];
+  destination = {};
+  constructor() {
+    FakeAudioContext.instances.push(this);
+  }
+  resume(): Promise<void> {
+    this.state = "running";
+    return Promise.resolve();
+  }
+  createBuffer(_ch: number, length: number, sampleRate: number) {
+    const data = new Float32Array(length);
+    return {
+      duration: length / sampleRate,
+      length,
+      sampleRate,
+      copyToChannel: (src: Float32Array) => data.set(src),
+    };
+  }
+  createBufferSource() {
+    const s = new FakeSource(this.started);
+    this.sources.push(s);
+    return s;
+  }
+}
+
+/** 100 ms of 16 kHz PCM16 = 1600 samples. */
+function pcmChunk(ms = 100): Uint8Array {
+  return floatToPcm16(new Float32Array((16_000 * ms) / 1000).fill(0.25));
+}
+
+const ctxOf = () => FakeAudioContext.instances[0];
+
+beforeEach(() => {
+  FakeAudioContext.instances = [];
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("VoicePlayer", () => {
+  it("schedules consecutive chunks back-to-back with no gap", () => {
+    const player = new VoicePlayer();
+    for (let n = 0; n < 3; n++) {
+      player.push({ streamId: "tx", userId: "ada", seq: n, audio: pcmChunk(100), sampleRate: 16_000 });
+    }
+
+    const started = ctxOf().started;
+    expect(started).toHaveLength(3);
+    // Each chunk begins exactly where the previous one ended — that equality is
+    // the whole point; any slack here is an audible click between chunks.
+    expect(started[1].at).toBeCloseTo(started[0].at + started[0].duration, 6);
+    expect(started[2].at).toBeCloseTo(started[1].at + started[1].duration, 6);
+    expect(started[0].duration).toBeCloseTo(0.1, 6);
+  });
+
+  it("starts slightly ahead of now so jitter has somewhere to absorb", () => {
+    const player = new VoicePlayer();
+    player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk() });
+    expect(ctxOf().started[0].at).toBeGreaterThan(ctxOf().currentTime);
+  });
+
+  it("re-anchors to the present when the stream has drifted too far ahead", () => {
+    const player = new VoicePlayer();
+    // A burst far longer than the drift ceiling: a listener who fell behind must
+    // skip forward rather than keep sliding further behind for the whole
+    // transmission.
+    for (let n = 0; n < 30; n++) {
+      player.push({ streamId: "tx", userId: "ada", seq: n, audio: pcmChunk(100) });
+    }
+    const started = ctxOf().started;
+    const last = started[started.length - 1].at;
+    expect(last - ctxOf().currentTime).toBeLessThanOrEqual(1.0 + 0.2 + 1e-6);
+  });
+
+  it("never schedules in the past after the context clock advances", () => {
+    const player = new VoicePlayer();
+    player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk() });
+    // Time moves on while the next chunk is in flight (a stall).
+    ctxOf().currentTime = 10;
+    player.push({ streamId: "tx", userId: "ada", seq: 1, audio: pcmChunk() });
+
+    const at = ctxOf().started[1].at;
+    expect(at).toBeGreaterThanOrEqual(10);
+  });
+
+  it("holds an out-of-order chunk and plays it in sequence", () => {
+    const player = new VoicePlayer();
+    player.push({ streamId: "tx", userId: "ada", seq: 1, audio: pcmChunk(50) });
+    expect(ctxOf().started).toHaveLength(0); // waiting on seq 0
+    player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk(100) });
+
+    const started = ctxOf().started;
+    expect(started).toHaveLength(2);
+    expect(started[0].duration).toBeCloseTo(0.1, 6); // seq 0 first
+    expect(started[1].duration).toBeCloseTo(0.05, 6);
+  });
+
+  it("mixes two teammates talking at once as independent streams", () => {
+    const player = new VoicePlayer();
+    player.push({ streamId: "a", userId: "ada", seq: 0, audio: pcmChunk() });
+    player.push({ streamId: "b", userId: "grace", seq: 0, audio: pcmChunk() });
+
+    // Both scheduled; neither cut the other off.
+    expect(ctxOf().started).toHaveLength(2);
+    expect(player.isPlaying()).toBe(true);
+  });
+
+  it("reports speaking start immediately and end only once the audio finishes", () => {
+    const events: Array<[string, boolean]> = [];
+    const player = new VoicePlayer({ onSpeakingChange: (u, s) => events.push([u, s]) });
+
+    player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk(100) });
+    expect(events).toEqual([["ada", true]]);
+
+    player.push({ streamId: "tx", userId: "ada", seq: 1, audio: pcmChunk(100), final: true });
+    // Still "talking": the buffered audio hasn't played out yet.
+    expect(events).toEqual([["ada", true]]);
+
+    vi.advanceTimersByTime(2000);
+    expect(events).toEqual([
+      ["ada", true],
+      ["ada", false],
+    ]);
+    expect(player.isPlaying()).toBe(false);
+  });
+
+  it("flushes a held chunk when the transmission ends rather than binning it", () => {
+    const player = new VoicePlayer();
+    // seq 0 is lost; seq 1 arrives and is held, then the sender releases.
+    player.push({ streamId: "tx", userId: "ada", seq: 1, audio: pcmChunk(), final: true });
+    expect(ctxOf().started).toHaveLength(1);
+  });
+
+  it("stops and forgets everything on stopAll", () => {
+    const player = new VoicePlayer();
+    player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk() });
+    player.stopAll();
+
+    expect(player.isPlaying()).toBe(false);
+    expect(ctxOf().sources.every((s) => s.stopped)).toBe(true);
+  });
+
+  it("degrades to silence when the platform gives us no AudioContext", () => {
+    vi.stubGlobal("AudioContext", function Broken() {
+      throw new Error("no audio device");
+    });
+    const player = new VoicePlayer();
+    expect(() =>
+      player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk() }),
+    ).not.toThrow();
+    expect(player.isPlaying()).toBe(false);
+  });
+
+  it("resumes a suspended context, since a receiver gets no user gesture", () => {
+    const player = new VoicePlayer();
+    FakeAudioContext.prototype.state = "suspended";
+    player.push({ streamId: "tx", userId: "ada", seq: 0, audio: pcmChunk() });
+    expect(ctxOf().state).toBe("running");
+    FakeAudioContext.prototype.state = "running";
+  });
+});

--- a/app/apps/desktop/src/lib/voice/__tests__/roster.test.ts
+++ b/app/apps/desktop/src/lib/voice/__tests__/roster.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { VoiceRoster } from "../roster";
+
+// The data behind the "someone is talking" micro-interaction: the receiving
+// animation and the speaker label both read off this, so a regression here is
+// a silent broadcast — audio with no indication of who it's from.
+
+describe("VoiceRoster", () => {
+  it("is empty and inactive until someone talks", () => {
+    const r = new VoiceRoster();
+    expect(r.list()).toEqual([]);
+    expect(r.active).toBe(false);
+  });
+
+  it("goes active the moment a speaker starts, which is what shakes the button", () => {
+    const r = new VoiceRoster();
+    r.learn("ada", "Ada Lovelace", "#6366f1");
+    expect(r.setSpeaking("ada", true)).toBe(true);
+
+    expect(r.active).toBe(true);
+    expect(r.list()).toEqual([{ userId: "ada", name: "Ada Lovelace", color: "#6366f1" }]);
+  });
+
+  it("keeps the label for the rest of the stream, since only chunk 0 carries it", () => {
+    const r = new VoiceRoster();
+    r.learn("ada", "Ada Lovelace", "#6366f1"); // opening chunk
+    r.setSpeaking("ada", true);
+    r.learn("ada", undefined, undefined); // every later chunk carries nothing
+
+    expect(r.list()[0].name).toBe("Ada Lovelace");
+    expect(r.list()[0].color).toBe("#6366f1");
+  });
+
+  it("falls back to a readable placeholder rather than showing a raw user id", () => {
+    const r = new VoiceRoster((id) => `color-${id}`);
+    r.setSpeaking("u-42", true);
+
+    expect(r.list()).toEqual([{ userId: "u-42", name: "Someone", color: "color-u-42" }]);
+  });
+
+  it("reports no change on repeat signals, so playback doesn't re-render per chunk", () => {
+    const r = new VoiceRoster();
+    expect(r.setSpeaking("ada", true)).toBe(true);
+    expect(r.setSpeaking("ada", true)).toBe(false);
+    expect(r.setSpeaking("ada", false)).toBe(true);
+    expect(r.setSpeaking("ada", false)).toBe(false);
+  });
+
+  it("tracks two teammates talking at once and clears them independently", () => {
+    const r = new VoiceRoster();
+    r.learn("ada", "Ada", "#111");
+    r.learn("grace", "Grace", "#222");
+    r.setSpeaking("ada", true);
+    r.setSpeaking("grace", true);
+
+    expect(r.list().map((s) => s.name).sort()).toEqual(["Ada", "Grace"]);
+
+    r.setSpeaking("ada", false);
+    expect(r.list()).toEqual([{ userId: "grace", name: "Grace", color: "#222" }]);
+    expect(r.active).toBe(true); // Grace is still going
+
+    r.setSpeaking("grace", false);
+    expect(r.active).toBe(false);
+  });
+
+  it("goes inactive once the last speaker stops, so the animation ends", () => {
+    const r = new VoiceRoster();
+    r.setSpeaking("ada", true);
+    r.setSpeaking("ada", false);
+
+    expect(r.active).toBe(false);
+    expect(r.list()).toEqual([]);
+  });
+
+  it("merges a partial label without wiping what it already knew", () => {
+    const r = new VoiceRoster();
+    r.learn("ada", "Ada", "#111");
+    r.learn("ada", "Ada Lovelace"); // name only — colour must survive
+    r.setSpeaking("ada", true);
+
+    expect(r.list()[0]).toEqual({ userId: "ada", name: "Ada Lovelace", color: "#111" });
+  });
+
+  it("forgets everything on clear, so audio can't leak across a vault switch", () => {
+    const r = new VoiceRoster();
+    r.learn("ada", "Ada", "#111");
+    r.setSpeaking("ada", true);
+    r.clear();
+
+    expect(r.active).toBe(false);
+    expect(r.list()).toEqual([]);
+    // The label is gone too, not just the speaking flag.
+    r.setSpeaking("ada", true);
+    expect(r.list()[0].name).toBe("Someone");
+  });
+});

--- a/app/apps/desktop/src/lib/voice/capture.ts
+++ b/app/apps/desktop/src/lib/voice/capture.ts
@@ -1,0 +1,126 @@
+// Microphone capture for push-to-talk. Opens the mic on press, streams 16 kHz
+// mono PCM16 chunks while held, closes it on release.
+//
+// The mic track is stopped every time the button comes up, not merely muted.
+// That is a privacy property, not a tidiness one: while a MediaStreamTrack is
+// live the OS shows the recording indicator, and a walkie-talkie that leaves it
+// on between transmissions looks exactly like one that is always listening.
+
+import {
+  downsampleTo16k,
+  floatToPcm16,
+  VOICE_SAMPLE_RATE,
+} from "./pcm";
+
+/** Emitted for each captured chunk, already in wire format. */
+export type ChunkSink = (audio: Uint8Array, seq: number) => void;
+
+export interface CaptureHandle {
+  /** Stop capturing, flush the tail, and release the mic. Idempotent. */
+  stop(): Promise<void>;
+}
+
+export class MicPermissionError extends Error {
+  constructor(
+    message: string,
+    /** True when the user (or the OS) refused, as opposed to no device etc. */
+    readonly denied: boolean,
+  ) {
+    super(message);
+    this.name = "MicPermissionError";
+  }
+}
+
+/**
+ * Start capturing. Each chunk is handed to `onChunk` with its sequence number.
+ *
+ * Rejects with {@link MicPermissionError} when the mic isn't available. On
+ * macOS that is the likely first failure for anyone running a signed build
+ * without `NSMicrophoneUsageDescription` and the `audio-input` entitlement —
+ * see `src-tauri/Info.plist` and `entitlements.plist`.
+ */
+export async function startCapture(onChunk: ChunkSink): Promise<CaptureHandle> {
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        // Let the platform do the work a walkie-talkie wants anyway; all three
+        // engines implement these, and they cost us nothing.
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    });
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    throw new MicPermissionError(
+      name === "NotAllowedError"
+        ? "Microphone access was refused."
+        : "No microphone is available.",
+      name === "NotAllowedError",
+    );
+  }
+
+  const ctx = new AudioContext();
+  // Autoplay policy can hand back a suspended context even for capture.
+  if (ctx.state === "suspended") await ctx.resume();
+
+  const release = () => {
+    for (const track of stream.getTracks()) track.stop();
+    void ctx.close().catch(() => {});
+  };
+
+  try {
+    await ctx.audioWorklet.addModule(new URL("./recorder-worklet.js", import.meta.url));
+  } catch (err) {
+    release();
+    throw err;
+  }
+
+  const source = ctx.createMediaStreamSource(stream);
+  const node = new AudioWorkletNode(ctx, "baalda-recorder");
+  let seq = 0;
+  let stopped = false;
+  let resolveStopped: (() => void) | null = null;
+
+  node.port.onmessage = (e: MessageEvent) => {
+    if (e.data === "stopped") {
+      resolveStopped?.();
+      return;
+    }
+    if (stopped) return;
+    const batch = e.data as Float32Array;
+    const audio = floatToPcm16(downsampleTo16k(batch, ctx.sampleRate));
+    if (audio.length > 0) onChunk(audio, seq++);
+  };
+
+  source.connect(node);
+  // A worklet with no downstream connection isn't guaranteed to be pulled, but
+  // routing the mic to the speakers would be feedback. A zero-gain sink keeps
+  // the graph running and silent.
+  const mute = ctx.createGain();
+  mute.gain.value = 0;
+  node.connect(mute).connect(ctx.destination);
+
+  return {
+    async stop() {
+      if (stopped) return;
+      // Let the worklet's flush land BEFORE we mark ourselves stopped, or the
+      // tail of every transmission is dropped by the guard above.
+      const flushed = new Promise<void>((r) => {
+        resolveStopped = r;
+      });
+      node.port.postMessage("stop");
+      await Promise.race([flushed, new Promise((r) => setTimeout(r, 250))]);
+      stopped = true;
+      source.disconnect();
+      node.disconnect();
+      mute.disconnect();
+      release();
+    },
+  };
+}
+
+/** The transmit format, for the opening chunk's header. */
+export const CAPTURE_FORMAT = { fmt: "pcm16", sr: VOICE_SAMPLE_RATE } as const;

--- a/app/apps/desktop/src/lib/voice/capture.ts
+++ b/app/apps/desktop/src/lib/voice/capture.ts
@@ -34,10 +34,26 @@ export class MicPermissionError extends Error {
 /**
  * Start capturing. Each chunk is handed to `onChunk` with its sequence number.
  *
- * Rejects with {@link MicPermissionError} when the mic isn't available. On
- * macOS that is the likely first failure for anyone running a signed build
- * without `NSMicrophoneUsageDescription` and the `audio-input` entitlement —
- * see `src-tauri/Info.plist` and `entitlements.plist`.
+ * Rejects with {@link MicPermissionError} when the mic isn't available.
+ *
+ * PLATFORM STATE (verified 2026-08-06, wry 0.55.1 / tauri 2.11.5):
+ *
+ *  - **macOS** — needs `NSMicrophoneUsageDescription` (`src-tauri/Info.plist`)
+ *    and `com.apple.security.device.audio-input` (`entitlements.plist`); both
+ *    are now present. Older macOS 14.0–14.1 double-prompted (once at app level,
+ *    once at webview level); Apple fixed that around 14.2.
+ *  - **Windows / WebView2** — expected to prompt normally.
+ *  - **Linux / WebKitGTK** — the known weak spot. WebKitGTK only grants media
+ *    capture if the embedder answers `WebKitUserMediaPermissionRequest`, and
+ *    wry's expanded permission API (`PermissionKind`, `PermissionResponse::Prompt`
+ *    across WebView2/WKWebView/WebKitGTK) landed in **wry 0.56.0**, which is
+ *    NEWER than the 0.55.1 this app pins. Users have reported Tauri v2 apps on
+ *    WebKitGTK getting no prompt and no access at all. So expect this to reject
+ *    on Linux until wry is bumped — which is exactly why the failure is surfaced
+ *    as a message in the UI rather than swallowed.
+ *
+ * Untested on real Windows/Linux hardware; treat the two non-macOS rows as
+ * expectations, not verified behaviour.
  */
 export async function startCapture(onChunk: ChunkSink): Promise<CaptureHandle> {
   let stream: MediaStream;

--- a/app/apps/desktop/src/lib/voice/pcm.ts
+++ b/app/apps/desktop/src/lib/voice/pcm.ts
@@ -1,0 +1,152 @@
+// Pure audio maths for push-to-talk. No WebAudio, no DOM — so the parts that
+// are easy to get subtly wrong (resampling, clipping, chunk ordering) are unit
+// tested in Node, and the WebAudio glue around them stays thin enough to read.
+//
+// WHY RAW PCM16 AND NOT OPUS
+//
+// The obvious instinct is "encode to Opus, it's 10x smaller". We deliberately
+// don't, for v1:
+//
+//   * `MediaRecorder` with a timeslice is the usual suggestion and is a trap
+//     here: only the FIRST chunk carries the container header, so later WebM/MP4
+//     chunks aren't independently decodable. Making that work needs MediaSource
+//     on the receiver, whose support across WKWebView / WebView2 / WebKitGTK is
+//     exactly the kind of per-platform lottery this feature can't afford.
+//   * A wasm Opus encoder (opus-recorder and friends) means a few hundred KB of
+//     dependency and a build step, against a brief that says "very light".
+//   * WebCodecs `AudioEncoder` would be ideal — native Opus, per-frame
+//     decodable, no dependency — but its availability in WKWebView is the one
+//     thing that would strand macOS users.
+//
+// PCM16 has none of those problems: every frame is independently decodable by
+// construction, there is no container, no codec, no dependency, and the
+// receiver skips decoding entirely (it fills an AudioBuffer directly). The cost
+// is bandwidth — 32 KB/s at the settings below, which for a handful of
+// teammates on broadband is unremarkable, and it stays far inside the vault
+// channel's existing 4 MB per-connection outbound budget.
+//
+// The wire header carries `fmt`, so a later Opus path can be added without a
+// protocol change: new senders set `fmt:"opus"`, receivers branch on it.
+
+/** Sample rate we transmit at. Speech is intelligible well below this; 16 kHz
+ *  is the usual wideband-voice floor and halves the bytes of 32 kHz. */
+export const VOICE_SAMPLE_RATE = 16_000;
+
+/** How much audio goes in one chunk. The tradeoff is latency vs overhead:
+ *  200 ms means ~5 frames/s (~6.4 KB each) and about a fifth of a second of
+ *  mouth-to-ear delay from chunking alone, which reads as "instant" for a
+ *  walkie-talkie without making the header overhead significant. */
+export const VOICE_CHUNK_MS = 200;
+
+/** Samples per chunk at the transmit rate. */
+export const VOICE_CHUNK_SAMPLES = (VOICE_SAMPLE_RATE * VOICE_CHUNK_MS) / 1000;
+
+/**
+ * Downsample mono Float32 audio to {@link VOICE_SAMPLE_RATE} by linear
+ * interpolation.
+ *
+ * Linear rather than a windowed-sinc filter is a real, bounded compromise: it
+ * doesn't fully suppress aliasing above the new Nyquist, which on speech is
+ * mild and on music would be audible. For a walkie-talkie carrying a voice it
+ * is the right amount of machinery — a proper polyphase resampler is a lot of
+ * code to make "hold to talk" imperceptibly cleaner.
+ *
+ * Returns the input untouched when the rates already match.
+ */
+export function downsampleTo16k(input: Float32Array, inputRate: number): Float32Array {
+  if (inputRate === VOICE_SAMPLE_RATE || input.length === 0) return input;
+  if (inputRate < VOICE_SAMPLE_RATE) return input; // already narrower; don't invent detail
+  const ratio = inputRate / VOICE_SAMPLE_RATE;
+  const outLength = Math.floor(input.length / ratio);
+  const out = new Float32Array(outLength);
+  for (let i = 0; i < outLength; i++) {
+    const pos = i * ratio;
+    const lo = Math.floor(pos);
+    const hi = Math.min(lo + 1, input.length - 1);
+    const frac = pos - lo;
+    out[i] = input[lo] * (1 - frac) + input[hi] * frac;
+  }
+  return out;
+}
+
+/**
+ * Float32 [-1, 1] to little-endian Int16 PCM.
+ *
+ * Clamps before scaling. Without the clamp a sample even slightly outside the
+ * nominal range — which WebAudio does produce — wraps around in the Int16 cast
+ * and turns a loud syllable into a burst of noise rather than clipping.
+ */
+export function floatToPcm16(input: Float32Array): Uint8Array {
+  const out = new Uint8Array(input.length * 2);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    // Asymmetric scaling: Int16 runs -32768..32767, so the two signs differ.
+    view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return out;
+}
+
+/** Little-endian Int16 PCM back to Float32 [-1, 1] for playback. */
+export function pcm16ToFloat(bytes: Uint8Array): Float32Array {
+  const samples = bytes.length >> 1; // a trailing odd byte can't form a sample
+  const out = new Float32Array(samples);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let i = 0; i < samples; i++) {
+    const v = view.getInt16(i * 2, true);
+    out[i] = v < 0 ? v / 0x8000 : v / 0x7fff;
+  }
+  return out;
+}
+
+/**
+ * Reorders the chunks of one transmission and reports when each is playable.
+ *
+ * The vault relay preserves order per socket, so out-of-order arrival is not the
+ * common case — but a chunk can be dropped (rate budget, a listener at its
+ * outbound bound), and playback must survive a gap rather than stall on it. So
+ * this holds a chunk only briefly for a missing predecessor, then gives up on it
+ * and moves on: in live audio a late packet is indistinguishable from a lost
+ * one, and waiting turns one dropped chunk into a growing delay for everything
+ * after it.
+ */
+export class ChunkOrderer {
+  private next = 0;
+  private readonly held = new Map<number, Uint8Array>();
+
+  constructor(
+    /** How many later chunks may pile up before we give up on the missing one. */
+    private readonly gapTolerance = 3,
+  ) {}
+
+  /** Feed one chunk; returns the chunks now playable, in order. */
+  push(seq: number, audio: Uint8Array): Uint8Array[] {
+    if (seq < this.next) return []; // already played past it — too late to matter
+    this.held.set(seq, audio);
+    const ready: Uint8Array[] = [];
+    for (;;) {
+      const hit = this.held.get(this.next);
+      if (hit) {
+        this.held.delete(this.next);
+        this.next++;
+        ready.push(hit);
+        continue;
+      }
+      // Nothing for the slot we want. Skip it only once enough has stacked up
+      // behind it that the chunk is clearly lost rather than merely in flight.
+      if (this.held.size > this.gapTolerance) {
+        this.next++;
+        continue;
+      }
+      break;
+    }
+    return ready;
+  }
+
+  /** End of transmission: release whatever is still held, in sequence order. */
+  flush(): Uint8Array[] {
+    const rest = [...this.held.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+    this.held.clear();
+    return rest;
+  }
+}

--- a/app/apps/desktop/src/lib/voice/playback.ts
+++ b/app/apps/desktop/src/lib/voice/playback.ts
@@ -1,0 +1,162 @@
+// Playback for incoming push-to-talk audio.
+//
+// Chunks are scheduled back-to-back on the AudioContext timeline rather than
+// played one at a time on arrival. Playing on arrival would put a network-jitter
+// gap between every 200 ms chunk, which is audible as chopping; keeping a
+// running cursor and starting each buffer exactly where the last one ends makes
+// the stream continuous as long as chunks keep up.
+//
+// Nothing is retained. A chunk is turned into an AudioBuffer, scheduled, and
+// dropped; when a transmission ends its state is deleted. There is no history
+// to replay and none is wanted — that is the feature.
+
+import { ChunkOrderer, pcm16ToFloat } from "./pcm";
+
+/** How far ahead of "now" a fresh stream starts playing. One chunk of slack
+ *  absorbs ordinary jitter without adding delay anyone would notice. */
+const LEAD_SECONDS = 0.2;
+
+/**
+ * Past this much scheduled-but-unplayed audio, a stream has fallen behind and
+ * is re-anchored to the present. Latency in a walkie-talkie is worse than a
+ * skip: without this, a listener whose network hiccuped keeps drifting further
+ * behind for the rest of the transmission and never catches up.
+ */
+const MAX_DRIFT_SECONDS = 1.0;
+
+interface Stream {
+  orderer: ChunkOrderer;
+  /** AudioContext time at which the next chunk should start. */
+  cursor: number;
+  sampleRate: number;
+  live: Set<AudioBufferSourceNode>;
+}
+
+export interface VoicePlayerEvents {
+  /** A teammate started or stopped transmitting — drives the "talking" UI. */
+  onSpeakingChange?: (userId: string, speaking: boolean) => void;
+}
+
+export class VoicePlayer {
+  private ctx: AudioContext | null = null;
+  private readonly streams = new Map<string, Stream>();
+
+  constructor(private readonly events: VoicePlayerEvents = {}) {}
+
+  /**
+   * Lazily create the shared AudioContext.
+   *
+   * Returns null when audio is unavailable, and callers treat that as "no
+   * sound" rather than an error — the same contract the mention chime uses, so
+   * a machine with no output device degrades to the visual indicator instead of
+   * throwing on every inbound chunk.
+   */
+  private audioContext(): AudioContext | null {
+    try {
+      this.ctx ??= new AudioContext();
+      // Receivers get no user gesture at all, so a suspended context is the
+      // expected state rather than an edge case. `resume()` is enough in the
+      // desktop webviews (the mention chime has shipped on exactly this), and
+      // if a platform ever refuses, playback silently no-ops.
+      if (this.ctx.state === "suspended") void this.ctx.resume();
+      return this.ctx;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Accept one inbound chunk.
+   *
+   * `streamId` groups a transmission, `seq` orders it, `final` closes it. Two
+   * teammates talking at once are two streams and both play — mixing is what
+   * the AudioContext does for free, and cutting one off would be a worse
+   * surprise than overlap.
+   */
+  push(opts: {
+    streamId: string;
+    userId: string;
+    seq: number;
+    audio: Uint8Array;
+    sampleRate?: number;
+    final?: boolean;
+  }): void {
+    const ctx = this.audioContext();
+    if (!ctx) return;
+
+    let stream = this.streams.get(opts.streamId);
+    if (!stream) {
+      stream = {
+        orderer: new ChunkOrderer(),
+        cursor: ctx.currentTime + LEAD_SECONDS,
+        sampleRate: opts.sampleRate ?? 16_000,
+        live: new Set(),
+      };
+      this.streams.set(opts.streamId, stream);
+      this.events.onSpeakingChange?.(opts.userId, true);
+    }
+
+    for (const chunk of stream.orderer.push(opts.seq, opts.audio)) {
+      this.schedule(ctx, stream, chunk);
+    }
+
+    if (opts.final) {
+      for (const chunk of stream.orderer.flush()) this.schedule(ctx, stream, chunk);
+      // Hold the entry until the audio actually finishes, so "talking" clears
+      // when the listener stops hearing them, not when the last byte arrived.
+      const endsIn = Math.max(0, stream.cursor - ctx.currentTime);
+      const id = opts.streamId;
+      const user = opts.userId;
+      setTimeout(
+        () => {
+          this.streams.delete(id);
+          this.events.onSpeakingChange?.(user, false);
+        },
+        endsIn * 1000 + 50,
+      );
+    }
+  }
+
+  private schedule(ctx: AudioContext, stream: Stream, pcm: Uint8Array): void {
+    const samples = pcm16ToFloat(pcm);
+    if (samples.length === 0) return;
+    const buffer = ctx.createBuffer(1, samples.length, stream.sampleRate);
+    buffer.copyToChannel(samples, 0);
+
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(ctx.destination);
+
+    // Never schedule in the past — a cursor that has fallen behind `currentTime`
+    // would make every remaining chunk play immediately and on top of the last.
+    const now = ctx.currentTime;
+    if (stream.cursor < now || stream.cursor - now > MAX_DRIFT_SECONDS) {
+      stream.cursor = now + LEAD_SECONDS;
+    }
+    src.start(stream.cursor);
+    stream.cursor += buffer.duration;
+
+    stream.live.add(src);
+    src.onended = () => stream.live.delete(src);
+  }
+
+  /** True while anything is playing — for the "someone is talking" indicator. */
+  isPlaying(): boolean {
+    return this.streams.size > 0;
+  }
+
+  /** Stop everything immediately and forget it (sign-out, vault switch, mute). */
+  stopAll(): void {
+    for (const stream of this.streams.values()) {
+      for (const src of stream.live) {
+        try {
+          src.stop();
+        } catch {
+          /* already ended */
+        }
+      }
+      stream.live.clear();
+    }
+    this.streams.clear();
+  }
+}

--- a/app/apps/desktop/src/lib/voice/recorder-worklet.js
+++ b/app/apps/desktop/src/lib/voice/recorder-worklet.js
@@ -1,0 +1,59 @@
+// AudioWorklet processor for push-to-talk capture.
+//
+// Plain JS on purpose: this runs in AudioWorkletGlobalScope, not the page, so
+// it is loaded as its own asset rather than bundled with the app code. It is
+// referenced via `new URL("./recorder-worklet.js", import.meta.url)` so Vite
+// emits it as a same-origin asset — the Tauri CSP is `script-src 'self'`, which
+// rules out the usual blob:-URL trick for inlining a worklet.
+//
+// Its whole job is to batch. The audio thread hands us 128-sample render
+// quanta; forwarding each one would mean ~375 postMessages a second. We
+// accumulate at the hardware rate and post roughly a chunk's worth at a time,
+// leaving resampling and Int16 conversion to the main thread where they're
+// testable.
+
+const BATCH_MS = 200;
+
+class RecorderProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    // `sampleRate` is a global in AudioWorkletGlobalScope — the hardware rate,
+    // typically 48000, which is why the main thread has to resample at all.
+    this._batchSize = Math.round((sampleRate * BATCH_MS) / 1000);
+    this._buffer = new Float32Array(this._batchSize);
+    this._filled = 0;
+    this._stopped = false;
+    this.port.onmessage = (e) => {
+      if (e.data === "stop") {
+        // Flush the tail so the last fraction of a second isn't clipped off the
+        // end of every transmission.
+        this._stopped = true;
+        if (this._filled > 0) {
+          this.port.postMessage(this._buffer.slice(0, this._filled));
+          this._filled = 0;
+        }
+        this.port.postMessage("stopped");
+      }
+    };
+  }
+
+  process(inputs) {
+    if (this._stopped) return false; // let the node be collected
+    const channel = inputs[0] && inputs[0][0];
+    // No input yet (or the track ended): keep the processor alive regardless,
+    // returning false here would permanently kill capture on a transient gap.
+    if (!channel) return true;
+
+    for (let i = 0; i < channel.length; i++) {
+      this._buffer[this._filled++] = channel[i];
+      if (this._filled === this._batchSize) {
+        // `slice` copies — the buffer is reused immediately for the next batch.
+        this.port.postMessage(this._buffer.slice(0));
+        this._filled = 0;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor("baalda-recorder", RecorderProcessor);

--- a/app/apps/desktop/src/lib/voice/roster.ts
+++ b/app/apps/desktop/src/lib/voice/roster.ts
@@ -1,0 +1,75 @@
+// Who is talking right now, and what to call them.
+//
+// Split out of the session layer because this is the data behind a
+// micro-interaction people actually rely on: when audio starts arriving you
+// need to know *immediately* that someone is speaking and *who*, or the sound
+// is just a disembodied voice in the room. Keeping it pure means that behaviour
+// is unit-tested rather than only observable by holding a button.
+//
+// Purely transient, like everything else in this feature — the roster is the
+// only trace a broadcast leaves, and it empties itself as each transmission
+// finishes playing.
+
+/** A teammate currently transmitting. */
+export interface VoiceSpeaker {
+  userId: string;
+  name: string;
+  color: string;
+}
+
+export class VoiceRoster {
+  private readonly speaking = new Set<string>();
+  /** Display info, cached per user: name/colour ride the opening chunk only,
+   *  so it has to outlive that first frame to label the rest of the stream. */
+  private readonly known = new Map<string, { name: string; color: string }>();
+
+  constructor(
+    /** Fallback colour for a speaker we've never seen labelled. */
+    private readonly colorFor: (userId: string) => string = () => "",
+  ) {}
+
+  /** Record the display info carried on a chunk (present on the first only). */
+  learn(userId: string, name?: string, color?: string): void {
+    if (!name && !color) return;
+    const prev = this.known.get(userId);
+    this.known.set(userId, {
+      name: name ?? prev?.name ?? "",
+      color: color ?? prev?.color ?? "",
+    });
+  }
+
+  /** Mark a user as started/stopped talking. Returns true if the set changed,
+   *  so callers can skip re-rendering on the ~10 chunks a second that don't. */
+  setSpeaking(userId: string, speaking: boolean): boolean {
+    const had = this.speaking.has(userId);
+    if (speaking === had) return false;
+    if (speaking) this.speaking.add(userId);
+    else this.speaking.delete(userId);
+    return true;
+  }
+
+  /** Everyone currently talking, each with the best label we have. */
+  list(): VoiceSpeaker[] {
+    return [...this.speaking].map((userId) => {
+      const known = this.known.get(userId);
+      return {
+        userId,
+        // "Someone" rather than a raw id: an opaque id is worse than an honest
+        // placeholder when this is the only thing telling you who you're hearing.
+        name: known?.name || "Someone",
+        color: known?.color || this.colorFor(userId),
+      };
+    });
+  }
+
+  /** True while anyone is talking — drives the receiving animation. */
+  get active(): boolean {
+    return this.speaking.size > 0;
+  }
+
+  /** Drop everything (vault switch, sign-out, disconnect). */
+  clear(): void {
+    this.speaking.clear();
+    this.known.clear();
+  }
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -1123,11 +1123,35 @@ export const useStore = create<AppStore>((set, get) => ({
       return;
     }
     const org = get().organizations.find((o) => o.id === organizationId);
+    const orgName = org?.name ?? "New vault";
+
+    // No folder bound yet. Give this vault one automatically and go straight
+    // in, rather than stopping on a "choose a folder" prompt.
+    //
+    // The prompt was a roadblock in the one flow that most needs to be
+    // frictionless: a teammate signing in for the first time doesn't yet have
+    // an opinion about which directory their shared vault lives in — they just
+    // want to be in it. A folder under the vaults root, named after the vault,
+    // is the answer they'd have picked anyway, and relocating it later is one
+    // item in the vault switcher menu.
+    //
+    // The prompt survives as the FALLBACK: if we can't create a folder (a bad
+    // vaults root, permissions), asking beats failing silently.
+    try {
+      const root = await ipc.getVaultsRoot();
+      if (superseded()) return;
+      const slug = uniqueFolderSlug(orgName, readOrgVaults());
+      await get().applyVaultFolder(organizationId, `${root}/${slug}`);
+      return;
+    } catch (e) {
+      console.warn("[vault] auto folder failed; asking instead", e);
+      if (superseded()) return;
+    }
     set({
       syncEnabled: false,
       pendingVaultFolder: {
         orgId: organizationId,
-        orgName: org?.name ?? "New vault",
+        orgName,
         previousOrgId: previousOrgId === organizationId ? null : previousOrgId,
       },
     });

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -180,6 +180,8 @@ interface AppStore {
   startBroadcast: () => Promise<void>;
   /** Stop broadcasting and release the mic (button released). */
   stopBroadcast: () => Promise<void>;
+  /** Dismiss the transient push-to-talk notice. */
+  clearVoiceError: () => void;
   /** A teammate joined — show the celebration (banner + confetti + chime). */
   celebrateMemberJoined: (name: string) => void;
   /** Dismiss the join celebration (auto-fires after a few seconds). */
@@ -970,6 +972,8 @@ export const useStore = create<AppStore>((set, get) => ({
     set({ broadcasting: false });
     if (handle) await handle.stop().catch(() => {});
   },
+
+  clearVoiceError: () => set({ voiceError: null }),
 
   celebrateMemberJoined: (name) => {
     const who = name?.trim() || "A new teammate";

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -118,9 +118,6 @@ interface AppStore {
   voiceSpeakers: VoiceSpeaker[];
   /** True while this user is holding the talk button. */
   broadcasting: boolean;
-  /** True when the vault channel is live, so talking would actually reach
-   *  someone. Mirrors the vault-wide channel, not the open note's socket. */
-  voiceReady: boolean;
   /** Set when the mic couldn't be opened, so the UI can say why once. */
   voiceError: string | null;
   /** Per-item accent colors (vault-local preference), path → color id. */
@@ -576,7 +573,6 @@ export const useStore = create<AppStore>((set, get) => ({
   vaultPresence: [],
   voiceSpeakers: [],
   broadcasting: false,
-  voiceReady: false,
   voiceError: null,
   itemColors: {},
   itemOrder: {},
@@ -778,13 +774,6 @@ export const useStore = create<AppStore>((set, get) => ({
     // Who's talking right now. Nothing is stored — this list empties itself as
     // each transmission finishes playing.
     syncManager.setVoiceListener((speaking) => set({ voiceSpeakers: speaking }));
-    // Push-to-talk rides the vault channel, so its availability tracks that
-    // channel — not the open note's socket, which may not exist at all.
-    syncManager.setVaultStatusListener((status) => {
-      const ready = status === "synced";
-      if (!ready && get().broadcasting) void get().stopBroadcast();
-      set({ voiceReady: ready });
-    });
     // Bulk-sync progress for the open vault. Both of these are already throttled
     // (~10 emissions/second) and batched by `SyncProgressReporter`, so a 500-note
     // run costs ~10 store writes per second rather than one per note.
@@ -944,10 +933,9 @@ export const useStore = create<AppStore>((set, get) => ({
     // Re-entrancy guard: key repeat fires press events continuously while held,
     // and a second capture would open the mic twice and double every chunk.
     if (get().broadcasting || activeBroadcast) return;
-    if (!syncManager.canBroadcastVoice()) {
-      set({ voiceError: "Not connected — nobody would hear you." });
-      return;
-    }
+    // Deliberately NOT gated on the channel being up. Talking to an empty (or
+    // disconnected) vault is a no-op, not an error, and refusing to open the mic
+    // would make the button feel broken exactly when someone wants to speak.
     set({ broadcasting: true, voiceError: null });
     try {
       activeBroadcast = await syncManager.startBroadcast();

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -24,6 +24,8 @@ import { vaultScopes } from "./lib/sync/vaultScope";
 import type { SyncStatus } from "./lib/sync/syncManager";
 import type { DocSyncState, SyncProgress } from "./lib/sync/vaultScope";
 import type { VaultPeer } from "./lib/sync/vaultSyncEngine";
+import type { VoiceSpeaker } from "./lib/sync/docSession";
+import { MicPermissionError } from "./lib/voice/capture";
 import { createWithUniqueSlug, slugifyName } from "./lib/orgSlug";
 import {
   type ActivityStatus,
@@ -111,6 +113,16 @@ interface AppStore {
   /** Live "who's viewing what" roster (teammates only) — drives the sidebar
    *  presence dots on notes/folders. Empty when sync is off or disconnected. */
   vaultPresence: VaultPeer[];
+  /** Teammates transmitting right now (push-to-talk). Purely transient — this
+   *  is the only record a voice broadcast ever leaves anywhere. */
+  voiceSpeakers: VoiceSpeaker[];
+  /** True while this user is holding the talk button. */
+  broadcasting: boolean;
+  /** True when the vault channel is live, so talking would actually reach
+   *  someone. Mirrors the vault-wide channel, not the open note's socket. */
+  voiceReady: boolean;
+  /** Set when the mic couldn't be opened, so the UI can say why once. */
+  voiceError: string | null;
   /** Per-item accent colors (vault-local preference), path → color id. */
   itemColors: Record<string, string>;
   /** Custom sidebar arrangement (vault-local preference), parent → child order. */
@@ -164,6 +176,10 @@ interface AppStore {
   updateProfile: (input: { name?: string; image?: string | null }) => Promise<void>;
   setActivityStatus: (status: ActivityStatus) => void;
   setMentionSound: (enabled: boolean) => void;
+  /** Open the mic and start broadcasting to the vault (button pressed). */
+  startBroadcast: () => Promise<void>;
+  /** Stop broadcasting and release the mic (button released). */
+  stopBroadcast: () => Promise<void>;
   /** A teammate joined — show the celebration (banner + confetti + chime). */
   celebrateMemberJoined: (name: string) => void;
   /** Dismiss the join celebration (auto-fires after a few seconds). */
@@ -462,6 +478,10 @@ async function landInLastVault(get: () => AppStore): Promise<void> {
  *  repeat join resets it rather than stacking). */
 let memberJoinedTimer: ReturnType<typeof setTimeout> | null = null;
 
+/** The in-flight push-to-talk capture, if the button is down. Module scope
+ *  rather than store state because it's a live mic handle, not view state. */
+let activeBroadcast: { stop: () => Promise<void> } | null = null;
+
 /** Bumped by every `setActiveOrganization`. A call whose captured generation no
  *  longer matches has been superseded by a newer switch and drops its remaining
  *  work rather than racing it to bind a folder / enable sync. */
@@ -552,6 +572,10 @@ export const useStore = create<AppStore>((set, get) => ({
   ...vaultScopedSyncReset(),
   lastSyncedAt: null,
   vaultPresence: [],
+  voiceSpeakers: [],
+  broadcasting: false,
+  voiceReady: false,
+  voiceError: null,
   itemColors: {},
   itemOrder: {},
   pendingVaultFolder: null,
@@ -749,6 +773,16 @@ export const useStore = create<AppStore>((set, get) => ({
     // Live sidebar presence — the vault channel tells us which teammate is
     // viewing which note; mirror the roster into the store for FileTree.
     syncManager.setVaultPresenceListener((peers) => set({ vaultPresence: peers }));
+    // Who's talking right now. Nothing is stored — this list empties itself as
+    // each transmission finishes playing.
+    syncManager.setVoiceListener((speaking) => set({ voiceSpeakers: speaking }));
+    // Push-to-talk rides the vault channel, so its availability tracks that
+    // channel — not the open note's socket, which may not exist at all.
+    syncManager.setVaultStatusListener((status) => {
+      const ready = status === "synced";
+      if (!ready && get().broadcasting) void get().stopBroadcast();
+      set({ voiceReady: ready });
+    });
     // Bulk-sync progress for the open vault. Both of these are already throttled
     // (~10 emissions/second) and batched by `SyncProgressReporter`, so a 500-note
     // run costs ~10 store writes per second rather than one per note.
@@ -902,6 +936,39 @@ export const useStore = create<AppStore>((set, get) => ({
   setMentionSound: (enabled) => {
     writeMentionSound(enabled);
     set({ mentionSound: enabled });
+  },
+
+  startBroadcast: async () => {
+    // Re-entrancy guard: key repeat fires press events continuously while held,
+    // and a second capture would open the mic twice and double every chunk.
+    if (get().broadcasting || activeBroadcast) return;
+    if (!syncManager.canBroadcastVoice()) {
+      set({ voiceError: "Not connected — nobody would hear you." });
+      return;
+    }
+    set({ broadcasting: true, voiceError: null });
+    try {
+      activeBroadcast = await syncManager.startBroadcast();
+    } catch (err) {
+      activeBroadcast = null;
+      set({
+        broadcasting: false,
+        voiceError:
+          err instanceof MicPermissionError && err.denied
+            ? "Microphone access is blocked. Enable it in your system settings."
+            : "Couldn't open the microphone.",
+      });
+      return;
+    }
+    // Released before the mic finished opening — don't leave it live.
+    if (!get().broadcasting) await get().stopBroadcast();
+  },
+
+  stopBroadcast: async () => {
+    const handle = activeBroadcast;
+    activeBroadcast = null;
+    set({ broadcasting: false });
+    if (handle) await handle.stop().catch(() => {});
   },
 
   celebrateMemberJoined: (name) => {

--- a/app/apps/desktop/vite.config.ts
+++ b/app/apps/desktop/vite.config.ts
@@ -8,6 +8,20 @@ const host = process.env.TAURI_DEV_HOST;
 export default defineConfig(async () => ({
   plugins: [react()],
 
+  build: {
+    /**
+     * Never inline the AudioWorklet module.
+     *
+     * It's ~2 KB, so Vite's default `assetsInlineLimit` turns it into a `data:`
+     * URL — and the Tauri CSP is `script-src 'self'`, which blocks a worklet
+     * loaded from `data:`. Push-to-talk then fails only in a packaged build,
+     * where `tauri dev` (which serves the file over http) looks fine. Keep it a
+     * real same-origin asset.
+     */
+    assetsInlineLimit: (filePath: string) =>
+      filePath.endsWith("recorder-worklet.js") ? false : undefined,
+  },
+
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
   // 1. prevent Vite from obscuring rust errors

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -16,7 +16,12 @@ import {
   encodePubsubMemberJoined,
   encodePubsubPresence,
   encodePubsubPresenceQuery,
+  encodePubsubVoice,
+  encodeVoiceFrame,
   decodePubsub,
+  decodeVoiceFrame,
+  VOICE_FRAME,
+  VOICE_RATE_BYTES_PER_SEC,
   type ServerControl,
   type PresenceFrame,
 } from "./vault-protocol.js";
@@ -279,6 +284,9 @@ class VaultConnection {
    *  telling it to re-pull structural changes it made itself. Null ⇒ no
    *  self-exclusion, so it hears about everything (older clients). */
   private clientId: string | null = null;
+  /** Feature flags from `hello.caps`. Gates new binary frame types, which older
+   *  clients would misparse as doc updates (see {@link HelloFrame.caps}). */
+  private caps = new Set<string>();
   private readable = new Set<string>();
   private unsubscribe: (() => void) | null = null;
   private helloSeen = false;
@@ -292,6 +300,15 @@ class VaultConnection {
   private myPresence: { docId: string | null; name: string; color: string; status: string } | null =
     null;
   private announced = false;
+  // ---- inbound voice budget ----
+  // Nothing else on this channel is client-*originated* bulk traffic, so voice
+  // is the first thing here that needs a rate limit rather than just
+  // backpressure: a peer that ignores the intended cadence would otherwise
+  // amplify straight into every other member's socket. A plain leaky bucket —
+  // credit refills at VOICE_RATE_BYTES_PER_SEC, chunks over budget are dropped.
+  private voiceCredit = VOICE_RATE_BYTES_PER_SEC;
+  private voiceCreditAt = 0;
+  private voiceDropped = 0;
 
   // ---- outbound accounting (F2) ----
   /** Cumulative bytes handed to `ws.send()`. Monotonic. */
@@ -328,7 +345,12 @@ class VaultConnection {
 
     ws.on("message", (data, isBinary) => {
       this.alive = true; // traffic from the peer is proof of life, like a pong
-      if (isBinary) return; // clients only send the JSON hello; ignore stray binary
+      if (isBinary) {
+        // The only binary a client sends is a push-to-talk voice chunk; anything
+        // else on this path is stray and ignored.
+        this.onBinary(toBytes(data));
+        return;
+      }
       void this.onText(data.toString());
     });
     ws.on("pong", () => {
@@ -371,6 +393,7 @@ class VaultConnection {
     if (!hello) return this.fail("expected hello");
     this.helloSeen = true;
     this.clientId = hello.origin ?? null;
+    this.caps = new Set(hello.caps ?? []);
     clearTimeout(this.helloTimer);
 
     let claims;
@@ -411,6 +434,13 @@ class VaultConnection {
     this.send({ t: "ready" });
   }
 
+  /** Binary from the client. Only voice frames are defined; the leading type
+   *  byte leaves room for more without another compat break. */
+  private onBinary(bytes: Uint8Array): void {
+    if (this.closed || bytes.length === 0) return;
+    if (bytes[0] === VOICE_FRAME) this.handleVoice(bytes);
+  }
+
   /** A client announced which note it's now viewing. Stamp the authenticated
    *  userId (never trust the client's), fan it out to the vault, and — on the
    *  first announce — ask everyone else to re-announce so this newcomer learns
@@ -431,6 +461,77 @@ class VaultConnection {
       this.announced = true;
       void this.pubsub.publish(vaultTopic(this.vaultId), encodePubsubPresenceQuery());
     }
+  }
+
+  /**
+   * A push-to-talk chunk from this client. Re-frame it with the speaker stamped
+   * from the authenticated token — never from the payload, so a client cannot
+   * put words in a teammate's mouth — and fan it out to the vault.
+   *
+   * Deliberately NOT gated on the per-doc ACL that filters presence: a voice
+   * broadcast is addressed to the team, not to a note, so it follows
+   * `member-joined` and reaches every member of the vault. Membership is
+   * already proven by the vault token, which is the right granularity here.
+   *
+   * Audio is never written anywhere. If nobody is connected, it evaporates.
+   */
+  private handleVoice(bytes: Uint8Array): void {
+    if (!this.helloSeen || !this.userId || !this.vaultId) return;
+    const parsed = decodeVoiceFrame(bytes);
+    if (!parsed) return; // malformed or over the per-chunk cap
+    if (!this.admitVoice(parsed.audio.length)) return;
+    const { header, audio } = parsed;
+    const speaker = this.myPresence;
+    const out = encodeVoiceFrame(
+      {
+        s: header.s,
+        n: header.n,
+        ...(header.f === 1 ? { f: 1 as const } : {}),
+        ...(header.fmt ? { fmt: header.fmt } : {}),
+        ...(header.sr ? { sr: header.sr } : {}),
+        u: this.userId,
+        // Name/colour ride the opening chunk only — the receiver caches them for
+        // the rest of the transmission, so the other ~10 chunks a second stay lean.
+        ...(header.n === 0 && speaker?.name ? { m: speaker.name } : {}),
+        ...(header.n === 0 && speaker?.color ? { c: speaker.color } : {}),
+      },
+      audio,
+    );
+    void this.pubsub
+      .publish(vaultTopic(this.vaultId), encodePubsubVoice(out))
+      .catch((err) => console.error("Vault channel voice publish failed:", err));
+  }
+
+  /** Leaky-bucket admission for inbound audio. Returns false when this speaker
+   *  is over budget, in which case the chunk is dropped rather than queued —
+   *  delayed audio is worthless, so shedding beats buffering. */
+  private admitVoice(bytes: number): boolean {
+    const now = Date.now();
+    if (this.voiceCreditAt === 0) {
+      this.voiceCreditAt = now;
+    } else {
+      const elapsed = (now - this.voiceCreditAt) / 1000;
+      this.voiceCreditAt = now;
+      this.voiceCredit = Math.min(
+        VOICE_RATE_BYTES_PER_SEC,
+        this.voiceCredit + elapsed * VOICE_RATE_BYTES_PER_SEC,
+      );
+    }
+    if (this.voiceCredit < bytes) {
+      // Log once per run of drops, not once per chunk — a spamming client would
+      // otherwise turn our own logs into the amplification.
+      if (this.voiceDropped === 0) {
+        console.warn(
+          `Vault channel dropping voice over budget (user=${this.userId ?? "?"} ` +
+            `vault=${this.vaultId ?? "?"})`,
+        );
+      }
+      this.voiceDropped++;
+      return false;
+    }
+    this.voiceCredit -= bytes;
+    this.voiceDropped = 0;
+    return true;
   }
 
   /** Stream missing ops for every readable doc, priority docs first. */
@@ -513,6 +614,25 @@ class VaultConnection {
       if (presence.docId === null || this.readable.has(presence.docId)) {
         this.send({ t: "presence", ...presence });
       }
+      return;
+    }
+    if (msg.type === "voice") {
+      // Vault-wide, like member-joined: audio is addressed to the team, and
+      // vault membership is already proven by the token behind every connection.
+      //
+      // Two gates. Never echo to the speaker — they are hearing themselves live
+      // and a loopback would be an echo, not a feature. And only send to clients
+      // that advertised `voice`: this is a new BINARY frame, which an older
+      // client would push through `decodeUpdateFrame` and apply as a corrupt doc
+      // update.
+      if (msg.speakerId === this.userId) return;
+      if (!this.caps.has("voice")) return;
+      // Shed rather than queue when the socket is already at its bound. Late
+      // audio is worse than missing audio, and unlike a doc update there is
+      // nothing to resync — the chunk is simply gone, which is what "ephemeral"
+      // means here.
+      if (this.bufferedBytes() >= this.deps.sendCapBytes) return;
+      this.sendBinary(msg.frame);
       return;
     }
     if (msg.type === "presence-query") {
@@ -790,6 +910,18 @@ class VaultConnection {
       this.unsubscribe = null;
     }
   }
+}
+
+/** Normalize whatever `ws` hands a binary message handler (Buffer, ArrayBuffer,
+ *  or a fragment array) into one flat Uint8Array. */
+function toBytes(data: unknown): Uint8Array {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (Array.isArray(data)) return Buffer.concat(data as Buffer[]);
+  if (ArrayBuffer.isView(data)) {
+    const v = data as ArrayBufferView;
+    return new Uint8Array(v.buffer, v.byteOffset, v.byteLength);
+  }
+  return new Uint8Array(0);
 }
 
 /** Run `fn` over items with at most `limit` in flight. Errors are swallowed per

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -620,6 +620,15 @@ class VaultConnection {
       // Vault-wide, like member-joined: audio is addressed to the team, and
       // vault membership is already proven by the token behind every connection.
       //
+      // KNOWN LIMITATION, inherited from this channel rather than introduced
+      // here: membership revocation is TTL-bound. There is no `disconnectDoc`
+      // equivalent for the vault channel, so a just-removed member keeps its
+      // socket — and keeps receiving vault-wide broadcasts — until the socket
+      // drops or their vault token expires (`SYNC_TOKEN_TTL_SECONDS`, 600s by
+      // default). `member-joined` already behaves this way, but a name is a
+      // smaller leak than live audio. Closing it means force-closing vault
+      // sockets on member removal; tracked as follow-up work, not solved here.
+      //
       // Two gates. Never echo to the speaker — they are hearing themselves live
       // and a loopback would be an echo, not a feature. And only send to clients
       // that advertised `voice`: this is a new BINARY frame, which an older

--- a/app/apps/server/src/sync/vault-protocol.ts
+++ b/app/apps/server/src/sync/vault-protocol.ts
@@ -11,6 +11,9 @@
 //
 // Keeping every byte layout here makes the channel logic small and the framing
 // unit-testable without a socket or Redis.
+//
+// A third surface was added for push-to-talk voice (see "Voice broadcast"
+// below): client->server binary frames, which until then were unused entirely.
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -33,6 +36,18 @@ export interface HelloFrame {
    * per-subscriber ACL recompute. Absent ⇒ no self-exclusion (older clients).
    */
   origin?: string;
+  /**
+   * Optional feature flags this client understands, e.g. `["voice"]`.
+   *
+   * Load-bearing for anything that adds a NEW binary server->client frame. JSON
+   * control frames are forward-compatible (an old client's `parseServerControl`
+   * returns null for an unknown `t` and ignores it), but the binary path is not:
+   * it assumes every binary frame is `[docIdLen u16][docId][update]` and would
+   * feed a voice frame straight into `coldApply` as a bogus doc update. Releases
+   * auto-update, so old clients stay in the field — the server must only send a
+   * new binary frame type to a connection that asked for it.
+   */
+  caps?: string[];
 }
 
 /** A teammate's live "who's viewing what" state, forwarded to every subscriber
@@ -116,6 +131,7 @@ export function parseHello(text: string): HelloFrame | null {
     manifest: f.manifest ?? {},
     priority: Array.isArray(f.priority) ? f.priority : undefined,
     origin: typeof f.origin === "string" && f.origin ? f.origin : undefined,
+    caps: Array.isArray(f.caps) ? f.caps.filter((c): c is string => typeof c === "string") : undefined,
   };
 }
 
@@ -131,6 +147,118 @@ export function decodeWsUpdate(
   return unframeDocPayload(bytes);
 }
 
+// ---- Voice broadcast (push-to-talk) ----
+//
+// Live, EPHEMERAL audio: while a user holds the talk button their client emits
+// small chunks that the relay fans out to every other member of the vault, who
+// plays them as they land. Nothing is stored — not on the server, not on any
+// client. There is no blob, no row, no file, and no history; a chunk that
+// arrives while a listener is offline is simply gone.
+//
+// Frame layout (identical in both directions, so one codec serves both):
+//
+//   [0x01 VOICE][headerLen u16 BE][header JSON utf8][audio bytes]
+//
+// The header is JSON because it is tiny and needs to stay extensible; the audio
+// stays raw so it is never base64-inflated. Keys are one character because this
+// rides once per chunk (~10/s while talking) — see {@link VoiceHeader}.
+//
+// Client->server headers carry only the transmission id, sequence and end flag.
+// The server re-frames with the speaker's identity stamped from the token — the
+// same anti-spoofing rule presence follows, and one the note-level ping notably
+// does NOT (there, `ping.name` is whatever the sender claims).
+
+/** Type byte for a voice frame. Client->server binary was an unused namespace
+ *  before this, so the leading byte keeps room for future frame types. */
+export const VOICE_FRAME = 0x01;
+
+/**
+ * Largest audio payload accepted in one chunk. At the 16 kHz mono PCM16 the
+ * desktop sends (32 KB/s) this is two seconds of speech, so a client using the
+ * intended ~10 chunks/s cadence sits ~20x under it; the cap only exists to stop
+ * a malicious client from framing something huge.
+ */
+export const MAX_VOICE_CHUNK_BYTES = 64 * 1024;
+
+/** Per-connection inbound voice budget: bytes per second of audio a single
+ *  speaker may push before the relay starts dropping their chunks. 128 KB/s is
+ *  4x the intended PCM16 rate, so it never trips on honest traffic. */
+export const VOICE_RATE_BYTES_PER_SEC = 128 * 1024;
+
+/** Chunk header. Short keys: this rides on every chunk of every transmission. */
+export interface VoiceHeader {
+  /** Transmission id — groups the chunks of one press-and-hold into a stream.
+   *  Client-chosen and opaque; two people talking at once produce two ids. */
+  s: string;
+  /** Chunk index within the transmission, from 0. Lets the receiver order
+   *  chunks and notice a gap without trusting arrival order. */
+  n: number;
+  /** 1 on the final chunk (the moment the button came up). */
+  f?: 0 | 1;
+  /** Audio encoding, e.g. `"pcm16"`. First chunk only. */
+  fmt?: string;
+  /** Sample rate in Hz. First chunk only. */
+  sr?: number;
+  /** Speaker's user id. Server->client only, stamped from the token. */
+  u?: string;
+  /** Speaker's display name. Server->client, first chunk only. */
+  m?: string;
+  /** Speaker's presence color. Server->client, first chunk only. */
+  c?: string;
+}
+
+export interface VoiceFrame {
+  header: VoiceHeader;
+  audio: Uint8Array;
+}
+
+export function encodeVoiceFrame(header: VoiceHeader, audio: Uint8Array): Uint8Array {
+  const h = enc.encode(JSON.stringify(header));
+  if (h.length > 0xffff) throw new Error("voice header too long to frame");
+  const out = new Uint8Array(3 + h.length + audio.length);
+  out[0] = VOICE_FRAME;
+  out[1] = (h.length >> 8) & 0xff;
+  out[2] = h.length & 0xff;
+  out.set(h, 3);
+  out.set(audio, 3 + h.length);
+  return out;
+}
+
+/** Decode a voice frame; null for anything malformed or not a voice frame.
+ *  Never throws — this parses bytes straight off a socket. */
+export function decodeVoiceFrame(bytes: Uint8Array): VoiceFrame | null {
+  if (bytes.length < 3 || bytes[0] !== VOICE_FRAME) return null;
+  const hLen = (bytes[1] << 8) | bytes[2];
+  if (bytes.length < 3 + hLen) return null;
+  let header: unknown;
+  try {
+    header = JSON.parse(dec.decode(bytes.subarray(3, 3 + hLen)));
+  } catch {
+    return null;
+  }
+  if (!header || typeof header !== "object") return null;
+  const h = header as Record<string, unknown>;
+  // `s` and `n` are the two fields the relay and the receiver both rely on;
+  // everything else is optional metadata that may legitimately be absent.
+  if (typeof h.s !== "string" || !h.s) return null;
+  if (typeof h.n !== "number" || !Number.isInteger(h.n) || h.n < 0) return null;
+  const audio = bytes.subarray(3 + hLen);
+  if (audio.length > MAX_VOICE_CHUNK_BYTES) return null;
+  return {
+    header: {
+      s: h.s,
+      n: h.n,
+      ...(h.f === 1 ? { f: 1 as const } : {}),
+      ...(typeof h.fmt === "string" ? { fmt: h.fmt } : {}),
+      ...(typeof h.sr === "number" ? { sr: h.sr } : {}),
+      ...(typeof h.u === "string" ? { u: h.u } : {}),
+      ...(typeof h.m === "string" ? { m: h.m } : {}),
+      ...(typeof h.c === "string" ? { c: h.c } : {}),
+    },
+    audio,
+  };
+}
+
 // ---- PubSub payloads (binary, cross-instance) ----
 
 export const PS_UPDATE = 0x01;
@@ -139,6 +267,7 @@ export const PS_REGISTRY_CHANGED = 0x03;
 export const PS_MEMBER_JOINED = 0x04;
 export const PS_PRESENCE = 0x05;
 export const PS_PRESENCE_QUERY = 0x06;
+export const PS_VOICE = 0x07;
 
 export function encodePubsubUpdate(docId: string, update: Uint8Array): Uint8Array {
   const body = frameDocPayload(docId, update);
@@ -185,6 +314,19 @@ export function encodePubsubPresence(p: PresenceState): Uint8Array {
   return out;
 }
 
+/**
+ * Fan one voice chunk out to the vault. `frame` is the already-encoded
+ * server->client {@link encodeVoiceFrame} payload, speaker identity included,
+ * so every instance forwards the exact same bytes it would have sent locally
+ * and no re-framing happens on the receiving side.
+ */
+export function encodePubsubVoice(frame: Uint8Array): Uint8Array {
+  const out = new Uint8Array(1 + frame.length);
+  out[0] = PS_VOICE;
+  out.set(frame, 1);
+  return out;
+}
+
 /** Ask every connection in the vault to re-announce its presence — sent when a
  *  client joins so it learns who's already viewing what (stateless: no instance
  *  holds the whole roster, so newcomers pull it via a re-announce round). */
@@ -198,7 +340,8 @@ export type PubsubMessage =
   | { type: "registry-changed"; origins: string[] }
   | { type: "member-joined"; name: string }
   | { type: "presence"; presence: PresenceState }
-  | { type: "presence-query" };
+  | { type: "presence-query" }
+  | { type: "voice"; frame: Uint8Array; speakerId: string };
 
 export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
   if (bytes.length < 1) return null;
@@ -235,6 +378,16 @@ export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
     }
     case PS_PRESENCE_QUERY:
       return { type: "presence-query" };
+    case PS_VOICE: {
+      // Copy: the frame is forwarded to sockets after this buffer may be reused,
+      // and a subarray would keep the whole pubsub payload alive besides.
+      const frame = bytes.slice(1);
+      const parsed = decodeVoiceFrame(frame);
+      // The speaker id is what lets a connection skip echoing audio back to the
+      // person talking, so a frame without one is unusable, not merely odd.
+      if (!parsed?.header.u) return null;
+      return { type: "voice", frame, speakerId: parsed.header.u };
+    }
     default:
       return null;
   }
@@ -244,7 +397,13 @@ export function decodePubsub(bytes: Uint8Array): PubsubMessage | null {
 
 function frameDocPayload(docId: string, update: Uint8Array): Uint8Array {
   const id = enc.encode(docId);
-  if (id.length > 0xffff) throw new Error("docId too long to frame");
+  // Bounded at 0xff, not 0xffff, and that is load-bearing rather than tidiness:
+  // doc-update and voice frames share the one binary path to the client, which
+  // tells them apart by the first byte. Capping the id length here pins the
+  // update frame's high length byte to 0x00, so VOICE_FRAME (0x01) can never
+  // collide with it. Ids are UUID/Better-Auth TEXT (~32-36 bytes), so the real
+  // ceiling is ~7x what anything actually uses.
+  if (id.length > 0xff) throw new Error("docId too long to frame");
   const out = new Uint8Array(2 + id.length + update.length);
   out[0] = (id.length >> 8) & 0xff;
   out[1] = id.length & 0xff;

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -2,7 +2,13 @@ import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it } from "vitest";
 import { VaultChannel } from "../src/sync/vault-channel.js";
 import { InMemoryPubSub } from "../src/sync/pubsub.js";
-import { decodeWsUpdate } from "../src/sync/vault-protocol.js";
+import {
+  decodeWsUpdate,
+  decodeVoiceFrame,
+  encodeVoiceFrame,
+  type VoiceFrame,
+  type VoiceHeader,
+} from "../src/sync/vault-protocol.js";
 import type { DocDiff } from "../src/yjs/persistence.js";
 
 // Exercises the relay logic (backfill -> ready -> live fanout -> acl drop) with a
@@ -22,8 +28,28 @@ class FakeWs extends EventEmitter {
     this.readyState = 3;
     this.emit("close");
   }
-  hello(token: string, manifest: Record<string, string> = {}, priority?: string[]): void {
-    this.emit("message", Buffer.from(JSON.stringify({ t: "hello", token, manifest, priority })), false);
+  hello(
+    token: string,
+    manifest: Record<string, string> = {},
+    priority?: string[],
+    caps?: string[],
+  ): void {
+    this.emit(
+      "message",
+      Buffer.from(JSON.stringify({ t: "hello", token, manifest, priority, caps })),
+      false,
+    );
+  }
+  /** Emit a push-to-talk chunk from this client (binary frame). */
+  voice(header: VoiceHeader, audio: Uint8Array): void {
+    this.emit("message", Buffer.from(encodeVoiceFrame(header, audio)), true);
+  }
+  /** Voice frames this client RECEIVED. */
+  voices(): VoiceFrame[] {
+    return this.sent
+      .filter((s) => s.kind === "binary")
+      .map((s) => decodeVoiceFrame((s as { bytes: Uint8Array }).bytes))
+      .filter((f): f is VoiceFrame => f !== null);
   }
   presence(docId: string | null, name = "Ada", color = "#6366f1", status = "online"): void {
     this.emit(
@@ -253,5 +279,153 @@ describe("VaultChannel relay (spec 05 §3.1)", () => {
     await new Promise((r) => setTimeout(r, 20));
     expect(aclCalls).toBe(1);
     expect(ws.controls().some((c) => c.t === "ready")).toBe(false);
+  });
+});
+
+// ---- push-to-talk voice broadcast ----------------------------------------
+
+/** Like `channelWith`, but the token IS the user id, so a test can put two
+ *  distinct speakers on one vault. */
+function voiceChannel(): { channel: VaultChannel; pubsub: InMemoryPubSub } {
+  const pubsub = new InMemoryPubSub();
+  pubsubs.push(pubsub);
+  const channel = new VaultChannel({
+    pubsub,
+    verifyToken: async (token: string) => ({ userId: token, vaultId: "v1" }),
+    listReadableDocs: async () => new Set<string>(),
+    loadDiff: async () => null,
+    backfillConcurrency: 4,
+  });
+  return { channel, pubsub };
+}
+
+/** Connect one voice-capable member and wait until it's live. */
+async function joinVoice(
+  channel: VaultChannel,
+  userId: string,
+  caps: string[] = ["voice"],
+): Promise<FakeWs> {
+  const ws = new FakeWs();
+  channel.handleConnection(ws as never);
+  ws.hello(userId, {}, undefined, caps);
+  await waitFor(() => ws.controls().some((c) => c.t === "ready"));
+  return ws;
+}
+
+describe("VaultChannel voice broadcast", () => {
+  it("fans a chunk out to every other member and never back to the speaker", async () => {
+    const { channel } = voiceChannel();
+    const ada = await joinVoice(channel, "ada");
+    const grace = await joinVoice(channel, "grace");
+    const alan = await joinVoice(channel, "alan");
+    ada.presence(null, "Ada", "#6366f1");
+
+    ada.voice({ s: "tx1", n: 0, fmt: "pcm16", sr: 16000 }, new Uint8Array([1, 2, 3, 4]));
+
+    await waitFor(() => grace.voices().length === 1 && alan.voices().length === 1);
+    expect(grace.voices()[0].audio).toEqual(new Uint8Array([1, 2, 3, 4]));
+    // Speakers hear themselves live from their own mic; a loopback would be an echo.
+    expect(ada.voices()).toHaveLength(0);
+  });
+
+  it("stamps the speaker from the token, ignoring any id the client claims", async () => {
+    const { channel } = voiceChannel();
+    const ada = await joinVoice(channel, "ada");
+    const grace = await joinVoice(channel, "grace");
+    ada.presence(null, "Ada", "#6366f1");
+
+    // Ada tries to broadcast as Grace. The relay must overwrite `u`.
+    ada.voice({ s: "tx1", n: 0, u: "grace", m: "Grace" }, new Uint8Array([9]));
+
+    await waitFor(() => grace.voices().length === 1);
+    const { header } = grace.voices()[0];
+    expect(header.u).toBe("ada");
+    expect(header.m).toBe("Ada"); // from server-held presence, not the payload
+    expect(header.c).toBe("#6366f1");
+  });
+
+  it("sends the speaker's name only on the opening chunk", async () => {
+    const { channel } = voiceChannel();
+    const ada = await joinVoice(channel, "ada");
+    const grace = await joinVoice(channel, "grace");
+    ada.presence(null, "Ada", "#6366f1");
+
+    ada.voice({ s: "tx1", n: 0 }, new Uint8Array([1]));
+    ada.voice({ s: "tx1", n: 1 }, new Uint8Array([2]));
+    ada.voice({ s: "tx1", n: 2, f: 1 }, new Uint8Array([3]));
+
+    await waitFor(() => grace.voices().length === 3);
+    const heard = grace.voices();
+    expect(heard.map((v) => v.header.n)).toEqual([0, 1, 2]);
+    expect(heard[0].header.m).toBe("Ada");
+    expect(heard[1].header.m).toBeUndefined();
+    expect(heard[2].header.m).toBeUndefined();
+    // The release flag survives the round trip so the receiver can close the stream.
+    expect(heard[2].header.f).toBe(1);
+  });
+
+  it("withholds voice from a client that did not advertise the capability", async () => {
+    // Old clients push every binary frame through `decodeUpdateFrame` and would
+    // apply a voice chunk as a corrupt doc update, so they must never receive one.
+    const { channel } = voiceChannel();
+    const ada = await joinVoice(channel, "ada");
+    const legacy = await joinVoice(channel, "legacy", []);
+    const grace = await joinVoice(channel, "grace");
+
+    ada.voice({ s: "tx1", n: 0 }, new Uint8Array([1]));
+
+    await waitFor(() => grace.voices().length === 1);
+    expect(legacy.voices()).toHaveLength(0);
+  });
+
+  it("ignores a malformed or oversized chunk instead of relaying it", async () => {
+    const { channel } = voiceChannel();
+    const ada = await joinVoice(channel, "ada");
+    const grace = await joinVoice(channel, "grace");
+
+    // Not a voice frame at all.
+    ada.emit("message", Buffer.from([0xff, 0x00, 0x01]), true);
+    // Voice frame, but the header is missing the transmission id.
+    ada.emit(
+      "message",
+      Buffer.from(encodeVoiceFrame({ n: 0 } as unknown as VoiceHeader, new Uint8Array([1]))),
+      true,
+    );
+    // Over MAX_VOICE_CHUNK_BYTES.
+    ada.voice({ s: "tx1", n: 0 }, new Uint8Array(64 * 1024 + 1));
+    // A good one afterwards proves the connection still works.
+    ada.voice({ s: "tx1", n: 1 }, new Uint8Array([7]));
+
+    await waitFor(() => grace.voices().length === 1);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(grace.voices()).toHaveLength(1);
+    expect(grace.voices()[0].header.n).toBe(1);
+  });
+
+  it("drops chunks from a speaker over the rate budget", async () => {
+    const { channel } = voiceChannel();
+    const ada = await joinVoice(channel, "ada");
+    const grace = await joinVoice(channel, "grace");
+
+    // The budget is 128 KB/s and refills with elapsed time, so blast well past
+    // it in one tick: 8 x 64 KB = 512 KB with no time to refill.
+    for (let n = 0; n < 8; n++) ada.voice({ s: "tx1", n }, new Uint8Array(64 * 1024));
+
+    await waitFor(() => grace.voices().length > 0);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(grace.voices().length).toBeGreaterThan(0);
+    expect(grace.voices().length).toBeLessThan(8);
+  });
+
+  it("refuses to relay audio from a socket that never said hello", async () => {
+    const { channel } = voiceChannel();
+    const grace = await joinVoice(channel, "grace");
+
+    const anon = new FakeWs();
+    channel.handleConnection(anon as never);
+    anon.voice({ s: "tx1", n: 0 }, new Uint8Array([1, 2, 3]));
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(grace.voices()).toHaveLength(0);
   });
 });

--- a/app/apps/server/tests/vault-protocol.test.ts
+++ b/app/apps/server/tests/vault-protocol.test.ts
@@ -10,7 +10,12 @@ import {
   encodePubsubMemberJoined,
   encodePubsubPresence,
   encodePubsubPresenceQuery,
+  encodePubsubVoice,
+  encodeVoiceFrame,
+  decodeVoiceFrame,
   decodePubsub,
+  MAX_VOICE_CHUNK_BYTES,
+  type VoiceHeader,
 } from "../src/sync/vault-protocol.js";
 
 // Pure framing round-trips (spec 05 §3.1) — no socket, DB, or Redis.
@@ -107,5 +112,71 @@ describe("vault channel framing", () => {
     expect(parseHello("not json")).toBeNull();
     expect(parseHello(JSON.stringify({ t: "nope", token: "x", manifest: {} }))).toBeNull();
     expect(parseHello(JSON.stringify({ t: "hello", manifest: {} }))).toBeNull(); // no token
+  });
+
+  it("carries hello caps through, defaulting to undefined and dropping non-strings", () => {
+    const withCaps = parseHello(
+      JSON.stringify({ t: "hello", token: "t", manifest: {}, caps: ["voice", 7, "x"] }),
+    );
+    expect(withCaps?.caps).toEqual(["voice", "x"]);
+    expect(parseHello(JSON.stringify({ t: "hello", token: "t", manifest: {} }))?.caps).toBeUndefined();
+  });
+});
+
+describe("voice frame codec", () => {
+  it("round-trips a header and its audio payload", () => {
+    const audio = new Uint8Array([0, 1, 2, 250, 255]);
+    const header: VoiceHeader = { s: "tx1", n: 3, f: 1, fmt: "pcm16", sr: 16000, u: "u1", m: "Ada", c: "#fff" };
+    const decoded = decodeVoiceFrame(encodeVoiceFrame(header, audio));
+    expect(decoded?.header).toEqual(header);
+    expect(decoded?.audio).toEqual(audio);
+  });
+
+  it("keeps an empty payload decodable (a bare end-of-transmission marker)", () => {
+    const decoded = decodeVoiceFrame(encodeVoiceFrame({ s: "tx1", n: 9, f: 1 }, new Uint8Array()));
+    expect(decoded?.header).toEqual({ s: "tx1", n: 9, f: 1 });
+    expect(decoded?.audio).toEqual(new Uint8Array());
+  });
+
+  it("omits absent optional fields rather than emitting undefined keys", () => {
+    const decoded = decodeVoiceFrame(encodeVoiceFrame({ s: "tx1", n: 0 }, new Uint8Array([1])));
+    expect(decoded?.header).toEqual({ s: "tx1", n: 0 });
+  });
+
+  it("rejects frames that are not voice, are truncated, or lack a usable header", () => {
+    expect(decodeVoiceFrame(new Uint8Array())).toBeNull();
+    expect(decodeVoiceFrame(new Uint8Array([0xff, 0, 2]))).toBeNull(); // wrong type byte
+    expect(decodeVoiceFrame(new Uint8Array([0x01, 0xff, 0xff, 1]))).toBeNull(); // header runs past the end
+    expect(decodeVoiceFrame(encodeVoiceFrame({ n: 0 } as unknown as VoiceHeader, new Uint8Array()))).toBeNull();
+    expect(decodeVoiceFrame(encodeVoiceFrame({ s: "" } as unknown as VoiceHeader, new Uint8Array()))).toBeNull();
+    expect(
+      decodeVoiceFrame(encodeVoiceFrame({ s: "tx", n: -1 } as unknown as VoiceHeader, new Uint8Array())),
+    ).toBeNull();
+    expect(
+      decodeVoiceFrame(encodeVoiceFrame({ s: "tx", n: 1.5 } as unknown as VoiceHeader, new Uint8Array())),
+    ).toBeNull();
+  });
+
+  it("rejects a chunk over the per-chunk cap", () => {
+    const ok = encodeVoiceFrame({ s: "tx", n: 0 }, new Uint8Array(MAX_VOICE_CHUNK_BYTES));
+    expect(decodeVoiceFrame(ok)).not.toBeNull();
+    const tooBig = encodeVoiceFrame({ s: "tx", n: 0 }, new Uint8Array(MAX_VOICE_CHUNK_BYTES + 1));
+    expect(decodeVoiceFrame(tooBig)).toBeNull();
+  });
+
+  it("round-trips a voice frame through the cross-instance pubsub envelope", () => {
+    const frame = encodeVoiceFrame({ s: "tx1", n: 0, u: "ada" }, new Uint8Array([4, 5, 6]));
+    const msg = decodePubsub(encodePubsubVoice(frame));
+    expect(msg?.type).toBe("voice");
+    if (msg?.type !== "voice") throw new Error("expected a voice message");
+    expect(msg.speakerId).toBe("ada");
+    expect(decodeVoiceFrame(msg.frame)?.audio).toEqual(new Uint8Array([4, 5, 6]));
+  });
+
+  it("drops a pubsub voice payload with no speaker stamped on it", () => {
+    // Only the relay produces these, and it always stamps `u`; one without it
+    // could not be attributed and must not reach a client.
+    const unstamped = encodeVoiceFrame({ s: "tx1", n: 0 }, new Uint8Array([1]));
+    expect(decodePubsub(encodePubsubVoice(unstamped))).toBeNull();
   });
 });

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -104,6 +104,13 @@ De-risk the hardest part before networking.
 - [x] Per-speaker leaky-bucket rate limit on the relay (the channel had no abuse guard before).
 - [x] Older clients are protected by a `hello` capability flag — a new *binary* frame would
   otherwise be misparsed as a doc update, and releases auto-update.
+- **Milestone:** two teammates in one vault, one holds the talk button, the other hears them
+  live with nothing written to disk on either side. ✔ (unit-tested end to end through the relay;
+  real-hardware audio between two machines still unverified)
+- **Known limitation:** revocation on the vault channel is TTL-bound (no `disconnectDoc`
+  equivalent), so a removed member can still receive broadcasts until their token expires
+  (≤600s). Pre-existing — `member-joined` behaves the same way — but louder for audio.
+- Specs: [[05-vault-sync-engine]] (transport), [[04-team-collaboration]] (membership gate)
 
 ### Phase 4: Polish / upgrades _(deferred)_ ⬜
 - [ ] Structural rich-text CRDT (y-prosemirror / `Y.XmlFragment`) for full WYSIWYG.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -90,6 +90,21 @@ De-risk the hardest part before networking.
 > local orphan only if the doc is still empty, preventing split-brain. Remote provider edits DO egest
 > to the local `.md` (only `'disk'`-origin changes are dropped).
 
+### Push-to-talk voice broadcast ✔
+- [x] Hold-to-talk on the vault relay: 16 kHz mono PCM16 chunks ride a new binary frame
+  (`VOICE_FRAME`) on `/vault-sync`, fanned out vault-wide via `PS_VOICE` like `member-joined`
+  (audio is addressed to the team, and the vault token already proves membership). The speaker
+  is stamped from the token, never trusted from the payload.
+- [x] **Nothing is persisted** — no blob, no row, no file, no history. A chunk is played and
+  dropped; a listener who was offline simply missed it. Adds no storage and no retention policy.
+- [x] Capture `getUserMedia` → `AudioWorklet` → downsample → PCM16; playback schedules buffers
+  back-to-back on an `AudioContext` cursor so the stream is gapless. Zero new dependencies:
+  no Opus/wasm encoder, no `MediaRecorder` container problem, no WebRTC/SFU. The `fmt` wire
+  field leaves room for a native WebCodecs Opus path later without a protocol change.
+- [x] Per-speaker leaky-bucket rate limit on the relay (the channel had no abuse guard before).
+- [x] Older clients are protected by a `hello` capability flag — a new *binary* frame would
+  otherwise be misparsed as a doc update, and releases auto-update.
+
 ### Phase 4: Polish / upgrades _(deferred)_ ⬜
 - [ ] Structural rich-text CRDT (y-prosemirror / `Y.XmlFragment`) for full WYSIWYG.
 - [ ] Vector / hybrid search (Orama) for semantic + AI retrieval.

--- a/scripts/voice-check/README.md
+++ b/scripts/voice-check/README.md
@@ -1,0 +1,55 @@
+# Voice broadcast live check
+
+Unit tests cover the framing, relay, ordering and playback logic (`pnpm test`).
+What they can't cover is the part that only exists at runtime: a **real second
+teammate** on a **real `/vault-sync` socket**, streaming **real audio** into a
+running desktop app. That's what this is for.
+
+It is a manual dev tool, not part of `pnpm test` — it needs a live server, a
+seeded vault, and a human with speakers.
+
+## Usage
+
+Server must be running (`pnpm run dev` in `app/apps/server`), and the desktop app
+must be **signed in with sync enabled** — otherwise it holds no vault channel and
+will hear nothing no matter how well the feature works. That is the single most
+common reason "it doesn't work".
+
+```bash
+# 1. Find your vault id
+docker exec context-pg psql -U context -d context -c "select id, name from vaults;"
+
+# 2. Seed two throwaway teammates into that vault (idempotent)
+VAULT_ID=<uuid> node scripts/voice-check/seed.mjs
+
+# 3. Confirm the app is actually on the channel, and see who else is
+VAULT_ID=<uuid> node scripts/voice-check/listen.mjs
+
+# 4. Broadcast as "Ada" — you should hear it and see the megaphone shake
+VAULT_ID=<uuid> node scripts/voice-check/broadcast.mjs "Hello from Ada"
+```
+
+`listen.mjs` is the diagnostic that matters. It prints every peer on the vault
+channel; if your desktop app isn't in that list, the app isn't connected and no
+amount of debugging the audio path will help.
+
+## What it proves
+
+Running `broadcast.mjs` while the app is open exercises the whole receive path
+end to end: Better Auth session → vault token → WS handshake with `caps` → relay
+fan-out → server-stamped identity → chunk ordering → PCM decode → gapless
+scheduling → the speaking indicator and the receiving animation.
+
+It does **not** exercise capture (`getUserMedia`, the AudioWorklet, the
+resampler) — it feeds a pre-rendered file. Holding the button yourself is the
+only way to test that half.
+
+## Cleanup
+
+The seeded users are `ada@example.com` / `grace@example.com`, members of your
+vault's organization. Remove them with:
+
+```bash
+docker exec context-pg psql -U context -d context \
+  -c "delete from \"user\" where email in ('ada@example.com','grace@example.com');"
+```

--- a/scripts/voice-check/broadcast.mjs
+++ b/scripts/voice-check/broadcast.mjs
@@ -1,0 +1,96 @@
+// Broadcast a real voice transmission into the vault as "Ada", so a running
+// desktop app can be checked for: audible playback, the "Ada is talking" label,
+// and the megaphone's receiving shake.
+//
+// Audio is synthesised with macOS `say` straight to 16 kHz mono PCM16 — the
+// exact format the desktop transmits — and paced at the same 200ms cadence, so
+// the server and the receiver see traffic indistinguishable from a live mic.
+//
+//   VAULT_ID=<uuid> node scripts/voice-check/broadcast.mjs "what to say"
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BASE, encodeVoiceFrame, loadWs, signIn, vaultToken, wsUrl } from "./common.mjs";
+
+const SAMPLE_RATE = 16_000;
+const CHUNK_MS = 200;
+const CHUNK_BYTES = (SAMPLE_RATE * 2 * CHUNK_MS) / 1000; // 16-bit mono
+
+const text =
+  process.argv.slice(2).join(" ") ||
+  "Hey! This is Ada testing the push to talk feature. If you can hear me, it works.";
+
+/** Strip the RIFF header — find the `data` chunk, take everything after it. */
+function pcmFromWav(buf) {
+  let off = 12; // past "RIFF____WAVE"
+  while (off < buf.length - 8) {
+    const id = buf.toString("ascii", off, off + 4);
+    const size = buf.readUInt32LE(off + 4);
+    if (id === "data") return buf.subarray(off + 8, off + 8 + size);
+    off += 8 + size + (size % 2);
+  }
+  throw new Error("no data chunk in wav");
+}
+
+const wav = join(tmpdir(), `voice-check-${process.pid}.wav`);
+try {
+  execFileSync("say", ["-v", "Samantha", "-o", wav, "--data-format=LEI16@16000", "--channels=1", text]);
+} catch {
+  console.error("`say` failed — this synthesiser is macOS-only.");
+  process.exit(1);
+}
+const pcm = pcmFromWav(readFileSync(wav));
+unlinkSync(wav);
+
+const WebSocket = await loadWs();
+const token = await vaultToken(await signIn("ada@example.com", "TestPassword123!"));
+console.log(`signed in as Ada @ ${BASE}`);
+
+const total = Math.ceil(pcm.length / CHUNK_BYTES);
+console.log(`${(pcm.length / (SAMPLE_RATE * 2)).toFixed(1)}s of audio → ${total} chunks`);
+
+const ws = new WebSocket(wsUrl());
+ws.binaryType = "arraybuffer";
+ws.on("open", () =>
+  ws.send(JSON.stringify({ t: "hello", token, manifest: {}, caps: ["voice"] })),
+);
+
+ws.on("message", async (data, isBinary) => {
+  if (isBinary) return;
+  const msg = JSON.parse(data.toString());
+  if (msg.t === "err") {
+    console.error("server refused:", msg.message);
+    process.exit(1);
+  }
+  if (msg.t !== "ready") return;
+
+  // Announce first: the relay stamps the opening chunk with the name/colour it
+  // holds for this connection, and that's what the listener displays.
+  ws.send(
+    JSON.stringify({ t: "presence", docId: null, name: "Ada Lovelace", color: "#e5484d", status: "online" }),
+  );
+  console.log("channel ready — transmitting…");
+
+  const streamId = `vc-${Date.now().toString(36)}`;
+  for (let n = 0; n < total; n++) {
+    ws.send(
+      encodeVoiceFrame(
+        { s: streamId, n, ...(n === 0 ? { fmt: "pcm16", sr: SAMPLE_RATE } : {}) },
+        pcm.subarray(n * CHUNK_BYTES, (n + 1) * CHUNK_BYTES),
+      ),
+    );
+    process.stdout.write(".");
+    await new Promise((r) => setTimeout(r, CHUNK_MS)); // pace like a live mic
+  }
+  ws.send(encodeVoiceFrame({ s: streamId, n: total, f: 1 }, Buffer.alloc(0)));
+  console.log(`\nsent ${total} chunks + end marker`);
+  setTimeout(() => ws.close(), 500);
+});
+
+ws.on("close", () => process.exit(0));
+ws.on("error", (e) => {
+  console.error("ws error:", e.message);
+  process.exit(1);
+});

--- a/scripts/voice-check/common.mjs
+++ b/scripts/voice-check/common.mjs
@@ -1,0 +1,69 @@
+// Shared plumbing for the voice live check. Talks to the server exactly the way
+// the desktop client does — no privileged endpoints, no test-only server code.
+
+export const BASE = process.env.SERVER_URL ?? "http://localhost:3010";
+export const VAULT_ID = process.env.VAULT_ID;
+export const VOICE_FRAME = 0x01;
+
+if (!VAULT_ID) {
+  console.error("VAULT_ID is required. Find it with:");
+  console.error(`  docker exec context-pg psql -U context -d context -c "select id, name from vaults;"`);
+  process.exit(1);
+}
+
+/** Better Auth rejects a request with no Origin, which Node's fetch omits. */
+const headers = (extra = {}) => ({ "Content-Type": "application/json", Origin: BASE, ...extra });
+
+export async function signIn(email, password) {
+  const res = await fetch(`${BASE}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify({ email, password }),
+  });
+  const body = await res.json();
+  if (!body.token) throw new Error(`sign-in failed for ${email}: ${JSON.stringify(body)}`);
+  return body.token;
+}
+
+export async function vaultToken(sessionToken) {
+  const res = await fetch(`${BASE}/api/vault-sync-token`, {
+    method: "POST",
+    headers: headers({ Authorization: `Bearer ${sessionToken}` }),
+    body: JSON.stringify({ vaultId: VAULT_ID }),
+  });
+  const body = await res.json();
+  if (!body.token) throw new Error(`vault token refused: ${JSON.stringify(body)}`);
+  return body.token;
+}
+
+export function wsUrl() {
+  return `${BASE.replace(/^http/, "ws")}/vault-sync`;
+}
+
+export function encodeVoiceFrame(header, audio) {
+  const h = Buffer.from(JSON.stringify(header), "utf8");
+  const out = Buffer.alloc(3 + h.length + audio.length);
+  out[0] = VOICE_FRAME;
+  out[1] = (h.length >> 8) & 0xff;
+  out[2] = h.length & 0xff;
+  h.copy(out, 3);
+  audio.copy(out, 3 + h.length);
+  return out;
+}
+
+export function decodeVoiceFrame(bytes) {
+  if (bytes.length < 3 || bytes[0] !== VOICE_FRAME) return null;
+  const hLen = (bytes[1] << 8) | bytes[2];
+  if (bytes.length < 3 + hLen) return null;
+  return {
+    header: JSON.parse(Buffer.from(bytes.subarray(3, 3 + hLen)).toString("utf8")),
+    audioBytes: bytes.length - 3 - hLen,
+  };
+}
+
+/** `ws` isn't hoisted under pnpm, so resolve it from the server workspace. */
+export async function loadWs() {
+  const { createRequire } = await import("node:module");
+  const require = createRequire(new URL("../../app/apps/server/package.json", import.meta.url));
+  return require("ws");
+}

--- a/scripts/voice-check/listen.mjs
+++ b/scripts/voice-check/listen.mjs
@@ -1,0 +1,65 @@
+// Diagnostic listener. Joins the vault channel as "Grace" and reports two
+// things, in this order of usefulness:
+//
+//   1. WHO ELSE IS ON THE CHANNEL. If the desktop app isn't listed, it isn't
+//      connected — it's signed out, or sync is off for this vault — and no
+//      broadcast will ever reach it. This is the first thing to check when
+//      "voice doesn't work", and it is almost always the answer.
+//   2. Every voice frame it receives, so a broadcast can be confirmed as
+//      leaving the server even when nothing is audible on the desktop. That
+//      splits a server-side bug from a client-side one in one run.
+//
+//   VAULT_ID=<uuid> node scripts/voice-check/listen.mjs
+
+import { decodeVoiceFrame, loadWs, signIn, vaultToken, wsUrl } from "./common.mjs";
+
+const SECONDS = Number(process.env.LISTEN_SECONDS ?? 30);
+
+const WebSocket = await loadWs();
+const token = await vaultToken(await signIn("grace@example.com", "TestPassword123!"));
+
+const ws = new WebSocket(wsUrl());
+ws.binaryType = "arraybuffer";
+
+const peers = new Set();
+let frames = 0;
+
+ws.on("open", () => ws.send(JSON.stringify({ t: "hello", token, manifest: {}, caps: ["voice"] })));
+
+ws.on("message", (data, isBinary) => {
+  if (!isBinary) {
+    const msg = JSON.parse(data.toString());
+    if (msg.t === "ready") {
+      console.log(`listening for ${SECONDS}s…\n`);
+      // Announcing triggers a presence-query round, so every other connection
+      // in this vault re-announces itself — that's how we enumerate them.
+      ws.send(
+        JSON.stringify({ t: "presence", docId: null, name: "Grace", color: "#30a46c", status: "online" }),
+      );
+    } else if (msg.t === "presence" && !peers.has(msg.userId)) {
+      peers.add(msg.userId);
+      console.log(`peer on channel: ${msg.name || "(unnamed)"} — ${msg.userId}`);
+    } else if (msg.t === "err") {
+      console.error("refused:", msg.message);
+      process.exit(1);
+    }
+    return;
+  }
+  const v = decodeVoiceFrame(new Uint8Array(data));
+  if (!v) return;
+  frames++;
+  if (v.header.n === 0) console.log(`\n▶ ${v.header.m ?? v.header.u} started talking`);
+  if (v.header.f === 1) console.log(`■ stopped after ${frames} frames`);
+});
+
+function report() {
+  console.log(`\n— ${peers.size} peer(s) seen, ${frames} voice frame(s) received`);
+  if (peers.size <= 1) {
+    console.log("Only this listener was on the channel. If the desktop app was open,");
+    console.log("it is NOT connected: sign in and turn sync on for this vault.");
+  }
+  process.exit(0);
+}
+
+process.on("SIGINT", report);
+setTimeout(report, SECONDS * 1000);

--- a/scripts/voice-check/seed.mjs
+++ b/scripts/voice-check/seed.mjs
@@ -1,0 +1,55 @@
+// Seed two throwaway teammates into the vault's organization, so the live check
+// has someone to broadcast AS and someone to listen AS. Idempotent.
+//
+// Sign-up goes through the real Better Auth endpoint (so the password hash and
+// account row are genuine); only the org membership is inserted directly,
+// because joining otherwise needs an invitation flow this doesn't need to test.
+
+import { execFileSync } from "node:child_process";
+import { BASE, VAULT_ID } from "./common.mjs";
+
+const PEOPLE = [
+  { email: "ada@example.com", name: "Ada Lovelace", password: "TestPassword123!" },
+  { email: "grace@example.com", name: "Grace Hopper", password: "TestPassword123!" },
+];
+
+const psql = (sql) =>
+  execFileSync("docker", ["exec", "context-pg", "psql", "-U", "context", "-d", "context", "-t", "-A", "-c", sql])
+    .toString()
+    .trim();
+
+const orgId = psql(`select organization_id from vaults where id = '${VAULT_ID}';`);
+if (!orgId) {
+  console.error(`No vault ${VAULT_ID}. List them with: select id, name from vaults;`);
+  process.exit(1);
+}
+console.log(`vault ${VAULT_ID} → org ${orgId}`);
+
+for (const person of PEOPLE) {
+  let userId = psql(`select id from "user" where email = '${person.email}';`);
+  if (userId) {
+    console.log(`${person.email} already exists (${userId})`);
+  } else {
+    const res = await fetch(`${BASE}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: BASE },
+      body: JSON.stringify(person),
+    });
+    const body = await res.json();
+    if (!body.user?.id) throw new Error(`sign-up failed: ${JSON.stringify(body)}`);
+    userId = body.user.id;
+    console.log(`created ${person.email} (${userId})`);
+  }
+  psql(
+    `insert into member (id, "organizationId", "userId", role, "createdAt")
+     select 'vc-' || substr(md5('${orgId}${userId}'), 1, 28), '${orgId}', '${userId}', 'member', now()
+     where not exists (
+       select 1 from member where "organizationId" = '${orgId}' and "userId" = '${userId}'
+     );`,
+  );
+  console.log(`  ↳ member of ${orgId}`);
+}
+
+console.log("\nseeded. now run:");
+console.log(`  VAULT_ID=${VAULT_ID} node scripts/voice-check/listen.mjs`);
+console.log(`  VAULT_ID=${VAULT_ID} node scripts/voice-check/broadcast.mjs "Hello from Ada"`);


### PR DESCRIPTION
## What does this PR do?

Adds **push-to-talk voice broadcast** — hold a button, talk, release; everyone in
the vault with the app open hears you live, auto-played. A walkie-talkie, not a
voice-note inbox.

**Nothing is stored.** No blob, no DB row, no file, no history, no playback. A
chunk is scheduled, played, and dropped; if you weren't listening, it's gone.
That's the product decision, and it's also why this adds no storage, no
retention policy, and no migration.

### Why it's small

The transport already existed. `sync/vault-channel.ts` is a stateless relay with
one socket per client per vault, already fanning opaque bytes to every online
member and already stamping `userId` from the token. This adds a message type,
not infrastructure.

| | |
|---|---|
| New deps | **none** |
| New tables / migrations | **none** |
| Wire | `PS_VOICE = 0x07`; `[0x01 VOICE][headerLen u16][header JSON][audio]` |
| Fan-out | vault-wide, like `member-joined` (audio is addressed to the team; the vault token already proves membership) |
| Bitrate | 16 kHz mono PCM16 ≈ 32 KB/s while talking — ~0.8% of the channel's existing 4 MB per-connection outbound budget |

### Why raw PCM16 and not Opus

- **`MediaRecorder` + `timeslice`** is the usual suggestion and is a trap: only
  the first chunk carries the container header, so later WebM/MP4 chunks aren't
  independently decodable. Fixing that needs MediaSource on the receiver, whose
  behaviour across WKWebView / WebView2 / WebKitGTK is exactly the per-platform
  lottery this feature can't afford.
- **A wasm Opus encoder** is a few hundred KB plus a build step, against a brief
  that says "very light".
- **WebRTC / an SFU** wants signalling, STUN/TURN and either N× upload or a media
  server — infrastructure added purely to avoid sending 32 KB/s over a socket we
  already hold open.

PCM16 has none of those failure modes: every frame is independently decodable by
construction, there's no container and no codec, and the receiver skips decoding
entirely (it fills an `AudioBuffer` directly). The `fmt` wire field is already
there so a native WebCodecs Opus path can land later without a protocol change.

### Two traps found and fixed while building this

1. **A new binary frame is not backward compatible.** JSON control frames are
   safely ignored by old clients (`parseServerControl` returns null on an unknown
   `t`), but the binary path assumes every frame is `[docIdLen u16][docId][update]`
   and would push a voice chunk into `coldApply` as a corrupt doc update. Releases
   auto-update, so old clients stay in the field. Fixed with a `caps` flag in
   `hello`; the relay only sends voice to clients that asked for it. To make the
   discriminator provably safe, `frameDocPayload` now caps doc ids at `0xff` bytes
   so an update frame's high length byte is always `0x00` and can never collide
   with `VOICE_FRAME` (ids are ~32–36 bytes, so the real ceiling is ~7× what's used).
2. **Vite inlined the AudioWorklet as a `data:` URL.** The Tauri CSP is
   `script-src 'self'`, which blocks that — and it would have failed *only* in a
   packaged build, since `tauri dev` serves the file over http. Pinned with a
   targeted `assetsInlineLimit` so it stays a real same-origin asset.

### macOS mic plumbing (was missing entirely)

The notarized build had no `NSMicrophoneUsageDescription` and no
`com.apple.security.device.audio-input` entitlement. Under the hardened runtime
the mic is refused outright, and a missing usage string terminates the app rather
than prompting. Both added.

### Safety / abuse

- Speaker identity is stamped from the token, never read from the payload (a test
  asserts a client can't broadcast as someone else). Worth noting the existing
  note-level ping does *not* do this — `ping.name` is whatever the sender claims.
- Per-connection leaky-bucket rate limit on inbound audio. The channel had no
  abuse guard before this; voice is its first client-originated bulk traffic.
- Chunks are shed, never queued, when a listener is at its outbound bound — late
  audio is worse than missing audio, and there's nothing to resync.
- Mic track is stopped on every release, so the OS recording indicator goes out
  between transmissions. Pointer-up outside the button, window blur, tab hide and
  unmount all end the transmission.
- Hold, never toggle: a toggle makes "am I live?" something the user has to
  remember, and getting it wrong means an open mic.

## Related issue

Closes #42.

## Testing

**43 new tests, all green.** No DB required for any of them.

- `app/apps/server/tests/vault-protocol.test.ts` — frame codec round-trips, malformed/oversized rejection, pubsub envelope, `caps` parsing.
- `app/apps/server/tests/vault-channel.test.ts` — fan-out to others but never the speaker, identity stamping vs. a spoofing client, name only on the opening chunk, capability withholding, malformed/oversized handling, rate-limit shedding, refusal before `hello`.
- `app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts` — `caps` advertised, voice routed clear of the doc sink, doc updates still correct alongside voice traffic, unattributed chunks dropped, audio copied off the socket buffer.
- `app/apps/desktop/src/lib/voice/__tests__/pcm.test.ts` — PCM round-trip, clipping (unclamped, +1.5 wraps to *negative* Int16 and turns a loud syllable into noise), byteOffset-correct decoding of socket subarrays, resampling, jitter-buffer ordering and gap recovery.
- `app/apps/desktop/src/lib/voice/__tests__/playback.test.ts` — gapless back-to-back scheduling, drift re-anchoring, never scheduling in the past, two speakers mixing, speaking-state transitions, graceful silence with no audio device.

Verified locally:

- `pnpm test` in `apps/desktop` — **321 passed**, 12 skipped (env-gated integration).
- `npx tsc --noEmit` — clean, both workspaces.
- `npx vite build` — clean; confirmed the worklet emits as a real asset and not a `data:` URL.
- DB-free server suites (`vault-protocol`, `vault-channel`, `vault-fanout-load`) — **36 passed**.

**Not run locally:** the DB-backed server suites, because `pnpm test` in
`apps/server` wipes the dev database. They're untouched by this change (it's
confined to `vault-protocol.ts` / `vault-channel.ts`) and CI runs the full suite
against its own throwaway Postgres.

**Not yet verified on real hardware:** end-to-end audio between two machines, and
mic capture on Windows/Linux webviews. The macOS entitlement change in particular
can only really be proven by a signed build.

## Checklist

- [x] I discussed non-trivial changes in an issue first.
- [x] Tests pass locally (see above for the one suite deliberately not run).
- [x] I added or updated tests for my change.
- [ ] New source files include `SPDX-License-Identifier: Apache-2.0`.
- [x] No secrets, credentials, or `.env` files are committed.
- [x] I did not break the core invariants (doc_id identity, binary-only wire, `.context/` untouched, load-bearing debounce timings).

> On SPDX: intentionally left unchecked. **No file in the repo carries the header
> (0 of 169 TS/TSX sources)**, so adding it only to these would be inconsistent
> with "follow the existing code style of the files you touched". Worth either
> applying it repo-wide or dropping it from `CONTRIBUTING.md` — happy to do either
> in a follow-up.

On invariants specifically: this touches no `.md` file, no CRDT doc, no SQLite
index and no `doc_id`. It's a live side-channel on the vault relay, and the
durable data model is untouched.
