### PR TITLE
Show only the Baalda Live demo video in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 https://github.com/user-attachments/assets/b24c60ee-124e-4831-a97f-d6d1920900c6
 
-
-
-
-
-https://github.com/user-attachments/assets/e258faaa-f299-4dd0-90bd-c7141dd2960a
-
 <div align="center">
 
 # Baalda


### PR DESCRIPTION
The README top-of-page player briefly had two embedded videos stacked. This removes the older one so only the new **Baalda Live** demo plays at the top.

- Keeps `b24c60ee…` (Baalda Live)
- Removes `e258faaa…` (the previous video)