### PR TITLE
Fix stale vault name, sidebar collapse on sync, and move search to a centered modal

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.14"
+version = "0.1.15"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/capabilities/default.json
+++ b/app/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,11 @@
   "permissions": [
     "core:default",
     "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "comment": "Open a vault's folder in the OS file manager. `open_path` enforces a path scope INDEPENDENTLY of this permission — listing the identifier alone leaves that scope empty, which rejects every call as ForbiddenPath. Scoped to the home directory so a webview compromise can't reach /Applications or /usr; vaults kept outside $HOME fall back to reveal_item_in_dir, which is unscoped.",
+      "allow": [{ "path": "$HOME/**" }]
+    },
     "dialog:default",
     "fs:default",
     "updater:default",

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -13,6 +13,7 @@
     "windows": [
       {
         "title": "Baalda",
+        "hiddenTitle": true,
         "width": 1200,
         "height": 800,
         "minWidth": 720,

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -594,9 +594,42 @@ button.primary.hero:hover:not(:disabled) {
    ============================================================ */
 .app {
   display: grid;
-  grid-template-columns: 264px 1fr;
+  /* Width is user-set (see SidebarResizer); the fallback is the default so the
+     layout is correct for one paint before React sets the variable. */
+  grid-template-columns: var(--sidebar-w, 264px) 1fr;
   height: 100%;
   background: var(--bg-app);
+  position: relative;
+}
+
+/* ---- Sidebar resize handle ----
+   Rides on top of the seam rather than taking a grid column of its own, so the
+   two panes stay flush and the hit area can be wider than the seam itself.
+   Purely a cursor affordance: it draws nothing, because a line down the middle
+   of a layout that otherwise floats panes on one canvas is a line too many. */
+.sidebar-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--sidebar-w, 264px) - 3px);
+  width: 7px;
+  z-index: 40;
+  cursor: col-resize;
+  background: transparent;
+  /* The handle is never text; without this a drag that starts on it can still
+     seed a selection in the panes either side. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+.sidebar-resizer:focus-visible {
+  outline: none;
+}
+/* While dragging, the pointer owns the window: the resize cursor holds as it
+   passes over the editor, and nothing anywhere can be selected by the sweep. */
+body:has(.sidebar-resizer.dragging) {
+  cursor: col-resize;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 /* ---- Sidebar rail (sits on the canvas) ---- */
@@ -605,6 +638,9 @@ button.primary.hero:hover:not(:disabled) {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* A grid item's default `min-width: auto` refuses to shrink past its content,
+     which would let a long note title override the width the user dragged. */
+  min-width: 0;
   padding: 0 var(--sp-1) 0 var(--sp-2);
 }
 .sidebar-header {
@@ -635,6 +671,40 @@ button.primary.hero:hover:not(:disabled) {
 .vault-name.none {
   font-weight: 600;
   color: var(--text-tertiary);
+}
+/* "Open in file manager" — a quiet companion to the title, not a second
+   focal point, so it only gains colour on hover of the header. */
+.vault-reveal {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  color: var(--text-tertiary);
+  opacity: 0;
+  transition:
+    color var(--t-fast) var(--ease),
+    opacity var(--t-fast) var(--ease);
+}
+.vault-reveal svg {
+  width: 15px;
+  height: 15px;
+}
+.sidebar-header:hover .vault-reveal,
+.vault-reveal:focus-visible {
+  opacity: 1;
+}
+.vault-reveal:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+/* Where the vault lives on disk, minus the home prefix. A storage detail, so
+   it sits a size below the rest of the line. A plain end-ellipsis is right
+   here even though it eats the tail: the tail is the vault folder, whose name
+   is already the title directly above. The tooltip has it all. */
+.vault-path {
+  font-size: var(--fs-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 /* The local folder backing the vault — a quiet storage detail. */
 .vault-line {
@@ -671,9 +741,25 @@ button.primary.hero:hover:not(:disabled) {
   color: var(--text-tertiary);
 }
 
-/* ---- Search ---- */
-.search-panel {
-  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+/* ---- Search ----
+   A centered overlay (see SearchPanel): the field is the whole chrome, and
+   results grow beneath it only once you've typed, so an empty search is just
+   one box on a dimmed window rather than a large hollow card. */
+.search-backdrop {
+  /* A little above centre: centred vertically, then lifted by reserving space
+     at the bottom. The list grows downward, so starting dead centre would push
+     the field below the middle as results arrive. */
+  align-items: center;
+  padding-bottom: 12vh;
+}
+.search-modal {
+  width: 560px;
+  max-width: min(92vw, 560px);
+  background: var(--bg-surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  padding: var(--sp-2);
+  animation: rise-in var(--t-med) var(--ease) both;
 }
 .search-field {
   position: relative;
@@ -684,41 +770,50 @@ button.primary.hero:hover:not(:disabled) {
   position: absolute;
   left: var(--sp-3);
   color: var(--text-tertiary);
-  font-size: var(--fs-md);
   pointer-events: none;
   display: inline-flex;
 }
+.search-field .search-icon svg {
+  width: 17px;
+  height: 17px;
+}
+/* Inside the modal the input IS the header — no border or fill of its own, so
+   the panel reads as one surface instead of a box within a box. */
 .search-box {
   width: 100%;
-  background: var(--bg-subtle);
-  border: 1px solid transparent;
-  border-radius: var(--radius-pill);
-  padding: var(--sp-2) var(--sp-3) var(--sp-2) var(--sp-8);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: var(--sp-3) var(--sp-8) var(--sp-3) calc(var(--sp-8) + var(--sp-1));
   color: var(--text-primary);
   font: inherit;
-  font-size: var(--fs-md);
+  font-size: var(--fs-lg);
   outline: none;
-  transition:
-    border-color var(--t-fast) var(--ease),
-    box-shadow var(--t-fast) var(--ease),
-    background var(--t-fast) var(--ease);
 }
 .search-box::placeholder {
   color: var(--text-tertiary);
 }
-.search-box:hover {
-  border-color: var(--border-strong);
-}
-.search-box:focus {
-  border-color: var(--accent);
-  box-shadow: var(--focus-ring);
-  background: var(--bg-surface);
+/* The field is auto-focused on open, so a focus ring here would only ever be
+   decoration — the caret already says where you are. */
+.search-esc {
+  position: absolute;
+  right: var(--sp-3);
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  background: var(--bg-subtle);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  pointer-events: none;
 }
 .search-results {
   list-style: none;
-  margin: var(--sp-3) 0 0;
-  padding: 0;
-  max-height: 280px;
+  margin: var(--sp-2) 0 0;
+  padding: var(--sp-2) 0 0;
+  border-top: 1px solid var(--border);
+  max-height: min(52vh, 420px);
   overflow: auto;
   display: flex;
   flex-direction: column;
@@ -728,13 +823,12 @@ button.primary.hero:hover:not(:disabled) {
   padding: var(--sp-2) var(--sp-3);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition:
-    background var(--t-fast) var(--ease),
-    box-shadow var(--t-fast) var(--ease);
+  transition: background var(--t-fast) var(--ease);
 }
-.search-result:hover {
-  background: var(--bg-surface);
-  box-shadow: var(--shadow-sm);
+/* One highlight, driven by the keyboard cursor — hover moves that cursor
+   rather than painting a second, competing one. */
+.search-result.active {
+  background: var(--accent-soft);
 }
 .search-title {
   font-size: var(--fs-md);
@@ -844,7 +938,11 @@ button.primary.hero:hover:not(:disabled) {
 .filetree-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* Left-anchored, NOT space-between: the buttons sit just after the label so
+     widening the sidebar doesn't drag them across the screen. Their position is
+     fixed relative to the sidebar's left edge, which is the edge that never
+     moves. */
+  justify-content: flex-start;
   gap: var(--sp-2);
   /* Left pad lines the label roughly under the row glyphs (the tree is nudged
      left by sp-2); right pad matches the row's own right inset. */
@@ -853,11 +951,17 @@ button.primary.hero:hover:not(:disabled) {
 }
 .filetree-head .section-label {
   white-space: nowrap;
+  /* The label yields first if the row ever runs short, so the buttons stay
+     inside the sidebar instead of the last one being pushed out past its edge. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .filetree-actions {
   display: flex;
   align-items: center;
   gap: 2px;
+  flex-shrink: 0;
 }
 .filetree-actions .tree-tool {
   flex: 0 0 auto;
@@ -2058,11 +2162,48 @@ button.primary.hero:hover:not(:disabled) {
   /* Break free of the narrow sidebar width so vault names, the settings
      row and the server URL read without truncating or feeling crowded. */
   right: auto;
-  width: 312px;
+  width: 348px;
   max-width: calc(100vw - var(--sp-4));
   /* No scroll — the whole menu fits, so let it size to its content. */
   max-height: none;
   overflow: visible;
+}
+
+/* A denser scale for this menu than the shared `menu-*` defaults, which are
+   tuned for the settings pages that also use them. The popover is wider than
+   the sidebar precisely so names get room; oversized rows spent that room on
+   air instead. Scoped so AccountSettings' tab list keeps the larger scale. */
+.account-popover .menu-item {
+  font-size: var(--fs-sm);
+  padding: 5px var(--sp-2);
+}
+.account-popover .menu-swatch {
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+}
+.account-popover .menu-icon {
+  width: 14px;
+  height: 14px;
+}
+.account-popover .menu-label {
+  padding: var(--sp-1) var(--sp-2) 2px;
+}
+.account-popover .menu-account {
+  padding: var(--sp-1) var(--sp-2) var(--sp-2);
+}
+.account-popover .menu-account .avatar {
+  width: 28px;
+  height: 28px;
+  font-size: var(--fs-xs);
+}
+.account-popover .menu-account .identity-line1 {
+  font-size: var(--fs-sm);
+}
+.account-popover .menu-current,
+.account-popover .ws-badge {
+  font-size: 10px;
+  padding: 1px 6px;
 }
 .sidebar-header {
   position: relative;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import { GraphView } from "./components/GraphView";
 import { SyncBadge } from "./components/Identity";
 import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
+import { SidebarResizer } from "./components/SidebarResizer";
 import { VaultPicker } from "./components/VaultPicker";
 import { bridgeManager } from "./lib/bridge";
 import { BRAND_NAME } from "./lib/brand";
@@ -18,6 +19,7 @@ import { syncManager } from "./lib/sync/docSession";
 import { checkForUpdate, installUpdate, useUpdateState } from "./lib/updater";
 import { runConfetti } from "./lib/celebrate/celebrate";
 import { previewKind } from "./lib/preview";
+import { useSidebarWidth } from "./lib/useSidebarWidth";
 import { useStore } from "./store";
 
 function RemovedBanner() {
@@ -239,6 +241,7 @@ export default function App() {
   const [booting, setBooting] = useState(true);
   const [graphOpen, setGraphOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const { width: sidebarWidth, setWidth: setSidebarWidth } = useSidebarWidth();
   // Guards the launch auto-reopen against StrictMode's double-invoke (dev).
   const didAutoReopenRef = useRef(false);
 
@@ -452,15 +455,21 @@ export default function App() {
   }
 
   return (
-    <div className="app">
+    <div
+      className="app"
+      style={{ "--sidebar-w": `${sidebarWidth}px` } as React.CSSProperties}
+    >
+      {/* Centered overlay, not a sidebar panel — it searches the whole vault
+          and its button lives in the main header. */}
+      {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
       <aside className="sidebar">
         <SidebarHeader />
-        {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
         <FileTree />
         <div className="sidebar-footer">
           <AccountMenu />
         </div>
       </aside>
+      <SidebarResizer width={sidebarWidth} onWidth={setSidebarWidth} />
 
       <main className="main">
         <MemberJoinedBanner />

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -110,11 +110,6 @@ export function AccountMenu() {
               setSettingsTab(undefined);
               setMembersOpen(true);
             }}
-            onViewAllLocal={() => {
-              setOpen(false);
-              setSettingsTab("vaults");
-              setMembersOpen(true);
-            }}
           />
         )}
         {authOpen && <AuthDialog onClose={() => setAuthOpen(false)} />}
@@ -179,18 +174,14 @@ export function AccountMenu() {
           <span className={`presence-light ${presence}`} aria-label={presenceLabel} />
         </span>
         <span className="identity-meta">
-          <span className="identity-line1">
-            {/* Name the vault that's actually OPEN — a local one wins over a
-                still-set activeOrg once sync is off (opening a local folder
-                disables sync but leaves the account's active org untouched). */}
-            {(syncEnabled && activeOrg ? activeOrg.name : vault?.name) ?? userLabel}
-          </span>
+          {/* This bar is the profile control — it names its person. The vault's
+              name is the sidebar header's job, so repeating it here would just
+              say the same thing twice down one column. When the account has no
+              display name, line 1 is already the email, so line 2 falls back to
+              presence rather than repeating it. */}
+          <span className="identity-line1">{userLabel}</span>
           <span className="identity-line2">
-            {syncEnabled && activeOrg
-              ? userLabel
-              : vault
-                ? "Local · not synced"
-                : "No vault yet"}
+            {session.user.name ? session.user.email : presenceLabel}
           </span>
         </span>
         {hasInvites && <span className="identity-alert" aria-label="Pending invitation" />}
@@ -205,11 +196,6 @@ export function AccountMenu() {
           onOpenMembers={() => {
             setOpen(false);
             setSettingsTab(undefined);
-            setMembersOpen(true);
-          }}
-          onOpenVaults={() => {
-            setOpen(false);
-            setSettingsTab("vaults");
             setMembersOpen(true);
           }}
           onOpenAccount={() => {
@@ -229,10 +215,33 @@ export function AccountMenu() {
   );
 }
 
-// How many vaults of EACH kind (synced, local) the popover shows inline.
-// Anything past this lives on the Vaults settings page — reached via
-// "View all" — so a long account never turns the menu into a scroll trap.
-const POPOVER_VAULT_LIMIT = 2;
+// How many vault rows the popover spends in total, across both kinds. A fixed
+// budget rather than a per-kind cap is what keeps the menu the same height for
+// everyone: whoever has vaults fills it. The rest live on the Vaults settings
+// page, reached from the Vault settings row at the foot of this menu.
+const POPOVER_VAULT_ROWS = 4;
+
+/**
+ * Divide the row budget between synced and local vaults: an even split when
+ * both kinds can fill their half, otherwise the kind that has vaults takes the
+ * space the other one isn't using. Signed out there are no synced vaults, so
+ * local takes all four.
+ *
+ * Deliberately not proportional — someone with 12 synced and 1 local should
+ * still see that 1 local vault, because it's the one the split is there to
+ * protect. It only loses its slot when it doesn't exist.
+ */
+export function splitVaultRows(
+  syncedCount: number,
+  localCount: number,
+  budget = POPOVER_VAULT_ROWS,
+): { synced: number; local: number } {
+  const half = Math.floor(budget / 2);
+  // Each kind is guaranteed its half; local then claims whatever synced left
+  // unused, and synced claims what's still free after that.
+  const local = Math.min(localCount, budget - Math.min(syncedCount, half));
+  return { synced: Math.min(syncedCount, budget - local), local };
+}
 
 /**
  * Recent on-disk folders that aren't bound to a synced vault — i.e. the
@@ -335,21 +344,24 @@ function NewVaultItem({ onDone }: { onDone: () => void }) {
 
 /**
  * The "On this device" rows: local vaults you can switch to with one click.
- * `limit` caps how many show inline; when there are more, an `onViewAll` link
- * hands off to the full Vaults page (which lists local + synced together).
- * The current local vault is always pinned to the top so it never hides
- * behind the cap.
+ * `limit` caps how many show inline; the rest are reached through the Vault
+ * settings row just below, which lists local and synced together — so there's
+ * no "All local vaults (N)" link here spending a row to say what the item
+ * under it already does. The current local vault is always pinned to the top
+ * so it never hides behind the cap.
  */
 function LocalVaultRows({
   onClose,
+  locals,
   limit,
-  onViewAll,
 }: {
   onClose: () => void;
+  /** Passed in rather than fetched here: the caller needs the count anyway to
+   *  divide the row budget, and two `useLocalVaults()` calls would mean two
+   *  IPC round-trips for one list. */
+  locals: RecentVault[];
   limit?: number;
-  onViewAll?: () => void;
 }) {
-  const locals = useLocalVaults();
   const vault = useStore((s) => s.vault);
   const syncEnabled = useStore((s) => s.syncEnabled);
   if (locals.length === 0) return null;
@@ -388,14 +400,6 @@ function LocalVaultRows({
           </button>
         );
       })}
-      {limit && onViewAll && locals.length > limit && (
-        <button className="menu-item subtle" onClick={onViewAll}>
-          <span className="menu-swatch more" aria-hidden="true">
-            …
-          </span>
-          <span className="menu-item-label">All local vaults ({locals.length})</span>
-        </button>
-      )}
     </>
   );
 }
@@ -409,22 +413,19 @@ function SignedOutPopover({
   onClose,
   onSignIn,
   onOpenSettings,
-  onViewAllLocal,
 }: {
   onClose: () => void;
   onSignIn: () => void;
   onOpenSettings: () => void;
-  onViewAllLocal: () => void;
 }) {
   const vault = useStore((s) => s.vault);
+  const locals = useLocalVaults();
+  // Signed out there are no synced vaults, so local vaults get the whole budget.
+  const rows = splitVaultRows(0, locals.length);
   return (
     <div className="account-popover" role="menu">
       <div className="menu-label">Vault</div>
-      <LocalVaultRows
-        onClose={onClose}
-        limit={POPOVER_VAULT_LIMIT}
-        onViewAll={onViewAllLocal}
-      />
+      <LocalVaultRows onClose={onClose} locals={locals} limit={rows.local} />
 
       <NewVaultItem onDone={onClose} />
 
@@ -455,12 +456,10 @@ function SignedOutPopover({
 function AccountPopover({
   onClose,
   onOpenMembers,
-  onOpenVaults,
   onOpenAccount,
 }: {
   onClose: () => void;
   onOpenMembers: () => void;
-  onOpenVaults: () => void;
   onOpenAccount: () => void;
 }) {
   const session = useStore((s) => s.session);
@@ -469,6 +468,7 @@ function AccountPopover({
   const pendingInvitations = useStore((s) => s.pendingInvitations);
   const userInvitations = useStore((s) => s.userInvitations);
   const vault = useStore((s) => s.vault);
+  const locals = useLocalVaults();
 
   const [joining, setJoining] = useState(false);
   const [joinCode, setJoinCode] = useState("");
@@ -476,6 +476,7 @@ function AccountPopover({
   const [busy, setBusy] = useState(false);
 
   if (!session) return null;
+  const rows = splitVaultRows(organizations.length, locals.length);
   const activeOrgId = session.activeOrganizationId;
   const userLabel = session.user.name || session.user.email;
   // "Current" tracks the vault whose folder is actually OPEN right now —
@@ -538,7 +539,7 @@ function AccountPopover({
         ...organizations.filter((o) => o.id === activeOrgId),
         ...organizations.filter((o) => o.id !== activeOrgId),
       ]
-        .slice(0, POPOVER_VAULT_LIMIT)
+        .slice(0, rows.synced)
         .map((o) => {
         const isActive = openPath != null && boundVaults[o.id] === openPath;
         return (
@@ -580,22 +581,7 @@ function AccountPopover({
         );
       })}
 
-      {organizations.length > POPOVER_VAULT_LIMIT && (
-        <button className="menu-item subtle" onClick={onOpenVaults}>
-          <span className="menu-swatch more" aria-hidden="true">
-            …
-          </span>
-          <span className="menu-item-label">
-            All synced vaults ({organizations.length})
-          </span>
-        </button>
-      )}
-
-      <LocalVaultRows
-        onClose={onClose}
-        limit={POPOVER_VAULT_LIMIT}
-        onViewAll={onOpenVaults}
-      />
+      <LocalVaultRows onClose={onClose} locals={locals} limit={rows.local} />
 
       <NewVaultItem onDone={onClose} />
 

--- a/app/apps/desktop/src/components/SearchPanel.tsx
+++ b/app/apps/desktop/src/components/SearchPanel.tsx
@@ -3,13 +3,26 @@ import type { SearchResult } from "../lib/ipc";
 import * as ipc from "../lib/ipc";
 import { useStore } from "../store";
 
+/**
+ * Search, as a centered overlay rather than a sidebar panel.
+ *
+ * It used to render inside the sidebar while its button lived in the main
+ * header on the opposite side of the window — click right, watch something
+ * appear far left. Searching is also a whole-window act: you're looking through
+ * the vault, not at the tree. So it takes the middle, like every other
+ * search-everything box people already know.
+ */
 export function SearchPanel({ onClose }: { onClose?: () => void }) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
+  // Which result the arrow keys are on. Reset whenever the result set changes,
+  // so Enter can never open whatever happened to be highlighted for an older query.
+  const [active, setActive] = useState(0);
   const timer = useRef<number | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
 
-  // Focus the box as soon as the panel opens so ⌘F is type-and-go.
+  // Focus the box as soon as it opens so ⌘F is type-and-go.
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -18,11 +31,13 @@ export function SearchPanel({ onClose }: { onClose?: () => void }) {
     if (timer.current) window.clearTimeout(timer.current);
     if (!query.trim()) {
       setResults([]);
+      setActive(0);
       return;
     }
     timer.current = window.setTimeout(async () => {
       try {
         setResults(await ipc.searchNotes(query));
+        setActive(0);
       } catch (e) {
         console.error("search failed", e);
       }
@@ -32,48 +47,94 @@ export function SearchPanel({ onClose }: { onClose?: () => void }) {
     };
   }, [query]);
 
+  // Keep the keyboard selection in view when it walks past the visible rows.
+  useEffect(() => {
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-idx="${active}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [active]);
+
   const open = (path: string) => {
     void useStore.getState().openNoteByPath(path);
     onClose?.();
   };
 
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onClose?.();
+    } else if (e.key === "ArrowDown" && results.length) {
+      setActive((i) => (i + 1) % results.length);
+    } else if (e.key === "ArrowUp" && results.length) {
+      setActive((i) => (i - 1 + results.length) % results.length);
+    } else if (e.key === "Enter" && results[active]) {
+      open(results[active].path);
+    } else {
+      return;
+    }
+    e.preventDefault();
+  };
+
+  const searching = query.trim().length > 0;
+
   return (
-    <div className="search-panel">
-      <div className="search-field">
-        <span className="search-icon" aria-hidden="true">⌕</span>
-        <input
-          ref={inputRef}
-          className="search-box"
-          placeholder="Search notes…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") onClose?.();
-          }}
-        />
-      </div>
-      {query.trim() && (
-        <ul className="search-results">
-          {results.length === 0 && <li className="search-none">No matches</li>}
-          {results.map((r) => (
-            <li
-              key={r.id}
-              className="search-result"
-              onClick={() => open(r.path)}
+    <div className="modal-backdrop search-backdrop" onClick={() => onClose?.()}>
+      <div
+        className="search-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search notes"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="search-field">
+          <span className="search-icon" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
             >
-              <div className="search-title">{r.title || r.path}</div>
-              <div
-                className="search-snippet"
-                // The snippet is HTML-escaped in Rust (see index.rs::html_escape)
-                // so the ONLY markup it can contain is our own <mark> highlight
-                // tags — note bodies can't inject anything. A CSP (tauri.conf.json)
-                // backstops this by blocking inline script even if that changed.
-                dangerouslySetInnerHTML={{ __html: r.snippet }}
-              />
-            </li>
-          ))}
-        </ul>
-      )}
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-3.5-3.5" />
+            </svg>
+          </span>
+          <input
+            ref={inputRef}
+            className="search-box"
+            placeholder="Search notes…"
+            value={query}
+            spellCheck={false}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+          />
+          <kbd className="search-esc">esc</kbd>
+        </div>
+
+        {searching && (
+          <ul className="search-results" ref={listRef}>
+            {results.length === 0 && <li className="search-none">No matches</li>}
+            {results.map((r, i) => (
+              <li
+                key={r.id}
+                data-idx={i}
+                className={`search-result${i === active ? " active" : ""}`}
+                onMouseEnter={() => setActive(i)}
+                onClick={() => open(r.path)}
+              >
+                <div className="search-title">{r.title || r.path}</div>
+                <div
+                  className="search-snippet"
+                  // The snippet is HTML-escaped in Rust (see index.rs::html_escape)
+                  // so the ONLY markup it can contain is our own <mark> highlight
+                  // tags — note bodies can't inject anything. A CSP (tauri.conf.json)
+                  // backstops this by blocking inline script even if that changed.
+                  dangerouslySetInnerHTML={{ __html: r.snippet }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/apps/desktop/src/components/SidebarHeader.tsx
+++ b/app/apps/desktop/src/components/SidebarHeader.tsx
@@ -1,47 +1,78 @@
+import * as ipc from "../lib/ipc";
 import { useStore } from "../store";
 
 /**
- * Sidebar header: the name of the vault you're in. That's all.
+ * Sidebar header: the name of the vault you're in, where it lives on disk,
+ * and a way to open that folder. A label, not a control — the vault switcher
+ * lives in the account menu at the foot of this same sidebar, and sync state
+ * is already reported by the indicator in the main header.
  *
- * It used to carry a "Switch" dropdown, which duplicated the vault switcher
- * already in the account menu at the foot of this same sidebar — two controls
- * for one job, at opposite ends of one column. The account menu's version is
- * the better one (it also joins by code, badges remote vaults, and links to
- * Vault settings for the full list), so this one went rather than being kept in
- * sync forever. Its one unique action, "Change local folder…", moved there too.
- *
- * The header is now a label, not a control: no popover, no outside-click
- * handling, no state. The full path is the tooltip.
+ * The name always names the vault whose folder is actually OPEN — a local
+ * vault wins over a still-set activeOrg once sync is off, because opening a
+ * local folder disables sync but leaves the account's active org untouched.
+ * Reading `activeOrganizationId` alone is what used to freeze a stale org
+ * name up here after switching to a local vault.
  */
 export function SidebarHeader() {
   const vault = useStore((s) => s.vault);
   const session = useStore((s) => s.session);
   const organizations = useStore((s) => s.organizations);
+  const syncEnabled = useStore((s) => s.syncEnabled);
 
   if (!vault) return null;
 
-  const activeOrgId = session?.activeOrganizationId ?? null;
-  const activeOrg = organizations.find((o) => o.id === activeOrgId) ?? null;
+  const activeOrg =
+    organizations.find((o) => o.id === session?.activeOrganizationId) ?? null;
+  const name = syncEnabled && activeOrg ? activeOrg.name : vault.name;
 
   return (
     <div className="sidebar-header">
       <div className="sidebar-header-main">
-        {/* One name, one place. The local folder used to get its own line here,
-            but a vault's folder is created as `slugify(vault name)`, so that
-            line said the same thing twice on every vault anyone actually has —
-            "BenAI OS" over "benai-os". */}
-        <span className="vault-name" title={vault.path}>
-          {activeOrg ? activeOrg.name : vault.name}
+        <span className="vault-name" title={name}>
+          {name}
         </span>
+        <button
+          className="icon-btn vault-reveal"
+          title={`Open ${vault.path} in your file manager`}
+          aria-label="Open vault folder"
+          onClick={() =>
+            void ipc.openInFileManager(vault.path).catch((e) => {
+              console.error("open vault folder failed", e);
+            })
+          }
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M4 20a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v2" />
+            <path d="M2 18l2.5-6h17L19 18a2 2 0 0 1-1.9 1.4H4" />
+          </svg>
+        </button>
       </div>
-      {/* A local folder is still a vault — it just isn't syncing yet, and that
-          IS worth a second line because nothing else on screen says so. */}
-      {!activeOrg && (
-        <div className="vault-line">
-          <span className="ws-badge local">Local</span>
-          <span className="vault-line-name">Not synced</span>
-        </div>
-      )}
+      <div className="vault-line" title={vault.path}>
+        <span className="vault-path">{displayPath(vault.path)}</span>
+      </div>
     </div>
   );
+}
+
+/**
+ * Shorten an absolute vault path for display by dropping the home directory —
+ * `/Documents/Baalda Vaults/notes` rather than the full `/Users/…` prefix,
+ * which is the same on every line and tells you nothing. The full path stays
+ * in the tooltip.
+ *
+ * The home prefix is inferred from the path itself rather than asked of the
+ * OS — this is a synchronous label, and `/Users/<me>/…` (macOS), `/home/<me>/…`
+ * (Linux) and `C:\Users\<me>\…` (Windows) are all recognizable on sight.
+ */
+function displayPath(path: string): string {
+  const home = /^(\/Users\/[^/]+|\/home\/[^/]+|[A-Za-z]:[\\/]Users[\\/][^\\/]+)/.exec(path);
+  return home ? path.slice(home[0].length) : path;
 }

--- a/app/apps/desktop/src/components/SidebarResizer.tsx
+++ b/app/apps/desktop/src/components/SidebarResizer.tsx
@@ -1,0 +1,81 @@
+import { useRef, useState } from "react";
+import {
+  clampSidebarWidth,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+  writeSidebarWidth,
+} from "../lib/prefs";
+
+/**
+ * Drag handle on the sidebar's right edge. Note titles are as long as people
+ * write them, so a fixed rail either truncates them or wastes space on someone
+ * whose notes are all called `2026-W30`; this lets the reader decide.
+ *
+ * Widen-only: the floor is the default width (see `SIDEBAR_WIDTH_MIN`). The
+ * width itself comes from `useSidebarWidth`.
+ */
+export function SidebarResizer({
+  width,
+  onWidth,
+}: {
+  width: number;
+  onWidth: (px: number) => void;
+}) {
+  const [dragging, setDragging] = useState(false);
+  // The pointer grabs the divider somewhere along its 7px width; tracking that
+  // offset stops the sidebar from jumping by a few pixels on the first move.
+  const grabOffset = useRef(0);
+
+  const commit = (px: number) => {
+    onWidth(px);
+    writeSidebarWidth(clampSidebarWidth(px, window.innerWidth));
+  };
+
+  return (
+    <div
+      className={`sidebar-resizer${dragging ? " dragging" : ""}`}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuenow={width}
+      aria-valuemin={SIDEBAR_WIDTH_MIN}
+      aria-valuemax={SIDEBAR_WIDTH_MAX}
+      tabIndex={0}
+      title="Drag to resize · double-click to reset"
+      onPointerDown={(e) => {
+        // Without this the press seeds a native text selection, and sweeping
+        // left highlights the whole sidebar as you drag. `user-select: none`
+        // alone can't help — by the time the class lands the selection has
+        // already begun.
+        e.preventDefault();
+        window.getSelection()?.removeAllRanges();
+        // Capture on the handle so the drag survives the pointer outrunning it —
+        // easy to do when you hit the min/max and keep moving.
+        e.currentTarget.setPointerCapture(e.pointerId);
+        grabOffset.current = e.clientX - width;
+        setDragging(true);
+      }}
+      onPointerMove={(e) => {
+        if (!dragging) return;
+        onWidth(e.clientX - grabOffset.current);
+      }}
+      onPointerUp={(e) => {
+        if (!dragging) return;
+        e.currentTarget.releasePointerCapture(e.pointerId);
+        setDragging(false);
+        commit(e.clientX - grabOffset.current);
+      }}
+      onDoubleClick={() => commit(SIDEBAR_WIDTH_DEFAULT)}
+      onKeyDown={(e) => {
+        // Keyboard users get the same control; Home restores the default.
+        const step = e.shiftKey ? 32 : 8;
+        if (e.key === "ArrowLeft") commit(width - step);
+        else if (e.key === "ArrowRight") commit(width + step);
+        else if (e.key === "Home") commit(SIDEBAR_WIDTH_DEFAULT);
+        else return;
+        e.preventDefault();
+      }}
+    />
+  );
+}

--- a/app/apps/desktop/src/components/vaultRows.test.ts
+++ b/app/apps/desktop/src/components/vaultRows.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { splitVaultRows } from "./AccountMenu";
+
+// The switcher spends a fixed number of rows on vaults so the menu is the same
+// height for everyone. How those rows are divided is the fiddly part: an even
+// split when both kinds can fill their half, and no wasted rows when one kind
+// is empty or nearly so.
+
+const total = (r: { synced: number; local: number }) => r.synced + r.local;
+
+describe("splitVaultRows", () => {
+  it("splits evenly when both kinds can fill their half", () => {
+    expect(splitVaultRows(5, 5)).toEqual({ synced: 2, local: 2 });
+    expect(splitVaultRows(2, 2)).toEqual({ synced: 2, local: 2 });
+  });
+
+  it("gives the whole budget to synced when there are no local vaults", () => {
+    expect(splitVaultRows(9, 0)).toEqual({ synced: 4, local: 0 });
+  });
+
+  it("gives the whole budget to local when signed out (no synced vaults)", () => {
+    expect(splitVaultRows(0, 9)).toEqual({ synced: 0, local: 4 });
+  });
+
+  it("lets each kind claim rows the other cannot use", () => {
+    // One local vault doesn't need its half, so synced takes the slack — and
+    // vice versa. The lone vault of the smaller kind still gets shown.
+    expect(splitVaultRows(9, 1)).toEqual({ synced: 3, local: 1 });
+    expect(splitVaultRows(1, 9)).toEqual({ synced: 1, local: 3 });
+  });
+
+  it("never shows more rows than there are vaults", () => {
+    expect(splitVaultRows(1, 1)).toEqual({ synced: 1, local: 1 });
+    expect(splitVaultRows(0, 0)).toEqual({ synced: 0, local: 0 });
+    expect(splitVaultRows(3, 1)).toEqual({ synced: 3, local: 1 });
+  });
+
+  it("never exceeds the budget, for any mix", () => {
+    for (let synced = 0; synced <= 8; synced++) {
+      for (let local = 0; local <= 8; local++) {
+        const rows = splitVaultRows(synced, local);
+        expect(total(rows)).toBeLessThanOrEqual(4);
+        expect(rows.synced).toBeLessThanOrEqual(synced);
+        expect(rows.local).toBeLessThanOrEqual(local);
+      }
+    }
+  });
+
+  it("fills the budget whenever enough vaults exist to fill it", () => {
+    for (let synced = 0; synced <= 8; synced++) {
+      for (let local = 0; local <= 8; local++) {
+        const rows = splitVaultRows(synced, local);
+        // No row is left on the table while a vault is waiting for one.
+        expect(total(rows)).toBe(Math.min(4, synced + local));
+      }
+    }
+  });
+
+  it("honours a custom budget", () => {
+    expect(splitVaultRows(5, 5, 6)).toEqual({ synced: 3, local: 3 });
+    expect(splitVaultRows(5, 0, 2)).toEqual({ synced: 2, local: 0 });
+  });
+});

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -5,10 +5,27 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { openUrl } from "@tauri-apps/plugin-opener";
+import { openPath, openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 
 /** Open an external URL (markdown links) in the user's default browser. */
 export const openExternal = (url: string) => openUrl(url);
+
+/**
+ * Show a vault folder in the OS file manager (Finder / Explorer / xdg).
+ *
+ * `openPath` opens the folder itself — what "open in folder" means to a user —
+ * but it's scoped to `$HOME/**` in `capabilities/default.json`, so a vault on
+ * an external volume is rejected. `revealItemInDir` carries no scope, so it
+ * covers those: the folder is selected in its parent rather than opened, which
+ * beats a button that does nothing.
+ */
+export const openInFileManager = async (path: string): Promise<void> => {
+  try {
+    await openPath(path);
+  } catch {
+    await revealItemInDir(path);
+  }
+};
 
 // ---- Types (mirror the Rust structs, serialized camelCase) ---------------
 

--- a/app/apps/desktop/src/lib/prefs.ts
+++ b/app/apps/desktop/src/lib/prefs.ts
@@ -57,3 +57,45 @@ export function writeMentionSound(enabled: boolean): void {
     /* localStorage unavailable — preference stays in-memory only */
   }
 }
+
+// ---- Sidebar width ----------------------------------------------------------
+
+const SIDEBAR_WIDTH_KEY = "context.sidebarWidth";
+
+/** The width the sidebar starts at, and what a double-click on the divider
+ *  restores. */
+export const SIDEBAR_WIDTH_DEFAULT = 264;
+/** The default is also the floor: the resizer only ever widens the sidebar.
+ *  Narrower than this and the tree header's toolbar runs out of room and pushes
+ *  its last button out past the edge — so there is nothing to be gained below
+ *  the width the layout was designed at. */
+export const SIDEBAR_WIDTH_MIN = SIDEBAR_WIDTH_DEFAULT;
+export const SIDEBAR_WIDTH_MAX = 560;
+
+/** Clamp a width to the usable range, also refusing to eat the whole window on
+ *  a small screen. NaN (a corrupted stored value) falls back to the default. */
+export function clampSidebarWidth(px: number, viewport = 1200): number {
+  if (!Number.isFinite(px)) return SIDEBAR_WIDTH_DEFAULT;
+  // Always leave room for the editor, even when the window is narrower than the
+  // nominal maximum.
+  const max = Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, viewport - 320));
+  return Math.round(Math.min(max, Math.max(SIDEBAR_WIDTH_MIN, px)));
+}
+
+export function readSidebarWidth(): number {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    if (raw === null) return SIDEBAR_WIDTH_DEFAULT;
+    return clampSidebarWidth(Number(raw), window.innerWidth);
+  } catch {
+    return SIDEBAR_WIDTH_DEFAULT;
+  }
+}
+
+export function writeSidebarWidth(px: number): void {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(px)));
+  } catch {
+    /* localStorage unavailable — the width stays in-memory only */
+  }
+}

--- a/app/apps/desktop/src/lib/sidebarWidth.test.ts
+++ b/app/apps/desktop/src/lib/sidebarWidth.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampSidebarWidth,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+} from "./prefs";
+
+// The sidebar width is dragged by the user and restored from localStorage, so
+// it arrives from two places that can both hand over nonsense: a pointer that
+// left the window, and a stored string from an older build or a smaller screen.
+// Whatever comes in, the editor has to survive it.
+
+describe("clampSidebarWidth", () => {
+  it("keeps a sensible width untouched", () => {
+    expect(clampSidebarWidth(300, 1400)).toBe(300);
+  });
+
+  it("holds the floor when dragged shut", () => {
+    expect(clampSidebarWidth(0, 1400)).toBe(SIDEBAR_WIDTH_MIN);
+    expect(clampSidebarWidth(-500, 1400)).toBe(SIDEBAR_WIDTH_MIN);
+  });
+
+  it("never narrows past the default — the resizer only widens", () => {
+    // Below the design width the tree header's toolbar overflows its last
+    // button past the sidebar edge, so there is nothing to gain down there.
+    expect(SIDEBAR_WIDTH_MIN).toBe(SIDEBAR_WIDTH_DEFAULT);
+    expect(clampSidebarWidth(SIDEBAR_WIDTH_DEFAULT - 60, 1400)).toBe(
+      SIDEBAR_WIDTH_DEFAULT,
+    );
+  });
+
+  it("holds the ceiling when dragged past it", () => {
+    expect(clampSidebarWidth(9000, 2400)).toBe(SIDEBAR_WIDTH_MAX);
+  });
+
+  it("always leaves room for the editor on a narrow window", () => {
+    // The nominal max is irrelevant if the window can't afford it — dragging
+    // the divider to the right edge must not leave a zero-width editor.
+    expect(clampSidebarWidth(9000, 700)).toBe(380);
+    expect(clampSidebarWidth(9000, 700)).toBeLessThan(700);
+  });
+
+  it("still yields a usable sidebar on a window narrower than the minimum", () => {
+    // Below this the floor wins: the window is too small to honour both the
+    // editor's reserve and the sidebar's floor, and the sidebar keeps its.
+    expect(clampSidebarWidth(9000, 400)).toBe(SIDEBAR_WIDTH_MIN);
+  });
+
+  it("falls back to the default for a corrupted stored value", () => {
+    expect(clampSidebarWidth(Number.NaN, 1400)).toBe(SIDEBAR_WIDTH_DEFAULT);
+    expect(clampSidebarWidth(Number("banana"), 1400)).toBe(SIDEBAR_WIDTH_DEFAULT);
+  });
+
+  it("rounds to whole pixels", () => {
+    expect(clampSidebarWidth(300.6, 1400)).toBe(301);
+  });
+
+  it("is idempotent — re-clamping a clamped value changes nothing", () => {
+    for (const w of [-100, 0, 190, 264, 500, 9000]) {
+      const once = clampSidebarWidth(w, 1400);
+      expect(clampSidebarWidth(once, 1400)).toBe(once);
+    }
+  });
+});

--- a/app/apps/desktop/src/lib/tree/lazyTree.test.ts
+++ b/app/apps/desktop/src/lib/tree/lazyTree.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type { TreeNode } from "../ipc";
+import { loadedFolderPaths, setChildrenAt } from "./lazyTree";
+
+// The sidebar folds itself up if a refresh forgets which folders were expanded.
+// `refreshTree` runs on every `file-changed` burst and every sync registry pull
+// — i.e. constantly while you type — so a refresh that rebuilt from the top
+// level alone dropped every expanded folder back to an unloaded placeholder:
+// open a folder, click through its notes, watch it empty out under you. These
+// tests pin the two halves that stop that: finding what was loaded, and putting
+// it back in an order where parents exist before their children are filled.
+
+const dir = (path: string, children?: TreeNode[], loaded?: boolean): TreeNode => ({
+  id: path,
+  name: path.split("/").pop() ?? path,
+  path,
+  isDir: true,
+  ...(children ? { children } : {}),
+  ...(loaded === undefined ? {} : { childrenLoaded: loaded }),
+});
+
+const file = (path: string): TreeNode => ({
+  id: path,
+  name: path.split("/").pop() ?? path,
+  path,
+  isDir: false,
+});
+
+/** The shape `refreshTree` starts from: root listed, subfolders placeholders. */
+const rootWith = (children: TreeNode[]): TreeNode => ({
+  id: "",
+  name: "vault",
+  path: "",
+  isDir: true,
+  children,
+  childrenLoaded: true,
+});
+
+describe("loadedFolderPaths", () => {
+  it("finds expanded folders and ignores placeholders", () => {
+    const tree = rootWith([
+      dir("Expanded", [file("Expanded/a.md")], true),
+      dir("Untouched", [], false),
+      file("top.md"),
+    ]);
+    expect(loadedFolderPaths(tree)).toEqual(["Expanded"]);
+  });
+
+  it("omits the root, which is always listed and never re-fetched", () => {
+    expect(loadedFolderPaths(rootWith([]))).toEqual([]);
+  });
+
+  it("treats an absent childrenLoaded flag as not loaded", () => {
+    // `children: []` alone is ambiguous — an empty folder and an unexpanded one
+    // look identical — so only the explicit flag counts as listed.
+    expect(loadedFolderPaths(rootWith([dir("Maybe", [])]))).toEqual([]);
+  });
+
+  it("keeps a genuinely empty folder, which IS loaded", () => {
+    expect(loadedFolderPaths(rootWith([dir("Empty", [], true)]))).toEqual(["Empty"]);
+  });
+
+  it("orders parents before their children", () => {
+    const tree = rootWith([
+      dir("A", [dir("A/B", [dir("A/B/C", [file("A/B/C/deep.md")], true)], true)], true),
+    ]);
+    expect(loadedFolderPaths(tree)).toEqual(["A", "A/B", "A/B/C"]);
+  });
+
+  it("survives a null tree (nothing open yet)", () => {
+    expect(loadedFolderPaths(null)).toEqual([]);
+  });
+});
+
+describe("setChildrenAt", () => {
+  it("fills a folder and marks it loaded", () => {
+    const next = setChildrenAt(rootWith([dir("Notes", [], false)]), "Notes", [
+      file("Notes/a.md"),
+    ]);
+    const notes = next.children?.[0];
+    expect(notes?.childrenLoaded).toBe(true);
+    expect(notes?.children?.map((c) => c.path)).toEqual(["Notes/a.md"]);
+  });
+
+  it("leaves siblings untouched", () => {
+    // By value, not by reference: the walk rebuilds every node it passes
+    // through. What matters is that B's loaded children survive A being filled.
+    const before = rootWith([dir("A", [], false), dir("B", [file("B/keep.md")], true)]);
+    const next = setChildrenAt(before, "A", [file("A/new.md")]);
+    expect(next.children?.[1]).toEqual(before.children?.[1]);
+  });
+
+  it("no-ops for a path that is gone (deleted or renamed folder)", () => {
+    const before = rootWith([dir("A", [], false)]);
+    expect(setChildrenAt(before, "Vanished", [file("Vanished/x.md")])).toEqual(before);
+  });
+});
+
+describe("restoring an expanded tree the way refreshTree does", () => {
+  // The regression itself: take a tree with nested folders open, rebuild from a
+  // fresh top-level listing, and replay the loaded paths in the order
+  // loadedFolderPaths hands back. Everything the user had open must come back.
+  it("re-expands nested folders after a top-level-only rebuild", () => {
+    const expanded = rootWith([
+      dir("A", [dir("A/B", [file("A/B/note.md")], true), file("A/x.md")], true),
+    ]);
+    const loaded = loadedFolderPaths(expanded);
+
+    // What Rust returns after the refresh: subfolders are placeholders again.
+    let rebuilt = rootWith([dir("A", [], false)]);
+    const listing: Record<string, TreeNode[]> = {
+      A: [dir("A/B", [], false), file("A/x.md")],
+      "A/B": [file("A/B/note.md")],
+    };
+    for (const path of loaded) rebuilt = setChildrenAt(rebuilt, path, listing[path]);
+
+    expect(loadedFolderPaths(rebuilt)).toEqual(["A", "A/B"]);
+    const b = rebuilt.children?.[0].children?.[0];
+    expect(b?.path).toBe("A/B");
+    expect(b?.children?.map((c) => c.path)).toEqual(["A/B/note.md"]);
+  });
+
+  it("shows changes made on disk while a folder was open", () => {
+    // Re-listing rather than carrying the old children over is the whole point:
+    // the folder you are looking at is the one most likely to have just changed.
+    const expanded = rootWith([dir("A", [file("A/old.md")], true)]);
+    let rebuilt = rootWith([dir("A", [], false)]);
+    for (const path of loadedFolderPaths(expanded)) {
+      rebuilt = setChildrenAt(rebuilt, path, [file("A/old.md"), file("A/added.md")]);
+    }
+    expect(rebuilt.children?.[0].children?.map((c) => c.path)).toEqual([
+      "A/old.md",
+      "A/added.md",
+    ]);
+  });
+
+  it("drops a folder that disappeared while it was open", () => {
+    const expanded = rootWith([dir("Gone", [file("Gone/n.md")], true)]);
+    // refreshTree skips paths whose listing failed, so nothing is replayed.
+    const rebuilt = rootWith([]);
+    expect(loadedFolderPaths(expanded)).toEqual(["Gone"]);
+    expect(rebuilt.children).toEqual([]);
+  });
+});

--- a/app/apps/desktop/src/lib/tree/lazyTree.ts
+++ b/app/apps/desktop/src/lib/tree/lazyTree.ts
@@ -1,0 +1,42 @@
+// Pure helpers for the sidebar's lazily-loaded tree. Kept out of the store (and
+// free of any Tauri import — the TreeNode import is type-only, so it erases) so
+// the invariants below can be tested in a plain Node environment.
+
+import type { TreeNode } from "../ipc";
+
+/**
+ * Every folder whose children have actually been listed, excluding the root,
+ * ordered shallowest first.
+ *
+ * `refreshTree` re-lists these so a refresh doesn't silently un-load whatever
+ * the user had expanded. The ordering is load-bearing: `setChildrenAt` only
+ * descends through nodes that already carry children, so a nested folder can't
+ * be filled in before its parent is.
+ */
+export function loadedFolderPaths(node: TreeNode | null): string[] {
+  const out: string[] = [];
+  const walk = (n: TreeNode) => {
+    if (!n.isDir) return;
+    if (n.path !== "" && n.childrenLoaded === true) out.push(n.path);
+    n.children?.forEach(walk);
+  };
+  if (node) walk(node);
+  return out.sort((a, b) => a.split("/").length - b.split("/").length);
+}
+
+/** Immutably replace one node's `children` (by path) in a lazy-loaded tree. */
+export function setChildrenAt(
+  node: TreeNode,
+  path: string,
+  children: TreeNode[],
+): TreeNode {
+  // Filling in a folder's children is also what makes it *loaded* — that flag is
+  // the only thing separating "this folder has no notes" from "nobody has opened
+  // it yet", and the sidebar labels the first case "empty".
+  if (node.path === path) return { ...node, children, childrenLoaded: true };
+  if (!node.children) return node;
+  return {
+    ...node,
+    children: node.children.map((c) => setChildrenAt(c, path, children)),
+  };
+}

--- a/app/apps/desktop/src/lib/useSidebarWidth.ts
+++ b/app/apps/desktop/src/lib/useSidebarWidth.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from "react";
+import { clampSidebarWidth, readSidebarWidth } from "./prefs";
+
+/**
+ * The user's sidebar width, restored from localStorage and kept honest against
+ * the window size.
+ *
+ * Lives apart from `SidebarResizer` because Fast Refresh gives up on a module
+ * that exports both a component and a plain function — mixing them there cost a
+ * full page reload on every edit to either.
+ *
+ * The width is handed to the layout as a CSS variable rather than kept in the
+ * store: nothing outside the grid needs it, and routing a drag through global
+ * state would re-render the whole tree on every pointer move.
+ */
+export function useSidebarWidth(): {
+  width: number;
+  setWidth: (px: number) => void;
+} {
+  const [width, setWidthState] = useState(readSidebarWidth);
+
+  const setWidth = useCallback((px: number) => {
+    setWidthState(clampSidebarWidth(px, window.innerWidth));
+  }, []);
+
+  // A window narrow enough to squeeze the editor pulls the sidebar back in with
+  // it. The stored preference is deliberately left alone, so the width the user
+  // chose returns when the window has room for it again.
+  useEffect(() => {
+    const onResize = () => setWidthState((w) => clampSidebarWidth(w, window.innerWidth));
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  return { width, setWidth };
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -8,6 +8,7 @@ import * as ipc from "./lib/ipc";
 import { bridgeManager } from "./lib/bridge";
 import { readItemColors, writeItemColors } from "./lib/appearance";
 import { readItemOrder, writeItemOrder, type ItemOrder } from "./lib/ordering";
+import { loadedFolderPaths, setChildrenAt } from "./lib/tree/lazyTree";
 import {
   ApiError,
   type BillingConfig,
@@ -285,23 +286,6 @@ export function readOrgVaults(): Record<string, string> {
  * A folder name for a vault that won't collide with a folder already bound
  * to another vault under the managed root. Deterministic-ish for the MVP.
  */
-/** Immutably replace one node's `children` (by path) in a lazy-loaded tree. */
-function setChildrenAt(
-  node: ipc.TreeNode,
-  path: string,
-  children: ipc.TreeNode[],
-): ipc.TreeNode {
-  // Filling in a folder's children is also what makes it *loaded* — that flag is
-  // the only thing separating "this folder has no notes" from "nobody has opened
-  // it yet", and the sidebar labels the first case "empty".
-  if (node.path === path) return { ...node, children, childrenLoaded: true };
-  if (!node.children) return node;
-  return {
-    ...node,
-    children: node.children.map((c) => setChildrenAt(c, path, children)),
-  };
-}
-
 function uniqueFolderSlug(name: string, bound: Record<string, string>): string {
   const base = slugify(name);
   const taken = new Set(
@@ -616,9 +600,17 @@ export const useStore = create<AppStore>((set, get) => ({
     // Folders load their children on first expand (see `loadChildren`), so
     // switching a large vault no longer ships/parses the entire node set.
     const vault = get().vault;
+    const epoch = vault?.epoch;
+    // Which folders were already expanded/listed. This refresh runs on every
+    // `file-changed` burst and every sync registry pull — i.e. constantly while
+    // you work — and rebuilding from the top level alone would drop each of
+    // them back to an unloaded placeholder. That is what made the sidebar fold
+    // itself up mid-edit: open a folder, click through its notes, and the
+    // write-triggered refresh emptied it under you.
+    const loaded = loadedFolderPaths(get().tree);
     let children: ipc.TreeNode[];
     try {
-      children = await ipc.listChildren("", vault?.epoch);
+      children = await ipc.listChildren("", epoch);
     } catch (e) {
       // These reads are epoch-pinned, so a vault switch mid-read makes Rust
       // REJECT them. That is the guard working, not a failure — and several call
@@ -629,19 +621,39 @@ export const useStore = create<AppStore>((set, get) => ({
     }
     // A vault switch during the read would otherwise paint the old vault's
     // children under the new vault's name.
-    if (!sameVault(get, vault?.epoch)) return;
-    set({
-      tree: {
-        id: "",
-        name: vault?.name ?? "vault",
-        path: "",
-        isDir: true,
-        children,
-        // The root's own listing IS what we just fetched; only its subfolders
-        // are still placeholders (Rust marks those `childrenLoaded: false`).
-        childrenLoaded: true,
-      },
-    });
+    if (!sameVault(get, epoch)) return;
+    let next: ipc.TreeNode = {
+      id: "",
+      name: vault?.name ?? "vault",
+      path: "",
+      isDir: true,
+      children,
+      // The root's own listing IS what we just fetched; only its subfolders
+      // are still placeholders (Rust marks those `childrenLoaded: false`).
+      childrenLoaded: true,
+    };
+
+    // Re-list the expanded folders rather than carrying their old children
+    // over: this refresh exists to show what changed on disk, and a folder the
+    // user is looking at is the one most likely to have changed. A folder that
+    // has since been deleted or renamed simply drops out.
+    if (loaded.length > 0) {
+      const listings = await Promise.all(
+        loaded.map(async (path) => {
+          try {
+            return { path, kids: await ipc.listChildren(path, epoch) };
+          } catch {
+            return { path, kids: null };
+          }
+        }),
+      );
+      if (!sameVault(get, epoch)) return;
+      for (const { path, kids } of listings) {
+        if (kids) next = setChildrenAt(next, path, kids);
+      }
+    }
+
+    set({ tree: next });
   },
 
   loadChildren: async (path) => {


### PR DESCRIPTION
Bumps the desktop app to **0.1.15** (all four version files), so merging ships a release.

## Bug fixes

**The sidebar header showed a stale vault name.** It read the session's `activeOrganizationId` unconditionally, but opening a local vault disables sync while leaving the account's active org set — so the title stayed frozen on the last synced vault while the footer, which checks `syncEnabled`, kept up. The header now derives its name the same way.

**Expanded folders collapsed while you worked.** `refreshTree()` rebuilds from only the vault's top level, dropping every lazily-loaded folder back to a placeholder. It runs on every `file-changed` burst and every sync registry pull, so opening a note emptied whatever folder you had open. It now records which folders were listed and re-lists them — re-fetching rather than carrying the old children over, since the folder you're looking at is the likeliest to have just changed. Restoring has to go parents-first: `setChildrenAt` only descends through nodes that already carry children.

**Search opened on the opposite side of the window from its button.** The button is in the main header on the right; the panel rendered inside the sidebar on the left. It's now a centered overlay on the shared `modal-backdrop`, with arrow/Enter/Escape navigation. The selection index resets when the result set changes, so Enter can't open a stale highlight after the debounce lands.

## Changes

- **Sidebar header** is a label: vault name, the on-disk path with the home prefix dropped, and a folder button that opens the vault in Finder. That button needed `opener:allow-open-path` — and a **path scope**, which the permission does not imply; without one every call is rejected as `ForbiddenPath`. Scoped to `$HOME/**` so a webview compromise can't reach `/Applications`, with a `revealItemInDir` fallback for vaults on other volumes.
- **Account popover** spends a fixed budget of 4 vault rows, split evenly when both kinds can fill their half and spilling over when one can't — a lone local vault keeps its row against 9 synced ones. The "All … vaults (N)" links are gone; the Vault settings row beneath them already leads there. Contents scaled down, frame widened to 348px.
- **Resizable sidebar** — drag the right edge, double-click or Home to reset, arrow keys to nudge. Persists per device. Widen-only: the floor is the default width, below which the tree toolbar pushes its last button past the edge. Tree header icons are left-anchored so they don't ride the moving edge.
- **Window title text hidden** on macOS via `hiddenTitle`, which keeps the name for Mission Control rather than blanking it.

## Tests

359 passing (+29). New coverage for the tree-preservation invariant, the row split, and the width clamp. `loadedFolderPaths`/`setChildrenAt` moved to `lib/tree/lazyTree.ts` so they're testable without pulling Tauri into the test env.
