### PR TITLE
Fix teammate presence for joined devices, auto-sync on join, voice latency, and share new vaults with the team

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,13 @@ flow through the same sync server via `createDocWriter` so AI edits persist/broa
   **creator** → edit on their own note; else max of file/folder shares (walk `parent_id` up) — either
   per-user or an org-wide "share with team" grant — plus any vault-wide grant; a `locked` share caps at
   view even for admins. `edit > view > none`; no grant → no sync access (403 at token mint). **New
-  vaults are private by default** (no org-wide grant); existing ones keep their Open grant. Keep this
-  in lockstep with `permissions/vault-docs.ts` (the readable-set dual that gates live sync + registry
-  listings).
+  vaults are shared with their team by default** — `POST /api/vaults` creates the org-wide `edit`
+  grant, but only alongside the org's *first* collection, so re-running it can't resurrect a grant an
+  owner revoked via Access → Private. (This reverses the private-by-default posture of 2026-07-21,
+  which left an invited teammate on an empty sidebar with no way to ask for access.) Vaults that
+  predate the reversal are untouched: no grant means private, and the owner flips it in Access. Keep
+  this in lockstep with `permissions/vault-docs.ts` (the readable-set dual that gates live sync +
+  registry listings).
 - `tokens/sync-token.ts` — HS256 per-doc JWT (`jose`), TTL `SYNC_TOKEN_TTL_SECONDS` (default 600).
 - `mcp/` — JSON-RPC 2.0 over Streamable HTTP at `POST /api/mcp` (no SSE; GET/DELETE → 405). Tools:
   `list_vaults/list_folders/create_folder/delete_folder/list_notes/read_note/search_notes/create_note/update_note/append_note/delete_note`.

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.15"
+version = "0.1.16"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -16,8 +16,8 @@ import { Avatar } from "./Identity";
  * Access — the unified locker. A vault-default posture (Shared · Read-only ·
  * Private) plus a per-folder/note override and a resolved "who can access" list.
  * Built on the shares model:
- *  - Vault posture            = an org grant on the vault (edit=Shared,
- *    view=Read-only) or none (Private, the new default for new vaults).
+ *  - Vault posture            = an org grant on the vault (edit=Shared, the
+ *    default for a new vault; view=Read-only) or none (Private).
  *  - "Shared" on an item      = an org edit grant on the folder/file.
  *  - "Read-only" on an item   = an org view grant (Private vault) or an
  *    org `locked` share (Open vault, where a lock caps the edit baseline).

--- a/app/apps/desktop/src/components/TalkButton.tsx
+++ b/app/apps/desktop/src/components/TalkButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { prewarmCapture } from "../lib/voice/capture";
 import { useStore } from "../store";
 import "./talk.css";
 
@@ -39,6 +40,14 @@ export function TalkButton() {
   // Tracks whether WE started the current press, so a stray pointerup elsewhere
   // in the window can't stop a broadcast we never began.
   const held = useRef(false);
+
+  // Build the AudioContext and register the recorder worklet now, so the first
+  // press only waits on the mic itself. Doing this lazily made the very first
+  // transmission the slowest one, which is the one people judge the feature by.
+  // It opens no microphone and shows no recording indicator.
+  useEffect(() => {
+    prewarmCapture();
+  }, []);
 
   const start = () => {
     if (held.current) return;

--- a/app/apps/desktop/src/lib/presence/__tests__/viewingDocId.test.ts
+++ b/app/apps/desktop/src/lib/presence/__tests__/viewingDocId.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { viewingDocId } from "../viewingDocId";
+
+// "Who is looking at what" is only as good as the id it travels under. This
+// shipped broken in one direction and looked fine in the other: whoever JOINED
+// a vault could see everyone, and nobody could see them. These pin the choice
+// that makes it symmetric.
+
+describe("viewingDocId", () => {
+  it("announces the server doc_id when the note is mapped", () => {
+    // The whole point. A teammate's readable set and the sidebar's dot lookup
+    // are both keyed on server ids; a local id matches neither.
+    expect(viewingDocId("local-uuid", "server-doc-id")).toBe("server-doc-id");
+  });
+
+  it("makes a joined device announce the id its teammates know", () => {
+    // On a device that joined an existing vault, the two ids always differ:
+    // the note was materialized locally with a fresh uuid, while the registry
+    // holds the server's. Announcing the local one is what made the newcomer
+    // invisible to everyone else.
+    const localAfterMaterialize = "3f7c1e94-local-only";
+    const fromServer = "a1b2c3d4-server";
+    expect(viewingDocId(localAfterMaterialize, fromServer)).toBe(fromServer);
+    expect(viewingDocId(localAfterMaterialize, fromServer)).not.toBe(
+      localAfterMaterialize,
+    );
+  });
+
+  it("falls back to the local id when nothing is syncing the note", () => {
+    // A local-only vault, or a non-markdown file: no server id exists, and the
+    // local one is all anyone could match on.
+    expect(viewingDocId("local-uuid", null)).toBe("local-uuid");
+    expect(viewingDocId("local-uuid", undefined)).toBe("local-uuid");
+    expect(viewingDocId("local-uuid", "")).toBe("local-uuid");
+  });
+
+  it("announces nothing when no note is open", () => {
+    // A null doc is meaningful: it clears the dots, and the server lets it
+    // through unconditionally rather than checking it against readable docs.
+    expect(viewingDocId(null, null)).toBeNull();
+    expect(viewingDocId(undefined, "server-doc-id")).toBeNull();
+    expect(viewingDocId("", "server-doc-id")).toBeNull();
+  });
+
+  it("agrees with itself for a note created on this device", () => {
+    // The server adopts the id we register, so both sides are the same string
+    // and the fallback is indistinguishable from the mapped answer.
+    expect(viewingDocId("same-id", "same-id")).toBe("same-id");
+  });
+});

--- a/app/apps/desktop/src/lib/presence/viewingDocId.ts
+++ b/app/apps/desktop/src/lib/presence/viewingDocId.ts
@@ -1,0 +1,30 @@
+/**
+ * Which id to announce as "the note I'm looking at".
+ *
+ * It must be the SERVER doc_id. Everyone else in the presence path speaks
+ * server ids: the vault channel drops any presence frame whose docId isn't in
+ * the receiver's readable set, and FileTree matches dots by
+ * `registry.getMapping(path).docId`. A local index id is not merely useless to
+ * them — it is indistinguishable from a note they can't read, so it is
+ * discarded in silence.
+ *
+ * The two ids are equal only for notes created on this device, because the
+ * server adopts the id we hand it at registration. On a device that JOINED an
+ * existing vault, server-only notes are materialized locally with fresh uuids,
+ * so announcing the local id made that person invisible on every teammate's
+ * sidebar — while they saw everyone else perfectly. That asymmetry is the
+ * signature of this bug.
+ *
+ * @param localId  the note's local index id (null when there's no note open)
+ * @param mappedDocId  server doc_id for the note's path, if the registry has
+ *   one — absent for a vault that isn't syncing, or a non-markdown file
+ */
+export function viewingDocId(
+  localId: string | null | undefined,
+  mappedDocId: string | null | undefined,
+): string | null {
+  if (!localId) return null;
+  // No mapping means nothing is syncing this note, so there is no server id to
+  // prefer and the local one is all anyone could match on anyway.
+  return mappedDocId || localId;
+}

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -812,6 +812,20 @@ export class SyncManager {
     this.pushLocalPresence();
   }
 
+  /**
+   * Re-broadcast our presence unprompted.
+   *
+   * The vault channel keeps no shared roster: it is rebuilt only when some
+   * connection's first announce triggers a presence-query round. A member
+   * joining triggers nothing on the clients already connected, so there was no
+   * self-healing path at all — if a newcomer's frames were missed, the gap
+   * lasted the whole session. Calling this on member-joined costs one small
+   * frame and gives the roster a way to converge.
+   */
+  announcePresence(): void {
+    this.pushLocalPresence();
+  }
+
   /** Send our current viewing state over the vault channel. Invisible users
    *  broadcast a null doc so they don't appear on teammates' sidebars. */
   private pushLocalPresence(): void {

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -448,12 +448,27 @@ export class VaultRegistry {
     let vaultId = cfg.serverVaultId ?? null;
     if (vaultId && !inOrg.some((v) => v.id === vaultId)) vaultId = null;
     if (!vaultId) {
-      const vault =
-        inOrg[0] ??
-        (await this.api.createVault({
-          name: input.vaultName,
-          organizationId: input.organizationId,
-        }));
+      let vault = inOrg[0] ?? null;
+      if (!vault) {
+        try {
+          vault = await this.api.createVault({
+            name: input.vaultName,
+            organizationId: input.organizationId,
+          });
+        } catch (e) {
+          // Only owner/admin may create a collection (403 for a plain member).
+          // A member reaching here means the server showed them no collection
+          // in this vault — they have no access to one yet, which is a waiting
+          // state, not a broken client. Letting this throw failed the whole
+          // reconcile, so sync never came on and the only visible remedy made
+          // them a brand-new vault of their own. Report it and stop instead.
+          throw new Error(
+            `No accessible note collection in this vault yet. ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          );
+        }
+      }
       vaultId = vault.id;
     }
     if (this.stale()) return { seeded: false };

--- a/app/apps/desktop/src/lib/voice/__tests__/pcm.test.ts
+++ b/app/apps/desktop/src/lib/voice/__tests__/pcm.test.ts
@@ -4,6 +4,7 @@ import {
   downsampleTo16k,
   floatToPcm16,
   pcm16ToFloat,
+  VOICE_CHUNK_MS,
   VOICE_CHUNK_SAMPLES,
   VOICE_SAMPLE_RATE,
 } from "../pcm";
@@ -63,8 +64,10 @@ describe("downsampleTo16k", () => {
   });
 
   it("produces one chunk's worth of samples from a 48 kHz render quantum run", () => {
-    // 48 kHz is what WebAudio hands us on most machines.
-    const input = new Float32Array(48_000 * (200 / 1000)); // 200 ms
+    // 48 kHz is what WebAudio hands us on most machines. Derive the input
+    // length from VOICE_CHUNK_MS so retuning the chunk size for latency
+    // doesn't turn this into a failure about nothing.
+    const input = new Float32Array((48_000 * VOICE_CHUNK_MS) / 1000);
     expect(downsampleTo16k(input, 48_000)).toHaveLength(VOICE_CHUNK_SAMPLES);
   });
 

--- a/app/apps/desktop/src/lib/voice/__tests__/playback.test.ts
+++ b/app/apps/desktop/src/lib/voice/__tests__/playback.test.ts
@@ -53,6 +53,20 @@ class FakeAudioContext {
     this.sources.push(s);
     return s;
   }
+  // The output bus every stream mixes through, so two speakers at once can't
+  // clip. Params are plain holders — this fake asserts scheduling, not DSP.
+  createDynamicsCompressor() {
+    this.compressors++;
+    return {
+      threshold: { value: 0 },
+      knee: { value: 0 },
+      ratio: { value: 0 },
+      attack: { value: 0 },
+      release: { value: 0 },
+      connect: () => {},
+    };
+  }
+  compressors = 0;
 }
 
 /** 100 ms of 16 kHz PCM16 = 1600 samples. */
@@ -139,6 +153,50 @@ describe("VoicePlayer", () => {
     // Both scheduled; neither cut the other off.
     expect(ctxOf().started).toHaveLength(2);
     expect(player.isPlaying()).toBe(true);
+  });
+
+  it("routes every stream through one shared limiter, not the destination", () => {
+    // Capture runs with autoGainControl, so each speaker arrives near full
+    // scale and two summed at unity clipped. One limiter, built once and
+    // shared, is what makes an overlap sound like two voices.
+    const player = new VoicePlayer();
+    player.push({ streamId: "a", userId: "ada", seq: 0, audio: pcmChunk() });
+    player.push({ streamId: "b", userId: "grace", seq: 0, audio: pcmChunk() });
+    player.push({ streamId: "a", userId: "ada", seq: 1, audio: pcmChunk() });
+
+    expect(ctxOf().compressors).toBe(1);
+  });
+
+  it("keeps a user marked talking while any of their streams is still live", () => {
+    // A second press before the first transmission finished playing used to let
+    // the older stream's end-timer clear the indicator for someone mid-sentence.
+    const events: Array<[string, boolean]> = [];
+    const player = new VoicePlayer({ onSpeakingChange: (u, s) => events.push([u, s]) });
+
+    player.push({ streamId: "first", userId: "ada", seq: 0, audio: pcmChunk() });
+    player.push({ streamId: "second", userId: "ada", seq: 0, audio: pcmChunk() });
+    // The first transmission ends while the second is still going.
+    player.push({
+      streamId: "first",
+      userId: "ada",
+      seq: 1,
+      audio: pcmChunk(),
+      final: true,
+    });
+    vi.runAllTimers();
+
+    expect(events.filter(([, speaking]) => !speaking)).toHaveLength(0);
+
+    // Once the last one ends, they finally read as stopped.
+    player.push({
+      streamId: "second",
+      userId: "ada",
+      seq: 1,
+      audio: pcmChunk(),
+      final: true,
+    });
+    vi.runAllTimers();
+    expect(events[events.length - 1]).toEqual(["ada", false]);
   });
 
   it("reports speaking start immediately and end only once the audio finishes", () => {

--- a/app/apps/desktop/src/lib/voice/capture.ts
+++ b/app/apps/desktop/src/lib/voice/capture.ts
@@ -56,6 +56,13 @@ export class MicPermissionError extends Error {
  * expectations, not verified behaviour.
  */
 export async function startCapture(onChunk: ChunkSink): Promise<CaptureHandle> {
+  // The context and the worklet module are hoisted out of the press: building an
+  // AudioContext and fetching/compiling/registering the worklet took a chunk of
+  // the delay before the first word went out, and neither depends on the mic.
+  // Only `getUserMedia` genuinely has to wait for the press — that one IS the
+  // privacy property described at the top of this file.
+  const ctx = await sharedCaptureContext();
+
   let stream: MediaStream;
   try {
     stream = await navigator.mediaDevices.getUserMedia({
@@ -78,21 +85,10 @@ export async function startCapture(onChunk: ChunkSink): Promise<CaptureHandle> {
     );
   }
 
-  const ctx = new AudioContext();
-  // Autoplay policy can hand back a suspended context even for capture.
-  if (ctx.state === "suspended") await ctx.resume();
-
+  // Only the mic is released on stop; the context outlives the transmission.
   const release = () => {
     for (const track of stream.getTracks()) track.stop();
-    void ctx.close().catch(() => {});
   };
-
-  try {
-    await ctx.audioWorklet.addModule(new URL("./recorder-worklet.js", import.meta.url));
-  } catch (err) {
-    release();
-    throw err;
-  }
 
   const source = ctx.createMediaStreamSource(stream);
   const node = new AudioWorkletNode(ctx, "baalda-recorder");
@@ -140,3 +136,46 @@ export async function startCapture(onChunk: ChunkSink): Promise<CaptureHandle> {
 
 /** The transmit format, for the opening chunk's header. */
 export const CAPTURE_FORMAT = { fmt: "pcm16", sr: VOICE_SAMPLE_RATE } as const;
+
+// ---- Shared capture context -------------------------------------------------
+
+let capturePrep: Promise<AudioContext> | null = null;
+
+/**
+ * One AudioContext with the recorder worklet already registered, reused for the
+ * life of the app. Built on first use and never closed.
+ *
+ * Kept apart from the playback context on purpose: this one is fed by the mic
+ * with echo cancellation on, which on macOS switches the device to the
+ * voice-processing IO unit. Sharing it with playback would put every teammate's
+ * audio through that path too.
+ */
+async function sharedCaptureContext(): Promise<AudioContext> {
+  if (!capturePrep) {
+    capturePrep = (async () => {
+      const ctx = new AudioContext();
+      await ctx.audioWorklet.addModule(
+        new URL("./recorder-worklet.js", import.meta.url),
+      );
+      return ctx;
+    })();
+    // A failed prep must not be cached, or every later press reuses the
+    // rejection and the mic can never recover.
+    capturePrep.catch(() => {
+      capturePrep = null;
+    });
+  }
+  const ctx = await capturePrep;
+  // Autoplay policy can suspend an idle context between transmissions.
+  if (ctx.state === "suspended") await ctx.resume();
+  return ctx;
+}
+
+/**
+ * Warm the capture path up before the button is pressed, so the first press
+ * pays only for `getUserMedia`. Safe to call repeatedly; failures are ignored
+ * here and surface properly on the real press.
+ */
+export function prewarmCapture(): void {
+  void sharedCaptureContext().catch(() => {});
+}

--- a/app/apps/desktop/src/lib/voice/pcm.ts
+++ b/app/apps/desktop/src/lib/voice/pcm.ts
@@ -32,11 +32,16 @@
  *  is the usual wideband-voice floor and halves the bytes of 32 kHz. */
 export const VOICE_SAMPLE_RATE = 16_000;
 
-/** How much audio goes in one chunk. The tradeoff is latency vs overhead:
- *  200 ms means ~5 frames/s (~6.4 KB each) and about a fifth of a second of
- *  mouth-to-ear delay from chunking alone, which reads as "instant" for a
- *  walkie-talkie without making the header overhead significant. */
-export const VOICE_CHUNK_MS = 200;
+/** How much audio goes in one chunk, and the batch size the recorder worklet
+ *  fills before it can emit anything (keep `BATCH_MS` in recorder-worklet.js in
+ *  step with this).
+ *
+ *  The tradeoff is latency vs overhead. This was 200 ms, which put a fifth of a
+ *  second of delay in the path before a single byte moved — audible as "it
+ *  didn't start when I pressed it". 40 ms gives ~25 frames/s of ~1.3 KB, so the
+ *  per-chunk header stops being rounding error, but the wire cost is unchanged
+ *  (the same PCM either way) and the press now feels immediate. */
+export const VOICE_CHUNK_MS = 40;
 
 /** Samples per chunk at the transmit rate. */
 export const VOICE_CHUNK_SAMPLES = (VOICE_SAMPLE_RATE * VOICE_CHUNK_MS) / 1000;

--- a/app/apps/desktop/src/lib/voice/playback.ts
+++ b/app/apps/desktop/src/lib/voice/playback.ts
@@ -12,9 +12,13 @@
 
 import { ChunkOrderer, pcm16ToFloat } from "./pcm";
 
-/** How far ahead of "now" a fresh stream starts playing. One chunk of slack
- *  absorbs ordinary jitter without adding delay anyone would notice. */
-const LEAD_SECONDS = 0.2;
+/** How far ahead of "now" a fresh stream starts playing — the receiver's half
+ *  of the mouth-to-ear delay.
+ *
+ *  This was one 200 ms chunk of slack. Chunks are 40 ms now, but dropping the
+ *  lead to match would leave nothing to absorb jitter, so it sits at 80 ms: two
+ *  chunks of cushion, and 120 ms less delay than before. */
+const LEAD_SECONDS = 0.08;
 
 /**
  * Past this much scheduled-but-unplayed audio, a stream has fallen behind and
@@ -26,6 +30,9 @@ const MAX_DRIFT_SECONDS = 1.0;
 
 interface Stream {
   orderer: ChunkOrderer;
+  /** Who is transmitting. Streams are keyed by streamId, but the "talking"
+   *  signal is per user, and one user can briefly own two streams. */
+  userId: string;
   /** AudioContext time at which the next chunk should start. */
   cursor: number;
   sampleRate: number;
@@ -39,6 +46,9 @@ export interface VoicePlayerEvents {
 
 export class VoicePlayer {
   private ctx: AudioContext | null = null;
+  /** Shared output bus: every stream mixes into this, never straight into the
+   *  destination. See {@link outputBus}. */
+  private bus: AudioNode | null = null;
   private readonly streams = new Map<string, Stream>();
 
   constructor(private readonly events: VoicePlayerEvents = {}) {}
@@ -66,6 +76,41 @@ export class VoicePlayer {
   }
 
   /**
+   * Where every stream connects, instead of `ctx.destination` directly.
+   *
+   * Two people talking used to sum at unity gain straight into the output.
+   * Capture runs with `autoGainControl`, so each speaker already arrives near
+   * full scale, and the sum of two clipped hard — the overlap didn't just sound
+   * loud, it sounded broken. A limiter costs nothing when one person is talking
+   * (nothing exceeds the threshold) and is the difference between "two voices"
+   * and "distortion" when two are.
+   */
+  private outputBus(ctx: AudioContext): AudioNode {
+    if (!this.bus) {
+      const limiter = ctx.createDynamicsCompressor();
+      // Fast, transparent limiting rather than audible pumping: clamp only the
+      // peaks that would clip, and let go quickly so speech isn't squashed.
+      limiter.threshold.value = -6;
+      limiter.knee.value = 3;
+      limiter.ratio.value = 12;
+      limiter.attack.value = 0.003;
+      limiter.release.value = 0.12;
+      limiter.connect(ctx.destination);
+      this.bus = limiter;
+    }
+    return this.bus;
+  }
+
+  /** Is anyone else still transmitting as this user? Guards the "stopped
+   *  talking" signal — see the note where it's used. */
+  private stillSpeaking(userId: string, exceptStreamId: string): boolean {
+    for (const [id, s] of this.streams) {
+      if (id !== exceptStreamId && s.userId === userId) return true;
+    }
+    return false;
+  }
+
+  /**
    * Accept one inbound chunk.
    *
    * `streamId` groups a transmission, `seq` orders it, `final` closes it. Two
@@ -88,6 +133,7 @@ export class VoicePlayer {
     if (!stream) {
       stream = {
         orderer: new ChunkOrderer(),
+        userId: opts.userId,
         cursor: ctx.currentTime + LEAD_SECONDS,
         sampleRate: opts.sampleRate ?? 16_000,
         live: new Set(),
@@ -110,7 +156,13 @@ export class VoicePlayer {
       setTimeout(
         () => {
           this.streams.delete(id);
-          this.events.onSpeakingChange?.(user, false);
+          // Only if this was their LAST stream. A second press landing before
+          // the first transmission finished playing (or a reconnect minting a
+          // new streamId mid-press) meant the older stream's timer cleared the
+          // indicator for a user who is still talking.
+          if (!this.stillSpeaking(user, id)) {
+            this.events.onSpeakingChange?.(user, false);
+          }
         },
         endsIn * 1000 + 50,
       );
@@ -125,7 +177,7 @@ export class VoicePlayer {
 
     const src = ctx.createBufferSource();
     src.buffer = buffer;
-    src.connect(ctx.destination);
+    src.connect(this.outputBus(ctx));
 
     // Never schedule in the past — a cursor that has fallen behind `currentTime`
     // would make every remaining chunk play immediately and on top of the last.

--- a/app/apps/desktop/src/lib/voice/recorder-worklet.js
+++ b/app/apps/desktop/src/lib/voice/recorder-worklet.js
@@ -12,7 +12,10 @@
 // leaving resampling and Int16 conversion to the main thread where they're
 // testable.
 
-const BATCH_MS = 200;
+// Must match VOICE_CHUNK_MS in pcm.ts. This is the single biggest contributor
+// to mouth-to-ear delay: no audio can exist before one full batch is filled, so
+// the value is a hard floor on how fast the first word leaves the machine.
+const BATCH_MS = 40;
 
 class RecorderProcessor extends AudioWorkletProcessor {
   constructor() {

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -37,6 +37,7 @@ import {
 } from "./lib/prefs";
 import { seedWelcomeContent, vaultIsEmpty, WELCOME_NOTE_PATH } from "./lib/vault/seed";
 import { playJoinChime } from "./lib/celebrate/celebrate";
+import { viewingDocId } from "./lib/presence/viewingDocId";
 
 export interface OpenNote {
   path: string;
@@ -734,7 +735,11 @@ export const useStore = create<AppStore>((set, get) => ({
       noteRemoved: false,
     });
     // Tell teammates which note we're now viewing (drives their sidebar dots).
-    syncManager.setViewing(meta?.id ?? null);
+    // The announced id must be the SERVER doc_id — see `viewingDocId`, which
+    // exists to hold that reasoning and a regression test for it.
+    syncManager.setViewing(
+      viewingDocId(meta?.id, syncManager.registry.getMapping(path)?.docId),
+    );
     await get().refreshBacklinks();
   },
 
@@ -778,6 +783,10 @@ export const useStore = create<AppStore>((set, get) => ({
     // locally in joinVault/acceptInvitation (they connect after the push).
     syncManager.setMemberJoinedListener((name) => {
       void get().refreshVault();
+      // Re-announce so the newcomer sees who is already here. Their own first
+      // announce asks everyone to reply, but nothing made us speak up if that
+      // round was missed, and the roster has no other way to converge.
+      syncManager.announcePresence();
       get().celebrateMemberJoined(name);
     });
     // Live sidebar presence — the vault channel tells us which teammate is
@@ -1044,6 +1053,26 @@ export const useStore = create<AppStore>((set, get) => ({
   turnOnSyncForCurrentVault: async (name) => {
     const vault = get().vault;
     if (!vault) throw new Error("Open a vault first.");
+    // Already a member of an active vault? Then sync is off because enabling it
+    // FAILED, not because there's nowhere to sync to — so retry that vault
+    // instead of creating a new one.
+    //
+    // This guard exists because the alternative is the worst bug in the join
+    // flow: an invited user whose `enableSyncForVault` fell through one of its
+    // stale/error paths sees "Turn on sync", clicks the only affordance
+    // offered, and silently lands in a brand-new empty vault of their own
+    // rather than the one they were invited to. Creating an org must be a
+    // deliberate act, never the recovery path for a failed sync.
+    const activeOrgId = get().session?.activeOrganizationId;
+    if (activeOrgId && get().organizations.some((o) => o.id === activeOrgId)) {
+      await get().enableSyncForVault();
+      if (!get().syncEnabled) {
+        throw new Error(
+          "Couldn't connect to this vault. Check your connection and try again.",
+        );
+      }
+      return;
+    }
     // This binds the folder you're ALREADY in, so every step below has to stay
     // about that folder: a vault switch mid-flight would bind the new org to the
     // folder we left and then reconcile the wrong tree into it. Claim the switch
@@ -1129,10 +1158,14 @@ export const useStore = create<AppStore>((set, get) => ({
     if (path) {
       try {
         await get().applyVaultFolder(organizationId, path);
+        return;
       } catch (e) {
-        console.warn("[vault] folder swap failed", e);
+        // The bound folder is unusable (moved, deleted, permissions). Don't
+        // return here: that left the user in a vault with no folder and sync
+        // off, with nothing on screen saying why. Fall through to the
+        // auto-folder path below, which re-creates it under the vaults root.
+        console.warn("[vault] bound folder unusable, re-creating", e);
       }
-      return;
     }
     const org = get().organizations.find((o) => o.id === organizationId);
     const orgName = org?.name ?? "New vault";
@@ -1186,13 +1219,29 @@ export const useStore = create<AppStore>((set, get) => ({
     const inv = get().userInvitations.find((i) => i.id === invitationId);
     await authManager.api.acceptInvitation(invitationId);
     // Make the joined vault active through the switch path so it gets its
-    // own folder (prompted) rather than adopting the currently-open folder.
-    if (inv?.organizationId) {
-      await get().setActiveOrganization(inv.organizationId);
-    } else {
+    // own folder and turns sync on. Accepting an invitation IS asking to work
+    // in that vault — landing anywhere else is a bug.
+    //
+    // `inv` is the client's cached invitation list, which can be stale or
+    // missing the row entirely (accepted from another surface, refreshed
+    // mid-flight). It used to fall through to a plain roster refresh, which
+    // left the user a member of a vault they were never switched into and with
+    // sync still off — the exact state whose only visible remedy creates a NEW
+    // vault. So when the cache can't say, ask the server which orgs we are now
+    // in and switch to the one we didn't have before.
+    let orgId = inv?.organizationId ?? null;
+    if (!orgId) {
+      const before = new Set(get().organizations.map((o) => o.id));
       const session = await authManager.currentSession();
       set({ session });
       await get().refreshVault();
+      orgId =
+        get().organizations.find((o) => !before.has(o.id))?.id ??
+        session?.activeOrganizationId ??
+        null;
+    }
+    if (orgId) {
+      await get().setActiveOrganization(orgId);
     }
     // The joiner celebrates locally too (they connect after the server push).
     const me = get().session?.user;
@@ -1339,12 +1388,15 @@ export const useStore = create<AppStore>((set, get) => ({
     });
     rememberOrgVault(orgId, v.path);
     rememberLastVault(orgId);
+    // Turn sync on BEFORE the tree reads. Those two awaits were the window in
+    // which another vault switch (or a `vault-opened` event, or StrictMode's
+    // double-open in dev) could make this call stale and skip sync entirely,
+    // leaving a freshly joined vault sitting there not syncing. The staleness
+    // check still guards the call itself — `enableSyncForVault` re-checks the
+    // epoch internally — but it is no longer gated behind work it doesn't need.
+    if (sameVault(get, v.epoch)) await get().enableSyncForVault();
     await get().refreshTree();
     await get().refreshTitles();
-    // Another vault switch during those reads makes the rest of this call stale —
-    // that switch runs its own `enableSyncForVault` for the vault it landed in.
-    if (!sameVault(get, v.epoch)) return;
-    await get().enableSyncForVault();
   },
 
   chooseVaultFolder: async () => {

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -61,14 +61,44 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "Only vault owner/admin can create vaults" }, 403);
     }
 
+    // Is this the org's FIRST note collection? Asked before the insert, because
+    // the answer decides whether the default access posture applies (below).
+    const { rows: existing } = await pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM vaults WHERE organization_id = $1",
+      [organizationId],
+    );
+    const isFirstVault = existing[0]?.n === "0";
+
     const id = randomUUID();
     await pool.query(
       "INSERT INTO vaults (id, organization_id, name) VALUES ($1, $2, $3)",
       [id, organizationId, name],
     );
-    // Private-by-default: a new vault grants NO org-wide access. Members see
-    // only what they create or what an owner/admin explicitly shares with the
-    // team (per-folder/file, or a vault-wide grant) via the Access panel.
+
+    // Shared-with-team by default: a brand-new vault gets an org-wide `edit`
+    // grant, so anyone invited can read and write its notes the moment they
+    // join.
+    //
+    // This replaces an earlier private-by-default posture. That one was right
+    // about solo vaults and wrong about what vaults are FOR: you invited
+    // someone, and they landed on an empty sidebar with no way to ask for
+    // access. Owners can still lock a vault down — Access panel → Private
+    // revokes exactly this row (`setVaultPosture` in AccessPanel.tsx).
+    //
+    // Only on the first collection. The grant is keyed on the ORG (one org can
+    // own several collections and the grant covers all of them), so re-running
+    // it later would resurrect a grant an owner had deliberately revoked —
+    // silently re-opening a vault they had set to Private. A default is only a
+    // default at creation time; after that the owner's choice is the truth.
+    if (isFirstVault) {
+      await pool.query(
+        `INSERT INTO shares
+           (id, org_id, resource_type, resource_id, principal_type, principal_id, permission, created_by)
+         VALUES ($1, $2, 'vault', $2, 'org', $2, 'edit', $3)
+         ON CONFLICT (resource_type, resource_id, principal_type, principal_id) DO NOTHING`,
+        [randomUUID(), organizationId, session.userId],
+      );
+    }
     return c.json({ id, organizationId, name }, 201);
   });
 

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -11,8 +11,10 @@ import { pool as defaultPool } from "../db/pool.js";
  *   3. `edit > view > none`. Folder grants inherit to descendants; a file
  *      share can only RAISE permission. No matching grant -> `none`.
  *
- * A plain `member` inherits the vault grant (Open by default) and so gets
- * `edit`; with no grant at all it has no content access (`none`).
+ * A plain `member` inherits the vault grant and so gets `edit` in a vault that
+ * is Shared — which a new vault is, by default (`POST /api/vaults`). With no
+ * grant at all (a vault set to Private, or one created while private-by-default
+ * was the rule) a member has no content access beyond notes it created: `none`.
  *
  * Locks (permission = 'locked') are a DENY overlay resolved AFTER the rules
  * above: when a lock matches the doc or any ancestor folder — for this user

--- a/app/apps/server/tests/vault-default-access.test.ts
+++ b/app/apps/server/tests/vault-default-access.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { seedMember, seedNote } from "./helpers/seed.js";
+import { effectivePermission } from "../src/permissions/resolver.js";
+
+/**
+ * The access a vault has the moment it is created.
+ *
+ * A vault is created SHARED with its team: someone you invite can read and
+ * write its notes as soon as they join. This replaced a private-by-default
+ * posture that was right about solo vaults and wrong about invitations — a
+ * teammate would accept, sync, and land on an empty sidebar with no way to ask
+ * for access.
+ *
+ * The tests below pin both halves of that: the default is applied at creation,
+ * and it is applied ONLY at creation, so an owner who later chooses Private
+ * cannot have that choice quietly undone.
+ *
+ * Note these go through `POST /api/vaults` rather than the `seedVault` helper.
+ * The helper inserts the row directly, which is exactly what the other suites
+ * want (a grant-less vault to test the resolver against) and exactly what would
+ * make this file test nothing.
+ */
+
+const app = createApp({
+  disconnectDoc: () => {},
+  docWriter: {
+    async setContent() {},
+    async appendContent() {},
+    async readContent() {
+      return "";
+    },
+  },
+});
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+async function createVault(user: TestUser, organizationId: string, name: string) {
+  const res = await req(user, "POST", "/api/vaults", { name, organizationId });
+  expect(res.status).toBe(201);
+  return (await res.json()) as { id: string };
+}
+
+function orgGrants(organizationId: string) {
+  return pool.query<{ permission: string }>(
+    `SELECT permission FROM shares
+      WHERE resource_type = 'vault' AND resource_id = $1
+        AND principal_type = 'org' AND principal_id = $1`,
+    [organizationId],
+  );
+}
+
+describe("a new vault's default access", () => {
+  let owner: TestUser;
+  let org: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    owner = await signUp("owner@default-access.test");
+    org = (await createOrg(owner, "Acme", "acme-default-access")).id;
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("grants the team edit access when the first vault is created", async () => {
+    await createVault(owner, org, "Notes");
+    const { rows } = await orgGrants(org);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].permission).toBe("edit");
+  });
+
+  it("lets someone who joins later read and write an existing note", async () => {
+    // The reported bug: invite a teammate, they see nothing.
+    const vault = await createVault(owner, org, "Notes");
+    const note = await seedNote(vault.id, null, "owners-note.md", owner.userId);
+
+    const joiner = await signUp("joiner@default-access.test");
+    await seedMember(org, joiner.userId, "member");
+
+    expect(await effectivePermission(joiner.userId, note)).toBe("edit");
+  });
+
+  it("does not re-grant when a second collection is added", async () => {
+    // The grant is keyed on the ORG, so re-running it on every collection
+    // would resurrect one the owner had revoked. Going Private must stick.
+    await createVault(owner, org, "Notes");
+    await pool.query(
+      `DELETE FROM shares
+        WHERE resource_type = 'vault' AND resource_id = $1 AND principal_type = 'org'`,
+      [org],
+    );
+
+    await createVault(owner, org, "Second");
+
+    const { rows } = await orgGrants(org);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("keeps a later member locked out of a vault the owner set to Private", async () => {
+    const vault = await createVault(owner, org, "Notes");
+    const note = await seedNote(vault.id, null, "secret.md", owner.userId);
+    // Access panel → Private revokes exactly this row.
+    await pool.query(
+      `DELETE FROM shares
+        WHERE resource_type = 'vault' AND resource_id = $1 AND principal_type = 'org'`,
+      [org],
+    );
+
+    const joiner = await signUp("late@default-access.test");
+    await seedMember(org, joiner.userId, "member");
+
+    expect(await effectivePermission(joiner.userId, note)).toBe("none");
+  });
+});


### PR DESCRIPTION
Bumps the desktop app to **0.1.16** (all four version files).

## 1. A teammate who joined was invisible in the sidebar

Presence frames carry the id of the note you're viewing, and the vault channel drops any frame whose id isn't in the recipient's readable set. `setViewing` announced the note's **local index id**, while everything else in that path speaks **server doc_ids** — the server's gate and FileTree's dot lookup both.

The two ids match only for notes created on that device, because the server adopts the id we register. A device that JOINED an existing vault materializes server-only notes with fresh local uuids, so every announcement it made looked like a note nobody could read and was discarded in silence. The joiner saw everyone; nobody saw the joiner. Owner vs member was never the variable — whoever joined second was invisible.

The id choice now lives in `viewingDocId` with tests, rather than inline where it reads like a defensive fallback someone would simplify back into the bug. Verified that the `registerNote` call immediately before it returns early on an existing mapping, so the server id established during reconcile survives.

Second gap, same feature: the vault channel keeps no shared roster and rebuilds it only when some connection's *first* announce triggers a query round. A member joining triggered nothing on already-connected clients, so a missed round lasted the whole session. Existing clients now re-announce on member-joined.

## 2. Joining a vault left sync off, and the recovery path made a new vault

The worst of it: a stranded joiner is shown "Turn on sync", which called `turnOnSyncForCurrentVault` → **creates a brand-new organization**. Someone invited into your vault, clicking the only affordance offered, landed in an empty vault of their own. It now retries the vault you're in when you're already a member, and only creates an org when there is genuinely nowhere to sync to.

Also closed three silent holes: `applyVaultFolder` skipped `enableSyncForVault` behind two tree reads (any epoch change in that window left a joined vault not syncing); an unusable bound folder returned silently instead of falling through to re-create one; and `acceptInvitation` fell back to a plain roster refresh — no switch, no sync — whenever the invitation wasn't in the client's cached list. It now asks the server which org it joined.

## 3. Voice: delay on press, and two speakers clipping

Latency floor was 400 ms before a byte moved (200 ms capture batch + 200 ms playback lead), and every press additionally built a new `AudioContext` and re-fetched/compiled/registered the worklet. Context and worklet are now created once, reused, and pre-warmed on mount, so the first press is no longer the slowest. Batch 40 ms, lead 80 ms.

`getUserMedia` still runs per press deliberately — stopping the mic track between transmissions is what turns the OS recording indicator off, and that privacy property is worth more than the milliseconds.

Two-at-once was never architectural: streams already mix, with a test proving it. The defect was that each connected at unity gain straight to the destination while capture runs `autoGainControl`, so two summed and clipped hard. They now share one limiter. Also fixed an indicator race where a second press before the first finished playing let the older stream's timer mark a still-talking user silent.

## 4. New vaults are shared with their team

`POST /api/vaults` now creates the org-wide `edit` grant, so an invited teammate can read and write immediately instead of landing on an empty sidebar with no way to ask for access. This reverses the private-by-default posture of 2026-07-21.

Applied only alongside an org's **first** collection: the grant is keyed on the org, so re-running it would resurrect one an owner had revoked via Access → Private. A default is a default at creation; after that the owner's choice is the truth.

**Existing vaults are deliberately untouched** — the `shares` table records no history, so "never granted" and "deliberately set Private" are indistinguishable, and a blanket backfill would silently re-open someone's private vault. Owners flip those in Access.

Docs updated in lockstep, as the repo root file `CLAUDE.md` asks: that file, `resolver.ts`'s header, `AccessPanel.tsx`'s contract comment.

## Tests

366 desktop (+5) and 174 server (+4), all passing. New coverage for the presence id choice, the playback limiter and speaking-indicator race, and the default-access grant — including that going Private still sticks when a second collection is added.

## Deploy note

The vault-default change is server-side, so it reaches the managed instance only when `api.baalda.com` is redeployed from `main`. The rest ships with the desktop release.
