### PR TITLE
Raise the free plan to ten members per vault

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.16"
+version = "0.1.17"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -2177,12 +2177,16 @@ function LimitNudge({
   onUpgrade: () => void;
 }) {
   const freeLimits = useStore((s) => s.billingConfig?.freeLimits);
+  // The server is the authority (the 402 carries `limit`, and billingConfig
+  // reports both caps); these are last-resort defaults for a nudge rendered
+  // before either arrived. They differ per kind — one shared number was right
+  // only while the two caps happened to be equal, and would have quietly
+  // claimed a 10-seat vault allows 3.
   const n =
     limit ??
     (kind === "member_limit"
-      ? freeLimits?.membersPerVault
-      : freeLimits?.vaultsPerUser) ??
-    3;
+      ? (freeLimits?.membersPerVault ?? 10)
+      : (freeLimits?.vaultsPerUser ?? 3));
   const message =
     kind === "member_limit"
       ? `Free plan limit reached — this vault allows ${n} member${n === 1 ? "" : "s"}.`

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -72,4 +72,4 @@ VAULT_SYNC_PATH=/vault-sync
 #
 # Free-tier caps (only enforced when billing is ON). Defaults: 3 and 3.
 # FREE_MAX_VAULTS=3              # unsubscribed vaults a user may own
-# FREE_MAX_MEMBERS=3             # members + pending invites per unsubscribed workspace
+# FREE_MAX_MEMBERS=10            # members + pending invites per unsubscribed vault

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -148,9 +148,13 @@ export const config = {
   polarProductYearlyId: optional("POLAR_PRODUCT_YEARLY_ID"),
   /** Free-tier caps (only enforced when billing is enabled). A user may OWN up
    *  to this many UNSUBSCRIBED vaults; each unsubscribed vault may hold
-   *  up to this many members (incl. pending invitations). */
+   *  up to this many members (incl. pending invitations).
+   *
+   *  Members sit well above vaults on purpose: a free vault should be able to
+   *  hold a real team, so the upgrade prompt arrives when a group outgrows the
+   *  product rather than the moment it stops being a pair. */
   freeMaxVaults: int("FREE_MAX_VAULTS", 3),
-  freeMaxMembers: int("FREE_MAX_MEMBERS", 3),
+  freeMaxMembers: int("FREE_MAX_MEMBERS", 10),
 } as const;
 
 /**

--- a/app/apps/server/tests/billing.test.ts
+++ b/app/apps/server/tests/billing.test.ts
@@ -14,9 +14,32 @@ import type {
   NormalizedBillingEvent,
 } from "../src/billing/provider.js";
 import { testAppDeps } from "./helpers/app.js";
+import { config } from "../src/config.js";
 import { pool } from "../src/db/pool.js";
 import { resetDb } from "./helpers/db.js";
 import { createOrg, signUp } from "./helpers/auth.js";
+
+// The seat cap is a product decision that moves (3 → 10 when free vaults were
+// opened up to real teams). These suites assert that it is ENFORCED, so they
+// read the configured value rather than restating it — a test that has to be
+// edited every time the number changes tests the number, not the rule.
+const SEAT_CAP = config.freeMaxMembers;
+
+/** Fill an org to exactly `SEAT_CAP` seats. The owner is seat 1; pending
+ *  invitations occupy the rest (they count against the cap, which is the point
+ *  — a free vault can't invite its way past the limit). */
+async function fillSeatsToCap(orgId: string, inviterId: string, tag: string) {
+  const values = Array.from({ length: SEAT_CAP - 1 }, (_, i) => {
+    const n = i + 1;
+    return `('${tag}-inv${n}', $1, '${tag}${n}@x.com', 'member', 'pending', now() + interval '1 day', $2)`;
+  }).join(",\n");
+  if (!values) return;
+  await pool.query(
+    `INSERT INTO invitation (id, "organizationId", email, role, status, "expiresAt", "inviterId")
+     VALUES ${values}`,
+    [orgId, inviterId],
+  );
+}
 
 const WEBHOOK_SECRET = "test-polar-webhook-secret";
 
@@ -130,7 +153,10 @@ describe("billing", () => {
       expect(body.plans.map((p) => p.id)).toEqual(["pro-monthly", "pro-yearly"]);
       expect(body.plans.find((p) => p.id === "pro-monthly")!.amount).toBe(1000);
       expect(body.plans.find((p) => p.id === "pro-yearly")!.amount).toBe(9700);
-      expect(body.freeLimits).toEqual({ vaultsPerUser: 3, membersPerVault: 3 });
+      expect(body.freeLimits).toEqual({
+        vaultsPerUser: config.freeMaxVaults,
+        membersPerVault: SEAT_CAP,
+      });
     });
 
     it("all other billing routes 404 when billing is off", async () => {
@@ -153,7 +179,7 @@ describe("billing", () => {
       expect(fourth.id).toBeTruthy();
       expect((await canCreateOrganization(user.userId)).allowed).toBe(true);
 
-      // Add more than FREE_MAX_MEMBERS (3) pending invitations to one vault — still unblocked.
+      // Pending invitations that would matter under a cap — still unblocked here.
       await pool.query(
         `INSERT INTO invitation (id, "organizationId", email, role, status, "expiresAt", "inviterId")
          VALUES ('unl-inv1', $1, 'a@x.com', 'member', 'pending', now() + interval '1 day', $2),
@@ -207,7 +233,13 @@ describe("billing", () => {
         [org.id, owner.userId],
       );
       expect(await seatCount(org.id)).toEqual({ members: 1, pendingInvitations: 2 });
-      // members(1)+pending(2) = 3 >= cap 3 → blocked.
+      // Two pending invitations are two seats, but they only BLOCK once the
+      // total reaches the cap — which is the counting rule this test is about.
+      expect((await canAddMember(org.id)).allowed).toBe(SEAT_CAP > 3);
+
+      // Fill the rest of the seats: pending invitations count, so the cap bites
+      // without a single extra person actually joining.
+      await fillSeatsToCap(org.id, owner.userId, "seat");
       expect((await canAddMember(org.id)).allowed).toBe(false);
 
       // An active subscription lifts the cap entirely.
@@ -239,7 +271,7 @@ describe("billing", () => {
         status: "none",
         currentPeriodEnd: null,
         cancelAtPeriodEnd: false,
-        seats: { members: 1, pendingInvitations: 0, limit: 3 },
+        seats: { members: 1, pendingInvitations: 0, limit: SEAT_CAP },
       });
     });
 
@@ -323,19 +355,27 @@ describe("billing", () => {
     it("invite-member → 402 member_limit_reached at the cap (via Better Auth)", async () => {
       const owner = await signUp("im@billing.com");
       const org = await createOrg(owner, "Im", "im-org");
-      // owner(1) + 2 pending = 3 = cap.
-      await pool.query(
-        `INSERT INTO invitation (id, "organizationId", email, role, status, "expiresAt", "inviterId")
-         VALUES ('imv1', $1, 'p1@x.com', 'member', 'pending', now() + interval '1 day', $2),
-                ('imv2', $1, 'p2@x.com', 'member', 'pending', now() + interval '1 day', $2)`,
-        [org.id, owner.userId],
-      );
+      await fillSeatsToCap(org.id, owner.userId, "im");
       const res = await req(app, "POST", "/api/auth/organization/invite-member", {
         token: owner.token,
-        body: { email: "p3@x.com", role: "member", organizationId: org.id },
+        body: { email: "one-too-many@x.com", role: "member", organizationId: org.id },
       });
       expect(res.status).toBe(402);
       expect(await res.text()).toContain("member_limit_reached");
+    });
+
+    it("invite-member is allowed on the last free seat", async () => {
+      // The cap must bite at cap+1, not cap — an off-by-one here would charge
+      // people for a seat they were promised.
+      const owner = await signUp("lastseat@billing.com");
+      const org = await createOrg(owner, "Last", "last-seat-org");
+      await fillSeatsToCap(org.id, owner.userId, "ls");
+      await pool.query(`DELETE FROM invitation WHERE id = $1`, [`ls-inv${SEAT_CAP - 1}`]);
+      const res = await req(app, "POST", "/api/auth/organization/invite-member", {
+        token: owner.token,
+        body: { email: "fits@x.com", role: "member", organizationId: org.id },
+      });
+      expect(res.status).toBe(200);
     });
 
     it("join-code redemption → 402 member_limit_reached at the cap", async () => {
@@ -344,18 +384,27 @@ describe("billing", () => {
       // Generate a join code.
       const codeRes = await req(app, "GET", "/api/orgs/join-code", { token: owner.token });
       const { code } = (await codeRes.json()) as { code: string };
-      // Fill to the cap: owner(1) + 2 joiners = 3.
-      const j1 = await signUp("jc1@billing.com");
-      const j2 = await signUp("jc2@billing.com");
-      expect((await req(app, "POST", "/api/orgs/join", { token: j1.token, body: { code } })).status).toBe(200);
-      expect((await req(app, "POST", "/api/orgs/join", { token: j2.token, body: { code } })).status).toBe(200);
-      // 3rd joiner is blocked.
-      const j3 = await signUp("jc3@billing.com");
-      const res = await req(app, "POST", "/api/orgs/join", { token: j3.token, body: { code } });
+      // Fill to the cap with the owner + pending invitations, so this stays a
+      // test about the cap rather than a loop of sign-ups.
+      await fillSeatsToCap(org.id, owner.userId, "jc");
+      const late = await signUp("jc-late@billing.com");
+      const res = await req(app, "POST", "/api/orgs/join", { token: late.token, body: { code } });
       expect(res.status).toBe(402);
       const body = (await res.json()) as { error: string; limit: number };
       expect(body.error).toBe("member_limit_reached");
-      expect(body.limit).toBe(3);
+      expect(body.limit).toBe(SEAT_CAP);
+    });
+
+    it("join-code redemption succeeds while a free seat remains", async () => {
+      const owner = await signUp("jcok@billing.com");
+      const org = await createOrg(owner, "JcOk", "jc-ok-org");
+      const codeRes = await req(app, "GET", "/api/orgs/join-code", { token: owner.token });
+      const { code } = (await codeRes.json()) as { code: string };
+      await fillSeatsToCap(org.id, owner.userId, "jco");
+      await pool.query(`DELETE FROM invitation WHERE id = $1`, [`jco-inv${SEAT_CAP - 1}`]);
+      const joiner = await signUp("jcok-joiner@billing.com");
+      const res = await req(app, "POST", "/api/orgs/join", { token: joiner.token, body: { code } });
+      expect(res.status).toBe(200);
     });
 
     it("a paid vault has no member cap on join-code redemption", async () => {

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -219,7 +219,7 @@ curl -sL https://railway.com/deploy/baalda-server | grep -o '<title>[^<]*</title
 | `POLAR_PRODUCT_YEARLY_ID` | with billing | unset | Polar product id for the yearly plan. |
 | `POLAR_SERVER` | no | `sandbox` | `sandbox` or `production` Polar environment. |
 | `FREE_MAX_VAULTS` | no | `3` | Free-tier cap on unsubscribed vaults per user (only enforced when billing is enabled). |
-| `FREE_MAX_MEMBERS` | no | `3` | Free-tier cap on members + pending invitations per unsubscribed vault (only enforced when billing is enabled). |
+| `FREE_MAX_MEMBERS` | no | `10` | Free-tier cap on members + pending invitations per unsubscribed vault (only enforced when billing is enabled). |
 
 > Billing note: the Polar organization must have **allow multiple subscriptions per customer** enabled
 > (Organization settings, or `PATCH /v1/organizations/:id` with `subscription_settings.allow_multiple_subscriptions: true`),


### PR DESCRIPTION
Free plan goes from 3 members per vault to **10**. Past ten, the vault needs Pro. The vault cap (3 unsubscribed vaults per user) is unchanged.

Bumps the desktop app to **0.1.17** (all four version files).

## The change

`FREE_MAX_MEMBERS` default 3 → 10 in `config.ts`. Everything downstream already reads it: the 402 `member_limit_reached` gate on invitations and join-code redemption, `GET /api/billing/config`'s `freeLimits.membersPerVault`, and the desktop's upgrade nudge. Self-hosters are unaffected — caps are only enforced when billing is on.

Docs updated alongside: `.env.example` and the env table in `docs/DEPLOY.md`.

## Tests

The billing suite hardcoded the cap of 3 in five places, so it was really testing the number rather than the rule. It now derives from `config.freeMaxMembers`, with a helper that fills an org to exactly the cap using pending invitations — which count toward seats, so the limit can be reached without a loop of sign-ups.

Two tests added while I was in there, both for the boundary that actually matters commercially: an invitation and a join-code redemption must each still **succeed on the last free seat**. An off-by-one would charge people for a seat they were promised, and nothing covered that direction before.

176 server tests and 366 desktop, all passing.

## One UI detail

The upgrade nudge fell back to a single hardcoded `3` for both caps when the server's limits hadn't loaded. That was only correct while the two numbers happened to match; it would now claim a 10-seat vault allows 3. The fallbacks are per-cap.

## Deploy note

This is a server-side default, so the managed instance picks it up when `api.baalda.com` is redeployed from `main` — or immediately by setting `FREE_MAX_MEMBERS=10` in its environment, which overrides the default without a deploy.
