### PR TITLE
Add loading states and micro-interactions across the desktop app

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.19",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.19"
+version = "0.1.18"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.18"
+version = "0.1.19"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.17"
+version = "0.1.18"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.19"
+version = "0.1.18"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.19",
+  "version": "0.1.18",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -443,6 +443,22 @@ button.primary.hero:hover:not(:disabled) {
   margin-top: var(--sp-1);
 }
 
+/* Post-sign-in landing: shown in place of the two primary actions while the
+   vault is being resolved (and, for a new account, created + seeded). Occupies
+   the same slot so the centered card doesn't jump. */
+.picker-landing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  min-height: 44px;
+}
+.picker-landing-label {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+
 /* ---- Recent vaults list ---- */
 .recent-list {
   display: flex;
@@ -904,35 +920,9 @@ body:has(.sidebar-resizer.dragging) {
 }
 /* Transient outcome pill after an import (menu or drop). Sits at the bottom of
    the sidebar, out of the way, and fades itself out. */
-.filetree-status {
-  position: absolute;
-  left: var(--sp-2);
-  right: var(--sp-2);
-  bottom: var(--sp-2);
-  padding: var(--sp-2) var(--sp-3);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
-  font-size: var(--fs-sm);
-  text-align: center;
-  animation: rise-in var(--t-fast) var(--ease) both;
-  pointer-events: none;
-}
-/* Green = success, red = failure, muted = nothing landed. */
-.filetree-status.success {
-  color: var(--success);
-  border-color: var(--success);
-  background: var(--success-soft);
-}
-.filetree-status.error {
-  color: var(--danger);
-  border-color: var(--danger);
-  background: var(--danger-soft);
-}
-.filetree-status.neutral {
-  color: var(--text-secondary);
-}
+/* The sidebar's private status pill used to live here. It is now the shared
+   toast (see "Toasts" below), so an import result and a failed export speak the
+   same language instead of the sidebar owning its own notification surface. */
 /* Section header: "Notes" label on the left, the tree's action icons on the
    right (create note/folder · fold/unfold). One tidy row, nothing stretches. */
 .filetree-head {
@@ -4403,5 +4393,322 @@ button.secondary:disabled {
   to {
     opacity: 0;
     transform: scale(1.7);
+  }
+}
+
+/* ============================================================
+   Loading states & micro-interactions
+   ------------------------------------------------------------
+   Feedback for asynchronous work, in one place so the same wait looks the same
+   everywhere. Three rules the whole section follows:
+
+   1. A press is acknowledged instantly (`:active`), a *wait* is only labelled
+      once it outlives ~140ms (`useAsyncAction`). Under that, an indicator
+      flashes and reads as a glitch rather than as progress.
+   2. Nothing changes size mid-action. Spinners are laid out beside a label whose
+      width is already reserved, so a control never resizes under the cursor and
+      pulls a different button into the click.
+   3. Every animation has a `prefers-reduced-motion` answer. The information has
+      to survive the motion being switched off.
+   ============================================================ */
+
+/* ---- Spinner (the app's one ring) ---- */
+.spinner {
+  flex: none;
+  display: inline-block;
+  border-radius: 50%;
+  border-style: solid;
+  border-color: color-mix(in srgb, currentColor 22%, transparent);
+  border-top-color: currentColor;
+  animation: btn-spin 0.62s linear infinite;
+}
+.spinner-xs {
+  width: 12px;
+  height: 12px;
+  border-width: 1.7px;
+}
+.spinner-sm {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+.spinner-md {
+  width: 22px;
+  height: 22px;
+  border-width: 2.4px;
+}
+/* `.spinner-inherit` needs no rule — the base above is already currentColor,
+   which is the right answer for a spinner inside a button (a red Delete spins
+   red). The rest exist only where currentColor would be wrong or absent. */
+.spinner-accent {
+  color: var(--accent);
+}
+.spinner-on-accent {
+  border-color: color-mix(in srgb, var(--text-on-accent) 35%, transparent);
+  border-top-color: var(--text-on-accent);
+}
+.spinner-neutral {
+  border-color: var(--border-strong);
+  border-top-color: var(--text-secondary);
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Slowed rather than stopped: a frozen ring says "hung", and the one thing
+     this element must never do is imply the app has died. */
+  .spinner {
+    animation-duration: 1.5s;
+  }
+}
+
+/* ---- Success tick: draws itself in, so it reads as "just completed" ---- */
+.checkmark {
+  flex: none;
+  color: var(--success);
+  stroke-dasharray: 26;
+  animation: check-draw 0.26s var(--ease) both;
+}
+.checkmark-xs {
+  width: 13px;
+  height: 13px;
+}
+.checkmark-sm {
+  width: 16px;
+  height: 16px;
+}
+.checkmark-md {
+  width: 20px;
+  height: 20px;
+}
+@keyframes check-draw {
+  from {
+    stroke-dashoffset: 26;
+    opacity: 0.4;
+  }
+  to {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .checkmark {
+    animation: none;
+    stroke-dasharray: none;
+  }
+}
+
+/* ---- AsyncButton layout ---- */
+/* Applies to any button that can grow a spinner, including the hand-rolled
+   sign-in submit — hence the bare selectors rather than a component class. */
+button:has(> .async-btn-label),
+button.is-busy,
+button.is-done {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+}
+/* A busy button stays interactive-looking rather than greying out: it IS doing
+   what you asked, and the standard 0.55 disabled opacity reads as "rejected". */
+button.is-busy:disabled,
+button.is-done:disabled {
+  opacity: 1;
+  cursor: progress;
+}
+button.is-done:disabled {
+  cursor: default;
+}
+/* `.selbar-icon` and friends are 28px squares; a spinner swapping in for the
+   glyph must not stretch them. */
+.selbar-icon.is-busy,
+.selbar-icon.is-done {
+  gap: 0;
+}
+
+/* ---- Vault switching ---- */
+/* The header renames itself to the destination at once; these two rules are the
+   supporting evidence that the rename is a *pending* claim, not a finished one. */
+.sidebar-header.is-switching .vault-path {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+.vault-switch-spinner {
+  margin-left: var(--sp-1);
+}
+/* The tree below still lists the outgoing vault. Fade it and refuse clicks
+   rather than letting someone open a note from a vault they're leaving (the
+   epoch guard would silently drop it, which looks like a dead row). */
+/* A real flex item in BOTH states, never `display: contents` switching to
+   `block`: the tree measures itself with a ResizeObserver, so a wrapper that
+   changes box type mid-switch would resize the tree and make it jump at exactly
+   the moment we're trying to say "nothing here is changing yet". */
+.sidebar-tree-wrap {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  transition:
+    opacity var(--t-med) var(--ease),
+    filter var(--t-med) var(--ease);
+}
+.sidebar-tree-wrap.is-switching {
+  opacity: 0.38;
+  pointer-events: none;
+  filter: saturate(0.6);
+}
+
+/* ---- A row whose note is being opened ---- */
+/* Selection is applied optimistically on click, so the row highlights before
+   the server has confirmed the note — the same trick as the vault rename. */
+.tree-row.opening {
+  background: var(--accent-soft);
+}
+.tree-row.opening .tree-label {
+  color: var(--text-primary);
+}
+
+/* ---- Update download progress ---- */
+.update-progress {
+  position: relative;
+  flex: 1;
+  min-width: 80px;
+  max-width: 240px;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--text-primary) 12%, transparent);
+  overflow: hidden;
+}
+.update-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width var(--t-med) var(--ease);
+}
+/* No content length from the server: sweep instead of lying about a target. */
+.update-progress.indeterminate .update-progress-fill {
+  width: 35%;
+  animation: progress-sweep 1.1s var(--ease) infinite;
+}
+@keyframes progress-sweep {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(340%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .update-progress.indeterminate .update-progress-fill {
+    animation-duration: 2.4s;
+  }
+}
+
+/* ---- Banners: the slot animates its own height ---- */
+/* `overflow: hidden` is what makes the height animation possible — without it
+   the banner's content spills out of the collapsing box mid-transition. */
+.banner-slot {
+  overflow: hidden;
+  flex: none;
+}
+
+/* ---- Toasts ---- */
+.toast-viewport {
+  position: fixed;
+  right: var(--sp-4);
+  bottom: var(--sp-4);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--sp-2);
+  /* The viewport itself must not swallow clicks meant for the editor beneath;
+     each toast re-enables them for its own box. */
+  pointer-events: none;
+  max-width: min(380px, calc(100vw - var(--sp-8)));
+}
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-2) var(--sp-2) var(--sp-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+}
+/* A 6px dot rather than a coloured background: the tone is legible at a glance
+   without the toast shouting over the note you're reading. */
+.toast-dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+}
+.toast-success .toast-dot {
+  background: var(--success);
+}
+.toast-error .toast-dot {
+  background: var(--danger);
+}
+.toast-error {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--border));
+}
+.toast-text {
+  flex: 1;
+  min-width: 0;
+}
+.toast-close {
+  flex: none;
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: var(--fs-lg);
+  line-height: 1;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  transition:
+    color var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease);
+}
+.toast-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover, color-mix(in srgb, var(--text-primary) 8%, transparent));
+}
+
+/* ---- Press feedback on the controls that had none ---- */
+/* Rule 1 of this section: a click is acknowledged in the same frame it happens,
+   whatever the action goes on to do. `.primary` already did this; these are the
+   controls where pressing produced no physical response at all. */
+.ghost-pill:active:not(:disabled),
+button.secondary:active:not(:disabled),
+.wf-btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.icon-btn:active:not(:disabled),
+.selbar-icon:active:not(:disabled),
+.tree-more:active {
+  transform: scale(0.9);
+}
+.icon-btn,
+.selbar-icon,
+.tree-more {
+  transition:
+    color var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease),
+    transform var(--t-fast) var(--ease);
+}
+@media (prefers-reduced-motion: reduce) {
+  .ghost-pill:active:not(:disabled),
+  button.secondary:active:not(:disabled),
+  .wf-btn:active:not(:disabled),
+  .icon-btn:active:not(:disabled),
+  .selbar-icon:active:not(:disabled),
+  .tree-more:active {
+    transform: none;
   }
 }

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import "./App.css";
 import { AccountMenu } from "./components/AccountMenu";
+import { AsyncButton } from "./components/AsyncButton";
 import { TalkButton } from "./components/TalkButton";
 import { BacklinksPanel } from "./components/BacklinksPanel";
 import { Editor } from "./components/Editor";
@@ -11,6 +13,7 @@ import { SyncBadge } from "./components/Identity";
 import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { SidebarResizer } from "./components/SidebarResizer";
+import { Toasts } from "./components/Toasts";
 import { VaultPicker } from "./components/VaultPicker";
 import { bridgeManager } from "./lib/bridge";
 import { BRAND_NAME } from "./lib/brand";
@@ -22,21 +25,65 @@ import { previewKind } from "./lib/preview";
 import { useSidebarWidth } from "./lib/useSidebarWidth";
 import { useStore } from "./store";
 
+/**
+ * Every banner in the app slides down out of the chrome it belongs to and
+ * collapses its own height on the way out.
+ *
+ * The height animation is the part that matters: a banner that appears with
+ * `display: none → block` shoves the editor down by 44px in one frame, and the
+ * eye reads that as the *content* jumping rather than as a message arriving.
+ * Animating `height` means the layout opens up for it, so attention follows the
+ * banner instead of chasing the text that moved.
+ */
+function Banner({
+  children,
+  show,
+  className = "",
+  role,
+}: {
+  children: React.ReactNode;
+  show: boolean;
+  className?: string;
+  role?: "status" | "alert";
+}) {
+  const reduceMotion = useReducedMotion();
+  return (
+    <AnimatePresence initial={false}>
+      {show && (
+        <motion.div
+          className="banner-slot"
+          initial={reduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+          animate={reduceMotion ? { opacity: 1 } : { height: "auto", opacity: 1 }}
+          exit={reduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+          transition={
+            reduceMotion
+              ? { duration: 0.12 }
+              : { type: "spring", stiffness: 380, damping: 34 }
+          }
+        >
+          <div className={`banner ${className}`.trim()} role={role}>
+            {children}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
 function RemovedBanner() {
   const noteRemoved = useStore((s) => s.noteRemoved);
   const openNote = useStore((s) => s.openNote);
-  if (!noteRemoved || !openNote) return null;
   return (
-    <div className="banner">
+    <Banner show={!!noteRemoved && !!openNote}>
       <span>
-        <strong>{openNote.title}</strong> was deleted on disk.
+        <strong>{openNote?.title}</strong> was deleted on disk.
       </span>
       <div className="banner-actions">
         <button className="primary" onClick={() => useStore.getState().closeNote()}>
           Close note
         </button>
       </div>
-    </div>
+    </Banner>
   );
 }
 
@@ -50,9 +97,8 @@ function RemovedBanner() {
  */
 function DeletedByTeammateBanner() {
   const trashedTo = useStore((s) => s.noteRemovedByTeammate);
-  if (!trashedTo) return null;
   return (
-    <div className="banner">
+    <Banner show={!!trashedTo}>
       <span>
         A teammate deleted this note. Your copy was moved to <code>{trashedTo}</code>.
       </span>
@@ -64,7 +110,7 @@ function DeletedByTeammateBanner() {
           Dismiss
         </button>
       </div>
-    </div>
+    </Banner>
   );
 }
 
@@ -84,14 +130,14 @@ function MemberJoinedBanner() {
     return cancel;
   }, [memberJoined?.at]);
 
-  if (!memberJoined) return null;
-
   return (
     <>
-      <canvas ref={canvasRef} className="celebrate-confetti" aria-hidden="true" />
-      <div className="banner celebrate-banner" role="status">
+      {memberJoined && (
+        <canvas ref={canvasRef} className="celebrate-confetti" aria-hidden="true" />
+      )}
+      <Banner show={!!memberJoined} className="celebrate-banner" role="status">
         <span>
-          🎉 <strong>{memberJoined.name}</strong> joined the vault
+          🎉 <strong>{memberJoined?.name}</strong> joined the vault
         </span>
         <div className="banner-actions">
           <button
@@ -101,7 +147,7 @@ function MemberJoinedBanner() {
             Dismiss
           </button>
         </div>
-      </div>
+      </Banner>
     </>
   );
 }
@@ -146,9 +192,12 @@ function VaultFolderPrompt() {
           folder — separate from your other vaults.
         </p>
         <div className="vault-folder-actions">
-          <button
+          {/* Both of these open a vault: a native picker, then a full vault open
+              + reconcile. Easily a second or two, so each reports for itself. */}
+          <AsyncButton
             className="wf-btn wf-btn-primary"
             disabled={busy}
+            spinnerTone="on-accent"
             onClick={run(() => useStore.getState().chooseVaultFolder())}
           >
             <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -156,8 +205,8 @@ function VaultFolderPrompt() {
               <path d="M3 10h16.5a2 2 0 0 1 1.95 2.46l-1.1 5A2 2 0 0 1 18.4 19H5a2 2 0 0 1-2-2z" />
             </svg>
             <span>Open a folder…</span>
-          </button>
-          <button
+          </AsyncButton>
+          <AsyncButton
             className="wf-btn wf-btn-ghost"
             disabled={busy}
             onClick={run(() => useStore.getState().startEmptyVault())}
@@ -166,7 +215,7 @@ function VaultFolderPrompt() {
               <path d="M12 5v14M5 12h14" />
             </svg>
             <span>Start with an empty folder</span>
-          </button>
+          </AsyncButton>
         </div>
         {error && <p className="error">{error}</p>}
         {pending.previousOrgId && (
@@ -199,20 +248,20 @@ function UpdateBanner() {
 
   if (update.phase === "available") {
     return (
-      <div className="banner update-banner">
+      <Banner show className="update-banner">
         <span>
           A new version of {BRAND_NAME} (<strong>{update.version}</strong>) is
           available.
         </span>
         <div className="banner-actions">
-          <button className="primary" onClick={() => void installUpdate()}>
+          <AsyncButton className="primary" onClick={() => installUpdate()}>
             Install &amp; Restart
-          </button>
+          </AsyncButton>
           <button className="secondary" onClick={() => setDismissed(true)}>
             Later
           </button>
         </div>
-      </div>
+      </Banner>
     );
   }
 
@@ -222,13 +271,29 @@ function UpdateBanner() {
         ? Math.round((update.downloaded / update.total) * 100)
         : null;
     return (
-      <div className="banner update-banner">
+      <Banner show className="update-banner" role="status">
         <span>
           {update.phase === "installing"
             ? "Installing update — the app will restart…"
             : `Downloading update${pct != null ? ` — ${pct}%` : "…"}`}
         </span>
-      </div>
+        {/* A determinate bar when the server sent a content length, an
+            indeterminate sweep when it didn't. The distinction is worth the
+            extra rule: a bar that fills to an unknown target and stalls is
+            worse than one that never claimed to know. */}
+        <div
+          className={`update-progress${pct == null ? " indeterminate" : ""}`}
+          role="progressbar"
+          aria-valuenow={pct ?? undefined}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <span
+            className="update-progress-fill"
+            style={pct != null ? { width: `${pct}%` } : undefined}
+          />
+        </div>
+      </Banner>
     );
   }
 
@@ -264,6 +329,7 @@ function SyncIndicator() {
 export default function App() {
   const vault = useStore((s) => s.vault);
   const openNote = useStore((s) => s.openNote);
+  const switchingVault = useStore((s) => s.switchingVault);
   // An open image/PDF preview isn't a synced note — hide the save/sync chrome.
   const isPreview = openNote != null && previewKind(openNote.path) != null;
   const [booting, setBooting] = useState(true);
@@ -492,7 +558,13 @@ export default function App() {
       {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
       <aside className="sidebar">
         <SidebarHeader />
-        <FileTree />
+        {/* The tree still lists the OUTGOING vault's files until the folder
+            swaps, so a switch fades it and stops taking clicks — opening a note
+            from a vault you're leaving would be cancelled by the epoch guard
+            anyway, and a row that highlights then does nothing reads as a bug. */}
+        <div className={`sidebar-tree-wrap${switchingVault ? " is-switching" : ""}`}>
+          <FileTree />
+        </div>
         <div className="sidebar-footer">
           <AccountMenu />
         </div>
@@ -569,6 +641,8 @@ export default function App() {
         </ErrorBoundary>
       )}
       <VaultFolderPrompt />
+      {/* Last child so it layers over everything without a z-index race. */}
+      <Toasts />
     </div>
   );
 }

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -15,7 +15,9 @@ import { readOrgVaults, useStore } from "../store";
 import { statusTone } from "../lib/presence/color";
 import { AccessPanel } from "./AccessPanel";
 import { AccountSettings } from "./AccountSettings";
+import { AsyncButton } from "./AsyncButton";
 import { Avatar, SyncBadge } from "./Identity";
+import { Spinner } from "./Spinner";
 import { ThemeToggle } from "./ThemeToggle";
 import { UpgradeDialog } from "./UpgradeDialog";
 
@@ -519,12 +521,16 @@ function AccountPopover({
               <span className="muted" title={inv.organizationId}>
                 Vault invitation · {inv.role}
               </span>
-              <button
+              {/* Accepting is: accept → re-read session → roster → switch into
+                  the vault → bind a folder → reconcile. Easily seconds, and it
+                  used to be a bare fire-and-forget click with no acknowledgement
+                  of any kind. */}
+              <AsyncButton
                 className="primary sm"
-                onClick={() => void useStore.getState().acceptInvitation(inv.id)}
+                onClick={() => useStore.getState().acceptInvitation(inv.id)}
               >
                 Accept
-              </button>
+              </AsyncButton>
             </div>
           ))}
         </div>
@@ -548,6 +554,10 @@ function AccountPopover({
             className={`menu-item${isActive ? " active" : ""}`}
             role="menuitemradio"
             aria-checked={isActive}
+            // Fire-and-forget on purpose: the switch is long and the menu should
+            // not sit open through it. The feedback lives in the sidebar header,
+            // which renames itself to this vault immediately (`switchingVault`)
+            // and spins until the folder has swapped.
             onClick={() => {
               if (!isActive) {
                 void useStore.getState().setActiveOrganization(o.id);
@@ -857,6 +867,7 @@ export function AuthDialog({
             >
               <GoogleGlyph />
               <span>{googleBusy ? "Waiting for your browser…" : "Continue with Google"}</span>
+              {googleBusy && <Spinner size="xs" tone="neutral" />}
             </button>
             {googleBusy && (
               <p className="auth-hint">
@@ -899,8 +910,16 @@ export function AuthDialog({
             minLength={8}
             required
           />
-          <button className="primary" type="submit" disabled={busy || googleBusy}>
-            {busy ? "…" : mode === "sign-in" ? "Sign in" : "Create account"}
+          <button
+            className={`primary${busy ? " is-busy" : ""}`}
+            type="submit"
+            disabled={busy || googleBusy}
+            aria-busy={busy || undefined}
+          >
+            <span className="async-btn-label">
+              {mode === "sign-in" ? "Sign in" : "Create account"}
+            </span>
+            {busy && <Spinner size="xs" tone="on-accent" />}
           </button>
         </form>
 
@@ -915,12 +934,13 @@ export function AuthDialog({
               placeholder="https://api.baalda.com"
               spellCheck={false}
             />
-            <button
+            <AsyncButton
               type="button"
-              onClick={() => void useStore.getState().setServerUrl(urlDraft.trim())}
+              confirm
+              onClick={() => useStore.getState().setServerUrl(urlDraft.trim())}
             >
               Save
-            </button>
+            </AsyncButton>
           </div>
         </details>
       </div>
@@ -1595,35 +1615,35 @@ function VaultsTab() {
                   >
                     Cancel
                   </button>
-                  <button
+                  <AsyncButton
                     className="link-btn danger"
                     disabled={busy}
-                    onClick={() => void deletePermanently(o.id)}
+                    onClick={() => deletePermanently(o.id)}
                   >
                     Delete
-                  </button>
+                  </AsyncButton>
                 </span>
               ) : (
                 <span className="vault-row-actions">
                   {isActive ? (
                     <span className="member-role">Current</span>
                   ) : (
-                    <button
+                    <AsyncButton
                       className="link-btn"
                       disabled={busy}
-                      onClick={() => void switchTo(o.id)}
+                      onClick={() => switchTo(o.id)}
                     >
                       Switch
-                    </button>
+                    </AsyncButton>
                   )}
-                  <button
+                  <AsyncButton
                     className="link-btn"
                     disabled={busy}
                     title="Stop syncing this vault here; server data is kept"
-                    onClick={() => void removeLocal(o.id)}
+                    onClick={() => removeLocal(o.id)}
                   >
                     Remove from device
-                  </button>
+                  </AsyncButton>
                   {canDelete(o.id) && (
                     <button
                       className="link-btn danger"
@@ -1733,26 +1753,26 @@ function VaultsTab() {
                       >
                         Cancel
                       </button>
-                      <button
+                      <AsyncButton
                         className="link-btn danger"
                         disabled={busy}
-                        onClick={() => void deleteLocalFiles(r.path)}
+                        onClick={() => deleteLocalFiles(r.path)}
                       >
                         Delete
-                      </button>
+                      </AsyncButton>
                     </span>
                   ) : (
                     <span className="vault-row-actions">
                       {isCurrent ? (
                         <span className="member-role">Current</span>
                       ) : (
-                        <button
+                        <AsyncButton
                           className="link-btn"
                           disabled={busy}
-                          onClick={() => void switchToLocal(r.path)}
+                          onClick={() => switchToLocal(r.path)}
                         >
                           Switch
-                        </button>
+                        </AsyncButton>
                       )}
                       <button
                         className="link-btn"
@@ -1961,13 +1981,13 @@ function MembersTab({ canManage }: { canManage: boolean }) {
               {canRemove(m) &&
                 (confirmRemoveId === m.userId ? (
                   <>
-                    <button
+                    <AsyncButton
                       className="link-btn danger"
                       disabled={removeBusy}
-                      onClick={() => void doRemove(m.userId)}
+                      onClick={() => doRemove(m.userId)}
                     >
-                      {removeBusy ? "Removing…" : "Confirm"}
-                    </button>
+                      Confirm
+                    </AsyncButton>
                     <button
                       className="link-btn"
                       disabled={removeBusy}
@@ -2099,15 +2119,13 @@ function BillingTab({ canManage }: { canManage: boolean }) {
           )}
           {error && <div className="auth-error">{error}</div>}
           {canManage ? (
-            <button
+            <AsyncButton
               className="secondary billing-action"
               disabled={busy}
-              aria-busy={busy}
-              onClick={() => void manage()}
+              onClick={manage}
             >
-              {busy && <span className="btn-spinner" aria-hidden="true" />}
-              <span>Manage subscription</span>
-            </button>
+              Manage subscription
+            </AsyncButton>
           ) : (
             <div className="muted">Ask an owner or admin to manage the subscription.</div>
           )}
@@ -2424,13 +2442,13 @@ function McpTab() {
                   >
                     {open ? "Hide tools" : `Tools · ${tools.length}`}
                   </button>
-                  <button
+                  <AsyncButton
                     className="link-btn danger"
                     disabled={busy}
-                    onClick={() => void revoke(t.id)}
+                    onClick={() => revoke(t.id)}
                   >
                     Revoke
-                  </button>
+                  </AsyncButton>
                 </div>
                 {open && (
                   <ul className="mcp-tool-list">
@@ -2571,9 +2589,9 @@ function UpdatesTab() {
         <div className="update-detail">
           <div className="subhead">Version {update.version} available</div>
           {update.notes && <div className="muted release-notes">{update.notes}</div>}
-          <button className="primary sm" onClick={() => void installUpdate()}>
+          <AsyncButton className="primary sm" onClick={() => installUpdate()}>
             Install &amp; Restart
-          </button>
+          </AsyncButton>
         </div>
       )}
     </div>

--- a/app/apps/desktop/src/components/AsyncButton.tsx
+++ b/app/apps/desktop/src/components/AsyncButton.tsx
@@ -1,0 +1,82 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { CheckMark, Spinner } from "./Spinner";
+import { useAsyncAction } from "../lib/useAsyncAction";
+
+type Native = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">;
+
+export interface AsyncButtonProps extends Native {
+  /** The action. Its promise is what the button reports on. */
+  onClick: () => Promise<unknown> | unknown;
+  children: ReactNode;
+  /** Show a success tick for a beat when it resolves. Off by default. */
+  confirm?: boolean;
+  /** Spinner colour: default reads the button's own fill. */
+  spinnerTone?: "neutral" | "accent" | "on-accent";
+  /**
+   * Replace the label with the spinner instead of sitting beside it. Use in
+   * cramped rows; the default (label + spinner) is calmer because the button
+   * doesn't appear to change identity mid-action.
+   */
+  replaceLabel?: boolean;
+  /** Extra disabling on top of "is it running". */
+  disabled?: boolean;
+}
+
+/**
+ * A button that reports on its own async work: pressed → disabled immediately,
+ * spinner once the wait outlives `SPINNER_DELAY`, optional tick when it lands.
+ *
+ * This exists because the alternative — a `useState` busy flag per call site —
+ * was already applied inconsistently across the app: some buttons swapped their
+ * label ("Opening…"), some disabled silently, and most did nothing at all, so
+ * pressing them looked identical to pressing a dead control. One component
+ * makes the behaviour uniform and makes *forgetting* it the exception.
+ *
+ * The label keeps its own width while a spinner is beside it, so the button
+ * never resizes mid-action — a control that changes shape under the cursor is
+ * how you get a mis-click on whatever moves into its place.
+ */
+export const AsyncButton = forwardRef<HTMLButtonElement, AsyncButtonProps>(
+  function AsyncButton(
+    {
+      onClick,
+      children,
+      confirm = false,
+      spinnerTone,
+      replaceLabel = false,
+      disabled,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    // `swallow` because a button is a leaf: there is nobody above it to catch a
+    // rejection, and an uncaught one in an event handler is just a console
+    // error. Callers that need the error render it from their own state.
+    const action = useAsyncAction(onClick, { confirm, swallow: true });
+    const tone =
+      spinnerTone ?? (className?.includes("primary") ? "on-accent" : "inherit");
+    const busy = action.showPending;
+
+    return (
+      <button
+        {...rest}
+        ref={ref}
+        className={`${className ?? ""}${busy ? " is-busy" : ""}${
+          action.done ? " is-done" : ""
+        }`.trim()}
+        // `pending`, not `showPending`: the guard has to bite on the first click,
+        // not 140ms later.
+        disabled={disabled || action.pending}
+        aria-busy={action.pending || undefined}
+        onClick={() => void action.run()}
+      >
+        {!(replaceLabel && (busy || action.done)) && (
+          <span className="async-btn-label">{children}</span>
+        )}
+        {busy && <Spinner size="xs" tone={tone} />}
+        {action.done && <CheckMark size="xs" />}
+      </button>
+    );
+  },
+);

--- a/app/apps/desktop/src/components/Editor.tsx
+++ b/app/apps/desktop/src/components/Editor.tsx
@@ -296,6 +296,9 @@ export function Editor() {
 
   const [peers, setPeers] = useState<Peer[]>([]);
   const [readOnly, setReadOnly] = useState(false);
+  // False from the moment a note starts opening until its CodeMirror view is in
+  // the DOM. Drives the loading skeleton over the (genuinely empty) pane.
+  const [viewMounted, setViewMounted] = useState(false);
   // Editability is held in a Compartment so a lock applied while the note is
   // open can flip the live view read-only without rebuilding it.
   const editableRef = useRef<Compartment | null>(null);
@@ -376,6 +379,11 @@ export function Editor() {
     let view: EditorView | null = null;
     let awareness: Awareness | null = null;
     let onAwarenessChange: (() => void) | null = null;
+    // The editor pane is empty until CodeMirror is constructed below, and
+    // getting there means opening the bridge, hydrating the CRDT from SQLite
+    // and — for a synced note — waiting out the provider's first sync. On a
+    // cold note that is a blank white sheet for long enough to look broken.
+    setViewMounted(false);
 
     const navigate = async (target: string) => {
       try {
@@ -446,6 +454,7 @@ export function Editor() {
 
       view = new EditorView({ state, parent: hostRef.current });
       viewRef.current = view;
+      setViewMounted(true);
       setActiveView(view); // let out-of-tree drops embed into this note
       if (!ro) view.focus();
 
@@ -475,6 +484,7 @@ export function Editor() {
       cancelled = true;
       if (onAwarenessChange && awareness) awareness.off("change", onAwarenessChange);
       setActiveView(null);
+      setViewMounted(false);
       if (view) view.destroy();
       viewRef.current = null;
       editableRef.current = null;
@@ -617,7 +627,33 @@ export function Editor() {
           )}
         </div>
       )}
+      {/* The host must stay mounted whether or not the view exists — the effect
+          above needs `hostRef.current` to attach CodeMirror to — so the skeleton
+          overlays it rather than replacing it. */}
       <div className="editor-host" ref={hostRef} />
+      {!viewMounted && <EditorSkeleton />}
+    </div>
+  );
+}
+
+/**
+ * Placeholder for a note that is still opening.
+ *
+ * Deliberately lines of text rather than a spinner. A spinner says "wait"; a
+ * skeleton says "text is arriving, and roughly this much of it" — and because it
+ * occupies the same column as the real content, the note doesn't visibly jump
+ * when it swaps in. The bars only appear after a beat (`skeleton-in` has a
+ * delay) so a note that opens from the local index in 40ms — the common case —
+ * never flashes one.
+ */
+function EditorSkeleton() {
+  return (
+    <div className="editor-skeleton" role="status" aria-label="Opening note">
+      <span className="skel-line skel-title" />
+      <span className="skel-line" style={{ width: "92%" }} />
+      <span className="skel-line" style={{ width: "78%" }} />
+      <span className="skel-line" style={{ width: "85%" }} />
+      <span className="skel-line" style={{ width: "45%" }} />
     </div>
   );
 }

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -27,7 +27,10 @@ import {
   type TreeSyncIndex,
 } from "../lib/syncRollup";
 import { embedDroppedFile } from "../lib/attachments";
+import { toast } from "../lib/toast";
 import { deletePaths } from "../lib/vault/mutatePaths";
+import { AsyncButton } from "./AsyncButton";
+import { Spinner } from "./Spinner";
 import { activeNoteEditable, insertIntoActiveNote } from "../lib/editor/activeView";
 import { useStore } from "../store";
 import { shareResourceId } from "../lib/api";
@@ -161,11 +164,6 @@ export function FileTree() {
   const [treeCollapsed, setTreeCollapsed] = useState(false);
   // True while an OS drag hovers the tree, for the drop-target highlight.
   const [dropActive, setDropActive] = useState(false);
-  // Transient status pill shown after an import (from the menu or a drop).
-  const [importStatus, setImportStatus] = useState<
-    { text: string; tone: "success" | "error" | "neutral" } | null
-  >(null);
-  const importStatusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Multi-select: a mode toggle + the set of picked paths. Kept local to the
   // tree (react-arborist's own selection is left alone) so the bulk-action bar
   // only exists while selecting and doesn't crowd the normal browsing UI.
@@ -376,10 +374,7 @@ export function FileTree() {
   useEffect(() => {
     const close = () => setMenu(null);
     window.addEventListener("click", close);
-    return () => {
-      window.removeEventListener("click", close);
-      if (importStatusTimer.current) clearTimeout(importStatusTimer.current);
-    };
+    return () => window.removeEventListener("click", close);
   }, []);
 
   async function refreshAll() {
@@ -408,12 +403,13 @@ export function FileTree() {
     }
   }
 
-  /** Flash a short-lived status pill (auto-dismisses). */
-  function flashStatus(text: string, tone: "success" | "error" | "neutral" = "success") {
-    setImportStatus({ text, tone });
-    if (importStatusTimer.current) clearTimeout(importStatusTimer.current);
-    importStatusTimer.current = setTimeout(() => setImportStatus(null), 4500);
-  }
+  /**
+   * Announce an outcome. Was a pill local to this component; now the shared
+   * toast, so an import result and (say) an export failure speak the same
+   * language and stack in the same corner instead of the sidebar owning a
+   * private notification surface nothing else could reach.
+   */
+  const flashStatus = toast;
 
   /** Announce an import outcome: green on success, neutral if nothing landed. */
   function announceImport(s: ipc.ImportSummary) {
@@ -550,8 +546,13 @@ export function FileTree() {
       // Pinned so a switch during the dialog can't export the OTHER vault's notes
       // to the destination the user chose for this one.
       await ipc.exportPath(node.data.path, dest, epoch);
+      // Export writes outside the vault, so nothing in the app changes to show it
+      // worked. Silence here read as "the menu item is broken"; a whole folder
+      // export can also take a while, and this is the only sign it finished.
+      flashStatus(`Exported ${basename(node.data.path)}`);
     } catch (e) {
       console.error("export failed", e);
+      flashStatus("Export failed", "error");
     }
   }
 
@@ -856,22 +857,29 @@ export function FileTree() {
             <div className="selbar-actions">
               {canManage && syncEnabled && (
                 <>
-                  <button
+                  {/* One server round trip per selected item, so a lock over a
+                      large selection is a real wait. `replaceLabel` swaps the
+                      padlock for the spinner — an icon button has no room for
+                      both, and a 28px control that grows would push its
+                      neighbours under the cursor mid-click. */}
+                  <AsyncButton
                     className="selbar-icon"
-                    onClick={() => void bulkLock()}
+                    onClick={bulkLock}
+                    replaceLabel
                     title="Lock selected"
                     aria-label="Lock selected"
                   >
                     {ICON_LOCK}
-                  </button>
-                  <button
+                  </AsyncButton>
+                  <AsyncButton
                     className="selbar-icon"
-                    onClick={() => void bulkUnlock()}
+                    onClick={bulkUnlock}
+                    replaceLabel
                     title="Unlock selected"
                     aria-label="Unlock selected"
                   >
                     {ICON_UNLOCK}
-                  </button>
+                  </AsyncButton>
                 </>
               )}
               <button
@@ -998,12 +1006,6 @@ export function FileTree() {
 
       {shareTarget && (
         <ShareDialog target={shareTarget} onClose={() => setShareTarget(null)} />
-      )}
-
-      {importStatus && (
-        <div className={`filetree-status ${importStatus.tone}`} role="status">
-          {importStatus.text}
-        </div>
       )}
     </div>
   );
@@ -1214,6 +1216,10 @@ function Node({
   const isEmpty =
     isDir && node.data.childrenLoaded === true && (node.data.children?.length ?? 0) === 0;
   const isSelected = !isDir && node.data.path === selectedPath;
+  // Subscribed as a boolean rather than by pulling the path and comparing, so a
+  // note opening elsewhere in the tree doesn't re-render every other row — this
+  // component is instantiated once per visible row.
+  const isOpening = useStore((s) => s.openingNotePath === node.data.path);
   const colorValue = itemColorValue(color);
   const peers = peersForNode(node, presenceByDoc);
   // Compose arborist's per-level indent with the row's base inset so every
@@ -1227,7 +1233,12 @@ function Node({
       data-tree-dir={isDir ? node.data.path : parentDir(node.data.path)}
       className={`tree-row${isSelected ? " selected" : ""}${isDir ? " is-dir" : ""}${
         node.willReceiveDrop ? " drop-target" : ""
-      }${node.isDragging ? " dragging" : ""}${checked ? " checked" : ""}`}
+      }${node.isDragging ? " dragging" : ""}${checked ? " checked" : ""}${
+        // Pre-selects the row the instant it's clicked, so the selection doesn't
+        // wait on `getNoteMeta` + `registerNote` to come back from the server.
+        isOpening ? " opening" : ""
+      }`}
+      aria-busy={isOpening || undefined}
       onContextMenu={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -1270,13 +1281,22 @@ function Node({
         style={colorValue ? { color: colorValue } : undefined}
         aria-hidden="true"
       >
-        {isDir
-          ? node.isOpen && !isEmpty
-            ? ICON_FOLDER_OPEN
-            : ICON_FOLDER
-          : isHtmlPath(node.data.path)
-            ? ICON_HTML
-            : ICON_FILE}
+        {/* The glyph slot is the row's own status light: while a note is being
+            opened it becomes the spinner. Reusing the slot rather than adding one
+            keeps the label from shifting sideways as the state changes. */}
+        {isOpening ? (
+          <Spinner size="xs" tone="accent" />
+        ) : isDir ? (
+          node.isOpen && !isEmpty ? (
+            ICON_FOLDER_OPEN
+          ) : (
+            ICON_FOLDER
+          )
+        ) : isHtmlPath(node.data.path) ? (
+          ICON_HTML
+        ) : (
+          ICON_FILE
+        )}
       </span>
       {node.isEditing ? (
         <input

--- a/app/apps/desktop/src/components/GraphView.tsx
+++ b/app/apps/desktop/src/components/GraphView.tsx
@@ -51,7 +51,10 @@ const FALLBACK_ACCENT = "#7f73ff";
 // So the settle now happens BEFORE the first frame (`presettle`), and the only
 // motion left on open is a soft fade + a barely-there scale — the "heartbeat".
 // The layout itself is static from frame one.
-const INTRO_MS = 620; // fade/scale-in only; no node motion
+// Must match the `graph-heartbeat` keyframes duration in graph.css — the CSS
+// drives the scale pulse, this drives the light pulse, and they have to peak
+// together or the graph reads as two effects rather than one heartbeat.
+const INTRO_MS = 1150;
 
 // Time budget for settling the layout before the first paint. This blocks the
 // UI thread, so it is a budget and not a tick count: small vaults converge in
@@ -121,6 +124,21 @@ function smoothstep(edge0: number, edge1: number, x: number): number {
  * is — alpha is monotonically decreasing, so an early exit means "slightly warm"
  * (a drift over a second) rather than "unsettled" (a visible rearrangement).
  */
+/**
+ * The heartbeat envelope, 0 at rest and peaking on each beat. Two Gaussian bumps
+ * at the same instants as the `graph-heartbeat` keyframes: a strong one at 16%
+ * and a weaker one at 40%.
+ *
+ * Gaussians rather than the triangular ramps the keyframes use, because a
+ * brightness change wants softer shoulders than a scale change — a linear light
+ * ramp has a visible corner at the peak where a size ramp does not.
+ */
+function heartbeatEnvelope(t: number): number {
+  const bump = (center: number, width: number) =>
+    Math.exp(-(((t - center) / width) ** 2));
+  return Math.min(1, bump(0.16, 0.075) + 0.55 * bump(0.4, 0.06));
+}
+
 function presettle(sim: Simulation<SimNode, SimLink>): void {
   const deadline = performance.now() + PRESETTLE_BUDGET_MS;
   const BATCH = 20;
@@ -909,16 +927,14 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       const zoomLabelAlpha =
         ls <= 0 ? 0 : clamp((k - start) / (end - start), 0, 1);
 
-      // The only per-node part of the entrance: nodes come up a touch brighter
-      // and ease down to their resting glow — a breath, on a layout that is
-      // already static. Nothing here moves anything.
+      // The light half of the heartbeat. The nodes brighten on the same two beats
+      // the CSS scales on, so the brain looks like it pulses rather than like it
+      // was merely animated in. The layout underneath does not move at all.
       const nowT = performance.now();
       const introT =
         S.introStart > 0 ? clamp((nowT - S.introStart) / INTRO_MS, 0, 1) : 1;
       const introEase = 1 - Math.pow(1 - introT, 3); // easeOutCubic
-      // Modest on purpose. This was 2.1× when it had a scattering layout to
-      // dress up; against a settled one that reads as a flashbulb.
-      const glowBoost = 1 + (1 - introEase) * 0.45;
+      const glowBoost = 1 + heartbeatEnvelope(introT) * 0.8;
 
       const nodeScale = s.nodeSize;
       const time = nowT / 1000;

--- a/app/apps/desktop/src/components/GraphView.tsx
+++ b/app/apps/desktop/src/components/GraphView.tsx
@@ -21,6 +21,7 @@ import { WebGLGraphRenderer, type RenderNode } from "../lib/graph/webglRenderer"
 import { SimClient } from "../lib/graph/simClient";
 import { useStore } from "../store";
 import { GraphControls } from "./GraphControls";
+import { Spinner } from "./Spinner";
 import "./graph.css";
 
 // ---------------------------------------------------------------------------
@@ -40,13 +41,25 @@ const LABEL_FADE_END = 2.4; // camera.k at which labels are fully opaque (labelS
 const DEFAULT_FONT_FAMILY = "sans-serif";
 const FALLBACK_ACCENT = "#7f73ff";
 
-// Startup "come to life" burst. Deliberately gentle: the graph should ease open,
-// not explode. A big random kick reads as chaos rather than life, because every
-// node scatters in an unrelated direction at once — the settle that follows is
-// then large enough to look like a glitch. A small nudge over a slightly longer
-// window gives the same "it's alive" impression while staying legible.
-const INTRO_MS = 1600; // duration of the light flare + settle
-const INTRO_KICK = 7; // initial random velocity magnitude — a nudge, not a shake
+// The graph opens ALREADY SETTLED. It used to seed positions, kick every node
+// with a random velocity and then animate the whole layout finding its shape on
+// screen — which reads as the view detonating and reassembling itself, not as
+// something coming to life. Watching furniture arrange itself is not an intro;
+// it's a wait you're forced to watch, and it happens every single time you press
+// ⌘G on a graph whose shape you already know.
+//
+// So the settle now happens BEFORE the first frame (`presettle`), and the only
+// motion left on open is a soft fade + a barely-there scale — the "heartbeat".
+// The layout itself is static from frame one.
+const INTRO_MS = 620; // fade/scale-in only; no node motion
+
+// Time budget for settling the layout before the first paint. This blocks the
+// UI thread, so it is a budget and not a tick count: small vaults converge in
+// well under it, and a big one stops early with alpha already low enough that
+// the remaining on-screen motion is a drift rather than a rearrangement.
+// ~650 ticks is full convergence at alphaDecay 0.0103 (see simulation.ts).
+const PRESETTLE_BUDGET_MS = 420;
+const PRESETTLE_MAX_TICKS = 700;
 
 // How hard a *data refresh* re-energizes the layout. The first build needs real
 // energy to find a shape from seeded positions; later rebuilds already have a
@@ -92,6 +105,31 @@ const EDGE_REST = "rgba(128,146,196,1)";
 function smoothstep(edge0: number, edge1: number, x: number): number {
   const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
   return t * t * (3 - 2 * t);
+}
+
+/**
+ * Run the force layout to equilibrium synchronously, before anything is drawn,
+ * so the graph's first frame is its final shape.
+ *
+ * `sim.tick(n)` is d3's own batch form — it advances the layout without
+ * dispatching tick events, which is exactly what a pre-settle wants (our
+ * renderer drives painting from its own rAF loop and must not run yet).
+ *
+ * Ticks are taken in small batches so the elapsed-time check is cheap relative
+ * to the work: `performance.now()` per tick would measure the clock as much as
+ * the physics. When the budget runs out we stop and leave the layout where it
+ * is — alpha is monotonically decreasing, so an early exit means "slightly warm"
+ * (a drift over a second) rather than "unsettled" (a visible rearrangement).
+ */
+function presettle(sim: Simulation<SimNode, SimLink>): void {
+  const deadline = performance.now() + PRESETTLE_BUDGET_MS;
+  const BATCH = 20;
+  let ticks = 0;
+  while (ticks < PRESETTLE_MAX_TICKS && sim.alpha() > sim.alphaMin()) {
+    sim.tick(BATCH);
+    ticks += BATCH;
+    if (performance.now() >= deadline) break;
+  }
 }
 
 /** Parse "#rgb"/"#rrggbb" or "rgb()/rgba()" into [r,g,b] 0–255; grey on failure. */
@@ -344,6 +382,10 @@ export function GraphView({ onClose }: { onClose: () => void }) {
   const webglNeedsFitRef = useRef(true);
 
   const { graph, loading, error, refresh } = useGraphData();
+  // Only the Web Worker path (8k+ nodes) can set this. Inline layouts are
+  // pre-settled synchronously before their first frame, so there is no window
+  // in which they'd need to hide; the worker has one, and this covers it.
+  const [settling, setSettling] = useState(false);
 
   // Settings live in BOTH a ref (read from inside the imperative canvas/sim
   // code, which can't see React state closures) and React state (drives the
@@ -441,6 +483,10 @@ export function GraphView({ onClose }: { onClose: () => void }) {
           if (gen !== S.workerGen) return;
           S.workerActive = false;
           S.needsDraw = true;
+          // Settled: restart the entrance clock so the fade begins now rather
+          // than having elapsed invisibly while the worker was still working.
+          S.introStart = performance.now();
+          setSettling(false);
           requestDrawRef.current();
         },
       );
@@ -517,16 +563,18 @@ export function GraphView({ onClose }: { onClose: () => void }) {
     const first = !S.introKicked;
     sim.alpha(first ? REHEAT_FIRST : Math.max(sim.alpha(), REHEAT_REFRESH));
 
-    // First time real data lands: light the graph up. Give every node a small
-    // random velocity impulse and start the intro clock so the draw loop paints
-    // the light flare from all nodes, then it all settles.
-    if (!S.introKicked && visNodes.length > 0) {
-      for (const node of visNodes) {
-        const a = Math.random() * Math.PI * 2;
-        const m = Math.random() * INTRO_KICK;
-        node.vx += Math.cos(a) * m;
-        node.vy += Math.sin(a) * m;
-      }
+    // First time real data lands: settle the layout NOW, off-screen, so the
+    // first painted frame is the finished shape. The intro clock then drives a
+    // fade + hairline scale only — the graph does not move.
+    //
+    // Not done for the worker path: that exists precisely because ticking a
+    // 8k+ node layout on this thread would freeze the window, and blocking here
+    // would be the same freeze by another name. The worker settles it off-thread
+    // instead (see `worker.init(..., first)` below).
+    if (first && visNodes.length > 0) {
+      const willUseWorker =
+        !openNode && workerRef.current !== null && visNodes.length > WORKER_THRESHOLD;
+      if (!willUseWorker) presettle(sim);
       S.introKicked = true;
       S.introStart = performance.now();
     }
@@ -558,6 +606,13 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         .filter((l) => l.source !== undefined && l.target !== undefined);
       S.workerGen = worker.init(nodeSpec, linkSpec, s, 1200, 800, first);
       S.workerActive = true;
+      // A pre-settle is impossible here — blocking the thread for an 8k+ node
+      // layout is exactly the freeze the worker exists to avoid. So the reveal
+      // waits instead: hold the graph hidden through the FIRST settle and fade
+      // it in cool, rather than showing a huge field rearranging itself. Only
+      // the first build; later refreshes are small warm nudges (REHEAT_REFRESH)
+      // that must not blank a graph the user is already looking at.
+      if (first) setSettling(true);
     } else if (worker) {
       // Switched to local or a small enough set: park the worker.
       worker.stop();
@@ -854,14 +909,16 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       const zoomLabelAlpha =
         ls <= 0 ? 0 : clamp((k - start) / (end - start), 0, 1);
 
-      // Startup burst: everything flares with extra light, then eases to rest.
+      // The only per-node part of the entrance: nodes come up a touch brighter
+      // and ease down to their resting glow — a breath, on a layout that is
+      // already static. Nothing here moves anything.
       const nowT = performance.now();
       const introT =
         S.introStart > 0 ? clamp((nowT - S.introStart) / INTRO_MS, 0, 1) : 1;
       const introEase = 1 - Math.pow(1 - introT, 3); // easeOutCubic
-      // Nodes are brightest at birth, but only modestly so — a 3.4× flare blew
-      // out to near-white and read as a flash rather than a fade-in.
-      const glowBoost = 1 + (1 - introEase) * 1.1;
+      // Modest on purpose. This was 2.1× when it had a scattering layout to
+      // dress up; against a settled one that reads as a flashbulb.
+      const glowBoost = 1 + (1 - introEase) * 0.45;
 
       const nodeScale = s.nodeSize;
       const time = nowT / 1000;
@@ -1005,27 +1062,11 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       ctx!.globalCompositeOperation = "source-over";
       ctx!.restore();
 
-      // ---- Startup light flash (screen space, additive) ----
-      if (introT < 1) {
-        ctx!.save();
-        ctx!.globalCompositeOperation = "lighter";
-        const flash = Math.pow(1 - introEase, 2) * 0.4;
-        const cx = width / 2;
-        const cy = height * 0.44;
-        const g = ctx!.createRadialGradient(
-          cx,
-          cy,
-          0,
-          cx,
-          cy,
-          Math.max(width, height) * 0.6,
-        );
-        g.addColorStop(0, `rgba(160,180,235,${flash})`);
-        g.addColorStop(1, "rgba(160,180,235,0)");
-        ctx!.fillStyle = g;
-        ctx!.fillRect(0, 0, width, height);
-        ctx!.restore();
-      }
+      // The full-screen additive light flash that used to fire here is gone. It
+      // was the visual cover for the layout rearranging itself underneath, and
+      // with the layout now settled before the first frame there is nothing to
+      // cover — it just read as a flashbulb. The entrance is the wrapper's fade
+      // (`.graph-intro`) plus `glowBoost` above, and that is deliberately all.
     }
 
     // Global scope: draw every node on the GPU (auto-fit to the viewport for
@@ -1391,7 +1432,13 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         </button>
       </div>
 
-      <div className="graph-canvas-wrap">
+      {/* The "heartbeat": the settled layout eases up in opacity and by a
+          hairline of scale, once, on open. Done on the wrapper rather than in
+          either canvas so the 2D and WebGL paths get exactly the same entrance,
+          and so it costs one compositor animation instead of per-frame work. */}
+      <div
+        className={`graph-canvas-wrap graph-intro${settling ? " is-settling" : ""}`}
+      >
         <canvas className="graph-canvas" ref={canvasRef} />
         <canvas
           className="graph-canvas"
@@ -1483,6 +1530,17 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         {loading && (
           <div className="graph-state">
             <div className="graph-state-card">Loading graph…</div>
+          </div>
+        )}
+        {settling && !loading && (
+          <div className="graph-state">
+            {/* Big-vault path only. The worker is arranging the layout
+                off-thread; saying so beats revealing thousands of nodes in
+                motion, which is the thing this change exists to remove. */}
+            <div className="graph-state-card graph-settling">
+              <Spinner size="sm" tone="accent" />
+              Arranging {counts.nodes.toLocaleString()} notes…
+            </div>
           </div>
         )}
         {error && !loading && (

--- a/app/apps/desktop/src/components/SidebarHeader.tsx
+++ b/app/apps/desktop/src/components/SidebarHeader.tsx
@@ -1,5 +1,7 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import * as ipc from "../lib/ipc";
 import { useStore } from "../store";
+import { Spinner } from "./Spinner";
 
 /**
  * Sidebar header: the name of the vault you're in, where it lives on disk,
@@ -18,19 +20,39 @@ export function SidebarHeader() {
   const session = useStore((s) => s.session);
   const organizations = useStore((s) => s.organizations);
   const syncEnabled = useStore((s) => s.syncEnabled);
+  const switching = useStore((s) => s.switchingVault);
+  const reduceMotion = useReducedMotion();
 
   if (!vault) return null;
 
   const activeOrg =
     organizations.find((o) => o.id === session?.activeOrganizationId) ?? null;
-  const name = syncEnabled && activeOrg ? activeOrg.name : vault.name;
+  // While a switch is in flight, name the vault we're going TO. This is an
+  // optimistic label, and deliberately so: the switch is many round trips, and
+  // showing the vault being left until the very last one is what made switching
+  // feel like it hadn't registered. If the switch fails the store clears the
+  // flag and this snaps back to the truth.
+  const name = switching?.name ?? (syncEnabled && activeOrg ? activeOrg.name : vault.name);
 
   return (
-    <div className="sidebar-header">
+    <div className={`sidebar-header${switching ? " is-switching" : ""}`}>
       <div className="sidebar-header-main">
-        <span className="vault-name" title={name}>
-          {name}
-        </span>
+        {/* Keyed on the name so a switch cross-fades between the two vaults
+            rather than swapping the text in place. */}
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.span
+            key={name}
+            className="vault-name"
+            title={name}
+            initial={reduceMotion ? false : { opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? undefined : { opacity: 0, y: 4 }}
+            transition={{ duration: reduceMotion ? 0 : 0.16, ease: [0.2, 0, 0, 1] }}
+          >
+            {name}
+          </motion.span>
+        </AnimatePresence>
+        {switching && <Spinner size="xs" tone="accent" className="vault-switch-spinner" />}
         <button
           className="icon-btn vault-reveal"
           title={`Open ${vault.path} in your file manager`}
@@ -56,7 +78,12 @@ export function SidebarHeader() {
         </button>
       </div>
       <div className="vault-line" title={vault.path}>
-        <span className="vault-path">{displayPath(vault.path)}</span>
+        {/* The path is the one thing that is genuinely still the OLD vault's
+            while switching — the folder hasn't swapped yet. Say so rather than
+            showing a path that contradicts the name above it. */}
+        <span className="vault-path">
+          {switching ? "Switching…" : displayPath(vault.path)}
+        </span>
       </div>
     </div>
   );

--- a/app/apps/desktop/src/components/Spinner.tsx
+++ b/app/apps/desktop/src/components/Spinner.tsx
@@ -1,0 +1,53 @@
+/**
+ * The app's one spinner. Before this there were three hand-rolled rings
+ * (updater button, vault picker, upgrade dialog) with different sizes and
+ * durations, which is how a product ends up feeling assembled rather than
+ * designed — the same wait should look the same everywhere.
+ *
+ * Tones exist only where `currentColor` would be wrong:
+ * - `inherit` (default) takes the colour of whatever it sits in, which is right
+ *   almost everywhere — including a red "Delete" link, where a fixed neutral
+ *   grey would quietly contradict the button it belongs to.
+ * - `on-accent` for a filled accent button, where the ring's translucent track
+ *   would vanish into the fill.
+ * - `accent` / `neutral` for standalone spinners with no meaningful inherited
+ *   colour (a vault row, the picker's landing state).
+ */
+export function Spinner({
+  size = "sm",
+  tone = "inherit",
+  className,
+}: {
+  size?: "xs" | "sm" | "md";
+  tone?: "inherit" | "neutral" | "accent" | "on-accent";
+  className?: string;
+}) {
+  return (
+    <span
+      className={`spinner spinner-${size} spinner-${tone}${className ? ` ${className}` : ""}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * The success half of a feedback loop: a check that draws itself in ~260ms
+ * rather than appearing whole. The stroke-dash animation is what makes it read
+ * as "this just completed" instead of "this was always ticked".
+ */
+export function CheckMark({ size = "sm" }: { size?: "xs" | "sm" | "md" }) {
+  return (
+    <svg
+      className={`checkmark checkmark-${size}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}

--- a/app/apps/desktop/src/components/Toasts.tsx
+++ b/app/apps/desktop/src/components/Toasts.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { dismissToast, useToasts, type Toast } from "../lib/toast";
+
+/**
+ * The toast viewport: bottom-right, above everything, never in the way of the
+ * sidebar or the editor's own status row.
+ *
+ * Two details carry most of the feel:
+ * - Toasts slide in from the edge they live on, so the motion explains where
+ *   they came from instead of just fading into existence.
+ * - Hovering the stack **pauses every auto-dismiss**. Reaching for a message
+ *   that then disappears under the cursor is the single most annoying thing a
+ *   toast can do, and it's the reason people distrust them.
+ */
+export function Toasts() {
+  const toasts = useToasts();
+  const hovering = useRef(false);
+
+  return (
+    <div
+      className="toast-viewport"
+      onMouseEnter={() => {
+        hovering.current = true;
+      }}
+      onMouseLeave={() => {
+        hovering.current = false;
+      }}
+    >
+      <AnimatePresence initial={false}>
+        {toasts.map((t) => (
+          <ToastRow key={t.id} toast={t} hovering={hovering} />
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function ToastRow({
+  toast,
+  hovering,
+}: {
+  toast: Toast;
+  hovering: React.RefObject<boolean>;
+}) {
+  const reduceMotion = useReducedMotion();
+
+  // Auto-dismiss, deferred while the pointer is over the stack. Polling on a
+  // slice of the ttl rather than one long timeout is what lets a hover extend
+  // the life of a toast that was already halfway gone.
+  useEffect(() => {
+    if (toast.ttl === 0) return; // sticky (errors)
+    let left = toast.ttl;
+    const STEP = 100;
+    const tick = window.setInterval(() => {
+      if (hovering.current) return;
+      left -= STEP;
+      if (left <= 0) {
+        window.clearInterval(tick);
+        dismissToast(toast.id);
+      }
+    }, STEP);
+    return () => window.clearInterval(tick);
+  }, [toast.id, toast.ttl, hovering]);
+
+  return (
+    <motion.div
+      className={`toast toast-${toast.tone}`}
+      role={toast.tone === "error" ? "alert" : "status"}
+      layout={!reduceMotion}
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, x: 24, scale: 0.96 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={reduceMotion ? { opacity: 0 } : { opacity: 0, x: 24, scale: 0.96 }}
+      transition={
+        reduceMotion
+          ? { duration: 0.12 }
+          : { type: "spring", stiffness: 420, damping: 32 }
+      }
+    >
+      <span className="toast-dot" aria-hidden="true" />
+      <span className="toast-text">{toast.text}</span>
+      <button
+        className="toast-close"
+        aria-label="Dismiss"
+        onClick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </motion.div>
+  );
+}

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -10,6 +10,7 @@ import {
 } from "../store";
 import { AuthDialog } from "./AccountMenu";
 import { Wordmark } from "./Logo";
+import { Spinner } from "./Spinner";
 
 /**
  * A row in the welcome-screen list: either a plain local folder (a recent vault
@@ -79,6 +80,10 @@ function tidyPath(path: string): string {
 
 export function VaultPicker() {
   const authStatus = useStore((s) => s.authStatus);
+  // Sign-in succeeded and a vault is being resolved/created. There's no vault
+  // yet, so App still renders this screen — and without saying so, a sign-in
+  // that is working looks identical to one that silently did nothing.
+  const landingVault = useStore((s) => s.landingVault);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [recents, setRecents] = useState<RecentVault[]>([]);
@@ -88,6 +93,9 @@ export function VaultPicker() {
   // New-vault flow: null = idle; a string = chosen parent, awaiting a name.
   const [newParent, setNewParent] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
+  // Which recent-vault card is being opened, by its key. A single boolean would
+  // only tell the list to grey out; the point is to mark the row you clicked.
+  const [opening, setOpening] = useState<string | null>(null);
   // Recents are collapsed to the 3 most recent; "Load more" reveals the rest
   // inside a scroll area locked to the collapsed height so the logo/buttons
   // above never shift (the vault-picker card is vertically centered).
@@ -188,23 +196,28 @@ export function VaultPicker() {
   // (opening its folder + resyncing); if we're signed out, remember it and
   // prompt sign-in — landInLastVault opens it once the session lands.
   async function openEntry(e: PickerEntry) {
-    if (e.kind === "local") {
-      await reopenLocal(e.path);
-      return;
-    }
-    if (authStatus === "signed-in") {
-      setBusy(true);
-      setError(null);
-      try {
-        await useStore.getState().setActiveOrganization(e.orgId);
-      } catch (err) {
-        setError(String(err));
-      } finally {
-        setBusy(false);
+    setOpening(e.key);
+    try {
+      if (e.kind === "local") {
+        await reopenLocal(e.path);
+        return;
       }
-    } else {
-      requestOpenVault(e.orgId);
-      setSignInOpen(true);
+      if (authStatus === "signed-in") {
+        setBusy(true);
+        setError(null);
+        try {
+          await useStore.getState().setActiveOrganization(e.orgId);
+        } catch (err) {
+          setError(String(err));
+        } finally {
+          setBusy(false);
+        }
+      } else {
+        requestOpenVault(e.orgId);
+        setSignInOpen(true);
+      }
+    } finally {
+      setOpening(null);
     }
   }
 
@@ -229,8 +242,10 @@ export function VaultPicker() {
   }
 
   const naming = newParent !== null;
-  // The naming step is showing — hide the recents/hint behind it.
-  const inFlow = naming;
+  // The naming step or the post-sign-in landing is showing — hide the
+  // recents/hint/sign-in behind it. Offering "New vault" while we are already
+  // making one is how you end up with two.
+  const inFlow = naming || landingVault;
 
   // Merge synced (remote) vaults with local recents into one list. Remote
   // vaults come from the locally-cached org list (survives sign-out) and are
@@ -295,7 +310,25 @@ export function VaultPicker() {
           transition={reduceMotion ? undefined : revealTransition(REVEAL_DELAY)}
         >
           <AnimatePresence mode="wait" initial={false}>
-            {naming ? (
+            {landingVault ? (
+              // ---- Signed in, opening (or creating) their vault. This screen
+              //      is still up only because there is no vault yet; say so,
+              //      or a working sign-in is indistinguishable from one that
+              //      dropped the user straight back here. ----
+              <motion.div
+                key="landing"
+                className="picker-landing"
+                initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reduceMotion ? undefined : { opacity: 0, y: -8 }}
+                transition={SPRING}
+              >
+                <Spinner size="sm" tone="accent" />
+                <p className="picker-landing-label" role="status">
+                  Opening your vault…
+                </p>
+              </motion.div>
+            ) : naming ? (
               // ---- Naming step: only reached via "Create inside" an existing
               //      vault, where a nested vault does need its own folder name.
               //      The normal "New vault" flow skips this — the picked folder
@@ -340,10 +373,17 @@ export function VaultPicker() {
                   </button>
                   <button
                     type="submit"
-                    className="primary sm"
+                    className={`primary sm${busy ? " is-busy" : ""}`}
                     disabled={busy || !newName.trim()}
+                    aria-busy={busy || undefined}
                   >
-                    {busy ? "Creating…" : "Create vault"}
+                    {/* Creating a vault writes the folder, opens it, and seeds
+                        ~20 starter notes — comfortably past the point where a
+                        static label reads as a stuck button. */}
+                    <span className="async-btn-label">
+                      {busy ? "Creating…" : "Create vault"}
+                    </span>
+                    {busy && <Spinner size="xs" tone="on-accent" />}
                   </button>
                 </div>
               </motion.form>
@@ -368,14 +408,18 @@ export function VaultPicker() {
                   New vault
                 </motion.button>
                 <motion.button
-                  className="ghost-pill lg"
+                  className={`ghost-pill lg${busy ? " is-busy" : ""}`}
                   disabled={busy}
+                  aria-busy={busy || undefined}
                   onClick={pickExisting}
                   whileHover={reduceMotion ? undefined : { scale: 1.03, y: -1 }}
                   whileTap={reduceMotion ? undefined : { scale: 0.97 }}
                   transition={SPRING}
                 >
-                  {busy ? "Opening…" : "Open existing"}
+                  <span className="async-btn-label">
+                    {busy ? "Opening…" : "Open existing"}
+                  </span>
+                  {busy && <Spinner size="xs" tone="neutral" />}
                 </motion.button>
               </motion.div>
             )}
@@ -402,21 +446,35 @@ export function VaultPicker() {
               }
             >
               {shownRecents.map((e) => (
-                <div className="recent-card" key={e.key}>
+                <div
+                  className={`recent-card${opening === e.key ? " is-opening" : ""}`}
+                  key={e.key}
+                >
                   <button
                     className="recent-open"
                     disabled={busy}
+                    aria-busy={opening === e.key || undefined}
                     onClick={() => void openEntry(e)}
                     title={e.path ?? e.name}
                   >
                     <span className="recent-name">{e.name}</span>
-                    {e.kind === "remote" ? (
+                    {/* The card the user clicked reports for itself. A single
+                        shared `busy` flag only greyed every row out, which says
+                        "the list is disabled" rather than "this one is opening"
+                        — and opening a vault is seconds of work. */}
+                    {opening === e.key ? (
+                      <Spinner size="xs" tone="accent" className="recent-badge" />
+                    ) : e.kind === "remote" ? (
                       <span className="ws-badge synced recent-badge">Remote</span>
                     ) : e.openedAt > 0 ? (
                       <span className="recent-time">{relativeTime(e.openedAt)}</span>
                     ) : null}
                     <span className="recent-path">
-                      {e.path ? tidyPath(e.path) : "Synced · sign in to open"}
+                      {opening === e.key
+                        ? "Opening…"
+                        : e.path
+                          ? tidyPath(e.path)
+                          : "Synced · sign in to open"}
                     </span>
                   </button>
                   {e.kind === "local" && (

--- a/app/apps/desktop/src/components/editor.css
+++ b/app/apps/desktop/src/components/editor.css
@@ -440,3 +440,69 @@
     opacity: 0;
   }
 }
+
+/* ---- Loading skeleton for a note that is still opening ----
+   Overlays the (genuinely empty) `.editor-host` rather than replacing it: the
+   open effect needs `hostRef.current` in the DOM to attach CodeMirror to.
+
+   The padding deliberately mirrors `.cm-content` in `lib/editor/theme.ts`
+   (`--sp-8` top, the same centred 76ch measure) so the skeleton lines sit
+   exactly where the real text lands. Getting this wrong is worse than no
+   skeleton at all — the content appears to jump sideways as it loads. */
+.editor-skeleton {
+  position: absolute;
+  inset: 0;
+  padding: var(--sp-8) max(var(--sp-8), calc((100% - 76ch) / 2));
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  background: var(--bg-surface);
+  pointer-events: none;
+  /* Held back ~180ms. A note served from the local SQLite index opens in tens of
+     milliseconds, and a skeleton that flashes for one frame reads as a rendering
+     fault rather than as loading. */
+  animation: skeleton-in 0.2s var(--ease) 0.18s both;
+}
+/* `.editor-column` is the positioning context for the overlay above. */
+.editor-column {
+  position: relative;
+}
+.skel-line {
+  height: 12px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--text-primary) 7%, transparent) 0%,
+    color-mix(in srgb, var(--text-primary) 13%, transparent) 50%,
+    color-mix(in srgb, var(--text-primary) 7%, transparent) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s linear infinite;
+}
+.skel-title {
+  height: 22px;
+  width: 58%;
+  margin-bottom: var(--sp-3);
+}
+@keyframes skeleton-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes skeleton-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Keep the shape and the delay, drop the travelling highlight. */
+  .skel-line {
+    animation: none;
+  }
+}

--- a/app/apps/desktop/src/components/graph.css
+++ b/app/apps/desktop/src/components/graph.css
@@ -434,32 +434,81 @@
    scale so it feels like it comes toward you rather than blinking on. Both are
    compositor-only properties, so this costs nothing per frame and cannot fight
    the render loop for the main thread. */
+/* Input is held off through the beats. Hit-testing maps a click via the canvas's
+   `getBoundingClientRect()`, which compensates the pulse's *translation* but not
+   its internal *scale* — so at the peak a click near the edge can land tens of
+   pixels off and open the wrong note. `step-end` holds `none` until the scale is
+   back to 1 at 54%, then releases. Deliberately on the WRAPPER: putting
+   pointer-events in the shared `.graph-canvas` keyframes would also override the
+   WebGL canvas's inline `pointer-events: none`, and that canvas sits on top — it
+   would swallow every interaction for the rest of the session. */
 .graph-intro {
-  animation: graph-intro 0.62s var(--ease) both;
+  animation: graph-intro-guard 0.62s step-end both;
 }
-@keyframes graph-intro {
+@keyframes graph-intro-guard {
   from {
-    opacity: 0;
-    transform: scale(0.985);
+    pointer-events: none;
   }
   to {
+    pointer-events: auto;
+  }
+}
+
+/* The pulse rides the CANVASES, not the wrapper. The wrapper owns the deep-space
+   backdrop and the vignette, and scaling those would shrink the void away from
+   its own edges and pump the vignette in and out. Only the brain beats; the space
+   it sits in holds still. */
+.graph-intro .graph-canvas {
+  animation: graph-heartbeat 1.15s var(--ease) both;
+  transform-origin: 50% 46%; /* matches the backdrop's optical centre */
+  will-change: transform, opacity;
+}
+/* A real lub-dub: one strong beat, a recoil under rest, then a smaller second
+   beat before settling. A single symmetric pulse reads as a zoom bounce; it's the
+   *asymmetry* of the pair — big, dip, small — that the eye recognises as a
+   heartbeat. `glowBoost` in GraphView.tsx brightens the nodes on the same two
+   peaks, so size and light beat together. That pairing is what sells it as alive;
+   scale alone just looks like a transition. */
+@keyframes graph-heartbeat {
+  0% {
+    opacity: 0;
+    transform: scale(0.965);
+  }
+  8% {
+    opacity: 1;
+  }
+  16% {
+    transform: scale(1.045); /* lub */
+  }
+  28% {
+    transform: scale(0.992); /* recoil, just under rest */
+  }
+  40% {
+    transform: scale(1.024); /* dub */
+  }
+  54% {
+    transform: scale(1);
+  }
+  100% {
     opacity: 1;
     transform: scale(1);
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  /* Keep a short fade — an instant hard cut on a full-screen dark surface is its
-     own kind of jolt — but drop the scale entirely. */
-  .graph-intro {
-    animation: graph-fade 0.2s var(--ease) both;
+  /* No pulse. A full-screen surface throbbing is exactly what this setting is
+     asking us not to do — but an instant hard cut is its own jolt, so it keeps
+     the fade. The node glow still breathes; that's light, not motion. */
+  .graph-intro .graph-canvas {
+    animation: graph-fade 0.24s var(--ease) both;
+    will-change: auto;
   }
-  @keyframes graph-fade {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
+}
+@keyframes graph-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 

--- a/app/apps/desktop/src/components/graph.css
+++ b/app/apps/desktop/src/components/graph.css
@@ -422,3 +422,59 @@
   background: var(--bg-hover);
   color: var(--text-primary);
 }
+
+/* ---- Opening the graph ----
+   The layout is settled BEFORE the first frame (`presettle` in GraphView.tsx),
+   so there is nothing to animate positionally — and that's the point. The graph
+   used to seed positions, kick every node with a random velocity and let you
+   watch the whole field find its shape, which reads as the view detonating and
+   reassembling rather than as something arriving. Every ⌘G replayed it.
+
+   What's left is a single settled state easing up: opacity, plus a hairline of
+   scale so it feels like it comes toward you rather than blinking on. Both are
+   compositor-only properties, so this costs nothing per frame and cannot fight
+   the render loop for the main thread. */
+.graph-intro {
+  animation: graph-intro 0.62s var(--ease) both;
+}
+@keyframes graph-intro {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Keep a short fade — an instant hard cut on a full-screen dark surface is its
+     own kind of jolt — but drop the scale entirely. */
+  .graph-intro {
+    animation: graph-fade 0.2s var(--ease) both;
+  }
+  @keyframes graph-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+/* Worker path only (8k+ nodes): the layout is being arranged off-thread and we
+   deliberately do not paint it mid-flight, so hide the canvases until it cools.
+   `visibility` rather than `display: none` — the canvases must keep their real
+   size, or the renderer re-measures to 0×0 and has to rebuild on reveal. */
+.graph-canvas-wrap.is-settling .graph-canvas {
+  visibility: hidden;
+}
+/* Scoped to the settling card only. The base `.graph-state-card` is a COLUMN
+   (the error card stacks a heading over its message), so overriding it globally
+   would lay that out sideways. */
+.graph-state-card.graph-settling {
+  flex-direction: row;
+  gap: var(--sp-2);
+  padding: var(--sp-4) var(--sp-6);
+}

--- a/app/apps/desktop/src/lib/__tests__/toast.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/toast.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearToasts, dismissToast, getToasts, toast } from "../toast";
+
+// The emitter, without React. What's worth pinning is the handful of rules a
+// careless change would quietly reverse — each of which is the difference
+// between a useful notification and one that actively misleads.
+
+afterEach(() => clearToasts());
+
+describe("toast", () => {
+  it("defaults to success and keeps insertion order", () => {
+    toast("first");
+    toast("second", "neutral");
+    expect(getToasts().map((t) => [t.text, t.tone])).toEqual([
+      ["first", "success"],
+      ["second", "neutral"],
+    ]);
+  });
+
+  it("gives errors NO ttl, so a failure can't be missed", () => {
+    // The rule this protects: an error that auto-dismissed while the user was
+    // looking elsewhere becomes "the button did nothing" in a bug report.
+    toast("saved", "success");
+    toast("could not save", "error");
+    const [ok, bad] = getToasts();
+    expect(ok.ttl).toBeGreaterThan(0);
+    expect(bad.ttl).toBe(0);
+  });
+
+  it("caps the stack, dropping the OLDEST", () => {
+    for (let i = 1; i <= 7; i++) toast(`t${i}`);
+    // Newest survive: an old confirmation is worth less than a fresh one, and a
+    // stack taller than the window is just noise.
+    expect(getToasts().map((t) => t.text)).toEqual(["t4", "t5", "t6", "t7"]);
+  });
+
+  it("hands out unique ids and dismisses only the named toast", () => {
+    const a = toast("a");
+    const b = toast("b");
+    expect(a).not.toBe(b);
+    dismissToast(a);
+    expect(getToasts().map((t) => t.text)).toEqual(["b"]);
+  });
+
+  it("treats a repeat or unknown dismiss as a no-op", () => {
+    // The auto-dismiss timer and a user's click race on every toast, and one of
+    // them always loses. Losing must be free, not an exception.
+    const id = toast("a");
+    dismissToast(id);
+    dismissToast(id);
+    dismissToast(4242);
+    expect(getToasts()).toEqual([]);
+  });
+
+  it("replaces the array on every change rather than mutating in place", () => {
+    // `useToasts` stores this array in React state, so an in-place mutation
+    // would be an identity-equal update and the viewport would never re-render.
+    const before = getToasts();
+    toast("a");
+    expect(getToasts()).not.toBe(before);
+  });
+
+  it("clearToasts empties the stack", () => {
+    toast("a");
+    toast("b", "error");
+    clearToasts();
+    expect(getToasts()).toEqual([]);
+  });
+});

--- a/app/apps/desktop/src/lib/toast.ts
+++ b/app/apps/desktop/src/lib/toast.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Transient, low-stakes notifications — "Imported 12 files", "Couldn't copy
+ * link", "Vault renamed".
+ *
+ * Deliberately NOT in the Zustand store. The store is documented as a UI
+ * view-state mirror of the vault, and a toast is neither vault state nor
+ * something any other component reads; putting it there would mean every
+ * subscriber re-renders because a message appeared in the corner. A module-level
+ * emitter also means non-React code (sync callbacks, IPC error paths) can raise
+ * one without reaching for the store.
+ *
+ * Three tones, and the distinction matters: `error` toasts do NOT auto-dismiss,
+ * because a failure the user blinked past is a failure they will report as
+ * "nothing happened". Successes and neutrals do — they're confirmations, and a
+ * confirmation you have to dismiss is a chore.
+ *
+ * This is for things that are *fine to miss twice*. Anything requiring a
+ * decision stays a banner (see `App.tsx`), which persists and has actions.
+ */
+export type ToastTone = "success" | "error" | "neutral";
+
+export interface Toast {
+  id: number;
+  text: string;
+  tone: ToastTone;
+  /** ms until auto-dismiss; 0 = sticky (errors). */
+  ttl: number;
+}
+
+const DEFAULT_TTL = 4200;
+/** Beyond this the oldest are dropped — a stack taller than the app is noise. */
+const MAX_VISIBLE = 4;
+
+let nextId = 1;
+let toasts: Toast[] = [];
+const listeners = new Set<(t: Toast[]) => void>();
+
+function emit(): void {
+  const snapshot = toasts;
+  for (const l of listeners) l(snapshot);
+}
+
+/** Raise a toast. Returns its id so a caller can dismiss it early. */
+export function toast(text: string, tone: ToastTone = "success"): number {
+  const id = nextId++;
+  // Errors stay until dismissed; everything else fades on its own.
+  const ttl = tone === "error" ? 0 : DEFAULT_TTL;
+  toasts = [...toasts, { id, text, tone, ttl }].slice(-MAX_VISIBLE);
+  emit();
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  const next = toasts.filter((t) => t.id !== id);
+  if (next.length === toasts.length) return;
+  toasts = next;
+  emit();
+}
+
+/** Test/teardown helper — drops everything without animating. */
+export function clearToasts(): void {
+  if (toasts.length === 0) return;
+  toasts = [];
+  emit();
+}
+
+/** The current stack. A snapshot: callers must not mutate it. */
+export function getToasts(): readonly Toast[] {
+  return toasts;
+}
+
+export function useToasts(): Toast[] {
+  const [list, setList] = useState<Toast[]>(toasts);
+  useEffect(() => {
+    // Re-sync on subscribe: a toast raised between render and effect would
+    // otherwise be missed until the next one arrived.
+    setList(toasts);
+    listeners.add(setList);
+    return () => {
+      listeners.delete(setList);
+    };
+  }, []);
+  return list;
+}

--- a/app/apps/desktop/src/lib/useAsyncAction.ts
+++ b/app/apps/desktop/src/lib/useAsyncAction.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * The feedback half of every asynchronous action in the app.
+ *
+ * Two numbers do the real work here, and both come from how people perceive
+ * delay rather than from taste:
+ *
+ * - **`SPINNER_DELAY` (140ms).** Under ~100ms an action already feels
+ *   instantaneous, so a spinner that appears immediately is *worse* than none:
+ *   it flashes on and off and reads as a glitch. Waiting a beat means fast
+ *   actions stay silent and only genuinely slow ones grow an indicator. The
+ *   press-down state on the button covers the gap, so the action is never
+ *   unacknowledged — it just isn't yet labelled "waiting".
+ * - **`DONE_HOLD` (900ms).** A success tick that vanishes with the spinner is
+ *   never seen. Holding it briefly closes the loop — the user learns the action
+ *   finished, rather than inferring it from the absence of a spinner.
+ *
+ * `pending` is the honest "still running" flag (use it to disable a control the
+ * instant it's pressed); `showPending` is the *display* flag that respects the
+ * delay. Keeping them separate is what stops a double-submit while also keeping
+ * fast paths visually quiet.
+ */
+export const SPINNER_DELAY = 140;
+export const DONE_HOLD = 900;
+
+export type AsyncPhase = "idle" | "pending" | "done" | "error";
+
+export interface AsyncAction<A extends unknown[]> {
+  /** Invoke the action. Re-entrant calls while pending are dropped. */
+  run: (...args: A) => Promise<void>;
+  /** True from the moment it's invoked until it settles. Use to disable. */
+  pending: boolean;
+  /** True only once the wait has outlived `SPINNER_DELAY`. Use to render. */
+  showPending: boolean;
+  /** Held for `DONE_HOLD` after a success, so the tick is actually seen. */
+  done: boolean;
+  /** The error the last run threw, if it threw. Cleared on the next run. */
+  error: unknown;
+  phase: AsyncPhase;
+  /** Drop a sticky error without re-running (e.g. the user edited the form). */
+  reset: () => void;
+}
+
+export interface AsyncActionOptions {
+  /**
+   * Show a success tick when the action resolves. Off by default: for actions
+   * whose *result* is the feedback (a vault opens, a dialog closes, a row
+   * disappears) a tick is redundant noise, and often the component has already
+   * unmounted by then.
+   */
+  confirm?: boolean;
+  /** Swallow the rejection instead of re-throwing. Default: re-throw. */
+  swallow?: boolean;
+}
+
+/**
+ * Wrap an async function so a control can report that it is working.
+ *
+ * Errors are recorded in `error` and re-thrown by default, because the callers
+ * that already show a message need the throw and silently-swallowed failures
+ * are how "the button did nothing" bugs happen. Pass `swallow` when the phase
+ * alone is the whole story.
+ */
+export function useAsyncAction<A extends unknown[]>(
+  fn: (...args: A) => Promise<unknown> | unknown,
+  opts: AsyncActionOptions = {},
+): AsyncAction<A> {
+  const { confirm = false, swallow = false } = opts;
+  const [phase, setPhase] = useState<AsyncPhase>("idle");
+  const [showPending, setShowPending] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  // `pending` is mirrored into a ref so the re-entrancy guard reads the truth
+  // synchronously — two clicks in the same tick both see the pre-render state.
+  const pendingRef = useRef(false);
+  const alive = useRef(true);
+  const timers = useRef<number[]>([]);
+  // The latest fn without making `run` a new function on every render (which
+  // would defeat memoized children and re-trigger effects that depend on it).
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  const clearTimers = () => {
+    for (const t of timers.current) window.clearTimeout(t);
+    timers.current = [];
+  };
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+      clearTimers();
+    };
+  }, []);
+
+  const run = useCallback(
+    async (...args: A) => {
+      if (pendingRef.current) return; // already running — ignore the second press
+      pendingRef.current = true;
+      clearTimers();
+      setPhase("pending");
+      setError(null);
+      timers.current.push(
+        window.setTimeout(() => {
+          if (alive.current && pendingRef.current) setShowPending(true);
+        }, SPINNER_DELAY),
+      );
+      try {
+        await fnRef.current(...args);
+        if (!alive.current) return;
+        setShowPending(false);
+        if (confirm) {
+          setPhase("done");
+          timers.current.push(
+            window.setTimeout(() => {
+              if (alive.current) setPhase("idle");
+            }, DONE_HOLD),
+          );
+        } else {
+          setPhase("idle");
+        }
+      } catch (e) {
+        if (alive.current) {
+          setShowPending(false);
+          setPhase("error");
+          setError(e);
+        }
+        if (!swallow) throw e;
+      } finally {
+        // Not gated on `alive`: an unmounted component must still release the
+        // guard, or a remounted one inherits a permanently "pending" action.
+        pendingRef.current = false;
+      }
+    },
+    [confirm, swallow],
+  );
+
+  const reset = useCallback(() => {
+    clearTimers();
+    setShowPending(false);
+    setError(null);
+    setPhase("idle");
+  }, []);
+
+  return {
+    run,
+    pending: phase === "pending",
+    showPending: showPending && phase === "pending",
+    done: phase === "done",
+    error,
+    phase,
+    reset,
+  };
+}

--- a/app/apps/desktop/src/lib/vault/__tests__/landing.test.ts
+++ b/app/apps/desktop/src/lib/vault/__tests__/landing.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { planLanding, type LandingInput } from "../landing";
+
+// Signing in must always end somewhere. The bug this suite pins was the absence
+// of the last two branches: a first sign-in holding two or more vaults, and an
+// account holding none, both fell through to "do nothing" — which renders as the
+// signed-out welcome screen, so signing in looked like it had failed.
+
+const base: LandingInput = {
+  orgIds: [],
+  requestedOrgId: null,
+  openPath: null,
+  orgVaults: {},
+  activeOrganizationId: null,
+  rememberedOrgId: null,
+  createIfNone: false,
+};
+const plan = (over: Partial<LandingInput>) => planLanding({ ...base, ...over });
+
+describe("planLanding — an explicit request wins", () => {
+  it("switches to the vault the user clicked before signing in", () => {
+    expect(
+      plan({
+        orgIds: ["a", "b"],
+        requestedOrgId: "b",
+        // Even with a synced folder open and a different vault active.
+        openPath: "/v/a",
+        orgVaults: { a: "/v/a" },
+        activeOrganizationId: "a",
+      }),
+    ).toEqual({ kind: "switch", orgId: "b" });
+  });
+
+  it("ignores a request for a vault we are not a member of", () => {
+    // Removed from the vault between clicking it and finishing sign-in.
+    expect(plan({ orgIds: ["a"], requestedOrgId: "gone" })).toEqual({
+      kind: "switch",
+      orgId: "a",
+    });
+  });
+});
+
+describe("planLanding — a folder is already open", () => {
+  it("just enables sync when the open folder is the active vault's", () => {
+    expect(
+      plan({
+        orgIds: ["a"],
+        openPath: "/v/a",
+        orgVaults: { a: "/v/a" },
+        activeOrganizationId: "a",
+      }),
+    ).toEqual({ kind: "enable-sync" });
+  });
+
+  it("switches when the open folder belongs to a DIFFERENT vault", () => {
+    expect(
+      plan({
+        orgIds: ["a", "b"],
+        openPath: "/v/b",
+        orgVaults: { a: "/v/a", b: "/v/b" },
+        activeOrganizationId: "a",
+      }),
+    ).toEqual({ kind: "switch", orgId: "b" });
+  });
+
+  it("keeps a local-only folder local rather than pulling the user elsewhere", () => {
+    // The whole point of a local-first app: being signed in must not relocate
+    // you. "Turn on sync" is the affordance for adopting this folder.
+    expect(
+      plan({
+        orgIds: ["a", "b"],
+        openPath: "/somewhere/local",
+        orgVaults: { a: "/v/a" },
+        activeOrganizationId: "a",
+        rememberedOrgId: "b",
+        createIfNone: true,
+      }),
+    ).toEqual({ kind: "stay-local" });
+  });
+
+  it("leaves a folder bound to a vault we've been removed from, for one we still have", () => {
+    // Not "stay-local": that binding is dead and can never sync again, so the
+    // restore chain gets to pick a vault the user actually still has.
+    expect(
+      plan({ orgIds: ["b"], openPath: "/v/a", orgVaults: { a: "/v/a" } }),
+    ).toEqual({ kind: "switch", orgId: "b" });
+  });
+});
+
+describe("planLanding — nothing open", () => {
+  it("restores the session's active vault", () => {
+    expect(
+      plan({ orgIds: ["a", "b"], activeOrganizationId: "b", rememberedOrgId: "a" }),
+    ).toEqual({ kind: "switch", orgId: "b" });
+  });
+
+  it("falls back to the last vault used on this device", () => {
+    expect(plan({ orgIds: ["a", "b"], rememberedOrgId: "b" })).toEqual({
+      kind: "switch",
+      orgId: "b",
+    });
+  });
+
+  it("ignores an active or remembered vault we are no longer a member of", () => {
+    expect(
+      plan({ orgIds: ["a"], activeOrganizationId: "gone", rememberedOrgId: "alsogone" }),
+    ).toEqual({ kind: "switch", orgId: "a" });
+  });
+
+  // The regression. Better Auth keeps `activeOrganizationId` on the SESSION row,
+  // so a first sign-in on a device starts null; with 2+ vaults the store's
+  // single-vault auto-activation doesn't fire either. Both prior signals are
+  // therefore empty in the most ordinary case there is, and the old code
+  // returned without doing anything.
+  it("opens the first vault on a first sign-in with several vaults", () => {
+    expect(plan({ orgIds: ["a", "b", "c"] })).toEqual({ kind: "switch", orgId: "a" });
+  });
+
+  it("opens the only vault on a first sign-in with one", () => {
+    expect(plan({ orgIds: ["solo"] })).toEqual({ kind: "switch", orgId: "solo" });
+  });
+});
+
+describe("planLanding — an account with no vaults", () => {
+  it("creates the first vault when the caller allows it", () => {
+    expect(plan({ createIfNone: true })).toEqual({ kind: "create-first-vault" });
+  });
+
+  it("does nothing on a silent session restore at launch", () => {
+    // `createIfNone` is false there on purpose: "I just signed in" earns a
+    // vault, "the app reopened" does not.
+    expect(plan({ createIfNone: false })).toEqual({ kind: "nothing" });
+  });
+
+  it("never creates a vault while a local folder is open", () => {
+    expect(plan({ openPath: "/somewhere/local", createIfNone: true })).toEqual({
+      kind: "stay-local",
+    });
+  });
+
+  it("never creates a vault while a folder with a dead binding is open", () => {
+    // Falls through the restore chain with no vault to restore. Creating one
+    // here would swap out the files the user is looking at.
+    expect(
+      plan({ openPath: "/v/gone", orgVaults: { gone: "/v/gone" }, createIfNone: true }),
+    ).toEqual({ kind: "nothing" });
+  });
+
+  it("never creates a vault when the user asked for one they're a member of", () => {
+    expect(
+      plan({ orgIds: ["a"], requestedOrgId: "a", createIfNone: true }),
+    ).toEqual({ kind: "switch", orgId: "a" });
+  });
+});

--- a/app/apps/desktop/src/lib/vault/landing.ts
+++ b/app/apps/desktop/src/lib/vault/landing.ts
@@ -1,0 +1,102 @@
+// Where a freshly-established session should put the user.
+//
+// This used to be an inline chain of early returns in `store.landInLastVault`,
+// and its bug was an *absent* branch: several perfectly ordinary states — a
+// first sign-in with two or more vaults, or an account with none at all — fell
+// off the end of the chain and did nothing, leaving the user looking at the
+// signed-out welcome screen they had just signed in from, with no error and no
+// hint that anything had happened. A decision table that can silently answer
+// "nothing" for a signed-in user is one that needs to be readable in one screen
+// and covered case by case, hence this module: pure, no store, no IPC.
+
+/** What the caller should do to land the user. */
+export type LandingAction =
+  /** The open folder already belongs to the active vault — just turn sync on. */
+  | { kind: "enable-sync" }
+  /** Make this vault active (which binds/creates its folder and syncs it). */
+  | { kind: "switch"; orgId: string }
+  /** A local-only folder is open; leave the user in it. */
+  | { kind: "stay-local" }
+  /** The account has no vaults — create its first one and open that. */
+  | { kind: "create-first-vault" }
+  /** Nothing to do (and nothing we're allowed to invent). */
+  | { kind: "nothing" };
+
+export interface LandingInput {
+  /** Vaults we are currently a member of. */
+  orgIds: readonly string[];
+  /** A vault the user explicitly asked for before being sent through sign-in. */
+  requestedOrgId: string | null;
+  /** The local folder open right now, if any. */
+  openPath: string | null;
+  /** Persisted { orgId → local folder } bindings. */
+  orgVaults: Readonly<Record<string, string>>;
+  /** `session.activeOrganizationId` — null on a fresh sign-in (it's per-session). */
+  activeOrganizationId: string | null;
+  /** The last vault used on this device. */
+  rememberedOrgId: string | null;
+  /** May we create a vault for an account that has none? */
+  createIfNone: boolean;
+}
+
+export function planLanding(input: LandingInput): LandingAction {
+  const isMember = (id: string | null): id is string =>
+    !!id && input.orgIds.includes(id);
+
+  // 1) An explicit "open this vault" request (a remote vault clicked on the
+  //    signed-out welcome screen, which routed through sign-in) wins over every
+  //    other heuristic — that's the vault the user just asked for.
+  if (isMember(input.requestedOrgId)) {
+    return { kind: "switch", orgId: input.requestedOrgId };
+  }
+
+  // The folder that's already open (App.tsx reopens the last one at launch) is
+  // the strongest signal for "the vault I was last in" — it unifies local and
+  // synced vaults under one recency signal.
+  const boundOrgOfOpen = input.openPath
+    ? (Object.entries(input.orgVaults).find(([, p]) => p === input.openPath)?.[0] ??
+      null)
+    : null;
+
+  // 2) The open folder belongs to a synced vault → make it active + sync.
+  if (input.openPath && isMember(boundOrgOfOpen)) {
+    return input.activeOrganizationId === boundOrgOfOpen
+      ? { kind: "enable-sync" }
+      : { kind: "switch", orgId: boundOrgOfOpen };
+  }
+
+  // 3) A local (unsynced) folder is open → keep it local. Don't pull the user
+  //    into a different vault just because they happen to be signed in; "Turn
+  //    on sync" is the affordance for adopting the folder they're in.
+  //
+  //    Note the condition is "bound to nothing", not "not bound to a vault we're
+  //    in": a folder bound to a vault we've been REMOVED from deliberately falls
+  //    through to the restore chain below, so we land in a vault the user still
+  //    has rather than sitting in an orphaned folder that can never sync again.
+  if (input.openPath && !boundOrgOfOpen) return { kind: "stay-local" };
+
+  // 4) Nothing open → restore the session's active vault, else the last vault
+  //    we used on this device (only if we're still a member of it).
+  if (isMember(input.activeOrganizationId)) {
+    return { kind: "switch", orgId: input.activeOrganizationId };
+  }
+  if (isMember(input.rememberedOrgId)) {
+    return { kind: "switch", orgId: input.rememberedOrgId };
+  }
+
+  // 5) We're a member of vaults, but neither signal named one. This is the
+  //    ordinary shape of a FIRST sign-in on a device: Better Auth keeps
+  //    `activeOrganizationId` on the *session* row, so a new sign-in starts
+  //    null, and the store only auto-activates when there is exactly one vault.
+  //    With two or more, every branch above came up empty — so open one rather
+  //    than none. The first, matching that single-vault auto-activation.
+  if (input.orgIds.length > 0) return { kind: "switch", orgId: input.orgIds[0] };
+
+  // 6) Signed in with no vaults at all — a brand-new account. Nothing can be
+  //    restored, so make the vault the account obviously needs. Only when the
+  //    screen is genuinely empty: creating a vault swaps the open folder for a
+  //    new one, which is never right while the user is looking at files.
+  return input.createIfNone && !input.openPath
+    ? { kind: "create-first-vault" }
+    : { kind: "nothing" };
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -36,6 +36,7 @@ import {
   writeMentionSound,
 } from "./lib/prefs";
 import { seedWelcomeContent, vaultIsEmpty, WELCOME_NOTE_PATH } from "./lib/vault/seed";
+import { planLanding } from "./lib/vault/landing";
 import { playJoinChime } from "./lib/celebrate/celebrate";
 import { viewingDocId } from "./lib/presence/viewingDocId";
 
@@ -83,6 +84,27 @@ interface AppStore {
   session: SessionInfo | null;
   serverUrl: string;
   authError: string | null;
+  /**
+   * A sign-in has landed but we're still resolving which vault to open (and
+   * possibly creating it, its folder, and its starter notes — a few seconds).
+   * Until it clears there is no vault, so `App` still renders the welcome
+   * screen; the picker reads this to say so rather than looking like the
+   * sign-in did nothing.
+   */
+  landingVault: boolean;
+  /**
+   * A vault switch is in flight, with the vault we're heading TO. Set before the
+   * first await of `setActiveOrganization` and cleared when it settles, so the
+   * chrome can rename itself to the destination immediately instead of showing
+   * the outgoing vault until the folder finally swaps.
+   */
+  switchingVault: { orgId: string; name: string } | null;
+  /**
+   * The note path currently being opened, if the open hasn't landed yet. Opening
+   * a note in a synced vault registers it server-side first (`openNoteByPath`),
+   * so a click can sit for a moment with nothing on screen acknowledging it.
+   */
+  openingNotePath: string | null;
   organizations: Organization[];
   members: Member[];
   pendingInvitations: Invitation[];
@@ -424,48 +446,65 @@ function forgetLastVault(orgId?: string): void {
  * opened on this device — instead of leaving them on whatever local folder
  * happened to be open. Restores only vaults we're still a member of; falls
  * back to syncing the open local vault when there's nothing to restore.
+ *
+ * The choice itself is `planLanding` (pure, unit-tested in `lib/vault/landing`);
+ * this is only its dispatcher. Signing in must ALWAYS end somewhere — never
+ * back on the signed-out welcome screen — so `createIfNone` is passed by the
+ * explicit auth actions (sign-in / sign-up / Google) but NOT by silent session
+ * restore at launch: "I just signed in" is a good reason to be given a vault,
+ * "the app reopened" is not.
  */
-async function landInLastVault(get: () => AppStore): Promise<void> {
-  const orgs = get().organizations;
-  // An explicit "open this vault" request (a remote vault clicked on the
-  // signed-out welcome screen, which routed through sign-in) wins over every
-  // other heuristic — that's the vault the user just asked for.
-  const requested = takePendingOpenVault();
-  if (requested && orgs.some((o) => o.id === requested)) {
-    await get().setActiveOrganization(requested);
-    return;
-  }
-  // The folder that's already open (App.tsx reopens the last one at launch) is
-  // the strongest signal for "the vault I was last in" — it unifies local
-  // and synced vaults under one recency signal.
-  const openPath = get().vault?.path ?? null;
-  const boundOrgOfOpen = openPath
-    ? (Object.entries(readOrgVaults()).find(([, p]) => p === openPath)?.[0] ?? null)
-    : null;
-
-  // 1) The open folder belongs to a synced vault → make it active + sync.
-  if (openPath && boundOrgOfOpen && orgs.some((o) => o.id === boundOrgOfOpen)) {
-    if (get().session?.activeOrganizationId === boundOrgOfOpen) {
-      await get().enableSyncForVault();
-    } else {
-      await get().setActiveOrganization(boundOrgOfOpen);
+async function landInLastVault(
+  get: () => AppStore,
+  opts: { createIfNone?: boolean } = {},
+): Promise<void> {
+  const action = planLanding({
+    orgIds: get().organizations.map((o) => o.id),
+    requestedOrgId: takePendingOpenVault(),
+    openPath: get().vault?.path ?? null,
+    orgVaults: readOrgVaults(),
+    activeOrganizationId: get().session?.activeOrganizationId ?? null,
+    rememberedOrgId: readLastVault(),
+    createIfNone: opts.createIfNone ?? false,
+  });
+  // Only the two actions that end with a vault on screen raise the flag, and
+  // only while they run: `stay-local`/`nothing` change nothing, so claiming to
+  // be "opening your vault" there would hang a spinner forever.
+  if (action.kind === "stay-local" || action.kind === "nothing") return;
+  useStore.setState({ landingVault: true });
+  try {
+    switch (action.kind) {
+      case "enable-sync":
+        await get().enableSyncForVault();
+        return;
+      case "switch":
+        await get().setActiveOrganization(action.orgId);
+        return;
+      case "create-first-vault":
+        // `createOrganization` routes through the switch path, so the new vault
+        // gets a folder under the vaults root, turns sync on, and the reconcile
+        // seeds welcome content into it. Failure is not fatal — the vault cap
+        // (402) or an offline server just leaves the picker up, where "New vault"
+        // still works — so it must never reject out of the sign-in itself.
+        try {
+          await get().createOrganization(FIRST_VAULT_NAME);
+        } catch (e) {
+          console.warn("[vault] could not create a first vault on sign-in", e);
+        }
+        return;
     }
-    return;
+  } finally {
+    useStore.setState({ landingVault: false });
   }
-
-  // 2) A local (unsynced) folder is open → keep it local. Don't pull the user
-  //    into a different vault just because they happen to be signed in.
-  if (openPath && !boundOrgOfOpen) return;
-
-  // 3) Nothing open → restore the session's active org, else the last vault
-  //    we used on this device (only if we're still a member).
-  const active = get().session?.activeOrganizationId ?? null;
-  const remembered = readLastVault();
-  const target =
-    (active && orgs.some((o) => o.id === active) ? active : null) ??
-    (remembered && orgs.some((o) => o.id === remembered) ? remembered : null);
-  if (target) await get().setActiveOrganization(target);
 }
+
+/**
+ * Name for the vault auto-created on a first sign-in. Deliberately not derived
+ * from the user's name: the display name becomes the folder slug
+ * (`uniqueFolderSlug`), and "Naveed's Vault" lands on disk as `naveed-s-vault`.
+ * Renaming a vault is one click in Vault Settings.
+ */
+const FIRST_VAULT_NAME = "My Vault";
 
 /** Auto-dismiss timer for the member-joined celebration (module-scoped so a
  *  repeat join resets it rather than stacking). */
@@ -559,6 +598,9 @@ export const useStore = create<AppStore>((set, get) => ({
   session: null,
   serverUrl: authManager.getServerUrl(),
   authError: null,
+  landingVault: false,
+  switchingVault: null,
+  openingNotePath: null,
   organizations: [],
   members: [],
   pendingInvitations: [],
@@ -724,33 +766,45 @@ export const useStore = create<AppStore>((set, get) => ({
 
   openNoteByPath: async (path) => {
     const epoch = get().vault?.epoch;
-    const meta = await ipc.getNoteMeta(path);
-    if (!sameVault(get, epoch)) return; // vault switched mid-open — drop it
-    const title = meta?.title ?? path.split("/").pop() ?? path;
-    // Ensure the note is registered server-side BEFORE the editor opens it, so
-    // its doc_id is known and the sync provider connects on first open.
-    // Only markdown notes sync — HTML pages are local files rendered in-app.
-    if (get().syncEnabled && path.toLowerCase().endsWith(".md")) {
-      try {
-        // Pass the local index doc_id so the server adopts the SAME id — the
-        // editor's bridge and the sync provider must key the note identically.
-        await syncManager.registry.registerNote(path, title, meta?.id);
-      } catch (e) {
-        console.warn("[sync] registerNote failed", e);
+    // Name the note being opened before the first await. In a synced vault this
+    // function makes a network call (`registerNote`) before `openNote` is set,
+    // so the row stays unselected and the editor keeps showing the previous note
+    // for the whole round trip — a click that visibly does nothing. The sidebar
+    // row and the editor both watch this and acknowledge the click at once.
+    set({ openingNotePath: path });
+    try {
+      const meta = await ipc.getNoteMeta(path);
+      if (!sameVault(get, epoch)) return; // vault switched mid-open — drop it
+      const title = meta?.title ?? path.split("/").pop() ?? path;
+      // Ensure the note is registered server-side BEFORE the editor opens it, so
+      // its doc_id is known and the sync provider connects on first open.
+      // Only markdown notes sync — HTML pages are local files rendered in-app.
+      if (get().syncEnabled && path.toLowerCase().endsWith(".md")) {
+        try {
+          // Pass the local index doc_id so the server adopts the SAME id — the
+          // editor's bridge and the sync provider must key the note identically.
+          await syncManager.registry.registerNote(path, title, meta?.id);
+        } catch (e) {
+          console.warn("[sync] registerNote failed", e);
+        }
+        if (!sameVault(get, epoch)) return;
       }
-      if (!sameVault(get, epoch)) return;
+      set({
+        openNote: { path, id: meta?.id ?? null, title },
+        noteRemoved: false,
+      });
+      // Tell teammates which note we're now viewing (drives their sidebar dots).
+      // The announced id must be the SERVER doc_id — see `viewingDocId`, which
+      // exists to hold that reasoning and a regression test for it.
+      syncManager.setViewing(
+        viewingDocId(meta?.id, syncManager.registry.getMapping(path)?.docId),
+      );
+      await get().refreshBacklinks();
+    } finally {
+      // Only the newest open clears it: two quick clicks would otherwise have the
+      // first one's completion cancel the second one's indicator.
+      if (get().openingNotePath === path) set({ openingNotePath: null });
     }
-    set({
-      openNote: { path, id: meta?.id ?? null, title },
-      noteRemoved: false,
-    });
-    // Tell teammates which note we're now viewing (drives their sidebar dots).
-    // The announced id must be the SERVER doc_id — see `viewingDocId`, which
-    // exists to hold that reasoning and a regression test for it.
-    syncManager.setViewing(
-      viewingDocId(meta?.id, syncManager.registry.getMapping(path)?.docId),
-    );
-    await get().refreshBacklinks();
   },
 
   refreshBacklinks: async () => {
@@ -873,8 +927,10 @@ export const useStore = create<AppStore>((set, get) => ({
       if (session) {
         await get().refreshVault();
         await get().refreshBillingConfig();
-        // Open the vault they last used, rather than making them pick one.
-        await landInLastVault(get);
+        // Open the vault they last used, rather than making them pick one — and
+        // if the account has none yet, make one. Signing in never dead-ends back
+        // on the welcome screen.
+        await landInLastVault(get, { createIfNone: true });
         await get().refreshOrgBilling();
         await get().openWelcomeIfPresent();
       }
@@ -895,8 +951,9 @@ export const useStore = create<AppStore>((set, get) => ({
     if (session) {
       await get().refreshVault();
       await get().refreshBillingConfig();
-      // Open the vault they last used, rather than making them pick one.
-      await landInLastVault(get);
+      // Same as email sign-in: land in a vault, creating the first one if the
+      // account has none.
+      await landInLastVault(get, { createIfNone: true });
       await get().refreshOrgBilling();
       await get().openWelcomeIfPresent();
     }
@@ -911,7 +968,13 @@ export const useStore = create<AppStore>((set, get) => ({
       if (session) {
         await get().refreshVault();
         await get().refreshBillingConfig();
+        // A brand-new account has nothing to restore, so this is what actually
+        // creates their first vault and opens it. Sign-up used to skip landing
+        // entirely, which is why signing up from the welcome screen returned you
+        // to the welcome screen.
+        await landInLastVault(get, { createIfNone: true });
         await get().refreshOrgBilling();
+        await get().openWelcomeIfPresent();
       }
     } catch (e) {
       set({ authError: errMsg(e) });
@@ -934,6 +997,7 @@ export const useStore = create<AppStore>((set, get) => ({
     set({
       session: null,
       authStatus: "signed-out",
+      landingVault: false,
       organizations: [],
       members: [],
       pendingInvitations: [],
@@ -1158,92 +1222,124 @@ export const useStore = create<AppStore>((set, get) => ({
     const gen = ++orgSwitchGen;
     const superseded = () => orgSwitchGen !== gen;
 
-    // Re-assert that the vault we're leaving solely owns its open folder,
-    // evicting any other vault still bound to it (this is what heals legacy
-    // state where several vaults collapsed onto one folder). Only do this
-    // when that vault ACTUALLY owns the open folder — if we're leaving a
-    // vault that never got its own folder (still on the pending prompt),
-    // the visible folder belongs to a *different* vault, so touching the
-    // binding here would wrongly steal it (and break Cancel → previous).
-    const currentVaultPath = get().vault?.path ?? null;
-    if (
-      previousOrgId &&
-      currentVaultPath &&
-      previousOrgId !== organizationId &&
-      readOrgVaults()[previousOrgId] === currentVaultPath
-    ) {
-      rememberOrgVault(previousOrgId, currentVaultPath);
-    }
-
-    // Stop syncing the vault we're leaving before anything else. Everything
-    // below awaits the network, and one branch swaps the Rust vault slot
-    // (applyVaultFolder) while the other leaves the old folder on screen with a
-    // different org active — in both cases the old vault's registry, engine and
-    // debounced pull must already be gone. `enableSyncForVault` re-arms sync for
-    // whatever vault we land in.
-    leaveVaultSync();
-    set(vaultScopedSyncReset());
-
-    await authManager.api.setActiveOrganization(organizationId);
-    if (superseded()) return;
-    const session = await authManager.currentSession();
-    if (superseded()) return;
-    set({ session });
-    await get().refreshVault();
-    if (superseded()) return;
-    // Seat usage + plan are per-vault, so refresh on every switch.
-    await get().refreshOrgBilling();
-    if (superseded()) return;
-
-    // Each vault owns its own local folder. If one is already bound, swap
-    // to it. If not, do NOT reuse the folder that's currently open — ask the
-    // user to choose one (or start empty) via the pending-folder prompt.
-    const path = readOrgVaults()[organizationId];
-    if (path) {
-      try {
-        await get().applyVaultFolder(organizationId, path);
-        return;
-      } catch (e) {
-        // The bound folder is unusable (moved, deleted, permissions). Don't
-        // return here: that left the user in a vault with no folder and sync
-        // off, with nothing on screen saying why. Fall through to the
-        // auto-folder path below, which re-creates it under the vaults root.
-        console.warn("[vault] bound folder unusable, re-creating", e);
-      }
-    }
-    const org = get().organizations.find((o) => o.id === organizationId);
-    const orgName = org?.name ?? "New vault";
-
-    // No folder bound yet. Give this vault one automatically and go straight
-    // in, rather than stopping on a "choose a folder" prompt.
-    //
-    // The prompt was a roadblock in the one flow that most needs to be
-    // frictionless: a teammate signing in for the first time doesn't yet have
-    // an opinion about which directory their shared vault lives in — they just
-    // want to be in it. A folder under the vaults root, named after the vault,
-    // is the answer they'd have picked anyway, and relocating it later is one
-    // item in the vault switcher menu.
-    //
-    // The prompt survives as the FALLBACK: if we can't create a folder (a bad
-    // vaults root, permissions), asking beats failing silently.
-    try {
-      const root = await ipc.getVaultsRoot();
-      if (superseded()) return;
-      const slug = uniqueFolderSlug(orgName, readOrgVaults());
-      await get().applyVaultFolder(organizationId, `${root}/${slug}`);
-      return;
-    } catch (e) {
-      console.warn("[vault] auto folder failed; asking instead", e);
-      if (superseded()) return;
-    }
+    // Announce the destination BEFORE the first await. A switch is many round
+    // trips (activate org → re-read session → roster → billing → open the folder
+    // → re-enable sync → reconcile), and until the folder actually swaps, the
+    // sidebar still shows the vault you just left. Clicking a vault and watching
+    // the old one sit there is indistinguishable from the click not registering,
+    // so the chrome reads this and renames itself to the target at once.
     set({
-      syncEnabled: false,
-      pendingVaultFolder: {
+      switchingVault: {
         orgId: organizationId,
-        orgName,
-        previousOrgId: previousOrgId === organizationId ? null : previousOrgId,
+        // Fall back to the locally-cached vault list for one we haven't listed
+        // yet (straight after a join): a generic label beats a blank one.
+        name:
+          get().organizations.find((o) => o.id === organizationId)?.name ??
+          readKnownVaults().find((v) => v.id === organizationId)?.name ??
+          "vault",
       },
     });
+    try {
+      await switchToOrg();
+    } finally {
+      // Only the newest switch may lower the flag. A superseded one landing late
+      // would otherwise declare the switch that replaced it finished.
+      if (!superseded()) set({ switchingVault: null });
+    }
+    return;
+
+    // The switch itself. Inlined as a closure rather than hoisted out of the
+    // store because it reads `get`/`set`/`previousOrgId`/`superseded` throughout;
+    // it exists purely so the `finally` above has a single place to hook, given
+    // the many early returns below.
+    async function switchToOrg(): Promise<void> {
+      // Re-assert that the vault we're leaving solely owns its open folder,
+      // evicting any other vault still bound to it (this is what heals legacy
+      // state where several vaults collapsed onto one folder). Only do this
+      // when that vault ACTUALLY owns the open folder — if we're leaving a
+      // vault that never got its own folder (still on the pending prompt),
+      // the visible folder belongs to a *different* vault, so touching the
+      // binding here would wrongly steal it (and break Cancel → previous).
+      const currentVaultPath = get().vault?.path ?? null;
+      if (
+        previousOrgId &&
+        currentVaultPath &&
+        previousOrgId !== organizationId &&
+        readOrgVaults()[previousOrgId] === currentVaultPath
+      ) {
+        rememberOrgVault(previousOrgId, currentVaultPath);
+      }
+
+      // Stop syncing the vault we're leaving before anything else. Everything
+      // below awaits the network, and one branch swaps the Rust vault slot
+      // (applyVaultFolder) while the other leaves the old folder on screen with a
+      // different org active — in both cases the old vault's registry, engine and
+      // debounced pull must already be gone. `enableSyncForVault` re-arms sync for
+      // whatever vault we land in.
+      leaveVaultSync();
+      set(vaultScopedSyncReset());
+
+      await authManager.api.setActiveOrganization(organizationId);
+      if (superseded()) return;
+      const session = await authManager.currentSession();
+      if (superseded()) return;
+      set({ session });
+      await get().refreshVault();
+      if (superseded()) return;
+      // Seat usage + plan are per-vault, so refresh on every switch.
+      await get().refreshOrgBilling();
+      if (superseded()) return;
+
+      // Each vault owns its own local folder. If one is already bound, swap
+      // to it. If not, do NOT reuse the folder that's currently open — ask the
+      // user to choose one (or start empty) via the pending-folder prompt.
+      const path = readOrgVaults()[organizationId];
+      if (path) {
+        try {
+          await get().applyVaultFolder(organizationId, path);
+          return;
+        } catch (e) {
+          // The bound folder is unusable (moved, deleted, permissions). Don't
+          // return here: that left the user in a vault with no folder and sync
+          // off, with nothing on screen saying why. Fall through to the
+          // auto-folder path below, which re-creates it under the vaults root.
+          console.warn("[vault] bound folder unusable, re-creating", e);
+        }
+      }
+      const org = get().organizations.find((o) => o.id === organizationId);
+      const orgName = org?.name ?? "New vault";
+
+      // No folder bound yet. Give this vault one automatically and go straight
+      // in, rather than stopping on a "choose a folder" prompt.
+      //
+      // The prompt was a roadblock in the one flow that most needs to be
+      // frictionless: a teammate signing in for the first time doesn't yet have
+      // an opinion about which directory their shared vault lives in — they just
+      // want to be in it. A folder under the vaults root, named after the vault,
+      // is the answer they'd have picked anyway, and relocating it later is one
+      // item in the vault switcher menu.
+      //
+      // The prompt survives as the FALLBACK: if we can't create a folder (a bad
+      // vaults root, permissions), asking beats failing silently.
+      try {
+        const root = await ipc.getVaultsRoot();
+        if (superseded()) return;
+        const slug = uniqueFolderSlug(orgName, readOrgVaults());
+        await get().applyVaultFolder(organizationId, `${root}/${slug}`);
+        return;
+      } catch (e) {
+        console.warn("[vault] auto folder failed; asking instead", e);
+        if (superseded()) return;
+      }
+      set({
+        syncEnabled: false,
+        pendingVaultFolder: {
+          orgId: organizationId,
+          orgName,
+          previousOrgId: previousOrgId === organizationId ? null : previousOrgId,
+        },
+      });
+    }
   },
 
   inviteMember: async (email, role) => {

--- a/docs/Baalda.md
+++ b/docs/Baalda.md
@@ -111,6 +111,15 @@ when CI cannot ship.
 
 ---
 
+## Interaction design
+
+[[INTERACTIONS]] is the inventory of every action the desktop app can take, how long
+each one realistically takes, and what it shows while it works — plus the eight rules
+that govern that feedback (delayed spinners, optimistic destinations, sticky errors,
+reduced-motion answers). Add a control, add a row.
+
+---
+
 ## Status
 
 See [[STATUS]] for the live build checklist.

--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -1,0 +1,150 @@
+---
+type: reference
+product: Baalda
+date: 2026-08-07
+tags: [baalda, design, ux, interactions]
+---
+
+# Interaction inventory & feedback rules
+
+> Every action the desktop app can take, how long it takes, and what it shows
+> while it does. Back to index: [[Baalda]].
+
+Two things live here: the **rules** (how any asynchronous action reports for
+itself) and the **inventory** (every action, audited against those rules). If you
+add a control, add it to the table.
+
+---
+
+## The rules
+
+Derived from the response-time thresholds people actually perceive
+([Nielsen's three limits](https://www.nngroup.com/articles/response-times-3-important-limits/),
+still the basis of modern guidance) and from Dan Saffer's
+[four parts of a microinteraction](https://www.oreilly.com/library/view/microinteractions-full-color/9781491945926/)
+— **trigger, rules, feedback, loops**. Features get people to the product;
+details are why they stay.
+
+1. **Acknowledge the trigger in the same frame.** Every button has a physical
+   press state (`:active`). This is free, needs no state, and it is what makes a
+   slow action feel *responsive* rather than *ignored* — the two are different
+   properties and only the second is a bug.
+2. **Label the wait only after ~140ms** (`SPINNER_DELAY` in
+   `lib/useAsyncAction.ts`). Under ~100ms an action already feels instantaneous;
+   a spinner that appears immediately flashes on and off and reads as a
+   rendering fault. Actions that are usually fast therefore stay visually silent
+   and only grow an indicator when they genuinely stall.
+3. **Disable on the first click, not on the first spinner.** `useAsyncAction`
+   keeps `pending` (true immediately, for the re-entrancy guard) separate from
+   `showPending` (true after the delay, for rendering). Conflating them
+   double-submits.
+4. **Never change size mid-action.** A spinner sits *beside* a label whose width
+   is already reserved. A control that grows under the cursor pulls a different
+   control into the click.
+5. **Optimism where the destination is known.** A vault switch renames the
+   sidebar to the target vault immediately; clicking a note selects its row
+   immediately. Showing the *old* state until the last round trip is what makes
+   a working action look broken. If it fails, the state snaps back.
+6. **Hold success long enough to be seen** (`DONE_HOLD`, 900ms). A tick that
+   vanishes with the spinner was never feedback.
+7. **Errors do not auto-dismiss.** A failure the user blinked past becomes
+   "nothing happened" in a bug report. Successes and neutrals fade on their own.
+8. **Every animation has a reduced-motion answer**, and the information survives
+   the motion being switched off. Spinners *slow* rather than stop — a frozen
+   ring says "hung", which is the one thing it must never say.
+
+### Which surface
+
+| Surface | For | Persistence |
+| --- | --- | --- |
+| Press state | acknowledging a click | instant |
+| In-control spinner | this control is working | until it settles |
+| Skeleton | content is arriving, roughly this shape | until content lands |
+| Toast (`lib/toast.ts`) | an outcome you may miss twice | ~4.2s; errors sticky |
+| Banner (`App.tsx`) | something needing a decision | until dismissed/resolved |
+| Progress bar | a determinate transfer | until complete |
+
+---
+
+## Inventory
+
+**Latency** is the realistic worst case, not the best. ✅ = reports for itself;
+n/a = synchronous or sub-100ms by construction.
+
+### Welcome screen — `components/VaultPicker.tsx`
+
+| Action | Work | Latency | Feedback |
+| --- | --- | --- | --- |
+| New vault | read vaults root | fast | n/a |
+| Create vault | mkdir + open + seed ~20 notes | 1–3s | ✅ label + spinner |
+| Open existing | native picker → open + reconcile | 1–5s | ✅ label + spinner |
+| Recent vault row | full vault open (+ switch if remote) | 1–5s | ✅ per-row spinner, "Opening…" |
+| Remove from recents | local list write | fast | n/a (row leaves) |
+| Sign in (link) | opens the modal | instant | n/a |
+| *post-sign-in landing* | resolve/create vault, folder, seed | 1–5s | ✅ "Opening your vault…" |
+
+### Auth — `components/AccountMenu.tsx` (`AuthDialog`)
+
+| Action | Work | Latency | Feedback |
+| --- | --- | --- | --- |
+| Sign in / Create account | auth + roster + billing + land in a vault | 1–5s | ✅ label + spinner |
+| Continue with Google | system browser + loopback | up to 3 min | ✅ "Waiting for your browser…" + spinner + Cancel |
+| Save server URL | re-read session against a new host | 0.3–2s | ✅ spinner + tick |
+
+### Vault switching & membership — `components/AccountMenu.tsx`
+
+| Action | Work | Latency | Feedback |
+| --- | --- | --- | --- |
+| Switch vault (menu row) | 6+ round trips, then folder swap | 1–5s | ✅ sidebar renames to target + spinner; tree fades and stops taking clicks |
+| Switch vault (settings) | same | 1–5s | ✅ per-button spinner + the above |
+| Accept invitation | accept → switch → bind folder → reconcile | 1–5s | ✅ spinner |
+| Join by code | join → switch → reconcile | 1–5s | ✅ existing busy state |
+| New vault (menu) | create org → folder → seed | 1–3s | ✅ existing busy state |
+| Remove from device | local teardown | 0.2–1s | ✅ spinner |
+| Delete vault (permanent) | server delete + local teardown | 0.5–3s | ✅ spinner, behind a confirm |
+| Delete local vault files | move folder to Trash | 0.2–2s | ✅ spinner, behind a confirm |
+| Invite member | server write + roster refresh | 0.3–1s | ✅ existing busy state |
+| Remove member | server write + ACL broadcast | 0.3–1s | ✅ spinner, behind a confirm |
+| Copy join code | clipboard | instant | ✅ existing "Copied" |
+| Manage subscription | billing portal + browser handoff | 1–4s | ✅ spinner |
+| Create / revoke MCP token | server write | 0.3–1s | ✅ spinner |
+| Import files / folder / Export vault | disk walk + registry | 1s–minutes | ✅ existing busy + counts |
+| Change vaults root | native picker + config write | fast | n/a |
+| Check for update | network | 0.5–3s | ✅ existing update state |
+| Install & Restart | download installer, then relaunch | 5s–minutes | ✅ spinner + progress bar in the banner |
+
+### Sidebar — `components/FileTree.tsx`
+
+| Action | Work | Latency | Feedback |
+| --- | --- | --- | --- |
+| Open a note | meta read + server register | 0.05–2s | ✅ row pre-selects, glyph → spinner, editor skeleton |
+| New note / New folder | atomic write + reindex | fast | n/a (row appears) |
+| Rename (inline) | disk rename + registry | 0.1–1s | n/a — inline edit already commits visibly |
+| Delete (single / bulk) | deepest-first disk + server | 0.2s–10s | ✅ bulk progress counter |
+| Lock / Unlock selected | one round trip **per item** | 0.3s–10s | ✅ spinner replaces the padlock |
+| Import files / folder | disk copy + registry | 1s–minutes | ✅ toast with counts |
+| Export… | disk copy outside the vault | 0.2s–30s | ✅ toast (nothing in-app changes otherwise) |
+| Share… | opens the dialog | instant | n/a |
+| Set colour, reorder, drag-move | local + registry | fast | n/a |
+
+### Editor & main — `components/Editor.tsx`, `App.tsx`
+
+| Action | Work | Latency | Feedback |
+| --- | --- | --- | --- |
+| Note open (bridge + first sync) | SQLite hydrate + provider sync | 0.05–3s | ✅ skeleton in the prose column, delayed 180ms |
+| Typing / autosave | debounced egest | n/a | ✅ existing "Auto-saved" |
+| Push-to-talk | mic + relay | instant | ✅ existing talk states |
+| Search | local FTS5 | fast | n/a |
+| Graph view | in-memory sim | fast | n/a |
+| Ping a peer | awareness field | instant | ✅ existing ping toast |
+
+### Known gaps (deliberate, not oversights)
+
+- **Rename** has no spinner. It is an inline edit that already commits visibly,
+  and a spinner over a text field you just typed into is noise.
+- **`useAsyncAction` has no unit test.** It is a React hook and the repo has no
+  `@testing-library/react`; adding one for a 140-line hook was not worth a new
+  dependency. Its two constants are exported and documented, and the pure pieces
+  around it (`lib/toast.ts`, `lib/vault/landing.ts`) are covered.
+- **Bulk lock/unlock has no per-item counter** the way bulk delete does. Same
+  shape of work, so it should get one; the spinner is the floor, not the ceiling.


### PR DESCRIPTION
Adds feedback to the asynchronous actions that had none, and a small set of
micro-interactions on top. Two problems were named directly: switching a vault
sat in the old vault with nothing moving, and signing in dropped you back on the
signed-out welcome screen.

> **Stacked on #48, and carries the release for both.** #48 merges first with its
> version *held* at 0.1.17 so it ships nothing; this PR then carries the single
> bump to **0.1.18**, so the two land in one release instead of publishing a
> throwaway 0.1.18 that users update to and then get prompted again 30 minutes
> later for 0.1.19. (`release.yml` has `concurrency: release`, so back-to-back
> runs would have queued rather than raced — this is about not shipping an
> intermediate build to everyone, not about a build collision.)

## The inventory

`docs/INTERACTIONS.md` (new) is the audit that came first: every action the
desktop app can take, its realistic worst-case latency, and what it shows while
it works — plus the rules that govern the feedback and three deliberate gaps.
Linked from the docs index. If you add a control, add a row.

## The rules it settled on

Drawn from the response-time limits people actually perceive and from Saffer's
trigger → rules → feedback → loops:

1. **Acknowledge the trigger in the same frame.** Every button now has a press
   state. Free, stateless, and it is what separates "slow" from "ignored" — only
   the second is a bug.
2. **Label the wait only after ~140ms** (`SPINNER_DELAY`). Under ~100ms an action
   already feels instant, so an immediate spinner flashes and reads as a
   rendering fault. Fast paths stay silent; only genuine stalls grow an indicator.
3. **Disable on the first click, not the first spinner.** `useAsyncAction` keeps
   `pending` (immediate, for the re-entrancy guard) separate from `showPending`
   (delayed, for rendering). Conflating them double-submits.
4. **Never change size mid-action.** Spinners sit beside a label whose width is
   already reserved, so a control can't grow under the cursor and pull a
   different one into the click.
5. **Optimism where the destination is known.** See the vault switch below.
6. **Hold success 900ms** (`DONE_HOLD`) — a tick that vanishes with the spinner
   was never feedback.
7. **Errors don't auto-dismiss.** A failure you blinked past becomes "nothing
   happened" in a bug report.
8. **Every animation has a reduced-motion answer,** and the information survives
   the motion being off. Spinners *slow* rather than stop: a frozen ring says
   "hung", which is the one thing it must never say.

## New shared primitives

- `lib/useAsyncAction.ts` — the phase machine behind all of it (the two constants
  above live here, documented with why).
- `components/AsyncButton.tsx` — a button that reports on its own promise.
  Retrofits a loading state onto a call site in one line, which is what makes
  *forgetting* one the exception rather than the norm.
- `components/Spinner.tsx` — the app's one ring, replacing three hand-rolled ones
  at different sizes and durations. Defaults to `currentColor`, so a spinner on a
  red **Delete** spins red. Plus a check that draws itself in.
- `lib/toast.ts` + `components/Toasts.tsx` — one transient-notification surface,
  promoted out of the private pill that lived inside `FileTree`. Hovering the
  stack pauses every auto-dismiss; errors are sticky. Deliberately *not* in the
  Zustand store (a corner message shouldn't re-render every subscriber, and sync
  callbacks can raise one without reaching for the store).

## The three latencies named in the request

**Vault switch** — a switch is 6+ round trips before the folder swaps. The store
now publishes `switchingVault` **before its first await**, and the sidebar renames
itself to the destination immediately (cross-faded), spins, and shows `Switching…`
in place of the path — the one field that genuinely is still the old vault's. The
tree fades and stops taking clicks, since it still lists files from the vault
you're leaving and the epoch guard would silently drop an open from it.

**Opening a note** — in a synced vault this makes a network call *before*
`openNote` is set, so the row stayed unselected and the editor kept the previous
note for the whole round trip. Now `openingNotePath` pre-selects the row on click
and turns its file glyph into a spinner, and the editor shows a skeleton shaped
like prose in the same 76ch column as the real text (delayed 180ms, so a note
served from the local index in 40ms never flashes one).

**Sign-in / vault creation** — the landing fix from earlier in the session, plus
`landingVault` so the picker says `Opening your vault…` instead of sitting there
looking identical to the bug it just fixed. The landing decision is now a pure,
unit-tested `planLanding()` (`lib/vault/landing.ts`) — the bug *was* a missing row
in that table.

## Buttons that gained a state

Sign in / Create account (was `"…"`, which threw the label away), Continue with
Google, Save server URL, Accept invitation (was fire-and-forget with no
acknowledgement at all), Switch / Remove from device / Delete vault, Switch /
Delete for local vaults, Confirm member removal, Manage subscription, Revoke MCP
token, Install & Restart, bulk Lock/Unlock, Create vault, Open existing, each
recent-vault card (per-row now, not one shared grey-out), and both
vault-folder-prompt actions.

## Also

- The update banner gained a real **progress bar** — determinate when the server
  sent a content length, an indeterminate sweep when it didn't, rather than
  filling toward a target it can't know.
- Banners animate their own height open and closed. A banner that appears with
  `display: block` shoves the editor down 44px in one frame, and the eye reads
  that as the *content* jumping rather than a message arriving.
- Export now reports. It writes outside the vault, so nothing in-app changed to
  show it had worked.

## Verification

`430` TS tests (`+23`: 16 for `planLanding`, 7 for the toast emitter), `78` Rust,
typecheck and production build clean, and the changes were exercised over HMR in
a running dev app.

Two honest caveats: `useAsyncAction` has **no unit test** — it's a React hook and
the repo has no `@testing-library/react`; adding a dependency for a 140-line hook
didn't seem worth it, so its constants are exported and documented and the pure
pieces around it are covered. And **visual QA is still yours** — I verified this
compiles, passes, and hot-reloads without errors, not that every spinner lands
where you'd want it.

Version bumped to `0.1.18` — the single bump for #48 + #49.

