### PR TITLE
Fix note resurrection after delete, adaptive tree menu, global-only graph

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.18"
+version = "0.1.19"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1546,6 +1546,11 @@ body:has(.sidebar-resizer.dragging) {
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   animation: rise-in var(--t-fast) var(--ease) both;
+  /* `placeMenu` flips the menu above its anchor when it won't fit below; this is
+     the last resort for a menu taller than the whole window, which would
+     otherwise run off both edges at once. */
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .context-menu li {
   padding: var(--sp-2) var(--sp-3);

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import {
   Tree,
   type CursorProps,
@@ -39,6 +46,7 @@ import type { VaultPeer } from "../lib/sync/vaultSyncEngine";
 import { PRESENCE_OFFLINE, ringShowsColor, statusTone } from "../lib/presence/color";
 import { characterSvg } from "./Identity";
 import { ShareDialog, type ShareTarget } from "./ShareDialog";
+import { placeMenu, type Placement } from "../lib/menuPlacement";
 
 interface Dimensions {
   width: number;
@@ -85,6 +93,8 @@ function dirAtClientPoint(x: number, y: number): string {
 interface MenuState {
   x: number;
   y: number;
+  /** Bottom edge to use if the menu has to open upward — see `placeMenu`. */
+  flipY?: number;
   node: NodeApi<TreeNode> | null;
 }
 
@@ -159,6 +169,10 @@ export function FileTree() {
   const [containerRef, dim] = useDimensions();
   const treeRef = useRef<TreeApi<TreeNode> | null>(null);
   const [menu, setMenu] = useState<MenuState | null>(null);
+  // Resolved once the menu has been measured; null means "not placed yet", which
+  // is also what keeps it invisible for that one frame.
+  const menuRef = useRef<HTMLUListElement | null>(null);
+  const [menuPos, setMenuPos] = useState<Placement | null>(null);
   const [shareTarget, setShareTarget] = useState<ShareTarget | null>(null);
   // Which way the fold toggle points: false → "collapse all", true → "expand all".
   const [treeCollapsed, setTreeCollapsed] = useState(false);
@@ -376,6 +390,27 @@ export function FileTree() {
     window.addEventListener("click", close);
     return () => window.removeEventListener("click", close);
   }, []);
+
+  // Measure the menu, then decide where it actually goes. This has to be a
+  // LAYOUT effect: it runs (and the re-render it schedules runs) before the
+  // browser paints, so the menu is never visibly drawn at the unplaced position.
+  // The `rise-in` animation only translates, so the measured box is the real one.
+  useLayoutEffect(() => {
+    if (!menu) {
+      setMenuPos(null);
+      return;
+    }
+    const el = menuRef.current;
+    if (!el) return;
+    const box = el.getBoundingClientRect();
+    setMenuPos(
+      placeMenu(
+        { x: menu.x, y: menu.y, flipY: menu.flipY },
+        { width: box.width, height: box.height },
+        { width: window.innerWidth, height: window.innerHeight },
+      ),
+    );
+  }, [menu]);
 
   async function refreshAll() {
     await useStore.getState().refreshTree();
@@ -924,7 +959,7 @@ export function FileTree() {
               syncIndex={syncIndex}
               presenceByDoc={presenceByDoc}
               color={itemColors[props.node.data.path]}
-              onMenu={(x, y, node) => setMenu({ x, y, node })}
+              onMenu={(x, y, node, flipY) => setMenu({ x, y, flipY, node })}
               selectMode={selectMode}
               checked={selected.has(props.node.data.path)}
               onToggleCheck={toggleSelect}
@@ -934,7 +969,17 @@ export function FileTree() {
       )}
 
       {menu && (
-        <ul className="context-menu" style={{ left: menu.x, top: menu.y }}>
+        <ul
+          className="context-menu"
+          ref={menuRef}
+          style={
+            menuPos
+              ? { left: menuPos.left, top: menuPos.top, maxHeight: menuPos.maxHeight }
+              : // Rendered off the anchor for the measuring pass only, and hidden
+                // so that pass can't flash on screen at the wrong place.
+                { left: menu.x, top: menu.y, visibility: "hidden" }
+          }
+        >
           <li onClick={() => createUniqueNote(menuDir)}>New note</li>
           <li onClick={() => createUniqueFolder(menuDir)}>New folder</li>
           <li className="menu-sep-item" onClick={() => void importFilesInto(menuDir)}>
@@ -1020,7 +1065,7 @@ interface NodeExtra {
   presenceByDoc: Map<string, VaultPeer[]>;
   /** Item color id (vault-local preference) — tints the type glyph. */
   color: string | undefined;
-  onMenu: (x: number, y: number, node: NodeApi<TreeNode>) => void;
+  onMenu: (x: number, y: number, node: NodeApi<TreeNode>, flipY?: number) => void;
   /** Multi-select: when on, rows show a checkbox and hide per-row actions. */
   selectMode: boolean;
   checked: boolean;
@@ -1341,7 +1386,9 @@ function Node({
             onClick={(e) => {
               e.stopPropagation();
               const r = e.currentTarget.getBoundingClientRect();
-              onMenu(r.left, r.bottom + 4, node);
+              // Below the ⋯ button normally; above it when there's no room, so a
+              // flipped menu never lands on top of the button that opened it.
+              onMenu(r.left, r.bottom + 4, node, r.top - 4);
             }}
           >
             <TreeSvg>

--- a/app/apps/desktop/src/components/GraphControls.tsx
+++ b/app/apps/desktop/src/components/GraphControls.tsx
@@ -3,7 +3,7 @@
 // shared GraphSettings shape and emits partial patches upward. All visual
 // styling lives in graph.css; this file just emits the agreed class names.
 
-import type { GraphSettings, ColorMode, GraphScope } from "../lib/graph/graphSettings";
+import type { GraphSettings, ColorMode } from "../lib/graph/graphSettings";
 import { SETTING_RANGES } from "../lib/graph/graphSettings";
 import type { LegendEntry } from "../lib/graph/graphColor";
 
@@ -18,7 +18,6 @@ export interface GraphControlsProps {
 type SliderKey = keyof typeof SETTING_RANGES;
 
 const SLIDER_LABELS: Record<SliderKey, string> = {
-  localDepth: "Depth",
   charge: "Repulsion",
   linkDistance: "Link distance",
   linkStrength: "Link force",
@@ -33,11 +32,6 @@ const COLOR_MODES: { mode: ColorMode; label: string }[] = [
   { mode: "folder", label: "Folder" },
   { mode: "degree", label: "Degree" },
   { mode: "uniform", label: "Uniform" },
-];
-
-const SCOPE_MODES: { scope: GraphScope; label: string }[] = [
-  { scope: "local", label: "Local" },
-  { scope: "global", label: "Global" },
 ];
 
 /** Round a slider value for display: integers stay whole, fractional steps
@@ -76,29 +70,9 @@ export function GraphControls(props: GraphControlsProps): React.JSX.Element {
 
   return (
     <div className="graph-controls">
-      <div className="graph-control-group">
-        <div className="graph-control-group-title">Scope</div>
-        <div className="graph-control-row">
-          <label>Show</label>
-          <div className="graph-seg" role="group" aria-label="Graph scope">
-            {SCOPE_MODES.map(({ scope, label }) => (
-              <button
-                key={scope}
-                type="button"
-                className={
-                  "graph-seg-btn" + (settings.scope === scope ? " is-active" : "")
-                }
-                aria-pressed={settings.scope === scope}
-                onClick={() => onChange({ scope })}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
-        {settings.scope === "local" && slider("localDepth")}
-      </div>
-
+      {/* No Scope section. The graph is the whole vault, always — a Local/Global
+          toggle meant this panel could be showing one of two different graphs
+          under one name, and the whole-vault view is the one that was wanted. */}
       <div className="graph-control-group">
         <div className="graph-control-group-title">Forces</div>
         {slider("charge")}

--- a/app/apps/desktop/src/components/GraphView.tsx
+++ b/app/apps/desktop/src/components/GraphView.tsx
@@ -438,6 +438,8 @@ export function GraphView({ onClose }: { onClose: () => void }) {
     // visNodes sorted small→large radius, so bigger ("nearer") orbs paint over
     // smaller ones and depth reads correctly. Order only changes on rebuild.
     drawOrder: [] as SimNode[],
+    // One-shot: has the 2D canvas been wiped since the GPU renderer took over?
+    cleared2d: false,
     colorById: new Map<string, string>(),
     camera: { x: 0, y: 0, k: 1 } as Camera,
     hoveredId: null as string | null,
@@ -1092,6 +1094,16 @@ export function GraphView({ onClose }: { onClose: () => void }) {
     let edgePositions = new Float32Array(0);
     function drawWebGL() {
       if (!webgl || !webglCanvas) return;
+      // Wipe the 2D canvas the first time the GPU renderer paints. Both canvases
+      // are stacked in the same box and the 2D one is never cleared once WebGL
+      // owns the frame, so whatever it last drew just sits there underneath — and
+      // any gap in the GPU layer (the entrance pulse briefly scaling under 1, a
+      // dpr change, a lost context) reveals a stale graph behind the live one.
+      // A canvas resize clears itself, so once is genuinely enough.
+      if (!S.cleared2d && ctx) {
+        ctx.clearRect(0, 0, canvas!.width, canvas!.height);
+        S.cleared2d = true;
+      }
       const fallback = S.colors.nodeFallback;
       const nodeScale = settingsRef.current.nodeSize;
       // Shrink nodes as the graph grows so a bigger vault reads as "smaller

--- a/app/apps/desktop/src/lib/graph/graphColor.test.ts
+++ b/app/apps/desktop/src/lib/graph/graphColor.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { assignColors, PALETTE } from "./graphColor";
+import type { GraphNode } from "./buildGraph";
+
+// The degree ramp's job is to make link-degree *visible*. It was doing the
+// opposite on any real vault, and the reason was arithmetic rather than taste:
+// linear tiers over a heavy-tailed distribution put nearly every node in one
+// bucket, so almost the whole graph drew in a single shade.
+
+const node = (id: string, linkCount: number, path = `${id}.md`): GraphNode =>
+  ({ id, title: id, path, linkCount }) as GraphNode;
+
+/**
+ * A vault shaped like a real one: a power-law spread, not a barbell. Degrees have
+ * to be *continuous* for this fixture to mean anything — an earlier version had
+ * leaves at 1–5 and mids at 300+ with nothing between, which left the middle tier
+ * empty for the honest reason that no node lived there. Real link counts don't
+ * have holes like that, and testing against a hole tests nothing.
+ */
+function heavyTailed(): GraphNode[] {
+  const nodes = [node("hub", 1259)];
+  // ~1..500, dense at the bottom and thinning out — a Zipf-ish tail.
+  for (let i = 1; i <= 220; i++) {
+    nodes.push(node(`n${i}`, Math.max(1, Math.round(500 / i))));
+  }
+  return nodes;
+}
+
+describe("assignColors — degree", () => {
+  it("spreads a heavy-tailed vault across tiers instead of piling into one", () => {
+    // The regression: with linear thirds of [1, 1259] the tiers came out as
+    // 1–420 → everything, 421–839 → nothing, 840–1259 → the hub. Log tiers put
+    // the boundaries where the nodes actually are, so no tier holds ~all of them.
+    const { legend } = assignColors(heavyTailed(), "degree", "#7f73ff");
+    const populated = legend.filter((l) => l.count > 0);
+    expect(populated.length).toBeGreaterThanOrEqual(3);
+
+    const total = legend.reduce((n, l) => n + l.count, 0);
+    const biggest = Math.max(...legend.map((l) => l.count));
+    expect(biggest / total).toBeLessThan(0.95);
+  });
+
+  it("gives the top hub a different colour from the leaves", () => {
+    const { colorById } = assignColors(heavyTailed(), "degree", "#7f73ff");
+    expect(colorById.get("hub")).not.toBe(colorById.get("leaf0"));
+  });
+
+  it("puts orphans in their own tier, distinct from linked nodes", () => {
+    const { colorById } = assignColors(
+      [node("orphan", 0), node("linked", 1)],
+      "degree",
+      "#7f73ff",
+    );
+    expect(colorById.get("orphan")).not.toBe(colorById.get("linked"));
+  });
+
+  it("is monotonic: more links never means a colder tier", () => {
+    const nodes = [1, 2, 5, 20, 100, 900].map((d) => node(`n${d}`, d));
+    const { legend, colorById } = assignColors(nodes, "degree", "#7f73ff");
+    const rank = new Map(legend.map((l, i) => [l.color, i]));
+    const ranks = nodes.map((n) => rank.get(colorById.get(n.id)!)!);
+    for (let i = 1; i < ranks.length; i++) {
+      expect(ranks[i]).toBeGreaterThanOrEqual(ranks[i - 1]);
+    }
+  });
+
+  it("survives a single-node graph without dividing by zero", () => {
+    const { colorById, legend } = assignColors([node("only", 0)], "degree", "#7f73ff");
+    expect(colorById.get("only")).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(legend).toHaveLength(4);
+  });
+});
+
+describe("assignColors — folder", () => {
+  it("gives each top-level folder its own palette colour, stable by name", () => {
+    const nodes = [
+      node("a", 1, "Work/a.md"),
+      node("b", 1, "Work/b.md"),
+      node("c", 1, "Personal/c.md"),
+      node("d", 1, "d.md"), // root
+    ];
+    const { colorById, legend } = assignColors(nodes, "folder", "#7f73ff");
+    expect(colorById.get("a")).toBe(colorById.get("b"));
+    expect(colorById.get("a")).not.toBe(colorById.get("c"));
+    expect(legend.map((l) => l.label).sort()).toEqual(["Personal", "Root", "Work"]);
+    for (const l of legend) expect(PALETTE).toContain(l.color);
+  });
+});

--- a/app/apps/desktop/src/lib/graph/graphColor.ts
+++ b/app/apps/desktop/src/lib/graph/graphColor.ts
@@ -15,23 +15,26 @@ export interface ColorResult {
 }
 
 /**
- * Muted, slightly desaturated hues chosen to stay legible on BOTH a light and a
- * deep-dark canvas. Pure primaries wash out or vibrate against dark bg, so these
- * sit in the mid-luminance / mid-saturation band that reads on either.
+ * Fully saturated hues at mid luminance. These were previously pastel-leaning so
+ * they'd read on a light canvas too — but the graph backdrop is a near-black void
+ * in every theme, and against that, desaturated fills all converge toward the
+ * same washed grey-lilac and folders stop being tellable apart. Deepened and
+ * saturated so each hue holds its own identity on the dark field, which is the
+ * only surface they're ever drawn on.
  */
 export const PALETTE: string[] = [
-  "#7c7cff", // indigo
-  "#25d6bf", // teal
-  "#ffc24d", // amber
-  "#ff5f8f", // rose
-  "#46d96f", // green
-  "#b06bff", // violet
-  "#38c6ff", // cyan
-  "#ff8a3d", // orange
-  "#b6e02a", // lime
-  "#ff6fd0", // pink
-  "#4d8dff", // blue
-  "#9fb0d8", // steel
+  "#6c5cff", // indigo
+  "#00c2a8", // teal
+  "#ffb020", // amber
+  "#ff3d71", // rose
+  "#1fc85c", // green
+  "#9d4edd", // violet
+  "#00aaff", // cyan
+  "#ff6b1a", // orange
+  "#a3d900", // lime
+  "#ff4fc3", // pink
+  "#2f6bff", // blue
+  "#7d90bd", // steel
 ];
 
 /** Clamp to a byte so channel math never overflows the 0–255 range. */
@@ -101,17 +104,29 @@ function assignByFolder(nodes: GraphNode[]): ColorResult {
 }
 
 function assignByDegree(nodes: GraphNode[], accent: string): ColorResult {
-  // Muted base → accent ramp across 4 tiers: {0, low, mid, high}.
-  const base = "#7a8290"; // slate, the "cold"/low end of the ramp
-  const shades = [0, 1, 2, 3].map((i) => lerpHex(base, accent, i / 3));
+  // The ramp runs from a deep cold slate to a colour BEYOND the accent. Ending
+  // exactly on the accent left the top tier the same purple as the app's buttons
+  // and only a shade off the tier below it; overshooting to a hot near-white
+  // gives the hubs somewhere to actually stand out to.
+  const base = "#2f3a52"; // deep slate — cold end, still clearly a colour
+  const hot = lerpHex(accent, "#fff3c4", 0.5); // accent pushed toward warm white
+  const shades = [0, 1, 2, 3].map((i) =>
+    i <= 2 ? lerpHex(base, accent, i / 2) : hot,
+  );
 
   const maxDeg = nodes.reduce((m, n) => Math.max(m, n.linkCount), 0);
 
-  // Tier boundaries over the positive range [1, maxDeg], split into thirds.
-  // tierOf returns 0 for orphans (0 links), else 1..3.
-  const span = Math.max(1, maxDeg - 1);
-  const lowMax = 1 + Math.floor(span / 3);
-  const midMax = 1 + Math.floor((span * 2) / 3);
+  // Tier boundaries on a LOG scale, not linear thirds.
+  //
+  // Link-degree in a real vault is heavy-tailed: on a 3.4k-note vault the top
+  // node had 1259 links while the vast majority had a handful. Linear thirds of
+  // [1, 1259] therefore produced tiers of "1–420 → 3370 nodes", "421–839 → 0",
+  // "840–1259 → 5" — one bucket holding 99.9% of the graph, so almost every node
+  // drew in the same shade and the colouring carried no information at all.
+  // Splitting log(degree) instead puts the boundaries where the nodes are.
+  const logSpan = Math.log(Math.max(2, maxDeg));
+  const lowMax = Math.max(1, Math.round(Math.exp(logSpan / 3)));
+  const midMax = Math.max(lowMax + 1, Math.round(Math.exp((logSpan * 2) / 3)));
 
   const tierOf = (deg: number): number => {
     if (deg <= 0) return 0;

--- a/app/apps/desktop/src/lib/graph/graphSettings.ts
+++ b/app/apps/desktop/src/lib/graph/graphSettings.ts
@@ -8,16 +8,22 @@
 /** How node fill colors are derived. */
 export type ColorMode = "folder" | "degree" | "uniform";
 
-/** What the graph draws: the whole vault (`global`) or just the neighborhood of
- *  the currently-open note (`local` — stays small and smooth on any vault, and
- *  re-centers as you move between notes). */
+/**
+ * What the graph draws. **Pinned to `global`** — the graph is the whole vault.
+ *
+ * The `local` mode (the open note's neighborhood, N hops out) is gone from the
+ * UI: two scopes meant the view could show two different things under the same
+ * name, and the one people actually wanted was always the whole vault. The union
+ * type survives so the renderer's non-WebGL fallback branch (which is written
+ * against `scope`) keeps type-checking; nothing sets it to `"local"` any more.
+ */
 export type GraphScope = "local" | "global";
 
 export interface GraphSettings {
   // ---- Scope ----
   /** Draw the open note's local neighborhood, or the whole vault. */
   scope: GraphScope;
-  /** How many link-hops out from the open note the local graph reaches. */
+  /** Vestigial: local scope has no UI. Retained so persisted blobs still parse. */
   localDepth: number;
 
   // ---- Forces (physics) ----
@@ -49,25 +55,29 @@ export interface GraphSettings {
   hideOrphans: boolean;
 }
 
+// Tuned by hand against a real ~3.4k-note vault rather than derived: long links
+// with a soft spring and light gravity let the hubs separate into distinct
+// clusters instead of packing into one ball, and small nodes with `minDegree: 1`
+// keep the field readable at that size. These are the values the graph is
+// actually designed to look right at, so they are the defaults.
 export const DEFAULT_SETTINGS: GraphSettings = {
-  scope: "local",
-  localDepth: 1,
+  scope: "global",
+  localDepth: 1, // vestigial; `scope` is pinned to global
   charge: -10.8,
-  linkDistance: 1.5,
-  linkStrength: 1,
-  gravity: 0.7,
-  nodeSize: 1,
-  edgeThickness: 1,
-  labelScale: 1,
-  colorMode: "folder",
+  linkDistance: 337,
+  linkStrength: 0.44,
+  gravity: 0.21,
+  nodeSize: 0.4,
+  edgeThickness: 1.3,
+  labelScale: 0.25,
+  colorMode: "degree",
   search: "",
-  minDegree: 0,
-  hideOrphans: false,
+  minDegree: 1,
+  hideOrphans: true,
 };
 
 /** Inclusive slider ranges + step for the numeric controls, keyed by setting. */
 export const SETTING_RANGES = {
-  localDepth: { min: 1, max: 3, step: 1 },
   charge: { min: -1500, max: -1, step: 0.2 },
   linkDistance: { min: 1, max: 400, step: 0.5 },
   linkStrength: { min: 0, max: 1, step: 0.02 },
@@ -78,8 +88,10 @@ export const SETTING_RANGES = {
   minDegree: { min: 0, max: 20, step: 1 },
 } as const;
 
-// Bumped to v4 so the new physics defaults take effect over any saved values.
-export const SETTINGS_STORAGE_KEY = "context.graph.settings.v4";
+// Bumped to v5 so the new physics/appearance defaults take effect over any saved
+// values — a persisted v4 blob would otherwise pin every existing install to the
+// old look, which is precisely what re-tuning the defaults is meant to fix.
+export const SETTINGS_STORAGE_KEY = "context.graph.settings.v5";
 
 /** Load persisted settings, merged over defaults (tolerant of missing/old keys). */
 export function loadSettings(): GraphSettings {
@@ -87,7 +99,10 @@ export function loadSettings(): GraphSettings {
     const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
     if (!raw) return { ...DEFAULT_SETTINGS };
     const parsed = JSON.parse(raw) as Partial<GraphSettings>;
-    return { ...DEFAULT_SETTINGS, ...parsed };
+    // `scope` is forced regardless of what was stored: local mode no longer has
+    // a control, so a saved `"local"` would strand someone in a scope they can't
+    // see the toggle for and can't get out of.
+    return { ...DEFAULT_SETTINGS, ...parsed, scope: "global" };
   } catch {
     return { ...DEFAULT_SETTINGS };
   }

--- a/app/apps/desktop/src/lib/graph/simulation.ts
+++ b/app/apps/desktop/src/lib/graph/simulation.ts
@@ -34,8 +34,11 @@ import type { GraphNode } from "./buildGraph";
  * the link force pointing at stale/missing refs. Order matters.
  */
 
-export const MIN_RADIUS = 4;
-export const MAX_RADIUS = 24;
+// A wider band than before (was 4..24). The point of sizing by degree is that a
+// hub should be unmistakable next to a leaf, and a 6× span reads as "one of these
+// is a sun and those are pebbles" where 6..24 read as "all roughly the same".
+export const MIN_RADIUS = 3.2;
+export const MAX_RADIUS = 40;
 
 export interface SimNode extends GraphNode {
   x: number;
@@ -62,11 +65,19 @@ export interface SimLink {
   target: string | SimNode;
 }
 
-/** Sublinear growth so hubs stay bounded; clamped to the visual radius band. */
+/**
+ * Radius from degree. Still sublinear — a 1200-link hub cannot be 1200× a leaf —
+ * but on a gentler exponent than √ so the mid-tier actually spreads out.
+ *
+ * `^0.62` rather than `^0.5`: with √, degrees 1 and 9 differ by 3× in radius
+ * while 100 and 900 also differ by 3×, which flattens exactly the range most
+ * notes live in. The higher exponent keeps pulling the low-to-mid range apart
+ * before the clamp catches the true outliers.
+ */
 export function nodeRadius(linkCount: number): number {
   return Math.max(
     MIN_RADIUS,
-    Math.min(MIN_RADIUS + Math.sqrt(linkCount) * 2.2, MAX_RADIUS),
+    Math.min(MIN_RADIUS + Math.pow(Math.max(0, linkCount), 0.62) * 2.4, MAX_RADIUS),
   );
 }
 
@@ -79,8 +90,13 @@ export function nodeRadius(linkCount: number): number {
  */
 export function centerWeight(linkCount: number, maxDegree: number): number {
   const importance = maxDegree > 0 ? linkCount / maxDegree : 0;
-  // Floor so even orphans drift gently inward; exponent < 1 spreads the mid-tier.
-  return 0.12 + Math.pow(importance, 0.7) * 1.4;
+  // Floor so even orphans drift gently inward. The exponent is well under 1
+  // because `importance` is a ratio against the single biggest hub: on a
+  // heavy-tailed vault almost every node scores near 0, so a linear (or worse,
+  // super-linear) curve would give the entire graph the floor weight and only the
+  // one hub any mass at all. 0.45 lifts the middle of the distribution enough
+  // that a moderately-linked note is meaningfully heavier than a leaf.
+  return 0.12 + Math.pow(importance, 0.45) * 1.9;
 }
 
 export function createSimulation(
@@ -129,7 +145,17 @@ export function configureForces(
   // send nodes to infinity (with weak/zero gravity the layout would explode).
   const scaledCharge = Math.max(-6000, settings.charge * chargeScale);
   const charge = sim.force("charge") as ForceManyBody<SimNode>;
-  charge.strength(scaledCharge);
+  // Repulsion PER NODE, scaled by its own size — the solar-system half of the
+  // model. A uniform charge made every node push equally hard, so a hub and a
+  // leaf cleared the same space and the layout had no sense of scale; giving the
+  // big ones a bigger field means they hold open a neighbourhood and the small
+  // ones settle into orbit around them. Area-proportional (r²/rMin², capped) so
+  // it tracks the visual size rather than fighting it.
+  const rMin = MIN_RADIUS;
+  charge.strength((d: SimNode) => {
+    const rel = Math.min(6, ((d.radius || rMin) / rMin) ** 2);
+    return scaledCharge * (0.5 + rel * 0.5);
+  });
   // CRUCIAL for large graphs: cap the RANGE of repulsion so each node only
   // pushes against nearby neighbors, not every node in the vault. Without a
   // cutoff, global many-body repulsion on thousands of nodes evacuates the
@@ -156,7 +182,9 @@ export function configureForces(
 
   // A little extra margin beyond each node's visual radius so nodes keep some
   // breathing room instead of touching — the even, spaced look of a good graph.
+  // Clearance scales with the node too, so a sun keeps its planets at a distance
+  // instead of letting them touch its surface the way a leaf's neighbours do.
   (sim.force("collide") as ForceCollide<SimNode>)
-    .radius((d) => d.radius + 5)
+    .radius((d) => d.radius + 4 + d.radius * 0.35)
     .strength(0.85);
 }

--- a/app/apps/desktop/src/lib/graph/webglRenderer.ts
+++ b/app/apps/desktop/src/lib/graph/webglRenderer.ts
@@ -45,19 +45,59 @@ void main() {
   vColor = aColor;
 }`;
 
+// Matte-sphere shading, computed per fragment. The disc used to be a flat fill,
+// which is what made the graph look like a field of stickers — every node the
+// same brightness edge to edge, so nothing read as an object with volume.
+//
+// Reconstructing a hemisphere normal from the quad corner is all it takes: with
+// z = sqrt(1 - x² - y²) the shading is real Lambert on a real sphere, evaluated
+// on the GPU at zero cost per node. Same light direction as the 2D canvas path's
+// baked sprites (upper-left, tilted toward the viewer) so the two renderers agree
+// about where the light is.
 const FRAG = `#version 300 es
 precision mediump float;
 in vec2 vCorner;
 in vec3 vColor;
 out vec4 fragColor;
 
+const vec3 LIGHT = normalize(vec3(-0.5, -0.62, 0.6));
+
 void main() {
-  // Solid disc: inside the rim it's opaque, outside is dropped. A small fixed
-  // feather softens the edge without collapsing sub-pixel discs to zero alpha.
-  float d = length(vCorner);
-  if (d > 1.0) discard;
-  float alpha = 1.0 - smoothstep(0.9, 1.0, d);
-  fragColor = vec4(vColor, alpha);
+  float d2 = dot(vCorner, vCorner);
+  if (d2 > 1.0) discard;
+
+  // Hemisphere normal at this pixel.
+  float z = sqrt(max(0.0, 1.0 - d2));
+  vec3 n = vec3(vCorner, z);
+
+  // Lambert, lifted by an ambient floor so the unlit limb stays coloured rather
+  // than going black — a fully dark terminator reads as a hole, not a shadow.
+  float diff = max(0.0, dot(n, LIGHT));
+  float shade = 0.34 + 0.66 * diff;
+
+  // Narrow soft highlight where the light hits square on: the cue that says
+  // "glossy sphere" rather than "gradient".
+  float spec = pow(diff, 22.0) * 0.5;
+
+  // Rim light on the far limb, which is what separates one node from another
+  // when they overlap in a dense cluster.
+  float rim = pow(1.0 - z, 3.0) * 0.22;
+
+  // Hover-dimming is applied by the caller as a multiplier on the fill colour,
+  // and a white specular would ignore it — dimmed nodes would keep a full-bright
+  // glint and stay just as eye-catching as the ones being highlighted, which
+  // defeats the dimming. Tying both additive terms to the fill's own brightness
+  // keeps a dark node's highlight dark. Not physically correct (real specular is
+  // light-coloured, not surface-coloured) but it is the behaviour we want, and it
+  // costs nothing versus threading a per-instance dim attribute through a buffer
+  // that can hold 50k nodes.
+  float intensity = max(vColor.r, max(vColor.g, vColor.b));
+  vec3 lit = vColor * shade + vec3(spec + rim) * intensity;
+
+  // Feather only the outermost pixels, in the same radial space as the normal.
+  float d = sqrt(d2);
+  float alpha = 1.0 - smoothstep(0.94, 1.0, d);
+  fragColor = vec4(lit, alpha);
 }`;
 
 // Edges: one shared program drawing gl.LINES. Each vertex is a world position;
@@ -276,19 +316,41 @@ export class WebGLGraphRenderer {
     gl.clearColor(0.04, 0.04, 0.07, 1); // near-black, matching the graph backdrop
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    // Edges first, under the nodes (faint, additive-ish via low alpha).
-    if (this.lineVertCount > 0) {
+    const drawLines = (
+      vao: WebGLVertexArrayObject,
+      vertCount: number,
+      r: number,
+      g: number,
+      b: number,
+      a: number,
+    ) => {
+      if (vertCount === 0) return;
       gl.useProgram(this.lineProgram);
-      gl.bindVertexArray(this.lineVao);
+      gl.bindVertexArray(vao);
       gl.uniform2f(this.uLineViewport, this.canvas.width, this.canvas.height);
       gl.uniform1f(this.uLineScale, scale);
       gl.uniform2f(this.uLinePan, panX, panY);
-      gl.uniform4f(this.uLineColor, 0.62, 0.68, 0.9, 0.35);
-      gl.drawArrays(gl.LINES, 0, this.lineVertCount);
+      gl.uniform4f(this.uLineColor, r, g, b, a);
+      gl.drawArrays(gl.LINES, 0, vertCount);
       gl.bindVertexArray(null);
-    }
+    };
 
-    // Nodes on top.
+    // Resting edges: quiet threads under everything. The alpha is low because
+    // these overlap in the thousands on a real vault — at 0.35 they accumulated
+    // into a solid pale field that washed the whole view lavender and buried the
+    // nodes. Faint per line is what keeps dense regions reading as *dense*
+    // rather than as a flat wash.
+    drawLines(this.lineVao, this.lineVertCount, 0.42, 0.5, 0.78, 0.12);
+
+    // Hover rays go UNDER the nodes, not over them. Drawn last, they crossed the
+    // hovered node itself — dozens of bright lines converging on top of the very
+    // thing being pointed at, which blew out its centre and hid it. Beneath the
+    // node layer they emerge from behind it instead, which is also what the
+    // geometry actually is: a link starts at the node, not on it.
+    drawLines(this.hlVao, this.hlVertCount, 1.0, 0.86, 0.38, 0.85);
+
+    // Nodes last, so every edge — resting or highlighted — is occluded by the
+    // discs it connects.
     if (this.count > 0) {
       gl.useProgram(this.program);
       gl.bindVertexArray(this.vao);
@@ -297,19 +359,6 @@ export class WebGLGraphRenderer {
       gl.uniform2f(this.uPan, panX, panY);
       gl.uniform1f(this.uMinPx, minPx);
       gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, this.count);
-      gl.bindVertexArray(null);
-    }
-
-    // Hover highlight edges — bright, drawn last so they sit on top of the
-    // dimmed cloud and read as rays from the hovered node to its neighbors.
-    if (this.hlVertCount > 0) {
-      gl.useProgram(this.lineProgram);
-      gl.bindVertexArray(this.hlVao);
-      gl.uniform2f(this.uLineViewport, this.canvas.width, this.canvas.height);
-      gl.uniform1f(this.uLineScale, scale);
-      gl.uniform2f(this.uLinePan, panX, panY);
-      gl.uniform4f(this.uLineColor, 1.0, 0.92, 0.5, 0.95);
-      gl.drawArrays(gl.LINES, 0, this.hlVertCount);
       gl.bindVertexArray(null);
     }
   }

--- a/app/apps/desktop/src/lib/menuPlacement.test.ts
+++ b/app/apps/desktop/src/lib/menuPlacement.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { placeMenu } from "./menuPlacement";
+
+const VIEWPORT = { width: 1200, height: 800 };
+const MENU = { width: 200, height: 300 };
+
+describe("placeMenu", () => {
+  it("opens downward from the anchor when there is room", () => {
+    const p = placeMenu({ x: 100, y: 120 }, MENU, VIEWPORT);
+    expect(p).toMatchObject({ left: 100, top: 120 });
+  });
+
+  it("flips above the anchor rather than running off the bottom", () => {
+    // 700 + 300 = 1000, past the 800px viewport. The regression this guards:
+    // the tail of the menu (Share…, Lock, Delete) fell below the fold, so a note
+    // at the bottom of the sidebar had no reachable Delete.
+    const p = placeMenu({ x: 100, y: 700 }, MENU, VIEWPORT);
+    expect(p.top).toBe(400);
+    expect(p.top + MENU.height).toBeLessThanOrEqual(VIEWPORT.height);
+  });
+
+  it("flips above the BUTTON when the anchor supplies flipY", () => {
+    // A ⋯ button whose bottom is at 700: opening upward has to clear the button
+    // itself, not just the point below it.
+    const p = placeMenu({ x: 100, y: 704, flipY: 676 }, MENU, VIEWPORT);
+    expect(p.top).toBe(376);
+  });
+
+  it("clamps into view when neither direction fits", () => {
+    const tall = { width: 200, height: 700 };
+    // Slid up to the lowest position that still fits, rather than pinned to the
+    // top — the menu stays as close to where it was asked for as it can.
+    const p = placeMenu({ x: 100, y: 600 }, tall, { width: 1200, height: 760 });
+    expect(p.top).toBe(52);
+    expect(p.top + tall.height).toBeLessThanOrEqual(760 - 8);
+  });
+
+  it("caps the height of a menu taller than the window so it can scroll", () => {
+    const p = placeMenu({ x: 10, y: 10 }, { width: 200, height: 2000 }, VIEWPORT);
+    expect(p.maxHeight).toBe(784);
+    expect(p.top).toBe(8);
+  });
+
+  it("flips to the left of the anchor rather than off the right edge", () => {
+    const p = placeMenu({ x: 1150, y: 100 }, MENU, VIEWPORT);
+    expect(p.left).toBe(950);
+  });
+
+  it("keeps the top-left corner visible when the menu is wider than the window", () => {
+    const p = placeMenu({ x: 40, y: 10 }, { width: 400, height: 100 }, { width: 300, height: 800 });
+    expect(p.left).toBe(8);
+  });
+});

--- a/app/apps/desktop/src/lib/menuPlacement.ts
+++ b/app/apps/desktop/src/lib/menuPlacement.ts
@@ -1,0 +1,91 @@
+/**
+ * Where to put a floating menu so all of it stays on screen.
+ *
+ * The file tree's context menu was positioned at the raw anchor point with no
+ * viewport check at all, so right-clicking a row near the bottom of the window
+ * pushed the tail of the menu below the fold. The items that live at the tail
+ * are `Share…`, `Lock for everyone` and `Delete` — i.e. the menu got *shorter*
+ * exactly where its most important action is, and a user with a note at the
+ * bottom of their sidebar had no way to delete it.
+ *
+ * Pure on purpose: it takes numbers and returns numbers, so the flip/clamp rules
+ * are a table test rather than something you can only check by dragging a window
+ * around.
+ */
+
+export interface MenuAnchor {
+  /** Preferred left edge, in viewport coordinates. */
+  x: number;
+  /** Preferred TOP edge when the menu opens downward. */
+  y: number;
+  /**
+   * Bottom edge to use when the menu has to open UPWARD instead. Defaults to
+   * `y`, which is right for a cursor anchor (the menu grows away from the
+   * pointer either way). A button anchor should pass the button's top so the
+   * flipped menu sits above the button rather than on top of it.
+   */
+  flipY?: number;
+}
+
+export interface Box {
+  width: number;
+  height: number;
+}
+
+export interface Placement {
+  left: number;
+  top: number;
+  /**
+   * Ceiling for the menu's height. Only ever binds when the menu is taller than
+   * the viewport, in which case it scrolls instead of overflowing off-screen.
+   */
+  maxHeight: number;
+}
+
+/** Breathing room kept between the menu and every window edge. */
+export const MENU_MARGIN = 8;
+
+function clamp(v: number, lo: number, hi: number): number {
+  // `hi < lo` when the menu is bigger than the space available; pinning to `lo`
+  // then keeps the top-left corner visible, which is the half that matters.
+  return hi < lo ? lo : Math.min(Math.max(v, lo), hi);
+}
+
+/**
+ * Resolve an anchor + a measured menu size into a position that fits.
+ *
+ * Vertically: open downward if it fits, else flip above the anchor if THAT fits,
+ * else clamp into the viewport and cap the height so the rest scrolls.
+ * Horizontally the same, mirrored — flip to the left of the anchor.
+ */
+export function placeMenu(
+  anchor: MenuAnchor,
+  size: Box,
+  viewport: Box,
+  margin = MENU_MARGIN,
+): Placement {
+  const maxHeight = Math.max(0, viewport.height - margin * 2);
+  const height = Math.min(size.height, maxHeight);
+  const flipBottom = anchor.flipY ?? anchor.y;
+
+  let top: number;
+  if (anchor.y + height <= viewport.height - margin) {
+    top = anchor.y;
+  } else if (flipBottom - height >= margin) {
+    top = flipBottom - height;
+  } else {
+    top = clamp(anchor.y, margin, viewport.height - margin - height);
+  }
+
+  const width = Math.min(size.width, Math.max(0, viewport.width - margin * 2));
+  let left: number;
+  if (anchor.x + width <= viewport.width - margin) {
+    left = anchor.x;
+  } else if (anchor.x - width >= margin) {
+    left = anchor.x - width;
+  } else {
+    left = clamp(anchor.x, margin, viewport.width - margin - width);
+  }
+
+  return { left, top, maxHeight };
+}

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -181,6 +181,24 @@ describe("planInbound — deletes", () => {
     expect(p.trash).toEqual([]);
   });
 
+  it("suppresses a tombstoned note whose file is still on disk under another id", () => {
+    // The undeletable-note bug. A note MATERIALIZED from the server has a local
+    // index id Rust minted for the new file, which is not the server's docId; if
+    // the registry mapping that joined the two has since been pruned, the doc
+    // reads as "gone locally" here while the file is very much still there. The
+    // outbound half then re-registered it under a brand-new docId, so a deleted
+    // note came back — and deleting it again just repeated the cycle.
+    const p = plan({
+      baseline: new Map([["server-id", "naveed-test.md"]]),
+      local: new Map([["local-index-id", "naveed-test.md"]]),
+      tombstones: new Set(["server-id"]),
+    });
+    expect([...p.suppress]).toEqual(["naveed-test.md"]);
+    // Suppress only. Without a docId match we cannot prove the file at that path
+    // is still this note, and a wrong guess here deletes someone's work.
+    expect(p.trash).toEqual([]);
+  });
+
   it("trashes deepest paths first", () => {
     const p = plan({
       baseline: new Map([

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -207,6 +207,9 @@ export function planInbound(input: InboundInput): InboundPlan {
   plan.createFolders.sort(byDepth);
 
   // ---- notes --------------------------------------------------------------
+  // Every note path on disk, for the "we lost this doc's local identity" case
+  // below. `input.local` is docId → path, so its values are exactly that set.
+  const localPaths = new Set(input.local.values());
   const docIds = new Set<string>([...input.baseline.keys(), ...input.server.keys()]);
   for (const docId of docIds) {
     const prev = input.baseline.get(docId);
@@ -245,7 +248,19 @@ export function planInbound(input: InboundInput): InboundPlan {
     if (prev === undefined) continue; // never agreed it was ours — not ours to touch
 
     if (dead) {
-      if (loc === undefined) continue; // already gone locally; the prune tidies the map
+      if (loc === undefined) {
+        // No local doc with this id. Usually that means the file really is gone
+        // and the prune tidies the map — but it ALSO happens when the file is
+        // still sitting at its baseline path under a different local identity
+        // (a materialized note whose registry mapping has since been pruned).
+        // Re-registering that file is what resurrects a deleted note under a new
+        // docId, so suppress the path. Deliberately no trash: without a docId
+        // match we can't prove the file at that path is still this note, and a
+        // wrong guess here deletes someone's work. It stays on disk as a purely
+        // local note the user can remove themselves.
+        if (prev !== undefined && localPaths.has(prev)) plan.suppress.add(prev);
+        continue;
+      }
       // Belt as well as braces: if the trash step is skipped or fails, this still
       // stops the note being re-registered as a ghost.
       plan.suppress.add(loc);

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -509,12 +509,43 @@ export class VaultRegistry {
     if (this.baselineVaultId !== vaultId) return none;
 
     const localNotePaths = new Set(args.notes.map((n) => n.path));
+    // What docId does this device believe each on-disk note has?
+    //
+    // The registry's OWN map answers first, and it has to: a note this device
+    // MATERIALIZED from the server got its file written by `writeNoteIfMissing`,
+    // and Rust's indexer mints a fresh local UUID for any file it hasn't seen
+    // before. That local id never equals the server's `doc_id` — `byPath` is the
+    // only place the two identities are joined (see viewingDocId.ts, which says
+    // the same thing for presence).
+    //
+    // Keying this map on index ids alone therefore made every remote delete of a
+    // materialized note a no-op: `local.get(serverDocId)` came back undefined, the
+    // plan read that as "already gone locally" and suppressed nothing, and the
+    // outbound half below re-registered the still-present file under its LOCAL id
+    // — resurrecting the note on the server as a brand-new row with a brand-new
+    // docId. Deleting it again just repeated the cycle, which is what made a
+    // deleted note look undeletable.
+    //
+    // The index id stays as the fallback for paths the registry doesn't map yet
+    // (a note created locally and not yet registered). One docId per path either
+    // way — `claimed` stops a mapped path also entering under its index id, which
+    // would let one file be both renamed and trashed in a single pass.
+    const local = new Map<string, string>();
+    const claimed = new Set<string>();
+    for (const path of localNotePaths) {
+      const m = this.byPath.get(path);
+      // `byPath` can still hold another collection's entries at this point (they
+      // are pruned after inbound runs), and those ids mean nothing here.
+      if (m && m.vaultId === vaultId) {
+        local.set(m.docId, path);
+        claimed.add(path);
+      }
+    }
     // Only notes that are BOTH in the tree and in the index have a docId we can
     // match on. (The index covers `.md`; a `.txt`/`.canvas` note therefore never
     // gets inbound-renamed or trashed, only materialized — the safe direction.)
-    const local = new Map<string, string>();
     for (const t of args.titles) {
-      if (localNotePaths.has(t.path)) local.set(t.id, t.path);
+      if (localNotePaths.has(t.path) && !claimed.has(t.path)) local.set(t.id, t.path);
     }
     const server = new Map<string, string>();
     for (const n of args.serverNotes) {

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -388,6 +388,41 @@ export async function createNote(
   if ((await folderWritePermission(ctx.auth, folderId)) !== "edit") {
     throw new McpToolError("You do not have edit access to create a note here");
   }
+  // Adopt the live note already at this path instead of inserting a second row,
+  // exactly as `createFolder` does. A vault-relative path addresses ONE note —
+  // nothing in the schema enforces that, and the desktop's path→docId map just
+  // picks one of a duplicate pair, so the loser becomes a row no client can see
+  // or delete. An LLM retrying a tool call must not be able to create that.
+  const existing = await pool.query<{ id: string; title: string | null; folder_id: string | null }>(
+    `SELECT id, title, folder_id FROM notes
+      WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL
+      ORDER BY created_at ASC LIMIT 1`,
+    [input.vaultId, input.relPath],
+  );
+  if (existing.rows[0]) {
+    const row = existing.rows[0];
+    // Seed content only into an EMPTY note. "Create" must never become a way to
+    // overwrite a note that already says something — that's `update_note`, which
+    // the caller can reach for once `adopted` has told it what happened.
+    let seeded = false;
+    if (input.content) {
+      const current = await ctx.docWriter.readContent(input.vaultId, row.id);
+      if (current.trim().length === 0) {
+        await ctx.docWriter.setContent(input.vaultId, row.id, input.content);
+        seeded = true;
+      }
+    }
+    return {
+      docId: row.id,
+      vaultId: input.vaultId,
+      folderId: row.folder_id,
+      title: row.title ?? relPathStem(input.relPath),
+      relPath: input.relPath,
+      adopted: true,
+      seeded,
+    };
+  }
+
   const docId = randomUUID();
   await pool.query(
     `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by)
@@ -406,6 +441,8 @@ export async function createNote(
     folderId,
     title: input.title ?? relPathStem(input.relPath),
     relPath: input.relPath,
+    adopted: false,
+    seeded: Boolean(input.content),
   };
 }
 

--- a/app/apps/server/tests/mcp.test.ts
+++ b/app/apps/server/tests/mcp.test.ts
@@ -160,6 +160,55 @@ describe("MCP server", () => {
     expect((await call(token, "read_note", { docId })).isError).toBe(true);
   });
 
+  it("create_note adopts the note already at that path instead of duplicating it", async () => {
+    const owner = await seedUser("owner@mcp-dup.com");
+    const org = await seedOrg("Acme", "acme-mcp-dup");
+    await seedMember(org, owner, "owner");
+    const vault = await seedVault(org);
+    const token = await tokenFor(owner, org);
+
+    const first = await call(token, "create_note", {
+      vaultId: vault,
+      relPath: "naveed-test.md",
+      content: "original",
+    });
+    const docId = first.data.docId as string;
+    expect(first.data.adopted).toBe(false);
+
+    // The retry an assistant makes when it isn't sure the first call landed. A
+    // second row at the same path is unreachable: the desktop's path→docId map
+    // picks one of the pair, so deleting "the" note leaves the other behind and
+    // the file looks undeletable.
+    const again = await call(token, "create_note", {
+      vaultId: vault,
+      relPath: "naveed-test.md",
+      content: "different",
+    });
+    expect(again.isError).toBe(false);
+    expect(again.data.docId).toBe(docId);
+    expect(again.data.adopted).toBe(true);
+    // Adoption is not an overwrite — that's what update_note is for.
+    expect(again.data.seeded).toBe(false);
+    expect(mem.store.get(docId)).toBe("original");
+
+    const { rows } = await pool.query(
+      "SELECT id FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL",
+      [vault, "naveed-test.md"],
+    );
+    expect(rows).toHaveLength(1);
+
+    // Once deleted, the path is free again — adoption only ever matches a LIVE
+    // note, so a delete really does clear the way for a fresh one.
+    await call(token, "delete_note", { docId });
+    const remade = await call(token, "create_note", {
+      vaultId: vault,
+      relPath: "naveed-test.md",
+      content: "fresh",
+    });
+    expect(remade.data.adopted).toBe(false);
+    expect(remade.data.docId).not.toBe(docId);
+  });
+
   it("member: only sees/edits shared content; no root create", async () => {
     const owner = await seedUser("owner@mcp3.com");
     const member = await seedUser("member@mcp3.com");


### PR DESCRIPTION
Three things, plus the 0.1.19 release bump.

## A deleted note came back with a new `doc_id`

Deleting a note over MCP (or anywhere else) soft-deleted the right row, and then the desktop put it straight back under a brand-new id. Deleting *that* repeated the cycle, so the note read as undeletable.

A note this device **materialized** from the server gets its file written by `writeNoteIfMissing`, and Rust's indexer mints a fresh local UUID for any file it hasn't seen. That local id is not the server's `doc_id` — `registry.byPath` is the only place the two identities are joined. `applyInbound` was building its docId→path map from the index ids alone, so `local.get(serverDocId)` came back `undefined` on a tombstone, the plan read that as "already gone locally", nothing was suppressed, and the outbound half re-registered the still-present file.

- `registry.ts` — build the inbound `local` map from the registry's own mapping first, falling back to the index id only for paths it doesn't map. One docId per path either way.
- `inbound.ts` — belt and braces for when the mapping has since been pruned: a tombstoned doc whose baseline path is still on disk gets its path **suppressed** so outbound can't re-register it. Deliberately no trash — without a docId match we can't prove the file at that path is still that note.

## `create_note` could leave an unreachable duplicate

MCP's `create_note` inserted unconditionally, so a retried tool call produced two live rows at one `rel_path`. The desktop's path→docId map picks one of the pair, and the loser is a row no client can see or delete. It now adopts the live note already at that path, exactly as `create_folder` does. Adoption seeds content only into an empty note — "create" must never become a silent overwrite — and reports `adopted` / `seeded` so the caller can reach for `update_note` instead.

## The tree context menu ran off the bottom of the window

The menu was positioned at the raw anchor with no viewport check, so right-clicking a row near the bottom pushed its tail below the fold. The tail is `Share…`, `Lock for everyone` and `Delete` — the menu got shorter exactly where its most important action lives.

New pure `placeMenu` helper: open downward if it fits, flip above the anchor if that fits, else clamp and cap the height so the rest scrolls. Horizontal mirror of the same rule. The ⋯ button passes its own top as the flip edge so a flipped menu never lands on the button that opened it. Measured in a layout effect, so it's never painted at the unplaced position.

## Tests

- `menuPlacement.test.ts` — 7 cases covering flip, clamp, height cap and the horizontal mirror.
- `inbound.test.ts` — the resurrection case: tombstoned doc, file still on disk under another id → suppressed, not trashed.
- `mcp.test.ts` — retried `create_note` adopts rather than duplicating; a delete frees the path again.

Desktop 444 passed, server 211 passed, both workspaces typecheck clean.