### PR TITLE
Sidebar sorting, graph view upgrades, join-with-code onboarding and a full-height window (0.1.21)

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.20",
+  "version": "0.1.21",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.20"
+version = "0.1.21"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/capabilities/default.json
+++ b/app/apps/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    {
+      "identifier": "core:window:allow-start-dragging",
+      "comment": "The window runs with `titleBarStyle: \"Overlay\"` (tauri.conf.json), so there is no system title bar to drag it by — the two header rows along the top edge carry `data-tauri-drag-region` instead. That attribute calls this command on mousedown, and `core:default` grants only read-only window commands, so without this the rows look draggable and silently do nothing."
+    },
     "opener:default",
     {
       "identifier": "opener:allow-open-path",

--- a/app/apps/desktop/src-tauri/src/tree.rs
+++ b/app/apps/desktop/src-tauri/src/tree.rs
@@ -21,6 +21,21 @@ pub struct TreeNode {
     /// fetched yet" — both are `children: []` — and every unexpanded folder is
     /// labelled "empty". Always true for files and for [`list_tree`]'s output.
     pub children_loaded: bool,
+    /// Last-modified time, milliseconds since the Unix epoch; 0 when the OS
+    /// won't say. Feeds the sidebar's "Recently modified" sort, which is the
+    /// default arrangement — so this is read for every entry, one extra stat
+    /// per `read_dir` entry.
+    pub modified: u64,
+}
+
+/// A directory entry's mtime in epoch millis, or 0 if it can't be read (a
+/// broken symlink, a racing delete). 0 sorts last under "recent", which is
+/// where an entry we know nothing about belongs.
+fn modified_millis(meta: Option<std::fs::Metadata>) -> u64 {
+    meta.and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// Walk the vault into a nested tree. Skips dotfolders, `.git`, `.context/`,
@@ -41,6 +56,7 @@ pub fn list_tree(vault: &Path) -> AppResult<TreeNode> {
         is_dir: true,
         children: Some(children),
         children_loaded: true,
+        modified: modified_millis(std::fs::metadata(vault).ok()),
     })
 }
 
@@ -96,6 +112,7 @@ pub fn list_children(vault: &Path, rel: &str) -> AppResult<Vec<TreeNode>> {
                 is_dir: true,
                 children: Some(Vec::new()), // lazy marker: expandable, not yet loaded
                 children_loaded: false,
+                modified: modified_millis(entry.metadata().ok()),
             });
         } else if file_type.is_file() {
             if !is_allowed_file(&name) {
@@ -108,6 +125,7 @@ pub fn list_children(vault: &Path, rel: &str) -> AppResult<Vec<TreeNode>> {
                 is_dir: false,
                 children: None,
                 children_loaded: true,
+                modified: modified_millis(entry.metadata().ok()),
             });
         }
     }
@@ -158,6 +176,7 @@ fn walk_dir(dir: &Path, rel_prefix: &str) -> AppResult<Vec<TreeNode>> {
                 is_dir: true,
                 children: Some(children),
                 children_loaded: true,
+                modified: modified_millis(entry.metadata().ok()),
             });
         } else if file_type.is_file() {
             // Only surface allowed file types (notes/images/PDFs); skip code,
@@ -172,6 +191,7 @@ fn walk_dir(dir: &Path, rel_prefix: &str) -> AppResult<Vec<TreeNode>> {
                 is_dir: false,
                 children: None,
                 children_loaded: true,
+                modified: modified_millis(entry.metadata().ok()),
             });
         }
     }
@@ -245,6 +265,34 @@ mod tests {
             .map(|n| n.name.as_str())
             .collect();
         assert!(inner.contains(&"attachments"));
+    }
+
+    /// The sidebar's default arrangement is "recently modified first", which it
+    /// can only do if every entry carries an mtime. Both listings must supply
+    /// it: the lazy one is what the sidebar actually renders after a folder is
+    /// expanded, so a 0 there would silently sort a whole folder to the bottom.
+    #[test]
+    fn both_listings_report_a_modified_time() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("Notes")).unwrap();
+        fs::write(root.join("Notes/a.md"), b"# A").unwrap();
+        fs::write(root.join("top.md"), b"# T").unwrap();
+
+        let tree = list_tree(root).unwrap();
+        assert!(tree.modified > 0, "the vault root itself");
+        let walk = |ns: &Vec<TreeNode>| {
+            for n in ns {
+                assert!(n.modified > 0, "{} has no mtime", n.path);
+            }
+        };
+        let children = tree.children.as_ref().unwrap();
+        walk(children);
+        walk(children.iter().find(|n| n.name == "Notes").unwrap().children.as_ref().unwrap());
+
+        for n in list_children(root, "").unwrap() {
+            assert!(n.modified > 0, "lazy listing: {} has no mtime", n.path);
+        }
     }
 
     /// `children: []` means two different things depending on which call produced

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
       {
         "title": "Baalda",
         "hiddenTitle": true,
+        "titleBarStyle": "Overlay",
         "width": 1200,
         "height": 800,
         "minWidth": 720,

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -443,6 +443,26 @@ button.primary.hero:hover:not(:disabled) {
   margin-top: var(--sp-1);
 }
 
+/* ---- Join-with-code step (same slot/shell as the naming step) ----
+   A join code is an opaque 8-character string read off someone else's screen,
+   so it gets the mono face and loose tracking that make O/0 and I/1 tellable
+   apart while typing. */
+.join-code-input {
+  font-family: var(--font-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.join-code-input::placeholder {
+  letter-spacing: 0.12em;
+  opacity: 0.45;
+}
+/* The step owns its own error line (a bad code is expected, not exceptional),
+   so it sits inside the form rather than in the card-level error slot. */
+.vault-picker-card .error.join-error {
+  margin-top: 0;
+  text-align: left;
+}
+
 /* Post-sign-in landing: shown in place of the two primary actions while the
    vault is being resolved (and, for a new account, created + seeded). Occupies
    the same slot so the centered card doesn't jump. */
@@ -618,6 +638,30 @@ button.primary.hero:hover:not(:disabled) {
   position: relative;
 }
 
+/* ---- Window drag regions ----
+   The window runs without a system title bar (`titleBarStyle: "Overlay"` in
+   tauri.conf.json) so the webview owns the full height. The trade Tauri makes
+   for that is that nothing is draggable by default, so the rows that sit along
+   the top edge opt in with `data-tauri-drag-region`. Text inside them must not
+   select, or a drag reads as a botched selection instead of moving the window. */
+[data-tauri-drag-region] {
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
+}
+/* Bare strip for screens with no header row of their own (the vault picker). */
+.titlebar-drag {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* Fixed rather than `--titlebar-inset`, which is 0 off macOS and would leave
+     nothing to grab. The picker is vertically centred, so this strip only ever
+     covers empty margin. */
+  height: 28px;
+  z-index: 2;
+}
+
 /* ---- Sidebar resize handle ----
    Rides on top of the seam rather than taking a grid column of its own, so the
    two panes stay flush and the hit area can be wider than the seam itself.
@@ -659,11 +703,15 @@ body:has(.sidebar-resizer.dragging) {
   min-width: 0;
   padding: 0 var(--sp-1) 0 var(--sp-2);
 }
+/* The window has no system title bar of its own (`titleBarStyle: "Overlay"`),
+   so this row starts at y=0 and the macOS traffic lights float over it — hence
+   the inset on top of the normal padding. It doubles as the window's drag
+   handle on this side; see `data-tauri-drag-region` in SidebarHeader.tsx. */
 .sidebar-header {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: var(--sp-4) var(--sp-3) var(--sp-3);
+  padding: calc(var(--sp-4) + var(--titlebar-inset)) var(--sp-3) var(--sp-3);
 }
 .sidebar-header-main {
   display: flex;
@@ -893,8 +941,12 @@ body:has(.sidebar-resizer.dragging) {
   margin-right: calc(-1 * var(--sp-1));
   /* A file tree is never selectable text. Covers react-arborist's own row
      wrapper divs (our rows set this too) so a double-click to rename can't
-     leave stray blue text-selection bands between rows. */
+     leave stray blue text-selection bands between rows — and so a drag that
+     the OS refuses can't fall back to smearing a selection across the rows.
+     Prefixed too: this runs in WKWebView, where the unprefixed property is
+     only honoured on recent versions. */
   user-select: none;
+  -webkit-user-select: none;
 }
 /* react-arborist otherwise widens its scroll area to the longest row so long
    names scroll horizontally. Clip that and pin the inner list + rows to the
@@ -911,12 +963,26 @@ body:has(.sidebar-resizer.dragging) {
   width: 100% !important;
 }
 /* OS files dragged over the tree: a dashed accent frame + soft wash invite the
-   drop. Purely a hint — the actual routing happens on the Tauri drop event. */
+   drop. Purely a hint — the actual routing happens on the Tauri drop event.
+   Only a drag from OUTSIDE the app gets here; dragging a row around inside the
+   sidebar is suppressed in FileTree, or this frame would cover the insertion
+   line the user is aiming with. */
 .filetree.drop-active {
   outline: 2px dashed var(--accent);
   outline-offset: -4px;
   border-radius: var(--radius-md);
   background: var(--accent-soft);
+}
+/* Rows are draggable, so press-and-hold reads as picking one up — the closed
+   hand is the whole feedback that a row is now "in your grip", before it has
+   moved far enough to show a drop cursor. Held for the length of the drag by
+   the container class, since the pointer leaves the source row immediately. */
+.tree-row:active {
+  cursor: grabbing;
+}
+.filetree.row-dragging,
+.filetree.row-dragging * {
+  cursor: grabbing !important;
 }
 /* Transient outcome pill after an import (menu or drop). Sits at the bottom of
    the sidebar, out of the way, and fades itself out. */
@@ -1196,6 +1262,7 @@ body:has(.sidebar-resizer.dragging) {
   color: var(--text-secondary);
   cursor: pointer;
   user-select: none;
+  -webkit-user-select: none;
   transition:
     background var(--t-fast) var(--ease),
     color var(--t-fast) var(--ease);
@@ -1215,9 +1282,14 @@ body:has(.sidebar-resizer.dragging) {
   background: var(--accent-soft-hover);
 }
 /* Folder about to receive a dragged note */
+/* "Release here and it goes inside this folder." Faded in rather than snapped
+   on, so brushing past a folder on the way somewhere else doesn't strobe. */
 .tree-row.drop-target {
   background: var(--accent-soft);
   box-shadow: inset 0 0 0 1px var(--accent);
+  transition:
+    background 120ms var(--ease),
+    box-shadow 120ms var(--ease);
 }
 
 /* The row wrapper is absolutely positioned by react-window via `top`; since
@@ -1230,12 +1302,15 @@ body:has(.sidebar-resizer.dragging) {
 }
 
 /* The row you've picked up — lift and dim it so the drag reads as tactile. */
+/* The row you picked up: it stays in place and recedes, so the line is the
+   thing your eye follows. Eased out slowly and in quickly — a gentle lift, a
+   clean settle. */
 .tree-row.dragging {
-  opacity: 0.55;
-  transform: scale(0.98);
+  opacity: 0.4;
+  transform: scale(0.985);
   transition:
-    opacity var(--t-fast) var(--ease),
-    transform var(--t-fast) var(--ease);
+    opacity 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* Honor reduced-motion: keep the reorder instant, drop the lift animation. */
@@ -1496,15 +1571,35 @@ body:has(.sidebar-resizer.dragging) {
 /* Drag-and-drop insertion line (replaces react-arborist's default blue).
    Fades/grows in so the drop target reads clearly as you drag over it, with a
    soft glow and a leading dot to anchor the eye. */
+/* The insertion line. It lives for the whole drag and is moved by transform
+   from the pointer handler, so it GLIDES from slot to slot on the compositor —
+   the difference between a marker that tracks your hand and one that blinks
+   from place to place. `top: 0` because the transform carries the whole offset;
+   `left` is set inline to match the destination's indent. */
 .drop-cursor {
   position: absolute;
+  top: 0;
   right: var(--sp-2);
   height: 2px;
   border-radius: var(--radius-pill);
   background: var(--accent);
   box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 60%, transparent);
   pointer-events: none;
-  animation: drop-cursor-in var(--t-fast) var(--ease);
+  opacity: 0;
+  will-change: transform;
+  /* ONLY the transform is animated, and only vertically. `left` is snapped,
+     never transitioned: it runs on the main thread while the transform runs on
+     the compositor, and the two desync under any load — the line then bows out
+     sideways and curves back instead of stepping straight up the list. `left`
+     also changes the line's WIDTH (it is anchored right), so animating it
+     morphs the line's shape mid-move on top of that.
+
+     Short and near-linear on purpose. This marks a slot, and a slot is a
+     discrete thing: it should step from row to row a beat behind your hand,
+     not glide or ease. */
+  transition:
+    transform 90ms cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 90ms linear;
 }
 .drop-cursor::before {
   content: "";
@@ -1517,19 +1612,10 @@ body:has(.sidebar-resizer.dragging) {
   background: var(--accent);
   transform: translateY(-50%);
 }
-@keyframes drop-cursor-in {
-  from {
-    opacity: 0;
-    transform: scaleX(0.9);
-  }
-  to {
-    opacity: 1;
-    transform: scaleX(1);
-  }
-}
 @media (prefers-reduced-motion: reduce) {
+  /* Snap rather than glide — but keep the fade, which carries no motion. */
   .drop-cursor {
-    animation: none;
+    transition: opacity 110ms var(--ease);
   }
 }
 
@@ -1579,6 +1665,75 @@ body:has(.sidebar-resizer.dragging) {
 .context-menu li.danger:hover {
   background: var(--danger-soft);
   color: var(--danger);
+}
+
+/* ---- Sort menu (toolbar popover + the ⋯ menu's sort group) ----
+   A non-clickable group label. Not a heading element: this is a menu, and the
+   label names the radio group below it rather than starting a document section. */
+.context-menu li.menu-heading {
+  padding: var(--sp-1) var(--sp-3) var(--sp-1) calc(var(--sp-3) + 18px);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  cursor: default;
+}
+.context-menu li.menu-heading:hover {
+  background: none;
+}
+/* As a group start inside the ⋯ menu it keeps the rule but not the sep's own
+   padding, which would double up with the heading's tighter one. */
+.context-menu li.menu-heading.menu-sep-item {
+  margin-top: var(--sp-1);
+  padding-top: var(--sp-2);
+  border-top: 1px solid var(--border);
+}
+/* Fixed-width tick gutter, so the two options' labels line up whether or not
+   they carry the check — and so the heading above can align to the same text. */
+.menu-tick {
+  display: inline-block;
+  width: 18px;
+  flex-shrink: 0;
+  color: var(--accent);
+  font-weight: 700;
+}
+.context-menu li.is-on {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+/* Trailing explanatory line — the one place the two-layer arrangement rule is
+   stated in the UI, so it reads as prose, not as another thing to click. */
+.context-menu li.menu-note {
+  margin-top: var(--sp-1);
+  padding-top: calc(var(--sp-2) + 1px);
+  border-top: 1px solid var(--border);
+  max-width: 230px;
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+  color: var(--text-tertiary);
+  white-space: normal;
+  cursor: default;
+}
+.context-menu li.menu-note:hover {
+  background: none;
+}
+/* The toolbar popover hangs off its button instead of the pointer, so it is
+   absolute within the wrapper rather than fixed like the row menu. */
+.tree-sort-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.context-menu.tree-sort-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  /* Opens down-and-right from the button. The toolbar is left-anchored (it sits
+     just after the "Notes" label, not at the sidebar's right edge), so
+     right-aligning would walk the menu off the sidebar's LEFT edge instead.
+     Overhanging to the right is fine — nothing in the sidebar clips, and a
+     popover laid briefly over the editor is what a popover is. */
+  left: 0;
+  min-width: 210px;
 }
 
 /* Color swatch row inside the ⋯ menu (Finder-tag style) */

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -574,7 +574,12 @@ export default function App() {
       <main className="main">
         <MemberJoinedBanner />
         <UpdateBanner />
-        <header className="main-header">
+        {/* Sits flush against the top of the window now that there's no system
+            title bar above it (`titleBarStyle: "Overlay"`), which is where the
+            reclaimed ~28px comes from — and that makes it the strip you'd expect
+            to drag the window by. "deep" hands the whole row over as a drag
+            region; Tauri exempts the buttons on the right, so they still click. */}
+        <header className="main-header" data-tauri-drag-region="deep">
           <span className="note-title">{openNote?.title ?? "No note open"}</span>
           {openNote && !isPreview && <SaveIndicator />}
           {openNote && !isPreview && <SyncIndicator />}

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -716,19 +716,25 @@ function MenuIcon({ children }: { children: React.ReactNode }) {
  * caller needs to act on a *successful* sign-in (vs. a cancel), it passes
  * `onSignedIn` — fired instead of `onClose` when the session arrives, so the
  * two outcomes stay distinguishable.
+ *
+ * `initialMode` picks which tab opens first. It defaults to sign-in, but the
+ * welcome screen's "Join a team" route opens on sign-up: someone holding a
+ * teammate's join code is usually here for the first time.
  */
 export function AuthDialog({
   onClose,
   onSignedIn,
+  initialMode = "sign-in",
 }: {
   onClose: () => void;
   onSignedIn?: () => void;
+  initialMode?: "sign-in" | "sign-up";
 }) {
   const authStatus = useStore((s) => s.authStatus);
   const authError = useStore((s) => s.authError);
   const serverUrl = useStore((s) => s.serverUrl);
 
-  const [mode, setMode] = useState<"sign-in" | "sign-up">("sign-in");
+  const [mode, setMode] = useState<"sign-in" | "sign-up">(initialMode);
   const [name, setName] = useState("");
   // Dev-only prefill of the local test account; production builds ship empty fields.
   const [email, setEmail] = useState(import.meta.env.DEV ? "test@context.local" : "");

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 import {
   Tree,
-  type CursorProps,
   type NodeApi,
   type NodeRendererProps,
   type TreeApi,
@@ -23,9 +22,11 @@ import {
   clearOrderAt,
   computeReorder,
   moveSubtreeOrder,
+  narrowPins,
   removeFromOrder,
   renameInOrder,
 } from "../lib/ordering";
+import { sortTree, TREE_SORTS } from "../lib/tree/sort";
 import { LOCK_TITLES, lockScopesByPath, type LockScope } from "../lib/locks";
 import { previewKind } from "../lib/preview";
 import {
@@ -90,6 +91,24 @@ function dirAtClientPoint(x: number, y: number): string {
   return row?.dataset.treeDir ?? "";
 }
 
+/**
+ * Where a hand-drag would land if it were released right now: an insertion line
+ * between two rows (`top`/`indent` place it), or inside a folder. `null` means
+ * the pointer is over somewhere nothing may be dropped.
+ */
+type DropAt =
+  | { kind: "line"; destDir: string; index: number; top: number; indent: number }
+  | { kind: "into"; destDir: string }
+  | null;
+
+/** Do two drop targets mean the same thing? Guards a re-render per pointer move. */
+function sameDrop(a: DropAt, b: DropAt): boolean {
+  if (a === null || b === null) return a === b;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "into" || b.kind === "into") return a.destDir === b.destDir;
+  return a.destDir === b.destDir && a.index === b.index && a.top === b.top;
+}
+
 interface MenuState {
   x: number;
   y: number;
@@ -123,6 +142,12 @@ const ICON_EXPAND_ALL = (
   <TreeSvg>
     <path d="m7 9 5-5 5 5" />
     <path d="m7 15 5 5 5-5" />
+  </TreeSvg>
+);
+/* Sort menu — descending bars, the conventional "sort" mark. */
+const ICON_SORT = (
+  <TreeSvg>
+    <path d="M4 6h13M4 12h9M4 18h5" />
   </TreeSvg>
 );
 /* Select-mode toggle — a ticked checkbox reads as "pick items". */
@@ -163,6 +188,7 @@ export function FileTree() {
   const members = useStore((s) => s.members);
   const itemColors = useStore((s) => s.itemColors);
   const itemOrder = useStore((s) => s.itemOrder);
+  const treeSort = useStore((s) => s.treeSort);
   const docSyncState = useStore((s) => s.docSyncState);
   const docIdByPath = useStore((s) => s.docIdByPath);
   const titles = useStore((s) => s.titles);
@@ -176,8 +202,15 @@ export function FileTree() {
   const [shareTarget, setShareTarget] = useState<ShareTarget | null>(null);
   // Which way the fold toggle points: false → "collapse all", true → "expand all".
   const [treeCollapsed, setTreeCollapsed] = useState(false);
+  // The sort popover under the toolbar's sort button.
+  const [sortOpen, setSortOpen] = useState(false);
   // True while an OS drag hovers the tree, for the drop-target highlight.
   const [dropActive, setDropActive] = useState(false);
+  // True while the user is dragging a ROW of this tree (react-arborist's own
+  // HTML5 drag), which is a different thing entirely from an OS file drag —
+  // see the listener below for why the two have to be told apart. Deliberately
+  // a ref and a CSS class rather than React state: see `dragstart` below.
+  const rowDrag = useRef(false);
   // Multi-select: a mode toggle + the set of picked paths. Kept local to the
   // tree (react-arborist's own selection is left alone) so the bulk-action bar
   // only exists while selecting and doesn't crowd the normal browsing UI.
@@ -261,11 +294,14 @@ export function FileTree() {
     return shareTargetForPath(node.data.path, node.data.isDir, node.data.name);
   }
 
-  // Rust returns folders-first/alphabetical; layer the user's manual
-  // arrangement on top so drag-to-reorder sticks.
+  // Two layers, in this order and only this order: sort what nobody arranged,
+  // then pin what somebody did. `applyOrder` leaves unranked items in the order
+  // it received them, so a folder dragged into place keeps its spot while
+  // everything untouched — including that folder's own contents — follows the
+  // sort. Flipping these two would make every sort change wipe the arrangement.
   const data = useMemo<TreeNode[]>(
-    () => applyOrder(tree?.children ?? [], "", itemOrder),
-    [tree, itemOrder],
+    () => applyOrder(sortTree(tree?.children ?? [], treeSort), "", itemOrder),
+    [tree, itemOrder, treeSort],
   );
 
   // Flatten the (arranged) tree so bulk actions can resolve any path — even a
@@ -386,7 +422,10 @@ export function FileTree() {
   }
 
   useEffect(() => {
-    const close = () => setMenu(null);
+    const close = () => {
+      setMenu(null);
+      setSortOpen(false);
+    };
     window.addEventListener("click", close);
     return () => window.removeEventListener("click", close);
   }, []);
@@ -458,6 +497,36 @@ export function FileTree() {
   // drag-drop (the webview never sees an HTML5 drop) and hands us absolute
   // paths + a physical cursor position; we scope it to the tree and route the
   // drop into the folder under the pointer (or the vault root).
+  // An HTML5 drag started anywhere in the app (selecting text in the editor and
+  // dragging it, say) is, at the OS level, a drag session over this same window
+  // — so Tauri reports it as `enter`/`over` exactly like a file from Finder, and
+  // the sidebar would throw up its "drop files here" frame for it. Only a drag
+  // from OUTSIDE should light that, so in-app drags are flagged here and the
+  // listener below skips them. A ref, because that listener is registered once
+  // and closes over its scope. (The tree's own reordering no longer uses HTML5
+  // drag at all — see the pointer-drag block further down.)
+  useEffect(() => {
+    const start = () => {
+      rowDrag.current = true;
+    };
+    const end = () => {
+      rowDrag.current = false;
+    };
+    window.addEventListener("dragstart", start, true);
+    // `dragend` ends a drag that started; the rest are belt-and-braces for one
+    // that never did. A stuck flag would swallow real file drops, so
+    // over-clearing is strictly the safer error — every clear is idempotent.
+    for (const ev of ["dragend", "drop", "mouseup", "pointerup", "blur"]) {
+      window.addEventListener(ev, end, true);
+    }
+    return () => {
+      window.removeEventListener("dragstart", start, true);
+      for (const ev of ["dragend", "drop", "mouseup", "pointerup", "blur"]) {
+        window.removeEventListener(ev, end, true);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let cancelled = false;
@@ -472,6 +541,10 @@ export function FileTree() {
     };
     void (async () => {
       const un = await getCurrentWebview().onDragDropEvent(async (event) => {
+        // Our own row drag, reported to us as if it came from the OS. Ignore it
+        // outright — including the `drop`, whose `paths` are empty anyway, so
+        // reacting could only ever mean flashing the frame or a stray import.
+        if (rowDrag.current) return;
         const p = event.payload;
         if (p.type === "enter" || p.type === "over") {
           setDropActive(insideTree(p.position.x, p.position.y) !== null);
@@ -647,16 +720,7 @@ export function FileTree() {
     void id;
   };
 
-  const onMove = async ({
-    dragIds,
-    parentNode,
-    index,
-  }: {
-    dragIds: string[];
-    parentNode: NodeApi<TreeNode> | null;
-    index: number;
-  }) => {
-    const destDir = parentNode ? parentNode.data.path : "";
+  const applyMove = async (dragIds: string[], destDir: string, index: number) => {
     // dragIds are node ids === current paths. Their paths after the drop only
     // change when the parent folder changes (a reorder keeps the same path).
     const from = dragIds;
@@ -669,12 +733,29 @@ export function FileTree() {
     //    (no disk change, no round-trip). Cross-folder drops snap into place
     //    after the tree refresh below re-materializes the moved paths.
     const store = useStore.getState();
-    const siblings = childrenAt(data, destDir).map((n) => n.path);
+    const destChildren = childrenAt(data, destDir);
+    const siblings = destChildren.map((n) => n.path);
+    // Folder-ness of every path the new order can mention: the destination's own
+    // children, plus the dragged items under their POST-drop paths (on a
+    // cross-folder drop they aren't among the destination's children yet).
+    const dirPaths = new Set<string>([
+      ...destChildren.filter((n) => n.isDir).map((n) => n.path),
+      ...from.flatMap((p, i) => (nodeByPath.get(p)?.isDir ? [to[i]] : [])),
+    ]);
+    const isDir = (p: string) => dirPaths.has(p);
     let order = store.itemOrder;
     for (let i = 0; i < from.length; i++) {
       if (from[i] !== to[i]) order = moveSubtreeOrder(order, from[i], to[i]);
     }
-    order = { ...order, [destDir]: computeReorder(siblings, from, to, index) };
+    order = {
+      ...order,
+      [destDir]: narrowPins(
+        computeReorder(siblings, from, to, index),
+        isDir,
+        to,
+        store.itemOrder[destDir],
+      ),
+    };
     store.setItemOrder(order);
 
     // 2) Apply cross-folder moves on disk (a pure reorder has from === to).
@@ -701,6 +782,236 @@ export function FileTree() {
     }
     if (movedOnDisk) await refreshAll();
   };
+
+  // ---- Reordering by hand (a pointer drag, deliberately not HTML5 DnD) ------
+  //
+  // react-arborist reorders via react-dnd's HTML5 backend, and inside a Tauri
+  // webview that can never complete: wry's `performDragOperation` returns YES
+  // and skips `super` whenever its drag-drop handler claims the event, and
+  // tauri-runtime-wry's handler claims EVERY event unconditionally. So WKWebView
+  // never dispatches `drop` to the page, `onMove` never fires, and a dragged row
+  // just springs back. Turning the window's `dragDropEnabled` off would fix that
+  // and break the thing it exists for — dropping files in from Finder, which
+  // needs real filesystem paths the DataTransfer API will not give us.
+  //
+  // So the tree's own drag is done with pointer events, which nothing intercepts.
+  // The drop still lands in `applyMove`, so the ordering rules (and their tests)
+  // are shared with every other path.
+
+  /** How far the pointer must travel before a press becomes a drag, in px. */
+  const DRAG_THRESHOLD = 4;
+
+  // The armed press: a row is under the finger but hasn't moved far enough yet.
+  const probe = useRef<{ path: string; x: number; y: number } | null>(null);
+  const [drag, setDrag] = useState<{ path: string } | null>(null);
+  // The folder a drop would land INSIDE, when the pointer is over one. This is
+  // the only per-move value that goes through React, and it changes about once
+  // per folder rather than once per pixel.
+  const [dropInto, setDropInto] = useState<string | null>(null);
+  // The insertion line is moved by writing its transform directly. Routing it
+  // through state instead would re-render every row in the tree on every
+  // pointermove — which is what made the drag feel shaky rather than tracked.
+  const lineRef = useRef<HTMLDivElement | null>(null);
+  // These refs are the AUTHORITY during a drag; the state above is only its
+  // render. Pointer events arrive faster than React re-renders, so a ref
+  // assigned at render time would still read `null` on the move right after
+  // the one that started the drag. Written by hand, beside each setState.
+  const dropAtRef = useRef<DropAt>(null);
+  const dragRef = useRef<string | null>(null);
+
+  /** A path may not be dropped into itself or anywhere under itself. */
+  const wouldSwallowItself = (moving: string, destDir: string) =>
+    destDir === moving || destDir.startsWith(moving + "/");
+
+  /**
+   * Resolve a pointer position to a drop. Rows are hit-tested through the DOM
+   * rather than by arithmetic on `rowHeight`, because the list is virtualized
+   * and scrolled — the DOM already knows exactly which row is where.
+   *
+   * A row's top and bottom quarters mean "put it between these two"; a folder's
+   * middle half means "put it inside". Files have no inside, so their middle
+   * band reads as "after this file" — the whole row stays a usable target.
+   *
+   * The folder band is HYSTERETIC: easy to leave (0.28–0.72 to enter) but held
+   * until 0.18–0.82 once you're in it. Without that, a hand resting on the
+   * boundary flickers between "inside this folder" and "above it" several times
+   * a second, which is the single thing that makes a drag feel unreliable.
+   */
+  function planDrop(moving: string, clientX: number, clientY: number): DropAt {
+    const container = containerRef.current;
+    if (!container) return null;
+    const box = container.getBoundingClientRect();
+    if (clientX < box.left || clientX > box.right) return null;
+    if (clientY < box.top) return null;
+
+    // Rows are measured, not hit-tested. `elementFromPoint` looked obvious and
+    // was the bug: a `.tree-row` is only as tall as its content, while the slot
+    // arborist positions it in is `rowHeight` tall, so there is a dead band
+    // between every pair of rows. Sweeping the pointer up the list crossed one
+    // of those on the way to each new row, the hit test came back empty, and
+    // the "nothing under the pointer" branch threw the line to the bottom of
+    // the tree — the line appearing to leap to the end at random.
+    //
+    // Measuring instead means every pixel of the list belongs to exactly one
+    // row, so the target changes once per row and never blinks elsewhere.
+    const rows = Array.from(container.querySelectorAll<HTMLElement>(".tree-row"));
+    const rects = rows.map((el) => el.getBoundingClientRect());
+    if (!rows.length) {
+      return { kind: "line", destDir: "", index: 0, top: 0, indent: 0 };
+    }
+
+    let hit = -1;
+    for (let i = 0; i < rects.length; i++) {
+      if (clientY >= rects[i].top && clientY < rects[i].bottom) {
+        hit = i;
+        break;
+      }
+    }
+    if (hit < 0) {
+      // Genuinely past the last row: append to the vault root. That is the only
+      // drop with no row of its own, and it still has to work.
+      const last = rects[rects.length - 1];
+      if (clientY >= last.bottom) {
+        const roots = childrenAt(data, "");
+        return {
+          kind: "line",
+          destDir: "",
+          index: roots.length,
+          top: last.bottom - box.top,
+          indent: 0,
+        };
+      }
+      // Otherwise the pointer is above the first row or in a dead band between
+      // two: hand it to the nearest row by centre, so the gap belongs to the
+      // row it looks like it belongs to.
+      let best = 0;
+      let bestDist = Infinity;
+      for (let i = 0; i < rects.length; i++) {
+        const d = Math.abs(clientY - (rects[i].top + rects[i].height / 2));
+        if (d < bestDist) {
+          bestDist = d;
+          best = i;
+        }
+      }
+      hit = best;
+    }
+
+    const row = rows[hit];
+    const r = rects[hit];
+    const path = row.dataset.treePath ?? "";
+    const isDir = row.dataset.treeIsdir === "1";
+    // Clamped: a pointer in a dead band sits slightly outside the row it was
+    // assigned to, and an unclamped fraction there reads as a wild -0.3 / 1.4.
+    const frac = Math.min(1, Math.max(0, (clientY - r.top) / r.height));
+    const parent = parentDir(path);
+    const siblings = childrenAt(data, parent).map((n) => n.path);
+    const at = siblings.indexOf(path);
+    const lineIndent = r.left - box.left + 16;
+
+    const held = dropAtRef.current;
+    const holding = held?.kind === "into" && held.destDir === path;
+    const lo = holding ? 0.18 : 0.28;
+    if (isDir && frac > lo && frac < 1 - lo) {
+      return wouldSwallowItself(moving, path) ? null : { kind: "into", destDir: path };
+    }
+    const after = frac >= 0.5;
+    if (wouldSwallowItself(moving, parent)) return null;
+    return {
+      kind: "line",
+      destDir: parent,
+      index: at < 0 ? siblings.length : at + (after ? 1 : 0),
+      top: (after ? r.bottom : r.top) - box.top,
+      indent: lineIndent,
+    };
+  }
+
+  /** Arm a press. It only becomes a drag once the pointer actually travels. */
+  function beginProbe(path: string, x: number, y: number) {
+    probe.current = { path, x, y };
+  }
+
+  // One window-level listener pair for the whole tree, live only while a press
+  // is armed or a drag is running. Window scope because the pointer routinely
+  // leaves the row — and often the sidebar — mid-drag.
+  useEffect(() => {
+    const move = (e: PointerEvent) => {
+      const p = probe.current;
+      if (!p) return;
+      if (!dragRef.current) {
+        if (Math.hypot(e.clientX - p.x, e.clientY - p.y) < DRAG_THRESHOLD) return;
+        if (!nodeByPath.has(p.path)) return;
+        dragRef.current = p.path;
+        setDrag({ path: p.path });
+        containerRef.current?.classList.add("row-dragging");
+      }
+      const next = planDrop(p.path, e.clientX, e.clientY);
+      if (sameDrop(next, dropAtRef.current)) return;
+      const wasInto = dropAtRef.current?.kind === "into" ? dropAtRef.current.destDir : null;
+      dropAtRef.current = next;
+      // The line: moved by hand, so it glides between slots (CSS transitions the
+      // transform) without React touching a single row.
+      const line = lineRef.current;
+      if (line) {
+        if (next?.kind === "line") {
+          line.style.transform = `translateY(${next.top - 1}px)`;
+          line.style.left = `${next.indent}px`;
+          line.style.opacity = "1";
+        } else {
+          line.style.opacity = "0";
+        }
+      }
+      // The folder highlight is the one thing React still owns — it changes per
+      // folder, not per pixel.
+      const nowInto = next?.kind === "into" ? next.destDir : null;
+      if (nowInto !== wasInto) setDropInto(nowInto);
+    };
+    /** Tear the drag down without committing it. */
+    const clear = () => {
+      probe.current = null;
+      dragRef.current = null;
+      dropAtRef.current = null;
+      containerRef.current?.classList.remove("row-dragging");
+      if (lineRef.current) lineRef.current.style.opacity = "0";
+      setDrag(null);
+      setDropInto(null);
+    };
+    const up = () => {
+      const p = probe.current;
+      const plan = dropAtRef.current;
+      const dragging = dragRef.current;
+      clear();
+      // A press that never travelled is a click; the row's own onClick has it.
+      if (!dragging) return;
+      // A press that DID travel is not. If it happens to end over the row it
+      // started on, the browser still fires a click there — which would toggle
+      // the folder you just finished moving. Swallow exactly that one.
+      const swallow = (ev: MouseEvent) => {
+        ev.stopPropagation();
+        ev.preventDefault();
+      };
+      window.addEventListener("click", swallow, true);
+      setTimeout(() => window.removeEventListener("click", swallow, true), 0);
+      if (!p || !plan) return;
+      const index = plan.kind === "into" ? childrenAt(data, plan.destDir).length : plan.index;
+      void applyMove([p.path], plan.destDir, index);
+    };
+    const cancel = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && dragRef.current) clear();
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    window.addEventListener("pointercancel", up);
+    window.addEventListener("keydown", cancel);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      window.removeEventListener("pointercancel", up);
+      window.removeEventListener("keydown", cancel);
+    };
+    // `data`/`nodeByPath` are read through the closure and change as the tree
+    // does; re-binding on each is cheaper than the staleness bugs otherwise.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, nodeByPath]);
 
   async function createUniqueNote(dir: string) {
     let name = "Untitled";
@@ -803,6 +1114,8 @@ export function FileTree() {
   }
 
   return (
+    // `row-dragging` is added/removed imperatively by the drag listener above,
+    // never through React — see the comment there.
     <div className={`filetree${dropActive ? " drop-active" : ""}`} ref={containerRef}>
       <div className="filetree-head">
         <span className="section-label">Notes</span>
@@ -843,6 +1156,58 @@ export function FileTree() {
               {ICON_EXPAND_ALL}
             </span>
           </button>
+          {/* Sort lives beside the fold toggle: both answer "how is this list
+              laid out", neither creates anything. The popover is anchored to
+              this button rather than reusing the row context menu, because the
+              choice is vault-wide and belongs to the header, not to a row. */}
+          <div className="tree-sort-wrap" onClick={(e) => e.stopPropagation()}>
+            <button
+              className={`tree-tool${sortOpen ? " on" : ""}`}
+              title={`Sort: ${TREE_SORTS.find((s) => s.id === treeSort)?.label}`}
+              aria-label="Sort notes"
+              aria-haspopup="menu"
+              aria-expanded={sortOpen}
+              // The wrapper swallows this click so the window-level dismiss
+              // can't close the popover we're opening — which also means a row
+              // menu left open would survive it, so close that here.
+              onClick={() => {
+                setMenu(null);
+                setSortOpen((v) => !v);
+              }}
+            >
+              {ICON_SORT}
+            </button>
+            {sortOpen && (
+              <ul className="context-menu tree-sort-menu" role="menu">
+                <li className="menu-heading">Sort notes by</li>
+                {TREE_SORTS.map((s) => (
+                  <li
+                    key={s.id}
+                    role="menuitemradio"
+                    aria-checked={treeSort === s.id}
+                    className={treeSort === s.id ? "is-on" : undefined}
+                    title={s.hint}
+                    onClick={() => {
+                      useStore.getState().setTreeSort(s.id);
+                      setSortOpen(false);
+                    }}
+                  >
+                    <span className="menu-tick" aria-hidden="true">
+                      {treeSort === s.id ? "✓" : ""}
+                    </span>
+                    {s.label}
+                  </li>
+                ))}
+                {/* Says out loud what the two layers do, because the rule is
+                    invisible otherwise: someone who has dragged rows around
+                    needs to know this button won't undo that. */}
+                <li className="menu-note">
+                  Folders and notes you've dragged into place keep their
+                  position.
+                </li>
+              </ul>
+            )}
+          </div>
           <span className="tool-divider" aria-hidden="true" />
           <button
             className={`tree-tool${selectMode ? " on" : ""}`}
@@ -947,13 +1312,22 @@ export function FileTree() {
           onToggle={onToggle}
           onActivate={onActivate}
           onRename={onRename}
-          onMove={onMove}
-          renderCursor={DropCursor}
+          // Arborist's own drag is HTML5-based and cannot complete inside this
+          // webview (see the pointer-drag block above), so it is switched off
+          // entirely rather than left to start drags that die silently — which
+          // is also what stopped a refused drag smearing a text selection
+          // across the rows, and what stopped Tauri mistaking a row drag for a
+          // file drop and throwing up the "drop files here" frame.
+          disableDrag
+          disableDrop
           rowClassName="tree-rowwrap"
         >
           {(props) => (
             <Node
               {...props}
+              dropInto={dropInto}
+              dragging={drag?.path === props.node.data.path}
+              onDragProbe={beginProbe}
               selectedPath={openNote?.path ?? null}
               lock={lockByPath.get(props.node.data.path) ?? null}
               syncIndex={syncIndex}
@@ -967,6 +1341,12 @@ export function FileTree() {
           )}
         </Tree>
       )}
+
+      {/* The insertion line. Mounted for the whole drag and moved by transform
+          (see the pointermove handler) so it glides between slots instead of
+          being torn down and rebuilt at each one. Positioned against
+          `.filetree`, which is the frame of reference `planDrop` measures in. */}
+      {drag && <div className="drop-cursor" ref={lineRef} aria-hidden="true" />}
 
       {menu && (
         <ul
@@ -988,18 +1368,41 @@ export function FileTree() {
           <li onClick={() => void importFolderInto(menuDir)}>Import folder…</li>
           {menu.node && <li onClick={() => void exportNode(menu.node!)}>Export…</li>}
           {menu.node && <li onClick={() => menu.node!.edit()}>Rename</li>}
+          {/* The same vault-wide sort as the header button. A per-folder sort
+              would be a third arrangement layer fighting the other two, so
+              there is one setting and it is reachable from both places. */}
+          <li className="menu-heading menu-sep-item">Sort notes by</li>
+          {TREE_SORTS.map((s) => (
+            <li
+              key={s.id}
+              role="menuitemradio"
+              aria-checked={treeSort === s.id}
+              className={treeSort === s.id ? "is-on" : undefined}
+              title={s.hint}
+              onClick={() => useStore.getState().setTreeSort(s.id)}
+            >
+              <span className="menu-tick" aria-hidden="true">
+                {treeSort === s.id ? "✓" : ""}
+              </span>
+              {s.label}
+            </li>
+          ))}
+          {/* Only offered where there IS an arrangement to drop — this clears
+              the hand-made order for one folder so its contents fall back to
+              the sort above, and leaves every other folder's alone. */}
           {(itemOrder[menuDir]?.length ?? 0) > 0 && (
             <li
+              className="menu-sep-item"
               title={
                 menu.node?.data.isDir
-                  ? "Sort this folder's contents alphabetically"
-                  : "Sort this folder alphabetically"
+                  ? "Forget the drag-and-drop arrangement inside this folder"
+                  : "Forget the drag-and-drop arrangement in this folder"
               }
               onClick={() =>
                 useStore.getState().setItemOrder(clearOrderAt(itemOrder, menuDir))
               }
             >
-              Reset order (A–Z)
+              Reset manual order
             </li>
           )}
           {menu.node && menuTarget && (
@@ -1070,6 +1473,12 @@ interface NodeExtra {
   selectMode: boolean;
   checked: boolean;
   onToggleCheck: (path: string) => void;
+  /** Arms a hand-drag on this row; it only starts once the pointer travels. */
+  onDragProbe: (path: string, x: number, y: number) => void;
+  /** This row is the one being dragged (it lifts and dims). */
+  dragging: boolean;
+  /** The folder a drop would land inside, if the pointer is over one. */
+  dropInto: string | null;
 }
 
 function TreeSvg({ children }: { children: React.ReactNode }) {
@@ -1243,7 +1652,6 @@ function SidebarPresence({ peers }: { peers: VaultPeer[] }) {
 function Node({
   node,
   style,
-  dragHandle,
   selectedPath,
   lock,
   syncIndex,
@@ -1253,6 +1661,9 @@ function Node({
   selectMode,
   checked,
   onToggleCheck,
+  onDragProbe,
+  dragging,
+  dropInto,
 }: NodeRendererProps<TreeNode> & NodeExtra) {
   const isDir = node.data.isDir;
   // Only a folder we have actually listed can be called empty. An unexpanded one
@@ -1273,12 +1684,16 @@ function Node({
   const indent = typeof style.paddingLeft === "number" ? style.paddingLeft : 0;
   return (
     <div
-      ref={dragHandle}
       style={{ ...style, paddingLeft: indent + 20 }}
       data-tree-dir={isDir ? node.data.path : parentDir(node.data.path)}
+      // Read back by `planDrop`, which hit-tests rows through the DOM: the
+      // list is virtualized and scrolled, so the DOM is the only thing that
+      // knows where a row actually is.
+      data-tree-path={node.data.path}
+      data-tree-isdir={isDir ? "1" : "0"}
       className={`tree-row${isSelected ? " selected" : ""}${isDir ? " is-dir" : ""}${
-        node.willReceiveDrop ? " drop-target" : ""
-      }${node.isDragging ? " dragging" : ""}${checked ? " checked" : ""}${
+        dropInto === node.data.path ? " drop-target" : ""
+      }${dragging ? " dragging" : ""}${checked ? " checked" : ""}${
         // Pre-selects the row the instant it's clicked, so the selection doesn't
         // wait on `getNoteMeta` + `registerNote` to come back from the server.
         isOpening ? " opening" : ""
@@ -1294,6 +1709,14 @@ function Node({
         // word/range selection (the stray blue bands between rows). Suppress it
         // only for the multi-click; the first press still drives click + drag.
         if (e.detail > 1) e.preventDefault();
+      }}
+      onPointerDown={(e) => {
+        // Left button only, and never from the row's own controls (⋯, the
+        // select checkbox) — those are buttons, not handles. Selection mode
+        // is for picking rows, not moving them.
+        if (e.button !== 0 || selectMode) return;
+        if ((e.target as HTMLElement).closest("button, input, .tree-check")) return;
+        onDragProbe(node.data.path, e.clientX, e.clientY);
       }}
       onClick={() => {
         if (isDir) node.toggle();
@@ -1404,7 +1827,3 @@ function Node({
   );
 }
 
-/** Drag-and-drop insertion line, in the system accent instead of arborist blue. */
-function DropCursor({ top, left }: CursorProps) {
-  return <div className="drop-cursor" style={{ top: top - 1, left: left + 16 }} />;
-}

--- a/app/apps/desktop/src/components/GraphView.tsx
+++ b/app/apps/desktop/src/components/GraphView.tsx
@@ -6,6 +6,11 @@ import {
   configureForces,
   nodeRadius,
   centerWeight,
+  layoutScale,
+  IDLE_ALPHA,
+  DRAG_ALPHA,
+  REARRANGE_ALPHA,
+  type FlowForce,
   type SimNode,
   type SimLink,
 } from "../lib/graph/simulation";
@@ -41,28 +46,62 @@ const LABEL_FADE_END = 2.4; // camera.k at which labels are fully opaque (labelS
 const DEFAULT_FONT_FAMILY = "sans-serif";
 const FALLBACK_ACCENT = "#7f73ff";
 
-// The graph opens ALREADY SETTLED. It used to seed positions, kick every node
-// with a random velocity and then animate the whole layout finding its shape on
-// screen — which reads as the view detonating and reassembling itself, not as
-// something coming to life. Watching furniture arrange itself is not an intro;
-// it's a wait you're forced to watch, and it happens every single time you press
-// ⌘G on a graph whose shape you already know.
-//
-// So the settle now happens BEFORE the first frame (`presettle`), and the only
-// motion left on open is a soft fade + a barely-there scale — the "heartbeat".
-// The layout itself is static from frame one.
+// The graph opens IN MOTION, but never out of shape, and the motion is never the
+// physics. Three attempts got here:
+//   - It used to seed positions, kick every node and animate the whole layout
+//     finding its shape on screen. That reads as the view detonating and
+//     reassembling itself, every time you press ⌘G on a graph you already know.
+//   - Then it settled the layout fully before the first frame — and arrived as a
+//     photograph. A converged force layout is motionless (the forces cancel), so
+//     it stayed a photograph until you grabbed a node and woke the sim up.
+//   - Then it stopped the settle early so the tail end played out live. That is
+//     motion, but it is the WRONG motion: a force layout doing real work at a
+//     working alpha buzzes, because d3 integrates with a plain explicit step and
+//     a stiff spring system overshoots.
+// So the layout is settled before the first paint, the physics is kept at a
+// whisper (IDLE_ALPHA / DRAG_ALPHA), and every bit of movement you see comes
+// from the flow field in simulation.ts — one smooth velocity field the whole
+// graph floats in. Alive on frame one, alive at rest, and laminar throughout.
 // Must match the `graph-heartbeat` keyframes duration in graph.css — the CSS
 // drives the scale pulse, this drives the light pulse, and they have to peak
 // together or the graph reads as two effects rather than one heartbeat.
 const INTRO_MS = 1150;
 
+// ---- The entrance heartbeat -------------------------------------------------
+// The graph arrives with more current in it than it will keep, pulsing on a slow
+// beat, and comes down to its resting drift over the better part of half a
+// minute. A single short burst reads as a loading animation finishing; a long
+// exponential settle reads as something calming down, which is the difference
+// between "it played its intro" and "it's alive".
+//
+// BEAT_PERIOD_S is the same 1.15s as INTRO_MS, so the extra motion, the CSS
+// scale pulse and the glow all swell on the same beat rather than three times
+// out of step.
+const BEAT_PERIOD_S = INTRO_MS / 1000;
+// Peak multiplier on the resting drift speed at t = 0.
+const INTRO_GAIN = 5;
+// e-folding time of the decay: strong for a few seconds, clearly settling by
+// ten, indistinguishable from rest by the time INTRO_SECONDS is up.
+const INTRO_TAU_S = 6;
+const INTRO_SECONDS = 26;
+
 // Time budget for settling the layout before the first paint. This blocks the
 // UI thread, so it is a budget and not a tick count: small vaults converge in
-// well under it, and a big one stops early with alpha already low enough that
-// the remaining on-screen motion is a drift rather than a rearrangement.
-// ~650 ticks is full convergence at alphaDecay 0.0103 (see simulation.ts).
+// well under it, and a big one stops early.
+// ~650 ticks is full convergence at alphaDecay 0.0103 (see simulation.ts);
+// PRESETTLE_TARGET_ALPHA is reached in ~315, so a normal vault arrives settled
+// well inside the budget.
 const PRESETTLE_BUDGET_MS = 420;
 const PRESETTLE_MAX_TICKS = 700;
+// Low enough that the layout is done moving on its own by the first frame. The
+// entrance is the flow's job now, not the settle's.
+const PRESETTLE_TARGET_ALPHA = 0.04;
+
+// Below this alpha the layout is done moving into place, so the auto-fit camera
+// locks — a couple of seconds after open, or immediately after a refresh. Without the lock the ambient drift keeps nudging the
+// bounding box and the whole viewport breathes its zoom by a percent or two,
+// which reads as the picture wobbling rather than the nodes drifting.
+const FIT_LOCK_ALPHA = 0.02;
 
 // How hard a *data refresh* re-energizes the layout. The first build needs real
 // energy to find a shape from seeded positions; later rebuilds already have a
@@ -71,7 +110,15 @@ const PRESETTLE_MAX_TICKS = 700;
 // `file-changed` event (a whole storm of them while a vault syncs) threw the
 // entire layout back to maximum energy and it visibly flew apart and re-settled.
 const REHEAT_FIRST = 1;
-const REHEAT_REFRESH = 0.22;
+const REHEAT_REFRESH = 0.1;
+
+// Smallest a node may be drawn on screen, in CSS px of radius. Applied in
+// quadrature by the shader (see webglRenderer's VERT), so it is a lift for the
+// leaves rather than a ceiling everything piles up against.
+const MIN_NODE_PX = 2.1;
+// Baseline strength of the additive halo around each node, before the
+// node-count falloff applied at draw time.
+const GLOW_BASE = 1.3;
 
 // Fallback cap for the global scope on the 2D canvas, which only stays smooth
 // up to a few hundred nodes. The GPU (WebGL) renderer draws the whole vault, so
@@ -111,8 +158,12 @@ function smoothstep(edge0: number, edge1: number, x: number): number {
 }
 
 /**
- * Run the force layout to equilibrium synchronously, before anything is drawn,
- * so the graph's first frame is its final shape.
+ * Advance the force layout synchronously, before anything is drawn, so the
+ * graph's first frame is already essentially its final shape — the user never
+ * watches it assemble from a seed spiral.
+ *
+ * It runs to PRESETTLE_TARGET_ALPHA rather than all the way to alphaMin purely
+ * to bound the cost; by that point the layout has stopped visibly moving.
  *
  * `sim.tick(n)` is d3's own batch form — it advances the layout without
  * dispatching tick events, which is exactly what a pre-settle wants (our
@@ -121,8 +172,8 @@ function smoothstep(edge0: number, edge1: number, x: number): number {
  * Ticks are taken in small batches so the elapsed-time check is cheap relative
  * to the work: `performance.now()` per tick would measure the clock as much as
  * the physics. When the budget runs out we stop and leave the layout where it
- * is — alpha is monotonically decreasing, so an early exit means "slightly warm"
- * (a drift over a second) rather than "unsettled" (a visible rearrangement).
+ * is — alpha is monotonically decreasing, so an early exit just means a little
+ * more of the settle happens on screen.
  */
 /**
  * The heartbeat envelope, 0 at rest and peaking on each beat. Two Gaussian bumps
@@ -139,11 +190,42 @@ function heartbeatEnvelope(t: number): number {
   return Math.min(1, bump(0.16, 0.075) + 0.55 * bump(0.4, 0.06));
 }
 
+/**
+ * Where we are in the current beat, 0..1, for a clock in seconds. Feeding this
+ * to `heartbeatEnvelope` gives a continuous pulse train rather than the single
+ * beat the original one-shot intro played.
+ */
+function beatPhase(seconds: number): number {
+  return (seconds % BEAT_PERIOD_S) / BEAT_PERIOD_S;
+}
+
+/**
+ * Strength of the entrance, 0 at rest and 1 at the instant the data lands. The
+ * decay is exponential — it fades fastest when it is strongest, which is what
+ * makes the calming-down read as natural rather than as a timer running out.
+ */
+function introStrength(seconds: number): number {
+  if (seconds < 0 || seconds >= INTRO_SECONDS) return 0;
+  return Math.exp(-seconds / INTRO_TAU_S);
+}
+
+/**
+ * Multiplier on the resting drift speed: extra current on arrival, pulsing on
+ * the beat, easing down to exactly 1. The floor term (0.45) is what keeps the
+ * graph moving *between* beats — a pure pulse train would freeze in the gaps.
+ */
+function introEnergy(seconds: number): number {
+  const s = introStrength(seconds);
+  if (s <= 0) return 1;
+  const beat = heartbeatEnvelope(beatPhase(seconds));
+  return 1 + INTRO_GAIN * s * (0.45 + 0.55 * beat);
+}
+
 function presettle(sim: Simulation<SimNode, SimLink>): void {
   const deadline = performance.now() + PRESETTLE_BUDGET_MS;
   const BATCH = 20;
   let ticks = 0;
-  while (ticks < PRESETTLE_MAX_TICKS && sim.alpha() > sim.alphaMin()) {
+  while (ticks < PRESETTLE_MAX_TICKS && sim.alpha() > PRESETTLE_TARGET_ALPHA) {
     sim.tick(BATCH);
     ticks += BATCH;
     if (performance.now() >= deadline) break;
@@ -421,9 +503,13 @@ export function GraphView({ onClose }: { onClose: () => void }) {
   openNotePathRef.current = openNotePath;
 
   // One d3 simulation for the component's whole life (survives re-renders and
-  // StrictMode remounts because refs persist).
+  // StrictMode remounts because refs persist). It is deliberately never allowed
+  // to go cold: the alpha target floors at IDLE_ALPHA so the restoring forces
+  // stay awake under the perpetual drift (see simulation.ts).
   const simRef = useRef<Simulation<SimNode, SimLink> | null>(null);
-  if (!simRef.current) simRef.current = createSimulation(settingsRef.current);
+  if (!simRef.current) {
+    simRef.current = createSimulation(settingsRef.current).alphaTarget(IDLE_ALPHA);
+  }
 
   const graphRef = useRef<Graph | null>(null);
 
@@ -603,6 +689,12 @@ export function GraphView({ onClose }: { onClose: () => void }) {
     S.visEdges = links; // now resolved in place by forceLink
     S.drawOrder = [...visNodes].sort((a, b) => a.radius - b.radius);
 
+    // Size the flow to the layout we just built (its own radius sets both the
+    // drift speed and the wavelength) so the motion looks the same whether this
+    // vault is 40 notes or 5000. Measured after the pre-settle, when positions
+    // mean something.
+    (sim.force("flow") as FlowForce).scale(layoutScale(visNodes));
+
     // Large global graphs: run the force layout in a Web Worker so the UI thread
     // never blocks. The worker owns its own copy and streams positions back into
     // these same node objects (loop() skips the main-thread tick while active).
@@ -690,7 +782,7 @@ export function GraphView({ onClose }: { onClose: () => void }) {
           S.workerActive = true;
         } else {
           configureForces(sim, next);
-          sim.alpha(Math.max(sim.alpha(), 0.3));
+          sim.alpha(Math.max(sim.alpha(), REARRANGE_ALPHA));
         }
         requestDrawRef.current();
         return;
@@ -767,6 +859,7 @@ export function GraphView({ onClose }: { onClose: () => void }) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     const sim = simRef.current!;
+    const flow = sim.force("flow") as FlowForce;
 
     // GPU renderer for the global scope (best-effort; if WebGL2 is unavailable
     // we simply never switch to it). Its own canvas — a canvas can hold only one
@@ -866,6 +959,14 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       attributeFilter: ["data-theme"],
     });
 
+    // Seconds since this graph's data landed — the entrance clock, shared by the
+    // extra drift, the glow swell and the CSS pulse. Clamped to the end of the
+    // entrance when there isn't one, so callers never see a non-finite phase.
+    const introSeconds = () =>
+      S.introStart > 0
+        ? (performance.now() - S.introStart) / 1000
+        : INTRO_SECONDS;
+
     function screenToWorld(sx: number, sy: number) {
       return {
         x: (sx - width / 2 - S.camera.x) / S.camera.k,
@@ -952,7 +1053,9 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       ctx!.globalCompositeOperation = "source-over";
       const edgeWidth = s.edgeThickness / k;
       ctx!.strokeStyle = EDGE_REST;
-      ctx!.globalAlpha = hovered ? 0.03 : 0.1 * (0.5 + 0.5 * introEase);
+      // Matched to the GPU path's edge alpha so the WebGL-unavailable fallback
+      // doesn't look like a different, dimmer product.
+      ctx!.globalAlpha = hovered ? 0.05 : 0.18 * (0.5 + 0.5 * introEase);
       ctx!.lineWidth = edgeWidth;
       ctx!.beginPath();
       for (const e of S.visEdges) {
@@ -1087,9 +1190,11 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       // (`.graph-intro`) plus `glowBoost` above, and that is deliberately all.
     }
 
-    // Global scope: draw every node on the GPU (auto-fit to the viewport for
-    // now; pan/zoom/hover come next). Rebuilds the instance buffer each frame —
-    // fine for this first cut.
+    // Global scope: draw every node on the GPU. The instance buffer is rebuilt
+    // every frame (the layout is always drifting), so the RenderNode wrappers
+    // are POOLED and mutated in place — allocating a few thousand objects plus
+    // their color arrays 60 times a second would hand the GC a steady diet for
+    // as long as the graph is open.
     const webglNodes: RenderNode[] = [];
     let edgePositions = new Float32Array(0);
     function drawWebGL() {
@@ -1107,10 +1212,13 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       const fallback = S.colors.nodeFallback;
       const nodeScale = settingsRef.current.nodeSize;
       // Shrink nodes as the graph grows so a bigger vault reads as "smaller
-      // dots, more space" rather than a compacted pile. ~1 for a few hundred
-      // nodes, ~0.2 at 50k. The layout also spreads (repulsion scales with n),
-      // so together the graph expands and keeps breathing room.
-      const countScale = Math.min(1, 40 / Math.sqrt(Math.max(1, S.visNodes.length)));
+      // dots, more space" rather than a compacted pile. The layout also spreads
+      // (repulsion scales with n), so together the graph expands and keeps
+      // breathing room. The constant is generous — it used to kick in at a few
+      // hundred notes and stack on top of the on-screen minimum, which between
+      // them squashed every node in a mid-size vault to the same floor size and
+      // erased the hub-vs-leaf hierarchy entirely.
+      const countScale = Math.min(1, 60 / Math.sqrt(Math.max(1, S.visNodes.length)));
       // Hover: light up the hovered node + its direct neighbors, dim the rest,
       // so you can see a note's connections at a glance.
       const hoveredId = S.hoveredId;
@@ -1118,19 +1226,25 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         hoveredId && graphRef.current
           ? neighborhoodIds(graphRef.current, hoveredId, 1)
           : null;
-      webglNodes.length = 0;
+      webglNodes.length = S.visNodes.length;
       let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-      for (const n of S.visNodes) {
+      for (let i = 0; i < S.visNodes.length; i++) {
+        const n = S.visNodes[i];
         const c = getRgb(S.colorById.get(n.id) ?? fallback);
         const dim = hlSet && !hlSet.has(n.id) ? 0.16 : 1;
         const big =
           n.id === hoveredId ? 2.4 : hlSet && hlSet.has(n.id) ? 1.8 : 1;
-        webglNodes.push({
-          x: n.x,
-          y: n.y,
-          r: n.radius * nodeScale * countScale * big,
-          color: [(c[0] / 255) * dim, (c[1] / 255) * dim, (c[2] / 255) * dim],
-        });
+        let rn = webglNodes[i];
+        if (!rn) {
+          rn = { x: 0, y: 0, r: 0, color: [0, 0, 0] };
+          webglNodes[i] = rn;
+        }
+        rn.x = n.x;
+        rn.y = n.y;
+        rn.r = n.radius * nodeScale * countScale * big;
+        rn.color[0] = (c[0] / 255) * dim;
+        rn.color[1] = (c[1] / 255) * dim;
+        rn.color[2] = (c[2] / 255) * dim;
         if (n.x < minX) minX = n.x;
         if (n.y < minY) minY = n.y;
         if (n.x > maxX) maxX = n.x;
@@ -1186,9 +1300,28 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         cam.k * dpr,
         (width / 2 + cam.x) * dpr,
         (height / 2 + cam.y) * dpr,
-        // Small floor so nodes can shrink to give space at the whole-graph
-        // overview (they grow back as you zoom in); avoids the compacted pile.
-        1.5 * dpr,
+        // Floor on a node's on-screen radius. The shader applies it in
+        // quadrature, not as a hard clamp, so this lifts the leaves to a
+        // legible dot without flattening the hubs down onto them.
+        MIN_NODE_PX * dpr,
+        performance.now() / 1000,
+        // Halos are additive, so they SUM: a glow that looks right on 200 nodes
+        // turns a 50k-node cluster into one white blob. Dial it back as the
+        // field fills up. Tuned against rendered frames at 800 / 3.4k nodes —
+        // the ceiling is where a sparse graph reads as luminous without the
+        // halos merging, the floor is where a huge one still shows some light.
+        //
+        // The entrance rides on top: the whole field brightens on each beat and
+        // the swell fades out with the extra motion, so the light and the
+        // movement are one heartbeat rather than two effects.
+        clamp(
+          GLOW_BASE *
+            (60 / Math.sqrt(Math.max(1, S.visNodes.length))) *
+            (1 + 0.5 * introStrength(introSeconds()) * heartbeatEnvelope(beatPhase(introSeconds()))),
+          0.3,
+          2.2,
+        ),
+        dpr,
       );
       diagRef.current =
         `webgl ✓ · nodes ${webglNodes.length} · buf ${webglCanvas.width}×${webglCanvas.height} · ` +
@@ -1199,8 +1332,6 @@ export function GraphView({ onClose }: { onClose: () => void }) {
 
     // Single frame clock. The loop stays alive the whole time the graph is
     // mounted so the lighting keeps breathing and the scene feels alive at rest.
-    // Physics is the expensive part, so we tick it ONLY while the sim is warm
-    // (or during the intro) — idle frames are a cheap repaint of a still layout.
     function loop() {
       S.rafId = null;
       const introActive =
@@ -1212,8 +1343,22 @@ export function GraphView({ onClose }: { onClose: () => void }) {
       if (S.useWorker) {
         active = S.workerActive || introActive;
       } else {
-        active = sim.alpha() > sim.alphaMin() || introActive;
-        if (active) sim.tick();
+        // The inline sim is never idle. The flow force means there is always
+        // new motion to integrate, so we tick (and therefore repaint) every
+        // frame the view is open — that is what makes the graph live from the
+        // moment it appears instead of a still image you have to poke first.
+        // Only the worker path (8k+ nodes) still settles and stops: perpetually
+        // re-uploading an instance buffer that large every frame is exactly the
+        // cost the worker exists to avoid.
+        active = true;
+        flow.energy(introEnergy(introSeconds()));
+        sim.tick();
+        // Once the layout stops visibly moving into place, stop chasing it with
+        // the camera — otherwise the drift breathes the bounding box and the
+        // auto-fit turns that into a wobble of the whole view.
+        if (webglNeedsFitRef.current && sim.alpha() <= FIT_LOCK_ALPHA) {
+          webglNeedsFitRef.current = false;
+        }
       }
       if (settingsRef.current.scope === "global" && webgl) {
         // Only rebuild + re-upload + redraw while the layout is moving (or on an
@@ -1269,7 +1414,7 @@ export function GraphView({ onClose }: { onClose: () => void }) {
           const i = S.indexById.get(hit.id);
           if (i !== undefined) workerRef.current?.fix(i, hit.x, hit.y);
         } else {
-          sim.alphaTarget(0.3);
+          sim.alphaTarget(DRAG_ALPHA);
         }
         S.drag = {
           type: "node",
@@ -1350,20 +1495,22 @@ export function GraphView({ onClose }: { onClose: () => void }) {
         if (S.useWorker) {
           if (wi !== undefined) workerRef.current?.release(wi);
         } else {
-          sim.alphaTarget(0); // stop feeding energy; let it cool naturally
+          // Stop feeding drag energy and let it cool — but only back down to the
+          // idle floor, never to zero: a graph that cools to zero is a graph
+          // that stops moving.
+          sim.alphaTarget(IDLE_ALPHA);
         }
         if (!drag.moved) {
           // A click, not a drag: open the note.
           const path = drag.node.path;
           useStore.getState().openNoteByPath(path).then(onClose);
-        } else if (S.useWorker) {
-          // A real drag: gentle reheat so the displaced node drifts home calmly.
-          if (wi !== undefined) workerRef.current?.reheat(0.25);
-          requestDrawRef.current();
         } else {
-          // A real drag: a gentle reheat so the displaced node drifts home
-          // slowly and calmly (low energy = slow return, not a snap-back).
-          sim.alpha(Math.max(sim.alpha(), 0.25));
+          // A real drag: NO reheat. Dropping a node used to kick the layout back
+          // up to alpha 0.25, and that reheat was the visible "boing" — the
+          // whole neighbourhood re-solving at a step size big enough to
+          // overshoot. Cooling straight to the idle floor instead lets the
+          // displaced node be carried home by the ambient flow over several
+          // seconds, which is the same journey without the buzz.
           requestDrawRef.current();
         }
       }

--- a/app/apps/desktop/src/components/SidebarHeader.tsx
+++ b/app/apps/desktop/src/components/SidebarHeader.tsx
@@ -35,7 +35,15 @@ export function SidebarHeader() {
   const name = switching?.name ?? (syncEnabled && activeOrg ? activeOrg.name : vault.name);
 
   return (
-    <div className={`sidebar-header${switching ? " is-switching" : ""}`}>
+    // Drag region: the window has no system title bar to grab (see
+    // `titleBarStyle: "Overlay"` in tauri.conf.json), and this row occupies the
+    // strip the macOS traffic lights float over. "deep" makes the whole subtree
+    // draggable — padding, name and path alike — while Tauri still lets real
+    // controls through, so the reveal-folder button below keeps working.
+    <div
+      className={`sidebar-header${switching ? " is-switching" : ""}`}
+      data-tauri-drag-region="deep"
+    >
       <div className="sidebar-header-main">
         {/* Keyed on the name so a switch cross-fades between the two vaults
             rather than swapping the text in place. */}

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -5,6 +5,7 @@ import * as ipc from "../lib/ipc";
 import {
   readKnownVaults,
   readOrgVaults,
+  requestJoinWithCode,
   requestOpenVault,
   useStore,
 } from "../store";
@@ -90,6 +91,15 @@ export function VaultPicker() {
   // When a signed-out user clicks a remote vault we open the sign-in modal;
   // the vault to land in afterwards is stashed via requestOpenVault().
   const [signInOpen, setSignInOpen] = useState(false);
+  // Why the sign-in modal is up. "open" is the remote-vault-card route (land in
+  // that vault); "join" is the join-code route, which comes back HERE for the
+  // code instead of landing anywhere.
+  const [signInFor, setSignInFor] = useState<"open" | "join">("open");
+  // Join-with-code step: true = the code form is showing (we already have a
+  // session). null/false = idle.
+  const [joining, setJoining] = useState(false);
+  const [joinCode, setJoinCode] = useState("");
+  const [joinError, setJoinError] = useState<string | null>(null);
   // New-vault flow: null = idle; a string = chosen parent, awaiting a name.
   const [newParent, setNewParent] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
@@ -119,6 +129,11 @@ export function VaultPicker() {
       alive = false;
     };
   }, []);
+
+  // If this screen goes away mid-join (a vault opened by some other route),
+  // the landing suppression must not outlive it. A *successful* join disarms
+  // it in the store before switching in, so this only catches abandonment.
+  useEffect(() => () => requestJoinWithCode(false), []);
 
   async function openVault(vault: VaultInfo | null) {
     if (!vault) return;
@@ -179,6 +194,63 @@ export function VaultPicker() {
     setError(null);
   }
 
+  // "Join a team": redeem a code a teammate shared, without first inventing a
+  // vault of your own.
+  //
+  // The code alone can't do anything — joining is a server action, so it needs
+  // an account. Signed out, we therefore run sign-up/sign-in first and come back
+  // here for the code. `requestJoinWithCode` is what keeps that round trip from
+  // ending somewhere else: it suppresses the post-auth landing, which would
+  // otherwise hand a brand-new account an auto-created "My Vault" and drop the
+  // user into it. That was the whole detour this replaces — create a vault you
+  // didn't want, then hunt for the code box in Vault settings.
+  function startJoin() {
+    setError(null);
+    setJoinError(null);
+    setJoinCode("");
+    requestJoinWithCode(true);
+    if (authStatus === "signed-in") {
+      setJoining(true);
+    } else {
+      setSignInFor("join");
+      setSignInOpen(true);
+    }
+  }
+
+  function cancelJoin() {
+    requestJoinWithCode(false);
+    setJoining(false);
+    setJoinCode("");
+    setJoinError(null);
+    // Backing out AFTER the sign-up this route required would otherwise leave a
+    // signed-in account holding nothing at all — the one state this screen has
+    // no good answer for, since its three buttons all assume you still have a
+    // choice to make. So run the landing the sign-in skipped, which makes the
+    // first vault. Only for an empty account: someone who already has vaults
+    // sees them listed right here, and yanking them into one they didn't click
+    // would be its own surprise.
+    const s = useStore.getState();
+    if (s.authStatus === "signed-in" && s.organizations.length === 0) {
+      void s.landAfterAuth();
+    }
+  }
+
+  async function confirmJoin() {
+    const code = joinCode.trim();
+    if (!code) return;
+    setBusy(true);
+    setJoinError(null);
+    try {
+      // On success the store switches into the joined vault, which binds it a
+      // folder and unmounts this screen — so there's nothing to do here after.
+      await useStore.getState().joinVault(code);
+    } catch (e) {
+      setJoinError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function reopenLocal(path: string) {
     setBusy(true);
     setError(null);
@@ -214,6 +286,7 @@ export function VaultPicker() {
         }
       } else {
         requestOpenVault(e.orgId);
+        setSignInFor("open");
         setSignInOpen(true);
       }
     } finally {
@@ -242,10 +315,11 @@ export function VaultPicker() {
   }
 
   const naming = newParent !== null;
-  // The naming step or the post-sign-in landing is showing — hide the
-  // recents/hint/sign-in behind it. Offering "New vault" while we are already
-  // making one is how you end up with two.
-  const inFlow = naming || landingVault;
+  // A step that owns the screen is showing (naming a new vault, entering a join
+  // code, or the post-sign-in landing) — hide the recents/hint/sign-in behind
+  // it. Offering "New vault" while we are already making one is how you end up
+  // with two.
+  const inFlow = naming || joining || landingVault;
 
   // Merge synced (remote) vaults with local recents into one list. Remote
   // vaults come from the locally-cached org list (survives sign-out) and are
@@ -282,6 +356,10 @@ export function VaultPicker() {
 
   return (
     <div className="vault-picker">
+      {/* The main app is draggable by its two header rows; this screen has no
+          chrome of its own, so without a strip here the window couldn't be
+          moved at all before a vault is open. */}
+      <div className="titlebar-drag" data-tauri-drag-region />
       {/* Ambient aurora — three blurred color fields drifting very slowly. */}
       {!reduceMotion && (
         <div className="aurora" aria-hidden="true">
@@ -328,6 +406,68 @@ export function VaultPicker() {
                   Opening your vault…
                 </p>
               </motion.div>
+            ) : joining ? (
+              // ---- Join step: the account exists (we forced sign-in first if
+              //      it didn't), so all that's left is the code. Redeeming it
+              //      switches straight into the team's vault — no vault of your
+              //      own required, which is the entire point of this route. ----
+              <motion.form
+                key="joining"
+                className="new-vault-form"
+                initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reduceMotion ? undefined : { opacity: 0, y: -8 }}
+                transition={SPRING}
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void confirmJoin();
+                }}
+              >
+                <label className="new-vault-label">Enter your team's join code</label>
+                {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+                <input
+                  className="new-vault-input join-code-input"
+                  autoFocus
+                  value={joinCode}
+                  disabled={busy}
+                  // Codes are generated uppercase; typing them lowercase is not
+                  // a mistake worth an error message.
+                  onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") cancelJoin();
+                  }}
+                  placeholder="K7MPX2RA"
+                  spellCheck={false}
+                  autoComplete="off"
+                />
+                <p className="new-vault-loc">
+                  Ask a teammate for it — Vault settings → Members.
+                </p>
+                {joinError && <p className="error join-error">{joinError}</p>}
+                <div className="new-vault-buttons">
+                  <button
+                    type="button"
+                    className="ghost-pill"
+                    disabled={busy}
+                    onClick={cancelJoin}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className={`primary sm${busy ? " is-busy" : ""}`}
+                    disabled={busy || !joinCode.trim()}
+                    aria-busy={busy || undefined}
+                  >
+                    {/* Joining is a round trip plus a full vault switch — folder,
+                        registry reconcile, first pull. Seconds, not a blink. */}
+                    <span className="async-btn-label">
+                      {busy ? "Joining…" : "Join team"}
+                    </span>
+                    {busy && <Spinner size="xs" tone="on-accent" />}
+                  </button>
+                </div>
+              </motion.form>
             ) : naming ? (
               // ---- Naming step: only reached via "Create inside" an existing
               //      vault, where a nested vault does need its own folder name.
@@ -420,6 +560,25 @@ export function VaultPicker() {
                     {busy ? "Opening…" : "Open existing"}
                   </span>
                   {busy && <Spinner size="xs" tone="neutral" />}
+                </motion.button>
+                {/*
+                  Third peer action: create / open / JOIN. It sits up here with
+                  the other two rather than down in the quiet register with the
+                  sign-in link, because for the person it's aimed at — a
+                  teammate who was handed a code — it IS the primary action.
+                  Reaching a team used to mean making a vault you didn't want
+                  and then finding the code box in Vault settings, which reads
+                  as "this app is for solo notes, and teams are a setting".
+                */}
+                <motion.button
+                  className="ghost-pill lg"
+                  disabled={busy}
+                  onClick={startJoin}
+                  whileHover={reduceMotion ? undefined : { scale: 1.03, y: -1 }}
+                  whileTap={reduceMotion ? undefined : { scale: 0.97 }}
+                  transition={SPRING}
+                >
+                  Join a team
                 </motion.button>
               </motion.div>
             )}
@@ -549,7 +708,10 @@ export function VaultPicker() {
               // read from the keychain, so offering sign-in would flash a
               // control that's about to become unnecessary.
               disabled={busy || authStatus === "unknown"}
-              onClick={() => setSignInOpen(true)}
+              onClick={() => {
+                setSignInFor("open");
+                setSignInOpen(true);
+              }}
             >
               Sign in
             </button>{" "}
@@ -560,13 +722,22 @@ export function VaultPicker() {
 
       {signInOpen && (
         <AuthDialog
-          // Success: keep the pending open target — the store's post-sign-in
-          // landing opens exactly that vault. Just dismiss the modal.
-          onSignedIn={() => setSignInOpen(false)}
-          // Cancel: drop the pending target so a later sign-in from elsewhere
-          // doesn't surprise-open this vault.
+          // Someone arriving with a join code most likely has no account yet.
+          initialMode={signInFor === "join" ? "sign-up" : "sign-in"}
+          // Success: for the "open" route, keep the pending open target — the
+          // store's post-sign-in landing opens exactly that vault, so just
+          // dismiss. For the "join" route the landing was suppressed on
+          // purpose, and this screen is still up: show the code step.
+          onSignedIn={() => {
+            setSignInOpen(false);
+            if (signInFor === "join") setJoining(true);
+          }}
+          // Cancel: drop whichever intent sent us here, so a later sign-in from
+          // elsewhere doesn't surprise-open a vault or strand itself waiting on
+          // a code that is never coming.
           onClose={() => {
-            requestOpenVault(null);
+            if (signInFor === "join") cancelJoin();
+            else requestOpenVault(null);
             setSignInOpen(false);
           }}
         />

--- a/app/apps/desktop/src/components/graph.css
+++ b/app/apps/desktop/src/components/graph.css
@@ -62,9 +62,11 @@
 }
 
 /* ---- Header bar overlay ---- */
+/* `.graph-view` is a full-window overlay, so this floating bar would sit under
+   the macOS traffic lights without the title-bar inset. */
 .graph-header {
   position: absolute;
-  top: var(--sp-4);
+  top: calc(var(--sp-4) + var(--titlebar-inset));
   left: var(--sp-4);
   right: var(--sp-4);
   z-index: 1;

--- a/app/apps/desktop/src/lib/__tests__/ordering.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/ordering.test.ts
@@ -6,6 +6,7 @@ import {
   clearOrderAt,
   computeReorder,
   moveSubtreeOrder,
+  narrowPins,
   removeFromOrder,
   renameInOrder,
   type ItemOrder,
@@ -129,5 +130,62 @@ describe("childrenAt", () => {
   });
   it("returns [] for a missing path", () => {
     expect(childrenAt(root, "Nope")).toEqual([]);
+  });
+});
+
+// A pin is permanent: anything named in the saved order stops following the
+// sidebar's sort. So a drop should name as little as it can. The case that
+// matters is the common one — reordering top-level FOLDERS shouldn't quietly
+// freeze that level's notes out of "Recently modified" forever.
+describe("narrowPins", () => {
+  const isDir = (p: string) => p === "A" || p === "B" || p === "C";
+
+  it("pins only the folders when the drag was folders-only", () => {
+    expect(
+      narrowPins(["B", "A", "n1.md", "n2.md"], isDir, ["B"], undefined),
+    ).toEqual(["B", "A"]);
+  });
+
+  it("pins everything when a note was dragged", () => {
+    // A note can legitimately be placed above a folder, and that arrangement
+    // only holds if every sibling is ranked.
+    expect(
+      narrowPins(["n2.md", "A", "B", "n1.md"], isDir, ["n2.md"], undefined),
+    ).toEqual(["n2.md", "A", "B", "n1.md"]);
+  });
+
+  it("pins everything on a mixed drag", () => {
+    expect(narrowPins(["B", "n1.md", "A"], isDir, ["B", "n1.md"], undefined)).toEqual([
+      "B",
+      "n1.md",
+      "A",
+    ]);
+  });
+
+  it("keeps the full list when this folder's notes are ALREADY arranged", () => {
+    // Narrowing here would silently discard the note arrangement the user made
+    // on an earlier drag.
+    expect(
+      narrowPins(["B", "A", "n2.md", "n1.md"], isDir, ["B"], ["A", "B", "n2.md", "n1.md"]),
+    ).toEqual(["B", "A", "n2.md", "n1.md"]);
+  });
+
+  it("narrows when the existing arrangement is folders-only", () => {
+    expect(narrowPins(["B", "A", "n1.md"], isDir, ["B"], ["A", "B"])).toEqual(["B", "A"]);
+  });
+
+  // The point of narrowing, stated as the behaviour it buys: folders stay put,
+  // notes keep sorting — and folders still come first, because they are the
+  // ranked ones and applyOrder puts unranked items after.
+  it("leaves the notes free to re-sort under applyOrder", () => {
+    const pins = narrowPins(["B", "A", "n1.md", "n2.md"], isDir, ["B"], undefined);
+    // Later, "Recently modified" hands the level over with n2 before n1.
+    const sorted = [dir("A", []), dir("B", []), file("n2.md"), file("n1.md")];
+    expect(applyOrder(sorted, "", { "": pins }).map((n) => n.path)).toEqual([
+      "B",
+      "A",
+      "n2.md",
+      "n1.md",
+    ]);
   });
 });

--- a/app/apps/desktop/src/lib/graph/graphColor.test.ts
+++ b/app/apps/desktop/src/lib/graph/graphColor.test.ts
@@ -86,3 +86,59 @@ describe("assignColors — folder", () => {
     for (const l of legend) expect(PALETTE).toContain(l.color);
   });
 });
+
+// The graph is only ever drawn on a near-black void, so "is this colour any
+// good?" reduces to one measurable thing: does it hold contrast against that
+// void. The palette that preceded this one failed here — its low tiers sat at
+// under 2:1, which is why a real vault looked flat and dim no matter what the
+// renderer did.
+describe("palette contrast on the void", () => {
+  // Darkest stop of the backdrop gradient (graph.css / the WebGL bg shader).
+  const BACKDROP = "#080910";
+
+  /** WCAG relative luminance. */
+  function luminance(hex: string): number {
+    const h = hex.replace("#", "");
+    const ch = [0, 2, 4].map((i) => {
+      const c = parseInt(h.slice(i, i + 2), 16) / 255;
+      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * ch[0] + 0.7152 * ch[1] + 0.0722 * ch[2];
+  }
+
+  const contrast = (a: string, b: string) => {
+    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+
+  it("keeps every categorical hue at 3:1 or better", () => {
+    for (const c of PALETTE) {
+      expect(
+        contrast(c, BACKDROP),
+        `${c} is too dim to read as a category`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("keeps every degree tier at 3:1 or better", () => {
+    const nodes = [node("a", 0), node("b", 2), node("c", 40), node("d", 900)];
+    const { legend } = assignColors(nodes, "degree", "#7f73ff");
+    for (const l of legend) {
+      expect(
+        contrast(l.color, BACKDROP),
+        `degree tier ${l.label} (${l.color}) sinks into the background`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("keeps neighbouring degree tiers distinguishable from each other", () => {
+    const nodes = [node("a", 0), node("b", 2), node("c", 40), node("d", 900)];
+    const { legend } = assignColors(nodes, "degree", "#7f73ff");
+    for (let i = 1; i < legend.length; i++) {
+      expect(
+        contrast(legend[i].color, legend[i - 1].color),
+        `tiers ${legend[i - 1].label} and ${legend[i].label} look the same`,
+      ).toBeGreaterThan(1.25);
+    }
+  });
+});

--- a/app/apps/desktop/src/lib/graph/graphColor.ts
+++ b/app/apps/desktop/src/lib/graph/graphColor.ts
@@ -15,25 +15,32 @@ export interface ColorResult {
 }
 
 /**
- * Fully saturated hues at mid luminance. These were previously pastel-leaning so
- * they'd read on a light canvas too — but the graph backdrop is a near-black void
- * in every theme, and against that, desaturated fills all converge toward the
- * same washed grey-lilac and folders stop being tellable apart. Deepened and
- * saturated so each hue holds its own identity on the dark field, which is the
- * only surface they're ever drawn on.
+ * Categorical palette for folder coloring: **Observable 10** (d3's `schemeObservable10`,
+ * the modern successor to Tableau 10), hue order preserved, with two changes for
+ * the near-black void this is the only palette ever drawn on:
+ *   - every hue is lifted toward its brighter, more saturated form, because a
+ *     palette designed for white paper loses most of its separation once the
+ *     surround goes black — the darker members converge toward the background
+ *     instead of toward each other;
+ *   - Observable 10's brown (#9c6b4e) and grey (#9498a0) are replaced by cyan
+ *     and lime. Both read as "unlit" rather than as a category on a dark field;
+ *     a folder should never look switched off.
+ * Ten hues is also about the ceiling for a categorical scale before neighbours
+ * stop being tellable apart, so the tail is two spares rather than an ambition
+ * to color thirty folders distinctly.
  */
 export const PALETTE: string[] = [
-  "#6c5cff", // indigo
-  "#00c2a8", // teal
-  "#ffb020", // amber
-  "#ff3d71", // rose
-  "#1fc85c", // green
-  "#9d4edd", // violet
-  "#00aaff", // cyan
-  "#ff6b1a", // orange
-  "#a3d900", // lime
-  "#ff4fc3", // pink
-  "#2f6bff", // blue
+  "#5b8ff9", // blue
+  "#f6c445", // amber
+  "#ff8360", // coral
+  "#4fd6b8", // teal
+  "#4ad66d", // green
+  "#ff8ab7", // pink
+  "#b47cff", // violet
+  "#9fd0ff", // sky
+  "#22d3ee", // cyan     (Observable's brown — too dark on black)
+  "#c3e64b", // lime     (Observable's grey — reads as disabled)
+  "#ff5c8a", // rose
   "#7d90bd", // steel
 ];
 
@@ -103,16 +110,32 @@ function assignByFolder(nodes: GraphNode[]): ColorResult {
   return { colorById, legend };
 }
 
-function assignByDegree(nodes: GraphNode[], accent: string): ColorResult {
-  // The ramp runs from a deep cold slate to a colour BEYOND the accent. Ending
-  // exactly on the accent left the top tier the same purple as the app's buttons
-  // and only a shade off the tier below it; overshooting to a hot near-white
-  // gives the hubs somewhere to actually stand out to.
-  const base = "#2f3a52"; // deep slate — cold end, still clearly a colour
-  const hot = lerpHex(accent, "#fff3c4", 0.5); // accent pushed toward warm white
-  const shades = [0, 1, 2, 3].map((i) =>
-    i <= 2 ? lerpHex(base, accent, i / 2) : hot,
-  );
+/**
+ * The degree ramp: four samples of **plasma**, the perceptually-uniform
+ * colormap that data-viz guidance singles out (with inferno) as the sequential
+ * scale built for dark backgrounds — it never touches a dark end, so no tier
+ * sinks into the void.
+ *
+ * It replaces a ramp that ran deep-slate → accent → warm white. Everything below
+ * the top tier came out a dim blue-grey barely separable from the background:
+ * on a heavy-tailed vault that is 99% of the graph, so the graph read as dull
+ * and flat *because the colouring made it dull and flat*. Plasma spends its
+ * whole range on saturated hue AND rising lightness, so degree is legible twice
+ * over — by colour and by brightness — and every node is unmistakably lit.
+ */
+// Truncated at both ends: plasma's own floor (#0d0887, a near-black indigo)
+// would put the lowest tier straight back into the void, and its ceiling
+// (#f0f921) is a green-yellow that fights the amber in the folder palette.
+// Every entry clears 3:1 against the backdrop — see the contrast test.
+const DEGREE_RAMP = [
+  "#b12a90", // plasma 0.40 — magenta
+  "#d8576b", // plasma 0.50 — rose
+  "#ed7953", // plasma 0.65 — orange
+  "#fdca26", // plasma 0.85 — gold
+];
+
+function assignByDegree(nodes: GraphNode[]): ColorResult {
+  const shades = DEGREE_RAMP;
 
   const maxDeg = nodes.reduce((m, n) => Math.max(m, n.linkCount), 0);
 
@@ -172,7 +195,7 @@ export function assignColors(
     case "folder":
       return assignByFolder(nodes);
     case "degree":
-      return assignByDegree(nodes, accent);
+      return assignByDegree(nodes);
     case "uniform":
     default: {
       const colorById = new Map<string, string>();

--- a/app/apps/desktop/src/lib/graph/simWorker.ts
+++ b/app/apps/desktop/src/lib/graph/simWorker.ts
@@ -11,6 +11,8 @@
 import {
   createSimulation,
   configureForces,
+  DRAG_ALPHA,
+  REARRANGE_ALPHA,
   type SimNode,
   type SimLink,
 } from "./simulation";
@@ -159,7 +161,7 @@ onmessage = (e: MessageEvent<InMsg>) => {
     case "settings":
       if (sim) {
         configureForces(sim, msg.settings);
-        sim.alpha(Math.max(sim.alpha(), 0.3));
+        sim.alpha(Math.max(sim.alpha(), REARRANGE_ALPHA));
         start();
       }
       break;
@@ -174,7 +176,8 @@ onmessage = (e: MessageEvent<InMsg>) => {
       if (n && sim) {
         n.fx = msg.x;
         n.fy = msg.y;
-        sim.alphaTarget(0.3);
+        // Same calm step size as the main-thread sim — see DRAG_ALPHA.
+        sim.alphaTarget(DRAG_ALPHA);
         start();
       }
       break;

--- a/app/apps/desktop/src/lib/graph/simulation.test.ts
+++ b/app/apps/desktop/src/lib/graph/simulation.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import {
+  createSimulation,
+  configureForces,
+  layoutScale,
+  nodeRadius,
+  centerWeight,
+  IDLE_ALPHA,
+  DRAG_ALPHA,
+  type FlowForce,
+  type SimNode,
+  type SimLink,
+} from "./simulation";
+import { DEFAULT_SETTINGS } from "./graphSettings";
+
+/** A small hub-and-spokes graph, seeded on a spiral like the renderer does. */
+function makeSim(count = 60) {
+  const links: SimLink[] = [];
+  for (let i = 1; i < count; i++) {
+    links.push({ source: `n${Math.floor(i / 12) * 12}`, target: `n${i}` });
+    if (i % 4 === 0) links.push({ source: `n${(i * 7) % count}`, target: `n${i}` });
+  }
+  const degree = new Map<string, number>();
+  for (const l of links) {
+    for (const id of [l.source as string, l.target as string]) {
+      degree.set(id, (degree.get(id) ?? 0) + 1);
+    }
+  }
+  const maxDegree = Math.max(...degree.values());
+  const nodes: SimNode[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = `n${i}`;
+    const linkCount = degree.get(id) ?? 0;
+    const a = i * 2.399963;
+    nodes.push({
+      id,
+      title: id,
+      path: `${id}.md`,
+      linkCount,
+      radius: nodeRadius(linkCount),
+      weight: centerWeight(linkCount, maxDegree),
+      x: Math.cos(a) * (20 + i * 4),
+      y: Math.sin(a) * (20 + i * 4),
+      vx: 0,
+      vy: 0,
+      fx: null,
+      fy: null,
+    });
+  }
+
+  const sim = createSimulation(DEFAULT_SETTINGS).alphaTarget(IDLE_ALPHA);
+  sim.nodes(nodes);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (sim.force("link") as any).links(links);
+  configureForces(sim, DEFAULT_SETTINGS);
+  return { sim, nodes, flow: sim.force("flow") as FlowForce };
+}
+
+/** Settle to the idle floor — the state the graph sits in when nobody touches it. */
+function settled(count = 60) {
+  const h = makeSim(count);
+  h.sim.alpha(1);
+  h.sim.tick(1200);
+  h.flow.scale(layoutScale(h.nodes));
+  return h;
+}
+
+const snapshot = (nodes: SimNode[]) => nodes.map((n) => ({ x: n.x, y: n.y }));
+const moved = (nodes: SimNode[], from: { x: number; y: number }[]) =>
+  nodes.map((n, i) => Math.hypot(n.x - from[i].x, n.y - from[i].y));
+const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+
+describe("ambient flow", () => {
+  it("keeps a fully settled layout in motion", () => {
+    const { sim, nodes } = settled();
+    const before = snapshot(nodes);
+    sim.tick(60); // one second
+
+    // The whole point: at rest, with no interaction, the graph is moving — and
+    // by an amount that reads on screen rather than a sub-pixel jitter. The
+    // resting drift is ~2% of the layout radius per second by design.
+    expect(mean(moved(nodes, before))).toBeGreaterThan(layoutScale(nodes) * 0.012);
+  });
+
+  it("moves neighbours together — the flow is laminar, not a scatter", () => {
+    const { sim, nodes } = settled();
+    const before = snapshot(nodes);
+    sim.tick(60);
+
+    // Take the closest pairs and compare their travel directions. A per-node
+    // wander (what this replaced) sends adjacent nodes opposite ways, which is
+    // what the link and collision forces then spend every tick correcting —
+    // felt as vibration. A shared velocity field carries them the same way.
+    const pairs: [number, number][] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      let best = -1;
+      let bestD = Infinity;
+      for (let j = 0; j < nodes.length; j++) {
+        if (i === j) continue;
+        const d = Math.hypot(nodes[i].x - nodes[j].x, nodes[i].y - nodes[j].y);
+        if (d < bestD) {
+          bestD = d;
+          best = j;
+        }
+      }
+      pairs.push([i, best]);
+    }
+    const cosines = pairs.map(([i, j]) => {
+      const ax = nodes[i].x - before[i].x;
+      const ay = nodes[i].y - before[i].y;
+      const bx = nodes[j].x - before[j].x;
+      const by = nodes[j].y - before[j].y;
+      const la = Math.hypot(ax, ay);
+      const lb = Math.hypot(bx, by);
+      if (la === 0 || lb === 0) return 1;
+      return (ax * bx + ay * by) / (la * lb);
+    });
+    // Perfect agreement isn't the bar — the layout's own slow creep rides along
+    // on top and it is not coherent. Without the field this measures ~0.3.
+    expect(mean(cosines)).toBeGreaterThan(0.6);
+  });
+
+  it("travels smoothly — no frame-to-frame direction flipping", () => {
+    const { sim, nodes } = settled();
+    const probe = nodes[Math.floor(nodes.length / 2)];
+    const steps: [number, number][] = [];
+    for (let i = 0; i < 180; i++) {
+      const px = probe.x;
+      const py = probe.y;
+      sim.tick();
+      steps.push([probe.x - px, probe.y - py]);
+    }
+    // Angle between one frame's step and the next. Smooth motion turns slowly;
+    // a shaky node reverses, which shows up here as angles near 180°.
+    let turn = 0;
+    let counted = 0;
+    for (let i = 1; i < steps.length; i++) {
+      const [ax, ay] = steps[i - 1];
+      const [bx, by] = steps[i];
+      const la = Math.hypot(ax, ay);
+      const lb = Math.hypot(bx, by);
+      if (la < 1e-9 || lb < 1e-9) continue;
+      const c = Math.min(1, Math.max(-1, (ax * bx + ay * by) / (la * lb)));
+      turn += (Math.acos(c) * 180) / Math.PI;
+      counted++;
+    }
+    expect(turn / counted).toBeLessThan(12);
+  });
+
+  it("settles smoothly after a drag — this is the one that used to buzz", () => {
+    const { sim, nodes, flow } = settled(160);
+    const radius = layoutScale(nodes);
+    // Grab the smallest, least-anchored node there is (the ones that shook
+    // worst) and haul it across a good fraction of the graph.
+    const target = nodes.reduce((a, b) => (a.linkCount <= b.linkCount ? a : b));
+    sim.alphaTarget(DRAG_ALPHA);
+    target.fx = target.x;
+    target.fy = target.y;
+    for (let f = 0; f < 60; f++) {
+      target.fx! += radius * 0.02;
+      target.fy! += radius * 0.01;
+      sim.tick();
+    }
+    target.fx = null;
+    target.fy = null;
+    sim.alphaTarget(IDLE_ALPHA);
+    flow.energy(1);
+
+    // Then watch the whole field for three seconds.
+    let last = snapshot(nodes);
+    const prev = nodes.map(() => ({ x: 0, y: 0 }));
+    const stats = nodes.map(() => ({ turn: 0, reversals: 0, frames: 0 }));
+    for (let f = 0; f < 180; f++) {
+      sim.tick();
+      for (let i = 0; i < nodes.length; i++) {
+        const dx = nodes[i].x - last[i].x;
+        const dy = nodes[i].y - last[i].y;
+        const la = Math.hypot(prev[i].x, prev[i].y);
+        const lb = Math.hypot(dx, dy);
+        if (la > 1e-9 && lb > 1e-9) {
+          const c = Math.min(
+            1,
+            Math.max(-1, (prev[i].x * dx + prev[i].y * dy) / (la * lb)),
+          );
+          stats[i].turn += (Math.acos(c) * 180) / Math.PI;
+          if (c < 0) stats[i].reversals++; // took a step back the way it came
+          stats[i].frames++;
+        }
+        prev[i] = { x: dx, y: dy };
+      }
+      last = snapshot(nodes);
+    }
+    const live = stats.filter((s) => s.frames > 90);
+    // At the old drag alpha of 0.3 these came out at ~26° and ~14%: every node
+    // in the neighbourhood jittering back and forth as the layout re-solved.
+    expect(mean(live.map((s) => s.turn / s.frames))).toBeLessThan(5);
+    expect(mean(live.map((s) => s.reversals / s.frames))).toBeLessThan(0.03);
+  });
+
+  it("is a drift, not a slow escape", () => {
+    // A settled d3 layout is never perfectly still — it keeps creeping toward a
+    // slightly better arrangement for as long as it runs. So the question isn't
+    // "does anything move over a long session" (it always did) but "does the
+    // flow ADD to that". A field that carried nodes out and never back would
+    // show up here as an excursion far beyond the layout's own.
+    const wander = (withFlow: boolean) => {
+      const h = settled();
+      if (!withFlow) h.flow.scale(0);
+      const home = snapshot(h.nodes);
+      let worst = 0;
+      for (let i = 0; i < 90; i++) {
+        h.sim.tick(60); // 90 seconds, sampled every second
+        for (const d of moved(h.nodes, home)) worst = Math.max(worst, d);
+      }
+      return worst;
+    };
+    expect(wander(true)).toBeLessThan(wander(false) * 1.35);
+  });
+
+  it("scales the entrance above the resting drift", () => {
+    const calm = settled();
+    const calmBefore = snapshot(calm.nodes);
+    calm.sim.tick(60);
+    const calmSpeed = mean(moved(calm.nodes, calmBefore));
+
+    const lively = settled();
+    lively.flow.energy(5);
+    const livelyBefore = snapshot(lively.nodes);
+    lively.sim.tick(60);
+    const livelySpeed = mean(moved(lively.nodes, livelyBefore));
+
+    expect(livelySpeed).toBeGreaterThan(calmSpeed * 2);
+  });
+
+  it("leaves a pinned (dragged) node exactly where it is put", () => {
+    const { sim, nodes } = settled();
+    const pinned = nodes[5];
+    pinned.fx = 123;
+    pinned.fy = -456;
+    sim.tick(120);
+    expect(pinned.x).toBe(123);
+    expect(pinned.y).toBe(-456);
+  });
+
+  it("never lets alpha fall to a dead stop while the view is open", () => {
+    const { sim } = settled();
+    sim.tick(5000);
+    expect(sim.alpha()).toBeGreaterThanOrEqual(IDLE_ALPHA * 0.99);
+  });
+
+  it("stays quiet until the renderer tells it how big the layout is", () => {
+    const unsized = makeSim();
+    unsized.sim.alpha(1);
+    unsized.sim.tick(1200);
+    unsized.flow.scale(0); // never sized — no field, so nothing to float in
+    const unsizedBefore = snapshot(unsized.nodes);
+    unsized.sim.tick(60);
+
+    const sized = settled();
+    const sizedBefore = snapshot(sized.nodes);
+    sized.sim.tick(60);
+
+    expect(mean(moved(unsized.nodes, unsizedBefore))).toBeLessThan(
+      mean(moved(sized.nodes, sizedBefore)) * 0.25,
+    );
+  });
+});

--- a/app/apps/desktop/src/lib/graph/simulation.ts
+++ b/app/apps/desktop/src/lib/graph/simulation.ts
@@ -66,6 +66,219 @@ export interface SimLink {
 }
 
 /**
+ * Velocity retained per tick — the complement of `.velocityDecay(0.7)` below.
+ * The flow force needs it to convert "how fast a node should drift" into the
+ * per-tick pull that produces that speed once damping is applied.
+ */
+const VELOCITY_RETAINED = 0.3;
+
+/**
+ * Floor the alpha never falls below while the graph is on screen.
+ *
+ * A d3 layout that reaches equilibrium is *motionless*, and alpha alone can't
+ * change that: at equilibrium the forces cancel, so a "hot" settled graph looks
+ * exactly like a cold one. What keeps it alive is the flow force below; this
+ * floor keeps the restoring forces (link/gravity) barely awake alongside it so
+ * the drift stays a drift and never becomes a deformation of the layout.
+ *
+ * Deliberately TINY. The alpha-scaled forces are the shaky ones at rest:
+ * many-body is a Barnes–Hut approximation, so a node crossing a quadtree cell
+ * boundary gets a small discontinuous kick, and at any meaningful alpha those
+ * kicks are what read as vibration. At 0.012 they are a whisper and the smooth
+ * flow field is what you actually see.
+ */
+export const IDLE_ALPHA = 0.012;
+
+/**
+ * Alpha held while a node is being dragged, and the ceiling for any other live
+ * disturbance (a settings change, a data refresh).
+ *
+ * This number IS the smoothness of the whole view, and it used to be 0.3.
+ * d3 integrates with a plain explicit step, so alpha is effectively the step
+ * size on a stiff system of springs and inverse-square repulsion: past a point
+ * every correction overshoots, the next one over-corrects back, and the graph
+ * buzzes. Measured over the three seconds after a drag, the mean frame-to-frame
+ * direction change of a node goes 18.7° at alpha 0.3 → 5.6° at 0.12 → 2.7° at
+ * 0.06, and outright reversals (the thing seen as vibration) go 9.7% → 1.8% →
+ * 0.5% of frames. 0.06 is where the motion stops reading as shake and starts
+ * reading as weight, while the neighbours still visibly give way — collision is
+ * not alpha-scaled, so a dragged node keeps shouldering its neighbours aside
+ * exactly as hard as before.
+ */
+export const DRAG_ALPHA = 0.06;
+
+/**
+ * Alpha for a change that genuinely needs the layout to rearrange — a physics
+ * slider, or new notes arriving. Higher than a drag because something structural
+ * actually has to move, still far below the old 0.3.
+ */
+export const REARRANGE_ALPHA = 0.15;
+
+/**
+ * Resting drift speed, as a fraction of the layout's own radius per second.
+ * Relative rather than absolute so a 40-note vault and a 5000-note one drift by
+ * the same amount *on screen* — the camera fits the graph, so a fixed
+ * world-unit speed would be obvious on one and invisible on the other.
+ */
+const FLOW_SPEED_FRACTION = 0.017;
+
+/**
+ * The flow asks for a velocity; the layout's own springs pull some of it back
+ * on the same tick, so a node never reaches the asked-for speed. This is the
+ * measured shortfall on settled layouts (see the drift tests), applied so that
+ * FLOW_SPEED_FRACTION means what it says on screen rather than four times less.
+ */
+const FLOW_SPRING_LOSS = 1.9;
+
+/** How hard a node is pulled toward the local flow velocity, per tick. */
+const FLOW_RELAX = 0.12;
+
+/**
+ * Fraction of the field velocity a node actually reaches in steady state.
+ * From v' = (v(1−F) + V·F)·d  ⇒  v = dFV / (1 − d(1−F)).
+ */
+const FLOW_GAIN =
+  (VELOCITY_RETAINED * FLOW_RELAX) /
+  (1 - VELOCITY_RETAINED * (1 - FLOW_RELAX));
+
+/**
+ * Three long plane waves whose curl makes up the flow. `wavelength` is in units
+ * of the layout radius — all of them are BIGGER than the gaps between nodes, on
+ * purpose: that is what makes neighbours move together instead of shouldering
+ * into each other. `period` is the time (seconds) for the wave to reverse, which
+ * is also what bounds how far a node can travel before it is carried back.
+ */
+const FLOW_WAVES = [
+  { angle: 0.35, wavelength: 1.4, period: 12, amp: 1.0 },
+  { angle: 2.31, wavelength: 0.9, period: 17, amp: 0.55 },
+  { angle: 4.19, wavelength: 0.6, period: 8, amp: 0.3 },
+];
+/**
+ * Typical magnitude of the summed waves. RMS, not the sum of the amplitudes:
+ * the waves are at different phases and angles, so they never all peak at once
+ * and adding them up would over-state the speed by better than a factor of two.
+ */
+const FLOW_AMP_NORM = Math.sqrt(
+  FLOW_WAVES.reduce((s, w) => s + w.amp * w.amp, 0) / 2,
+);
+/** Mass factor for the lightest nodes — the ones the drift speed is quoted for. */
+const FLOW_MASS_BIAS = 0.35;
+const LEAF_MASS = 1 / (1 + FLOW_MASS_BIAS * 0.12);
+const TAU = Math.PI * 2;
+const TICKS_PER_SECOND = 60;
+
+export interface FlowForce {
+  (alpha: number): void;
+  initialize(nodes: SimNode[]): void;
+  /** Layout radius in world units — sets both wavelength and speed. 0 disables. */
+  scale(rms: number): FlowForce;
+  /** Multiplier on the drift speed. 1 at rest; higher during the entrance. */
+  energy(multiplier: number): FlowForce;
+}
+
+/**
+ * The "alive" force: a slow, perpetual current the whole graph floats in.
+ *
+ * WHY it exists: everything else here converges. Once the layout settles, a
+ * force graph is a still photograph — which is what the graph used to open as,
+ * and it read as broken until you grabbed a node and woke it up. This force
+ * never converges and never scales with alpha, so the field keeps drifting at
+ * rest while the real forces continue to hold the shape.
+ *
+ * WHY a field and not per-node wander: the first version gave every node its own
+ * phase, which meant adjacent nodes routinely drifted in opposite directions —
+ * so the link springs and the collision force spent every tick correcting them
+ * and the whole graph vibrated. Here the velocity is read from ONE smooth
+ * spatial field, so a cluster moves almost as a body and there is nothing for
+ * the other forces to fight. It is the curl of a scalar potential, which makes
+ * it divergence-free: the flow shears and swirls but never compresses nodes
+ * into each other. That is the laminar part.
+ *
+ * Bounded by construction: each wave reverses on its own period, so a node is
+ * carried out and then carried back rather than wandering off.
+ *
+ * The pull is a relaxation toward the field velocity, not a shove: it doubles as
+ * a smoother, bleeding off any high-frequency jitter a node picked up elsewhere.
+ */
+export function createFlow(): FlowForce {
+  let nodes: SimNode[] = [];
+  let layout = 0;
+  let energy = 1;
+  let tick = 0;
+  const force = (() => {
+    tick += 1;
+    if (layout <= 0 || nodes.length === 0) return;
+    const seconds = tick / TICKS_PER_SECOND;
+    // World units per tick a light node should actually travel at energy 1,
+    // converted into the field velocity that produces it.
+    const speed =
+      ((FLOW_SPEED_FRACTION * layout * energy) / TICKS_PER_SECOND) *
+      (FLOW_SPRING_LOSS / (FLOW_GAIN * FLOW_AMP_NORM * LEAF_MASS));
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i];
+      if (n.fx != null || n.fy != null) continue; // pinned (dragged) — leave alone
+      let vx = 0;
+      let vy = 0;
+      for (let w = 0; w < FLOW_WAVES.length; w++) {
+        const { angle, wavelength, period, amp } = FLOW_WAVES[w];
+        const ca = Math.cos(angle);
+        const sa = Math.sin(angle);
+        const k = TAU / (wavelength * layout);
+        const phase = k * (n.x * ca + n.y * sa) + (TAU * seconds) / period;
+        // v = curl(ψ) for ψ = (amp/k)·sin(phase): perpendicular to the wave
+        // vector, constant along it — a sheet of fluid sliding past its
+        // neighbour rather than a scatter of independent wanderers.
+        const c = Math.cos(phase) * amp;
+        vx += sa * c;
+        vy += -ca * c;
+      }
+      // Heavier nodes are less carried: a hub holds its place while the leaves
+      // around it drift, which is what makes the motion read as orbital rather
+      // than as the whole picture sliding sideways.
+      const m = speed * (1 / (1 + FLOW_MASS_BIAS * (n.weight ?? 0.12)));
+      n.vx += (vx * m - n.vx) * FLOW_RELAX;
+      n.vy += (vy * m - n.vy) * FLOW_RELAX;
+    }
+  }) as unknown as FlowForce;
+  force.initialize = (n: SimNode[]) => {
+    nodes = n;
+  };
+  force.scale = (rms: number) => {
+    layout = rms;
+    return force;
+  };
+  force.energy = (multiplier: number) => {
+    energy = multiplier;
+    return force;
+  };
+  return force;
+}
+
+/**
+ * The layout's own radius: RMS distance from its centroid. Everything
+ * scale-relative (flow speed, flow wavelength) is measured against this, so the
+ * graph behaves identically whether it holds 40 notes or 5000.
+ */
+export function layoutScale(nodes: SimNode[]): number {
+  if (nodes.length === 0) return 0;
+  let cx = 0;
+  let cy = 0;
+  for (const n of nodes) {
+    cx += n.x;
+    cy += n.y;
+  }
+  cx /= nodes.length;
+  cy /= nodes.length;
+  let sum = 0;
+  for (const n of nodes) {
+    const dx = n.x - cx;
+    const dy = n.y - cy;
+    sum += dx * dx + dy * dy;
+  }
+  return Math.sqrt(sum / nodes.length);
+}
+
+/**
  * Radius from degree. Still sublinear — a 1200-link hub cannot be 1200× a leaf —
  * but on a gentler exponent than √ so the mid-tier actually spreads out.
  *
@@ -114,11 +327,15 @@ export function createSimulation(
     .force("x", forceX<SimNode>(0))
     .force("y", forceY<SimNode>(0))
     .force("collide", forceCollide<SimNode>())
+    // The one force that never converges — see createFlow(). Starts disabled;
+    // the renderer sizes it to the layout on every rebuild.
+    .force("flow", createFlow())
     // Slow, calm cooling (~650 ticks to settle). Stretched 1.5x vs the baseline
     // 0.0155 so the (now more damped) motion still reaches equilibrium.
     .alphaDecay(0.0103)
     // Damping: 0.70 — heavy friction so nodes drift back slowly and calmly after
     // a drag (~2x slower again vs 0.52; steady velocity ∝ (1-vd)/vd).
+    // Keep VELOCITY_RETAINED (= 1 - this) in step: the drift force inverts it.
     .velocityDecay(0.7)
     // CRUCIAL: renderer ticks manually inside its own rAF loop.
     .stop();
@@ -184,7 +401,12 @@ export function configureForces(
   // breathing room instead of touching — the even, spaced look of a good graph.
   // Clearance scales with the node too, so a sun keeps its planets at a distance
   // instead of letting them touch its surface the way a leaf's neighbours do.
+  // Strength is deliberately short of 1: collision is the one force d3 does NOT
+  // scale by alpha, so at rest it is the loudest thing in the sim. Resolving an
+  // overlap in one hard step made settled neighbours trade tiny corrections
+  // every tick, which is felt as vibration; easing them apart over several ticks
+  // reads as weight instead.
   (sim.force("collide") as ForceCollide<SimNode>)
     .radius((d) => d.radius + 4 + d.radius * 0.35)
-    .strength(0.85);
+    .strength(0.7);
 }

--- a/app/apps/desktop/src/lib/graph/webglRenderer.test.ts
+++ b/app/apps/desktop/src/lib/graph/webglRenderer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { PROGRAM_SOURCES } from "./webglRenderer";
+
+// These are source-level checks, not GL ones: there is no WebGL2 context under
+// vitest. They exist because the failure they guard against is invisible on a
+// software rasteriser (which links happily) and fatal on real hardware — the
+// user sees "WebGL unavailable" and the capped 2D fallback, with the real cause
+// buried in a driver message.
+
+const declarations = (src: string, keyword: "uniform" | "in" | "out") => {
+  const names = new Set<string>();
+  const re = new RegExp(
+    `^\\s*(?:precision\\s+\\w+\\s+\\w+;)?\\s*(?:layout\\([^)]*\\)\\s*)?${keyword}\\s+(?:lowp|mediump|highp\\s+)?\\s*\\w+\\s+(\\w+)\\s*;`,
+    "gm",
+  );
+  for (const m of src.matchAll(re)) names.add(m[1]);
+  return names;
+};
+
+describe("shader portability", () => {
+  for (const { name, vert, frag } of PROGRAM_SOURCES) {
+    it(`${name}: declares no uniform in both stages`, () => {
+      const shared = [...declarations(vert, "uniform")].filter((u) =>
+        declarations(frag, "uniform").has(u),
+      );
+      // If a stage genuinely needs the same value, pass it through as a varying
+      // instead — see vQuad in the node/glow programs.
+      expect(shared, `shared between stages: ${shared.join(", ")}`).toEqual([]);
+    });
+
+    it(`${name}: every fragment input is produced by the vertex stage`, () => {
+      const outs = declarations(vert, "out");
+      const missing = [...declarations(frag, "in")].filter((v) => !outs.has(v));
+      expect(missing, `no vertex output for: ${missing.join(", ")}`).toEqual([]);
+    });
+
+    it(`${name}: both stages pin an explicit float precision`, () => {
+      // Relying on the defaults is what makes cross-stage mismatches possible in
+      // the first place — vertex defaults to highp, fragment does not.
+      expect(vert).toMatch(/precision\s+highp\s+float;/);
+      expect(frag).toMatch(/precision\s+highp\s+float;/);
+    });
+  }
+});

--- a/app/apps/desktop/src/lib/graph/webglRenderer.ts
+++ b/app/apps/desktop/src/lib/graph/webglRenderer.ts
@@ -1,10 +1,22 @@
 // Zero-dependency WebGL2 renderer for the global graph. Draws every node as a
-// GPU-shaded disc via instanced rendering, so the whole vault stays at 60fps
+// GPU-shaded sphere via instanced rendering, so the whole vault stays at 60fps
 // regardless of size (the 2D-canvas path repaints each node on the CPU and only
 // scales to a few hundred). Local-first: raw WebGL2, no libraries.
 //
-// This first cut renders nodes only and auto-fits the node cloud to the
-// viewport. Edges, pan/zoom, hover, and sphere shading are layered on next.
+// Four passes, back to front, all instanced or full-screen — never per-node CPU
+// work:
+//   1. backdrop  — a dithered radial gradient, so the void has depth instead of
+//                  being one flat dark fill
+//   2. edges     — feathered quads, NOT gl.LINES (see below)
+//   3. glow      — additive halos, the light each node sheds
+//   4. cores     — the lit spheres themselves
+//
+// WHY quads for edges: gl.LINES is capped at one device pixel on essentially
+// every desktop GL implementation, so links rendered as a hard, aliased hairline
+// — and once the alpha was dropped far enough to stop thousands of them washing
+// the view out, they became a faint dotted mess. A quad can be 2–3px wide with a
+// soft alpha falloff across its width, which reads as a *thread* at any zoom and
+// stays quiet in bulk because the feathering, not the opacity, does the work.
 
 /** A node to draw, in world (simulation) coordinates. */
 export interface RenderNode {
@@ -16,7 +28,52 @@ export interface RenderNode {
   color: [number, number, number];
 }
 
+// Halo extent, in multiples of the node's own radius. The glow pass expands the
+// instanced quad by this much; the core pass draws at 1.0.
+const HALO = 3.2;
+
+// ---------------------------------------------------------------------------
+// Backdrop: a radial gradient matching `.graph-canvas-wrap` in graph.css, drawn
+// in the shader rather than left to CSS because the node/glow passes need an
+// opaque surface to blend against (an alpha-clearing canvas can't do additive
+// glow over the page behind it).
+// ---------------------------------------------------------------------------
+const BG_VERT = `#version 300 es
+precision highp float;
+layout(location=0) in vec2 aCorner;
+void main() { gl_Position = vec4(aCorner, 0.0, 1.0); }`;
+
+const BG_FRAG = `#version 300 es
+precision highp float;
+uniform vec2 uViewport;
+out vec4 fragColor;
+
+// Same three stops as the CSS backdrop, so the 2D fallback and the GPU path
+// sit on an identical void.
+const vec3 C_CORE = vec3(0.059, 0.067, 0.106); // #0f111b
+const vec3 C_MID  = vec3(0.031, 0.035, 0.063); // #080910
+const vec3 C_RIM  = vec3(0.012, 0.016, 0.035); // #030409
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uViewport;
+  // CSS puts the centre at 44% from the TOP; gl_FragCoord counts from the
+  // bottom, hence 0.56.
+  vec2 p = (uv - vec2(0.5, 0.56)) / 0.65;
+  float d = length(p);
+  vec3 c = mix(C_CORE, C_MID, smoothstep(0.0, 0.52, d));
+  c = mix(c, C_RIM, smoothstep(0.52, 1.0, d));
+  // Ordered-ish dither at ±1/255. Without it a gradient this dark and this
+  // gradual bands into visible rings on an 8-bit display — the single biggest
+  // giveaway that a background is "cheap".
+  float n = fract(sin(dot(gl_FragCoord.xy, vec2(12.9898, 78.233))) * 43758.5453);
+  fragColor = vec4(c + (n - 0.5) / 255.0, 1.0);
+}`;
+
+// ---------------------------------------------------------------------------
+// Nodes. One program, two passes, switched by uHalo/uPass.
+// ---------------------------------------------------------------------------
 const VERT = `#version 300 es
+precision highp float;
 layout(location=0) in vec2 aCorner;   // unit-quad corner in [-1,1]
 layout(location=1) in vec2 aPos;      // per-instance world position
 layout(location=2) in float aRadius;  // per-instance world radius
@@ -26,23 +83,47 @@ uniform vec2 uViewport;  // drawing-buffer size in device px
 uniform vec2 uPan;       // world origin -> screen px (top-left origin)
 uniform float uScale;    // world units -> screen px
 uniform float uMinPx;    // floor on a node's on-screen radius (device px)
+uniform float uHalo;     // quad half-extent in radii (1.0 core, HALO glow)
+uniform float uTime;     // seconds, for the per-node breathing
 
-out vec2 vCorner;
+out vec2 vLocal;   // position within the quad, in radii (|vLocal| <= 1 is the disc)
+// The same corner in [-1,1] whatever uHalo is, so the glow's falloff can be
+// written without the fragment stage needing uHalo at all. Sharing a uniform
+// across stages is a portability trap: the default float precision differs
+// between vertex and fragment shaders, and a driver that enforces the spec
+// (Apple's does) refuses to link with "Precisions of uniform 'uHalo' differ".
+out vec2 vQuad;
 out vec3 vColor;
+out float vPulse;  // 0..1 breathing phase, unique per node
+out float vPx;     // the node's on-screen radius in device px
 
 void main() {
-  // Keep every node at least uMinPx wide on screen so tiny-degree nodes don't
-  // vanish when the whole vault is fit into the viewport.
-  float r = max(aRadius, uMinPx / uScale);
-  vec2 world = aPos + aCorner * r;
+  // SOFT floor on the on-screen radius, in quadrature rather than a max().
+  //
+  // A hard max() was flattening the entire graph: at whole-vault zoom almost
+  // every node fell under the floor, so a 1200-link hub and a 1-link leaf came
+  // out exactly the same size and the field read as undifferentiated pixel
+  // spray. Adding the floor in quadrature lifts the small nodes to something
+  // visible while leaving the big ones proportional, so the size hierarchy
+  // survives all the way out.
+  float px = sqrt(aRadius * uScale * aRadius * uScale + uMinPx * uMinPx);
+  float r = px / uScale;
+
+  vec2 world = aPos + aCorner * r * uHalo;
   vec2 screen = world * uScale + uPan;          // px, origin top-left
   vec2 clip = vec2(
     screen.x / (uViewport.x * 0.5) - 1.0,
     1.0 - screen.y / (uViewport.y * 0.5)
   );
   gl_Position = vec4(clip, 0.0, 1.0);
-  vCorner = aCorner;
+  vLocal = aCorner * uHalo;
+  vQuad = aCorner;
   vColor = aColor;
+  vPx = px;
+  // Golden-angle phase off the instance index: neighbours never breathe in
+  // step, so the field shimmers instead of blinking as one.
+  float phase = float(gl_InstanceID) * 2.399963;
+  vPulse = 0.5 + 0.5 * sin(uTime * 0.55 + phase);
 }`;
 
 // Matte-sphere shading, computed per fragment. The disc used to be a flat fill,
@@ -55,33 +136,42 @@ void main() {
 // baked sprites (upper-left, tilted toward the viewer) so the two renderers agree
 // about where the light is.
 const FRAG = `#version 300 es
-precision mediump float;
-in vec2 vCorner;
+precision highp float;
+in vec2 vLocal;
+in vec2 vQuad;
 in vec3 vColor;
+in float vPulse;
+in float vPx;
 out vec4 fragColor;
 
 const vec3 LIGHT = normalize(vec3(-0.5, -0.62, 0.6));
 
 void main() {
-  float d2 = dot(vCorner, vCorner);
+  float d2 = dot(vLocal, vLocal);
   if (d2 > 1.0) discard;
 
   // Hemisphere normal at this pixel.
   float z = sqrt(max(0.0, 1.0 - d2));
-  vec3 n = vec3(vCorner, z);
+  vec3 n = vec3(vLocal, z);
+
+  // Deliberately NO surface pattern. Banding and mottling were tried — they made
+  // the nodes read as little planets, and that is a different product: the eye
+  // starts inspecting individual nodes instead of reading the shape of the
+  // graph. The volume comes from lighting alone.
 
   // Lambert, lifted by an ambient floor so the unlit limb stays coloured rather
   // than going black — a fully dark terminator reads as a hole, not a shadow.
   float diff = max(0.0, dot(n, LIGHT));
-  float shade = 0.34 + 0.66 * diff;
+  float shade = 0.42 + 0.72 * diff;
 
   // Narrow soft highlight where the light hits square on: the cue that says
-  // "glossy sphere" rather than "gradient".
-  float spec = pow(diff, 22.0) * 0.5;
+  // "sphere" rather than "gradient". It breathes very slightly with the node's
+  // own phase, which is what keeps a settled graph from looking like a print.
+  float spec = pow(diff, 20.0) * (0.42 + 0.22 * vPulse);
 
   // Rim light on the far limb, which is what separates one node from another
   // when they overlap in a dense cluster.
-  float rim = pow(1.0 - z, 3.0) * 0.22;
+  float rim = pow(1.0 - z, 3.0) * 0.30;
 
   // Hover-dimming is applied by the caller as a multiplier on the fill colour,
   // and a white specular would ignore it — dimmed nodes would keep a full-bright
@@ -94,35 +184,107 @@ void main() {
   float intensity = max(vColor.r, max(vColor.g, vColor.b));
   vec3 lit = vColor * shade + vec3(spec + rim) * intensity;
 
-  // Feather only the outermost pixels, in the same radial space as the normal.
+  // Feather the outermost pixels. The width of the feather is one device pixel
+  // expressed in local units, so a 2px dot at overview zoom is antialiased just
+  // as carefully as a 200px hub — a fixed 0.94 threshold turned small nodes into
+  // hard-edged, visibly stair-stepped squares of colour.
   float d = sqrt(d2);
-  float alpha = 1.0 - smoothstep(0.94, 1.0, d);
+  float aa = clamp(1.0 / max(vPx, 1.0), 0.02, 0.5);
+  float alpha = 1.0 - smoothstep(1.0 - aa, 1.0, d);
   fragColor = vec4(lit, alpha);
 }`;
 
-// Edges: one shared program drawing gl.LINES. Each vertex is a world position;
-// the same uScale/uPan/uViewport as the nodes, so edges line up with them.
+// The glow pass: the light a node sheds into the void around it. Additive, so
+// overlapping halos in a cluster sum into a genuine bright core the way a
+// star field does — that accumulation is the whole reason dense regions read as
+// dense rather than as a uniform speckle.
+const GLOW_FRAG = `#version 300 es
+precision highp float;
+in vec2 vLocal;
+in vec2 vQuad;
+in vec3 vColor;
+in float vPulse;
+out vec4 fragColor;
+
+uniform float uGlow;  // global glow scale (drops as the graph grows)
+
+void main() {
+  float d = length(vLocal);
+  if (d > 1.0) {
+    // Outside the sphere: a soft, steep falloff to nothing at the quad's edge.
+    // Measured in quad space (vQuad), which is 0..1 across the halo whatever
+    // its extent — so this needs no uniform, and the program links on drivers
+    // that enforce cross-stage precision matching.
+    float t = clamp(1.0 - length(vQuad), 0.0, 1.0);
+    float g = pow(t, 2.4);
+    float amp = uGlow * (0.55 + 0.45 * vPulse);
+    fragColor = vec4(vColor * g * amp, g * amp * 0.9);
+    return;
+  }
+  // Under the sphere the glow is flat and full: the core pass paints over it,
+  // and a hole here would show as a dark ring around every small node.
+  float amp = uGlow * (0.55 + 0.45 * vPulse) * 0.34;
+  fragColor = vec4(vColor * amp, amp);
+}`;
+
+// ---------------------------------------------------------------------------
+// Edges: instanced quads, one per link, expanded in SCREEN space so the width
+// is a constant number of device pixels at any zoom.
+// ---------------------------------------------------------------------------
 const LINE_VERT = `#version 300 es
-layout(location=0) in vec2 aPos;
+precision highp float;
+layout(location=0) in vec2 aCorner;  // x: 0..1 along the segment, y: -1..1 across
+layout(location=1) in vec4 aSeg;     // per-instance x0,y0,x1,y1 in world units
 uniform vec2 uViewport;
 uniform vec2 uPan;
 uniform float uScale;
+uniform float uWidthPx;              // full width of the quad, device px
+out float vAcross;
 void main() {
-  vec2 screen = aPos * uScale + uPan;
+  vec2 p0 = aSeg.xy * uScale + uPan;
+  vec2 p1 = aSeg.zw * uScale + uPan;
+  vec2 dir = p1 - p0;
+  float len = max(1e-4, length(dir));
+  dir /= len;
+  vec2 nrm = vec2(-dir.y, dir.x);
+  vec2 p = mix(p0, p1, aCorner.x) + nrm * (aCorner.y * uWidthPx * 0.5);
   vec2 clip = vec2(
-    screen.x / (uViewport.x * 0.5) - 1.0,
-    1.0 - screen.y / (uViewport.y * 0.5)
+    p.x / (uViewport.x * 0.5) - 1.0,
+    1.0 - p.y / (uViewport.y * 0.5)
   );
   gl_Position = vec4(clip, 0.0, 1.0);
+  vAcross = aCorner.y;
 }`;
 
 const LINE_FRAG = `#version 300 es
-precision mediump float;
+precision highp float;
+in float vAcross;
 uniform vec4 uLineColor;
 out vec4 fragColor;
-void main() { fragColor = uLineColor; }`;
+void main() {
+  // Soft across the width: solid down the spine, faded to nothing at the rim.
+  // This is what replaces MSAA on a 1px line — and it is why the resting alpha
+  // can be raised without thousands of overlapping links turning into a wash.
+  float a = pow(1.0 - abs(vAcross), 1.5);
+  fragColor = vec4(uLineColor.rgb, uLineColor.a * a);
+}`;
 
 const FLOATS_PER_NODE = 6; // x, y, r, cr, cg, cb
+
+/**
+ * The exact (vertex, fragment) pairs this renderer links, exported so a unit
+ * test can check them for portability traps that only some drivers enforce —
+ * chiefly a uniform declared in BOTH stages, which links fine on a software
+ * rasteriser and is rejected outright by Apple's driver ("Precisions of uniform
+ * 'x' differ between VERTEX and FRAGMENT shaders"), taking the whole GPU
+ * renderer offline and dropping the graph to its capped 2D fallback.
+ */
+export const PROGRAM_SOURCES = [
+  { name: "background", vert: BG_VERT, frag: BG_FRAG },
+  { name: "node", vert: VERT, frag: FRAG },
+  { name: "glow", vert: VERT, frag: GLOW_FRAG },
+  { name: "line", vert: LINE_VERT, frag: LINE_FRAG },
+];
 
 function compile(gl: WebGL2RenderingContext, type: number, src: string): WebGLShader {
   const sh = gl.createShader(type);
@@ -137,50 +299,103 @@ function compile(gl: WebGL2RenderingContext, type: number, src: string): WebGLSh
   return sh;
 }
 
+function link(
+  gl: WebGL2RenderingContext,
+  vertSrc: string,
+  fragSrc: string,
+  label: string,
+): WebGLProgram {
+  const prog = gl.createProgram();
+  if (!prog) throw new Error(`createProgram (${label}) failed`);
+  gl.attachShader(prog, compile(gl, gl.VERTEX_SHADER, vertSrc));
+  gl.attachShader(prog, compile(gl, gl.FRAGMENT_SHADER, fragSrc));
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    throw new Error(`${label} program link failed: ` + gl.getProgramInfoLog(prog));
+  }
+  return prog;
+}
+
+/** Uniform locations shared by the node core + glow programs. */
+interface NodeUniforms {
+  viewport: WebGLUniformLocation | null;
+  pan: WebGLUniformLocation | null;
+  scale: WebGLUniformLocation | null;
+  minPx: WebGLUniformLocation | null;
+  halo: WebGLUniformLocation | null;
+  time: WebGLUniformLocation | null;
+  glow: WebGLUniformLocation | null;
+}
+
 export class WebGLGraphRenderer {
   private gl: WebGL2RenderingContext;
   private program: WebGLProgram;
+  private glowProgram: WebGLProgram;
+  private nodeU: NodeUniforms;
+  private glowU: NodeUniforms;
   private vao: WebGLVertexArrayObject;
   private instBuf: WebGLBuffer;
   private instData = new Float32Array(0);
   private count = 0;
-  private uViewport: WebGLUniformLocation | null;
-  private uPan: WebGLUniformLocation | null;
-  private uScale: WebGLUniformLocation | null;
-  private uMinPx: WebGLUniformLocation | null;
+
+  private bgProgram: WebGLProgram;
+  private bgVao: WebGLVertexArrayObject;
+  private uBgViewport: WebGLUniformLocation | null;
+
   private lineProgram: WebGLProgram;
   private lineVao: WebGLVertexArrayObject;
   private lineBuf: WebGLBuffer;
-  private lineVertCount = 0;
-  private lineData = new Float32Array(0);
+  private lineCount = 0;
   private hlVao: WebGLVertexArrayObject;
   private hlBuf: WebGLBuffer;
-  private hlVertCount = 0;
+  private hlCount = 0;
   private uLineViewport: WebGLUniformLocation | null;
   private uLinePan: WebGLUniformLocation | null;
   private uLineScale: WebGLUniformLocation | null;
   private uLineColor: WebGLUniformLocation | null;
+  private uLineWidth: WebGLUniformLocation | null;
 
   constructor(private canvas: HTMLCanvasElement) {
-    const gl = canvas.getContext("webgl2", { antialias: true, alpha: true, premultipliedAlpha: false });
+    const gl = canvas.getContext("webgl2", {
+      antialias: true,
+      alpha: true,
+      premultipliedAlpha: false,
+    });
     if (!gl) throw new Error("WebGL2 is not available");
     this.gl = gl;
 
-    const prog = gl.createProgram();
-    if (!prog) throw new Error("createProgram failed");
-    const vs = compile(gl, gl.VERTEX_SHADER, VERT);
-    const fs = compile(gl, gl.FRAGMENT_SHADER, FRAG);
-    gl.attachShader(prog, vs);
-    gl.attachShader(prog, fs);
-    gl.linkProgram(prog);
-    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
-      throw new Error("program link failed: " + gl.getProgramInfoLog(prog));
-    }
-    this.program = prog;
-    this.uViewport = gl.getUniformLocation(prog, "uViewport");
-    this.uPan = gl.getUniformLocation(prog, "uPan");
-    this.uScale = gl.getUniformLocation(prog, "uScale");
-    this.uMinPx = gl.getUniformLocation(prog, "uMinPx");
+    // ---- Backdrop ----
+    this.bgProgram = link(gl, BG_VERT, BG_FRAG, "background");
+    this.uBgViewport = gl.getUniformLocation(this.bgProgram, "uViewport");
+    const bgVao = gl.createVertexArray();
+    if (!bgVao) throw new Error("createVertexArray (bg) failed");
+    this.bgVao = bgVao;
+    gl.bindVertexArray(bgVao);
+    const bgQuad = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, bgQuad);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]),
+      gl.STATIC_DRAW,
+    );
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+
+    // ---- Nodes (core + glow share one VAO and one instance buffer) ----
+    this.program = link(gl, VERT, FRAG, "node");
+    this.glowProgram = link(gl, VERT, GLOW_FRAG, "glow");
+    const uniformsOf = (p: WebGLProgram): NodeUniforms => ({
+      viewport: gl.getUniformLocation(p, "uViewport"),
+      pan: gl.getUniformLocation(p, "uPan"),
+      scale: gl.getUniformLocation(p, "uScale"),
+      minPx: gl.getUniformLocation(p, "uMinPx"),
+      halo: gl.getUniformLocation(p, "uHalo"),
+      time: gl.getUniformLocation(p, "uTime"),
+      glow: gl.getUniformLocation(p, "uGlow"),
+    });
+    this.nodeU = uniformsOf(this.program);
+    this.glowU = uniformsOf(this.glowProgram);
 
     const vao = gl.createVertexArray();
     if (!vao) throw new Error("createVertexArray failed");
@@ -213,45 +428,37 @@ export class WebGLGraphRenderer {
 
     gl.bindVertexArray(null);
 
-    // ---- Edge line program ----
-    const lp = gl.createProgram();
-    if (!lp) throw new Error("createProgram (line) failed");
-    gl.attachShader(lp, compile(gl, gl.VERTEX_SHADER, LINE_VERT));
-    gl.attachShader(lp, compile(gl, gl.FRAGMENT_SHADER, LINE_FRAG));
-    gl.linkProgram(lp);
-    if (!gl.getProgramParameter(lp, gl.LINK_STATUS)) {
-      throw new Error("line program link failed: " + gl.getProgramInfoLog(lp));
-    }
-    this.lineProgram = lp;
-    this.uLineViewport = gl.getUniformLocation(lp, "uViewport");
-    this.uLinePan = gl.getUniformLocation(lp, "uPan");
-    this.uLineScale = gl.getUniformLocation(lp, "uScale");
-    this.uLineColor = gl.getUniformLocation(lp, "uLineColor");
+    // ---- Edge quads ----
+    this.lineProgram = link(gl, LINE_VERT, LINE_FRAG, "line");
+    this.uLineViewport = gl.getUniformLocation(this.lineProgram, "uViewport");
+    this.uLinePan = gl.getUniformLocation(this.lineProgram, "uPan");
+    this.uLineScale = gl.getUniformLocation(this.lineProgram, "uScale");
+    this.uLineColor = gl.getUniformLocation(this.lineProgram, "uLineColor");
+    this.uLineWidth = gl.getUniformLocation(this.lineProgram, "uWidthPx");
 
-    const lineVao = gl.createVertexArray();
-    if (!lineVao) throw new Error("createVertexArray (line) failed");
-    this.lineVao = lineVao;
-    gl.bindVertexArray(lineVao);
-    const lineBuf = gl.createBuffer();
-    if (!lineBuf) throw new Error("createBuffer (line) failed");
-    this.lineBuf = lineBuf;
-    gl.bindBuffer(gl.ARRAY_BUFFER, lineBuf);
-    gl.enableVertexAttribArray(0);
-    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
-    gl.bindVertexArray(null);
+    // Quad corners for a segment: x runs 0→1 along it, y ±1 across it.
+    const segQuad = new Float32Array([0, -1, 0, 1, 1, -1, 1, 1]);
+    const segQuadBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, segQuadBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, segQuad, gl.STATIC_DRAW);
 
-    // Highlight-edge VAO/buffer (hover): same line program, its own buffer.
-    const hlVao = gl.createVertexArray();
-    if (!hlVao) throw new Error("createVertexArray (hl) failed");
-    this.hlVao = hlVao;
-    gl.bindVertexArray(hlVao);
-    const hlBuf = gl.createBuffer();
-    if (!hlBuf) throw new Error("createBuffer (hl) failed");
-    this.hlBuf = hlBuf;
-    gl.bindBuffer(gl.ARRAY_BUFFER, hlBuf);
-    gl.enableVertexAttribArray(0);
-    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
-    gl.bindVertexArray(null);
+    const makeSegVao = (): [WebGLVertexArrayObject, WebGLBuffer] => {
+      const v = gl.createVertexArray();
+      const b = gl.createBuffer();
+      if (!v || !b) throw new Error("createVertexArray/Buffer (seg) failed");
+      gl.bindVertexArray(v);
+      gl.bindBuffer(gl.ARRAY_BUFFER, segQuadBuf);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, b);
+      gl.enableVertexAttribArray(1); // aSeg — one x0,y0,x1,y1 per instance
+      gl.vertexAttribPointer(1, 4, gl.FLOAT, false, 16, 0);
+      gl.vertexAttribDivisor(1, 1);
+      gl.bindVertexArray(null);
+      return [v, b];
+    };
+    [this.lineVao, this.lineBuf] = makeSegVao();
+    [this.hlVao, this.hlBuf] = makeSegVao();
 
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
@@ -290,11 +497,10 @@ export class WebGLGraphRenderer {
     gl.bufferData(gl.ARRAY_BUFFER, d.subarray(0, nodes.length * FLOATS_PER_NODE), gl.DYNAMIC_DRAW);
   }
 
-  /** Upload edge line vertices as flat world coords [x0,y0,x1,y1,…] — two
-   *  vertices per edge (a gl.LINES list). */
+  /** Upload edge segments as flat world coords [x0,y0,x1,y1,…] — four floats
+   *  per link, consumed as one quad instance each. */
   setEdges(positions: Float32Array): void {
-    this.lineVertCount = positions.length / 2;
-    if (this.lineData.length < positions.length) this.lineData = positions;
+    this.lineCount = Math.floor(positions.length / 4);
     const gl = this.gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.lineBuf);
     gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
@@ -303,64 +509,102 @@ export class WebGLGraphRenderer {
   /** Upload the hover-highlight edges (bright lines from the hovered node),
    *  same flat [x0,y0,x1,y1,…] layout as `setEdges`. */
   setHighlightEdges(positions: Float32Array): void {
-    this.hlVertCount = positions.length / 2;
+    this.hlCount = Math.floor(positions.length / 4);
     const gl = this.gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.hlBuf);
     gl.bufferData(gl.ARRAY_BUFFER, positions, gl.DYNAMIC_DRAW);
   }
 
-  /** Draw edges then nodes with the given world→screen transform. `minPx` is
-   *  the floor on each node's on-screen radius, in device px. */
-  draw(scale: number, panX: number, panY: number, minPx: number): void {
+  /**
+   * Draw one frame with the given world→screen transform.
+   * `minPx` floors a node's on-screen radius (device px), `time` drives the
+   * per-node breathing, and `glow` scales the halos (turned down as the node
+   * count rises so a dense vault doesn't bloom into a single white cloud).
+   */
+  draw(
+    scale: number,
+    panX: number,
+    panY: number,
+    minPx: number,
+    time: number,
+    glow: number,
+    dpr: number,
+  ): void {
     const gl = this.gl;
-    gl.clearColor(0.04, 0.04, 0.07, 1); // near-black, matching the graph backdrop
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    const vw = this.canvas.width;
+    const vh = this.canvas.height;
 
-    const drawLines = (
+    // ---- 1. Backdrop ----
+    gl.disable(gl.BLEND);
+    gl.useProgram(this.bgProgram);
+    gl.bindVertexArray(this.bgVao);
+    gl.uniform2f(this.uBgViewport, vw, vh);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    gl.bindVertexArray(null);
+    gl.enable(gl.BLEND);
+
+    const drawSegments = (
       vao: WebGLVertexArrayObject,
-      vertCount: number,
+      instances: number,
+      widthPx: number,
       r: number,
       g: number,
       b: number,
       a: number,
     ) => {
-      if (vertCount === 0) return;
+      if (instances === 0) return;
       gl.useProgram(this.lineProgram);
       gl.bindVertexArray(vao);
-      gl.uniform2f(this.uLineViewport, this.canvas.width, this.canvas.height);
+      gl.uniform2f(this.uLineViewport, vw, vh);
       gl.uniform1f(this.uLineScale, scale);
       gl.uniform2f(this.uLinePan, panX, panY);
       gl.uniform4f(this.uLineColor, r, g, b, a);
-      gl.drawArrays(gl.LINES, 0, vertCount);
+      gl.uniform1f(this.uLineWidth, widthPx);
+      gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, instances);
       gl.bindVertexArray(null);
     };
 
-    // Resting edges: quiet threads under everything. The alpha is low because
-    // these overlap in the thousands on a real vault — at 0.35 they accumulated
-    // into a solid pale field that washed the whole view lavender and buried the
-    // nodes. Faint per line is what keeps dense regions reading as *dense*
-    // rather than as a flat wash.
-    drawLines(this.lineVao, this.lineVertCount, 0.42, 0.5, 0.78, 0.12);
+    // ---- 2. Edges ----
+    // Resting links: a cool blue-steel thread. Feathered quads let this sit at a
+    // real alpha — hairlines at this opacity used to accumulate into a flat
+    // lavender wash over dense regions, so they had to be dialled down until
+    // they nearly disappeared. The softness carries the density now.
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    drawSegments(this.lineVao, this.lineCount, 1.6 * dpr, 0.44, 0.56, 0.9, 0.3);
 
     // Hover rays go UNDER the nodes, not over them. Drawn last, they crossed the
     // hovered node itself — dozens of bright lines converging on top of the very
     // thing being pointed at, which blew out its centre and hid it. Beneath the
     // node layer they emerge from behind it instead, which is also what the
     // geometry actually is: a link starts at the node, not on it.
-    drawLines(this.hlVao, this.hlVertCount, 1.0, 0.86, 0.38, 0.85);
+    drawSegments(this.hlVao, this.hlCount, 2.6 * dpr, 1.0, 0.86, 0.38, 0.95);
 
-    // Nodes last, so every edge — resting or highlighted — is occluded by the
-    // discs it connects.
-    if (this.count > 0) {
-      gl.useProgram(this.program);
+    if (this.count === 0) return;
+
+    const bindNodes = (u: NodeUniforms, halo: number) => {
       gl.bindVertexArray(this.vao);
-      gl.uniform2f(this.uViewport, this.canvas.width, this.canvas.height);
-      gl.uniform1f(this.uScale, scale);
-      gl.uniform2f(this.uPan, panX, panY);
-      gl.uniform1f(this.uMinPx, minPx);
+      gl.uniform2f(u.viewport, vw, vh);
+      gl.uniform1f(u.scale, scale);
+      gl.uniform2f(u.pan, panX, panY);
+      gl.uniform1f(u.minPx, minPx);
+      gl.uniform1f(u.halo, halo);
+      gl.uniform1f(u.time, time);
       gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, this.count);
       gl.bindVertexArray(null);
-    }
+    };
+
+    // ---- 3. Glow (additive) ----
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.useProgram(this.glowProgram);
+    gl.uniform1f(this.glowU.glow, glow);
+    bindNodes(this.glowU, HALO);
+
+    // ---- 4. Cores ----
+    // Last, so every edge — resting or highlighted — is occluded by the discs
+    // it connects, and every halo is capped by its own sphere.
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.useProgram(this.program);
+    bindNodes(this.nodeU, 1.0);
   }
 
   /** The most recent GL error code (0 = none). Diagnostic only. */
@@ -373,6 +617,9 @@ export class WebGLGraphRenderer {
     gl.deleteBuffer(this.instBuf);
     gl.deleteVertexArray(this.vao);
     gl.deleteProgram(this.program);
+    gl.deleteProgram(this.glowProgram);
+    gl.deleteVertexArray(this.bgVao);
+    gl.deleteProgram(this.bgProgram);
     gl.deleteBuffer(this.lineBuf);
     gl.deleteVertexArray(this.lineVao);
     gl.deleteProgram(this.lineProgram);

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -68,6 +68,10 @@ export interface TreeNode {
    *  nobody has expanded look identical — which is why an unexpanded folder used
    *  to be labelled "empty" in the sidebar. Absent ⇒ treat as not loaded. */
   childrenLoaded?: boolean;
+  /** Last-modified time in epoch millis (0 when the OS wouldn't say). Drives the
+   *  sidebar's "Recently modified" sort. Absent on nodes synthesized client-side
+   *  before a refresh lands. */
+  modified?: number;
 }
 
 export interface SearchResult {

--- a/app/apps/desktop/src/lib/ordering.ts
+++ b/app/apps/desktop/src/lib/ordering.ts
@@ -1,6 +1,6 @@
 // Custom sidebar order for folders and notes. Like item colors, order is a
-// local, per-vault preference (Rust always returns folders-first/alphabetical;
-// the user's manual arrangement is layered on top here, client-side). Stored in
+// local, per-vault preference: the user's manual drag-and-drop arrangement,
+// layered client-side on top of the base sort (`lib/tree/sort`). Stored in
 // localStorage keyed by vault path, then by parent path → ordered child paths.
 
 import type { TreeNode } from "./ipc";
@@ -29,8 +29,12 @@ export function writeItemOrder(vaultPath: string, order: ItemOrder): void {
 
 /**
  * Re-sort each folder's children by the saved order. Items with no saved rank
- * keep the incoming order (Rust's folders-first/alphabetical), sorted after the
- * ranked ones — so a freshly-created note lands at the bottom until moved.
+ * keep the incoming order — whatever the base sort produced — and land after
+ * the ranked ones, so a freshly-created note appears at the bottom until moved.
+ *
+ * That "keep the incoming order" rule is what lets the sort and a hand-made
+ * arrangement coexist: run this AFTER `sortTree`, and changing the sort only
+ * rearranges rows nobody pinned. See `lib/tree/sort` for the full argument.
  */
 export function applyOrder(
   nodes: TreeNode[],
@@ -98,6 +102,36 @@ export function computeReorder(
 }
 
 /**
+ * Narrow a freshly computed sibling order down to the group the drop was
+ * actually about, so a drag pins as little as it can get away with.
+ *
+ * `computeReorder` returns the folder's WHOLE child list, and every path in it
+ * becomes a pin — which means dragging one folder would also freeze that
+ * folder's notes at their current positions, and they'd stop following the
+ * "Recently modified" sort forever after. Since folders and notes are separate
+ * groups on screen anyway (folders always above notes), a folders-only drag
+ * only needs to pin folders: the notes stay unranked and keep sorting.
+ *
+ * A drag involving a note keeps the full list — a note CAN be dragged above a
+ * folder, and that arrangement only survives if everything is ranked. Likewise
+ * a folder whose notes are already hand-arranged keeps its full list rather
+ * than silently discarding that arrangement.
+ */
+export function narrowPins(
+  nextOrder: string[],
+  isDir: (path: string) => boolean,
+  /** The dragged items under their POST-drop paths. */
+  draggedPaths: readonly string[],
+  /** This folder's existing saved order, if it has one. */
+  previous: readonly string[] | undefined,
+): string[] {
+  const draggedAllFolders = draggedPaths.length > 0 && draggedPaths.every(isDir);
+  if (!draggedAllFolders) return nextOrder;
+  if (previous?.some((p) => !isDir(p))) return nextOrder;
+  return nextOrder.filter(isDir);
+}
+
+/**
  * Move an item's whole subtree within the order map: re-prefix its own and its
  * descendants' entries from `from` to `to`, and drop every other reference to
  * `from` (e.g. its former parent's list). The caller sets the destination
@@ -134,8 +168,8 @@ export function renameInOrder(order: ItemOrder, oldPath: string, newPath: string
 }
 
 /**
- * Forget the custom arrangement for one folder's children, so it falls back to
- * Rust's folders-first/alphabetical default. Other folders keep their order.
+ * Forget the custom arrangement for one folder's children, so they fall back to
+ * the base sort. Other folders keep their arrangement.
  */
 export function clearOrderAt(order: ItemOrder, parentPath: string): ItemOrder {
   if (!(parentPath in order)) return order;

--- a/app/apps/desktop/src/lib/platform.ts
+++ b/app/apps/desktop/src/lib/platform.ts
@@ -1,0 +1,27 @@
+/**
+ * Stamp the host platform onto `<html>` so CSS can react to it.
+ *
+ * The only thing this currently drives is the macOS traffic-light inset. The
+ * window runs with `titleBarStyle: "Overlay"` (see `tauri.conf.json`), which
+ * hands the webview the full window height and floats the close/minimise/zoom
+ * buttons *over* our own top-left corner. Windows and Linux keep a real system
+ * title bar above the webview, so reserving that space there would just
+ * reintroduce the dead strip we removed.
+ *
+ * Read from the user agent rather than `@tauri-apps/plugin-os` on purpose: this
+ * has to run synchronously before the first paint (an async platform lookup
+ * would land a frame late and visibly shove the sidebar down), and it keeps the
+ * bundle free of a plugin we'd otherwise pull in for one boolean.
+ */
+export function platformClass(): "macos" | "windows" | "linux" | "other" {
+  const ua = navigator.userAgent;
+  // Apple Silicon still reports "Intel Mac OS X" in WKWebView, so match loosely.
+  if (/Mac OS X|Macintosh/.test(ua)) return "macos";
+  if (/Windows/.test(ua)) return "windows";
+  if (/Linux|X11/.test(ua)) return "linux";
+  return "other";
+}
+
+export function initPlatform(): void {
+  document.documentElement.dataset.platform = platformClass();
+}

--- a/app/apps/desktop/src/lib/prefs.ts
+++ b/app/apps/desktop/src/lib/prefs.ts
@@ -4,6 +4,8 @@
 // avatar) are NOT here — those are server-backed via Better Auth so they follow
 // the account across devices; see `ApiClient.updateUser`.
 
+import type { TreeSort } from "./tree/sort";
+
 export type ActivityStatus = "online" | "away" | "busy" | "invisible";
 
 export const ACTIVITY_STATUSES: Array<{
@@ -55,6 +57,36 @@ export function writeMentionSound(enabled: boolean): void {
     localStorage.setItem(MENTION_SOUND_KEY, enabled ? "on" : "off");
   } catch {
     /* localStorage unavailable — preference stays in-memory only */
+  }
+}
+
+// ---- Sidebar sort -----------------------------------------------------------
+
+const TREE_SORT_KEY = "context.treeSort";
+
+/**
+ * How the sidebar arranges what the user hasn't arranged by hand. Device-level
+ * rather than per-vault (unlike item order/colors, which describe one vault's
+ * contents): this is a habit about how you read a sidebar, and having it flip
+ * as you switch vaults would be its own surprise.
+ *
+ * Defaults to "recent" — a second brain is mostly read from the top, and the
+ * note you want is nearly always one you touched lately.
+ */
+export function readTreeSort(): TreeSort {
+  try {
+    const v = localStorage.getItem(TREE_SORT_KEY);
+    return v === "name" || v === "recent" ? v : "recent";
+  } catch {
+    return "recent";
+  }
+}
+
+export function writeTreeSort(sort: TreeSort): void {
+  try {
+    localStorage.setItem(TREE_SORT_KEY, sort);
+  } catch {
+    /* localStorage unavailable — the sort stays in-memory only */
   }
 }
 

--- a/app/apps/desktop/src/lib/tree/__tests__/sort.test.ts
+++ b/app/apps/desktop/src/lib/tree/__tests__/sort.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { TreeNode } from "../../ipc";
+import { sortTree } from "../sort";
+import { applyOrder } from "../../ordering";
+
+const dir = (name: string, modified: number, children: TreeNode[] = []): TreeNode => ({
+  id: name,
+  name,
+  path: name,
+  isDir: true,
+  modified,
+  children,
+  childrenLoaded: true,
+});
+
+const file = (path: string, modified: number): TreeNode => ({
+  id: path,
+  name: path.split("/").pop()!,
+  path,
+  isDir: false,
+  modified,
+});
+
+const names = (ns: TreeNode[]) => ns.map((n) => n.name);
+
+describe("sortTree", () => {
+  it("puts folders before files in both modes", () => {
+    const nodes = [file("z.md", 9), dir("Archive", 1), file("a.md", 1), dir("Work", 9)];
+    expect(names(sortTree(nodes, "recent"))).toEqual(["Archive", "Work", "z.md", "a.md"]);
+    expect(names(sortTree(nodes, "name"))).toEqual(["Archive", "Work", "a.md", "z.md"]);
+  });
+
+  it("orders files newest first under 'recent'", () => {
+    const nodes = [file("old.md", 100), file("newest.md", 300), file("mid.md", 200)];
+    expect(names(sortTree(nodes, "recent"))).toEqual(["newest.md", "mid.md", "old.md"]);
+  });
+
+  // A folder's mtime moves whenever anything inside it is saved, so sorting
+  // folders by recency would reshuffle the sidebar's skeleton on every edit.
+  it("keeps folders alphabetical even under 'recent'", () => {
+    const nodes = [dir("Zoo", 999), dir("Apple", 1)];
+    expect(names(sortTree(nodes, "recent"))).toEqual(["Apple", "Zoo"]);
+  });
+
+  it("breaks ties (and missing mtimes) by name so the result is stable", () => {
+    const nodes = [file("b.md", 5), file("a.md", 5), { ...file("c.md", 0), modified: undefined }];
+    expect(names(sortTree(nodes, "recent"))).toEqual(["a.md", "b.md", "c.md"]);
+  });
+
+  it("compares names naturally and case-insensitively", () => {
+    const nodes = [file("note 10.md", 1), file("note 9.md", 1), file("Note 1.md", 1)];
+    expect(names(sortTree(nodes, "name"))).toEqual(["Note 1.md", "note 9.md", "note 10.md"]);
+  });
+
+  it("sorts every level, not just the top", () => {
+    // "a.md" is oldest, so the two modes disagree — which is the point.
+    const tree = [dir("Work", 1, [file("Work/a.md", 1), file("Work/z.md", 9)])];
+    expect(names(sortTree(tree, "recent")[0].children!)).toEqual(["z.md", "a.md"]);
+    expect(names(sortTree(tree, "name")[0].children!)).toEqual(["a.md", "z.md"]);
+  });
+
+  it("does not mutate the input", () => {
+    const nodes = [file("b.md", 1), file("a.md", 2)];
+    const snapshot = names(nodes);
+    sortTree(nodes, "name");
+    expect(names(nodes)).toEqual(snapshot);
+  });
+});
+
+// The contract the whole feature rests on: changing the sort must never undo a
+// drag-and-drop arrangement, while still reaching everything nobody arranged.
+describe("sortTree + applyOrder — the two layers", () => {
+  // Inside Alpha, "a.md" is the OLDEST and "z.md" the newest, so the two sort
+  // modes must produce opposite orders there.
+  const build = () => [
+    dir("Alpha", 1, [file("Alpha/a.md", 10), file("Alpha/z.md", 90)]),
+    dir("Beta", 1, []),
+    file("loose.md", 50),
+  ];
+
+  it("keeps a hand-arranged root while sorting inside the folders", () => {
+    // The user dragged Beta above Alpha at the root — reversing the alphabetical
+    // order the sort would give — and never touched Alpha's contents.
+    const order = { "": ["Beta", "Alpha"] };
+
+    const recent = applyOrder(sortTree(build(), "recent"), "", order);
+    expect(names(recent).slice(0, 2)).toEqual(["Beta", "Alpha"]);
+    expect(names(recent.find((n) => n.name === "Alpha")!.children!)).toEqual([
+      "z.md",
+      "a.md",
+    ]);
+
+    // Flipping the sort rearranges the unpinned inside, and ONLY that: the root
+    // still reads Beta, Alpha.
+    const byName = applyOrder(sortTree(build(), "name"), "", order);
+    expect(names(byName).slice(0, 2)).toEqual(["Beta", "Alpha"]);
+    expect(names(byName.find((n) => n.name === "Alpha")!.children!)).toEqual([
+      "a.md",
+      "z.md",
+    ]);
+  });
+
+  it("leaves unranked siblings to the sort, after the pinned ones", () => {
+    // Only "loose.md" is pinned — to the top, above the folders it would
+    // normally sit below.
+    const out = applyOrder(sortTree(build(), "recent"), "", { "": ["loose.md"] });
+    expect(names(out)).toEqual(["loose.md", "Alpha", "Beta"]);
+  });
+});

--- a/app/apps/desktop/src/lib/tree/sort.ts
+++ b/app/apps/desktop/src/lib/tree/sort.ts
@@ -1,0 +1,65 @@
+// The sidebar's BASE arrangement — what the tree looks like before the user's
+// own drag-and-drop arrangement is layered on top of it.
+//
+// Two layers, and the order between them is the whole design:
+//
+//   sortTree()  →  the base order, from a preference (recent / A–Z)
+//   applyOrder() →  the user's manual per-folder arrangement, pinned on top
+//
+// Because `applyOrder` ranks the items a folder has been arranged with and
+// leaves every *unranked* item in the order it received, sorting first means
+// changing the sort can never disturb an arrangement someone made by hand: a
+// folder they dragged into place keeps its position, while the folders and
+// files they never touched — including everything inside that folder — follow
+// the sort. That is the property to preserve if this is ever refactored.
+//
+// Pure and dependency-free (the TreeNode import is type-only) so it tests in a
+// plain Node environment.
+
+import type { TreeNode } from "../ipc";
+
+/** How the sidebar arranges anything the user hasn't arranged themselves. */
+export type TreeSort = "recent" | "name";
+
+export const TREE_SORTS: Array<{ id: TreeSort; label: string; hint: string }> = [
+  { id: "recent", label: "Recently modified", hint: "Newest notes first" },
+  { id: "name", label: "Name (A–Z)", hint: "Alphabetical" },
+];
+
+/** Sidebar rows are titles, so compare them the way a reader would: "note 10"
+ *  after "note 9", case- and accent-insensitively. */
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
+function byName(a: TreeNode, b: TreeNode): number {
+  return collator.compare(a.name, b.name);
+}
+
+/**
+ * Sort a tree level (and, recursively, everything under it).
+ *
+ * Folders always come first and always sort A–Z, in BOTH modes. A folder's
+ * mtime moves whenever anything inside it does, so sorting folders by recency
+ * would shuffle the sidebar's skeleton every time a note is saved — the part of
+ * the tree a user navigates by muscle memory. Recency is a property of the
+ * notes, so that is where the mode applies. (This is also what "default to
+ * recent for the files, mostly not the folders" asks for.)
+ *
+ * Ties and missing mtimes (0/absent) fall back to name order, so the result is
+ * total and stable rather than dependent on what `read_dir` happened to yield.
+ */
+export function sortTree(nodes: TreeNode[], mode: TreeSort): TreeNode[] {
+  const dirs: TreeNode[] = [];
+  const files: TreeNode[] = [];
+  for (const n of nodes) (n.isDir ? dirs : files).push(n);
+
+  dirs.sort(byName);
+  files.sort(
+    mode === "name"
+      ? byName
+      : (a, b) => (b.modified ?? 0) - (a.modified ?? 0) || byName(a, b),
+  );
+
+  return [...dirs, ...files].map((n) =>
+    n.children ? { ...n, children: sortTree(n.children, mode) } : n,
+  );
+}

--- a/app/apps/desktop/src/lib/vault/__tests__/landing.test.ts
+++ b/app/apps/desktop/src/lib/vault/__tests__/landing.test.ts
@@ -152,3 +152,34 @@ describe("planLanding — an account with no vaults", () => {
     ).toEqual({ kind: "switch", orgId: "a" });
   });
 });
+
+// "Join a team" on the welcome screen runs sign-in/sign-up FIRST and then comes
+// back for the code, so the auth that just happened must not land the user
+// anywhere. Every case below would otherwise unmount the screen still holding
+// the flow — most damagingly the brand-new account, which is exactly who this
+// route is for and who would be handed an auto-created "My Vault" instead.
+describe("planLanding — mid join-with-code", () => {
+  it("does nothing for a brand-new account that would otherwise get one made", () => {
+    expect(plan({ joiningWithCode: true, createIfNone: true })).toEqual({
+      kind: "nothing",
+    });
+  });
+
+  it("does nothing for an existing account with vaults to restore", () => {
+    expect(
+      plan({
+        joiningWithCode: true,
+        orgIds: ["a", "b"],
+        activeOrganizationId: "a",
+        rememberedOrgId: "b",
+        createIfNone: true,
+      }),
+    ).toEqual({ kind: "nothing" });
+  });
+
+  it("outranks even an explicit open-this-vault request", () => {
+    expect(
+      plan({ joiningWithCode: true, orgIds: ["a"], requestedOrgId: "a" }),
+    ).toEqual({ kind: "nothing" });
+  });
+});

--- a/app/apps/desktop/src/lib/vault/landing.ts
+++ b/app/apps/desktop/src/lib/vault/landing.ts
@@ -37,11 +37,24 @@ export interface LandingInput {
   rememberedOrgId: string | null;
   /** May we create a vault for an account that has none? */
   createIfNone: boolean;
+  /**
+   * The user is part-way through "join a team with a code" on the welcome
+   * screen, which runs sign-in/sign-up first and then comes back for the code.
+   */
+  joiningWithCode?: boolean;
 }
 
 export function planLanding(input: LandingInput): LandingAction {
   const isMember = (id: string | null): id is string =>
     !!id && input.orgIds.includes(id);
+
+  // 0) Mid join-with-code: land NOWHERE. The welcome screen still owns this
+  //    flow and is waiting to ask for the code, and every branch below would
+  //    unmount it — a brand-new account would be handed an auto-created "My
+  //    Vault" (branch 6) and an existing one dropped into an old vault, either
+  //    way burying the step the user explicitly asked for. `joinVault` is this
+  //    flow's landing: it switches into the vault the code names.
+  if (input.joiningWithCode) return { kind: "nothing" };
 
   // 1) An explicit "open this vault" request (a remote vault clicked on the
   //    signed-out welcome screen, which routed through sign-in) wins over every

--- a/app/apps/desktop/src/main.tsx
+++ b/app/apps/desktop/src/main.tsx
@@ -12,10 +12,14 @@ import "@fontsource/jetbrains-mono/400.css";
 import "./styles/tokens.css";
 
 import App from "./App";
+import { initPlatform } from "./lib/platform";
 import { initTheme } from "./lib/theme";
 
 // Paint the persisted (or system) theme before the first render.
 initTheme();
+// Same deal for the platform flag: it sets the macOS traffic-light inset, and
+// applying it after the first paint would visibly shove the sidebar down.
+initPlatform();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -32,9 +32,12 @@ import {
   type ActivityStatus,
   readActivityStatus,
   readMentionSound,
+  readTreeSort,
   writeActivityStatus,
   writeMentionSound,
+  writeTreeSort,
 } from "./lib/prefs";
+import type { TreeSort } from "./lib/tree/sort";
 import { seedWelcomeContent, vaultIsEmpty, WELCOME_NOTE_PATH } from "./lib/vault/seed";
 import { planLanding } from "./lib/vault/landing";
 import { playJoinChime } from "./lib/celebrate/celebrate";
@@ -172,6 +175,9 @@ interface AppStore {
   activityStatus: ActivityStatus;
   /** Whether the mention chime plays when someone pings you. */
   mentionSound: boolean;
+  /** How the sidebar arranges everything the user hasn't arranged by hand.
+   *  Layered UNDER `itemOrder`, never replacing it — see `lib/tree/sort`. */
+  treeSort: TreeSort;
   /** Set briefly when a teammate joins the vault, to drive the celebration
    *  banner + confetti. `at` changes each time so a repeat join re-triggers it. */
   memberJoined: { name: string; at: number } | null;
@@ -179,6 +185,7 @@ interface AppStore {
   setVault: (v: ipc.VaultInfo | null) => void;
   setItemColor: (path: string, colorId: string | null) => void;
   setItemOrder: (order: ItemOrder) => void;
+  setTreeSort: (sort: TreeSort) => void;
   refreshTree: () => Promise<void>;
   /** Lazily load one folder's immediate children into the sidebar tree. */
   loadChildren: (path: string) => Promise<void>;
@@ -199,6 +206,12 @@ interface AppStore {
   signInWithGoogle: () => Promise<void>;
   signUp: (name: string, email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
+  /**
+   * Run the post-sign-in landing on demand, for a flow that deliberately
+   * suppressed it and then fell through (abandoning "join a team" after the
+   * sign-up it required). Same rules as signing in, `createIfNone` included.
+   */
+  landAfterAuth: () => Promise<void>;
   setServerUrl: (url: string) => Promise<void>;
 
   // Account profile & preferences
@@ -406,6 +419,17 @@ function takePendingOpenVault(): string | null {
   return id;
 }
 
+// A "join a team with a code" flow started from the welcome screen, which runs
+// sign-in/sign-up first. While it's armed the post-auth landing must put the
+// user NOWHERE: a brand-new account would otherwise be handed an auto-created
+// "My Vault" (and an existing account dropped into an old one), unmounting the
+// welcome screen and burying the code step the user explicitly asked for. The
+// landing is `joinVault` itself — it switches into the vault the code names.
+let joiningWithCode = false;
+export function requestJoinWithCode(on: boolean): void {
+  joiningWithCode = on;
+}
+
 // The vault the user was last actually working in (folder + org resolved
 // together). The server session carries an `activeOrganizationId`, but it can be
 // null (fresh session, 2+ orgs) and it doesn't know which *folder* to open — so
@@ -460,7 +484,10 @@ async function landInLastVault(
 ): Promise<void> {
   const action = planLanding({
     orgIds: get().organizations.map((o) => o.id),
+    // Consumed even when the join flow is about to override it: the join
+    // supersedes whatever open-request was pending.
     requestedOrgId: takePendingOpenVault(),
+    joiningWithCode,
     openPath: get().vault?.path ?? null,
     orgVaults: readOrgVaults(),
     activeOrganizationId: get().session?.activeOrganizationId ?? null,
@@ -618,6 +645,7 @@ export const useStore = create<AppStore>((set, get) => ({
   orgBilling: null,
   activityStatus: readActivityStatus(),
   mentionSound: readMentionSound(),
+  treeSort: readTreeSort(),
   memberJoined: null,
 
   setVault: (v) => {
@@ -646,6 +674,15 @@ export const useStore = create<AppStore>((set, get) => ({
     if (!vault) return;
     writeItemOrder(vault.path, order);
     set({ itemOrder: order });
+  },
+
+  setTreeSort: (sort) => {
+    // Deliberately does NOT touch `itemOrder`: the sort is the layer beneath a
+    // hand-made arrangement, so switching it rearranges only what the user
+    // never arranged. Unlike the vault-scoped prefs above it needs no open
+    // vault — it's a device preference.
+    writeTreeSort(sort);
+    set({ treeSort: sort });
   },
 
   refreshTree: async () => {
@@ -1019,6 +1056,13 @@ export const useStore = create<AppStore>((set, get) => ({
     });
   },
 
+  landAfterAuth: async () => {
+    // Callers reach here only after disarming whatever suppressed the landing
+    // in the first place — otherwise planLanding still answers "nothing".
+    await landInLastVault(get, { createIfNone: true });
+    await get().openWelcomeIfPresent();
+  },
+
   setServerUrl: async (url) => {
     set({ authError: null });
     const session = await authManager.setServerUrl(url);
@@ -1390,6 +1434,10 @@ export const useStore = create<AppStore>((set, get) => ({
 
   joinVault: async (code) => {
     const joined = await authManager.api.joinVault(code.trim());
+    // The code was good, so the welcome screen's join flow is over: disarm the
+    // landing suppression before switching in (it's module state, and leaving it
+    // armed would silently strand the NEXT sign-in on the welcome screen).
+    requestJoinWithCode(false);
     await get().setActiveOrganization(joined.organizationId);
     // The joiner sees the celebration too (their vault channel connects after
     // the server broadcast, so they'd otherwise miss the live push).

--- a/app/apps/desktop/src/styles/tokens.css
+++ b/app/apps/desktop/src/styles/tokens.css
@@ -81,6 +81,13 @@
   --sp-8: 32px;
   --sp-10: 40px;
 
+  /* Height to keep clear at the very top of the window for system window
+     controls. Zero everywhere the OS still draws its own title bar above the
+     webview; only macOS runs `titleBarStyle: "Overlay"`, where the webview owns
+     the full height and the traffic lights float over our top-left corner.
+     `[data-platform]` is stamped on <html> by `lib/platform.ts`. */
+  --titlebar-inset: 0px;
+
   /* Typography */
   --font-body: "Open Sauce Two", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-display: "Radio Canada Big", "Open Sauce Two", -apple-system, sans-serif;
@@ -104,6 +111,14 @@
   /* How the editor's selection layer blends over content (see theme.ts
      .cm-selectionLayer): darken on light, lighten on dark. */
   --selection-blend: multiply;
+}
+
+/* Traffic lights are ~12px tall centred around y≈19, so 28px clears them —
+   the same strip macOS would have reserved for itself before we took the
+   title bar over. Deliberately outside the theme blocks: it's a property of
+   the host OS, not of light/dark. */
+:root[data-platform="macos"] {
+  --titlebar-inset: 28px;
 }
 
 /* ---- Dark theme tokens (shared by explicit toggle + system fallback) ---- */


### PR DESCRIPTION
Ships as **0.1.21** (all four version files bumped, so `release.yml`'s `gate` job will publish).

## Sidebar arrangement

The tree can now be arranged by **Recently modified** (the new default) or **Name (A–Z)**.

- `tree.rs` reports an mtime on every entry, from both the eager and the lazy listing — a missing one in the lazy path would silently sink a whole folder to the bottom once expanded.
- `lib/tree/sort.ts` is the base order; the user's manual per-folder drag arrangement is layered on top, so changing the sort never disturbs a folder someone placed by hand.
- The preference is device-level rather than per-vault — it's a habit about reading a sidebar, and flipping as you switch vaults would be its own surprise.

## Graph view

Colour derivation, the force simulation, the worker and the WebGL renderer all reworked, with new coverage for `graphColor`, `simulation` and `webglRenderer`.

## Join a team with a code

Redeeming a teammate's code from the welcome screen no longer detours through a vault you didn't want. Joining is a server action, so signed-out users still sign in first — but `planLanding` now suppresses the post-auth landing while that round trip is in flight. Previously a brand-new account was handed an auto-created "My Vault" and dropped into it, leaving the user to hunt for the code box in Vault settings.

## Full-height window (no title bar)

The macOS title bar strip was pure overhead — the app already draws its own header row directly beneath it.

- `titleBarStyle: "Overlay"` hands the webview the full window height; the traffic lights float over the sidebar and the main header row moves up into the reclaimed ~28px.
- A `--titlebar-inset` token (0 by default, 28px on macOS) keeps the sidebar header and the graph overlay's floating bar clear of the traffic lights. Windows and Linux still get a real system title bar above the webview, where reserving that space would just re-add the dead strip.
- Overlay costs you window dragging, so both header rows carry `data-tauri-drag-region="deep"` and the vault picker gets its own strip — without it the window would be unmovable before a vault is open.
- **`core:window:allow-start-dragging` had to be granted explicitly.** `core:default` covers only read-only window commands, so the drag regions matched correctly but the IPC they fire was denied by the ACL: the rows looked draggable and silently did nothing.

## Verification

- Desktop TS: 489 passed, 12 skipped.
- Desktop Rust: 80 tests, all green.
- `tsc --noEmit` clean.
- Window chrome checked in a running dev build: title bar gone, traffic lights clear of both the sidebar header and the graph bar. The drag path was confirmed end to end from inside the app — mousedown lands on the region, Tauri's matcher returns `DRAG (deep)`, and `start_dragging` resolves as allowed.
