### PR TITLE
Fix multi-vault sync, the auto-created vault on sign-in, and the stale welcome-screen list (0.1.22)

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.21"
+version = "0.1.22"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -81,6 +81,10 @@ function tidyPath(path: string): string {
 
 export function VaultPicker() {
   const authStatus = useStore((s) => s.authStatus);
+  // The live vault list. Signed in, this is the truth and the cache below is
+  // only its mirror; signed out it is empty and the cache is all we have.
+  const organizations = useStore((s) => s.organizations);
+  const serverUrl = useStore((s) => s.serverUrl);
   // Sign-in succeeded and a vault is being resolved/created. There's no vault
   // yet, so App still renders this screen — and without saying so, a sign-in
   // that is working looks identical to one that silently did nothing.
@@ -115,6 +119,13 @@ export function VaultPicker() {
   const reduceMotion = useReducedMotion();
 
   // Surface recently opened vaults as one-tap "reopen" affordances.
+  //
+  // Re-read whenever the vault set changes, NOT just on mount. Deleting your
+  // last vaults leaves this screen mounted the whole time (App renders it as
+  // soon as `vault` goes null), so a mount-only load left the deleted vaults
+  // listed until the app was reloaded — the deletion looked like it hadn't
+  // worked. `organizations` and `authStatus` are the store's account-level
+  // signals; both change on delete, sign-out and server switch.
   useEffect(() => {
     let alive = true;
     (async () => {
@@ -128,7 +139,7 @@ export function VaultPicker() {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [organizations, authStatus]);
 
   // If this screen goes away mid-join (a vault opened by some other route),
   // the landing suppression must not outlive it. A *successful* join disarms
@@ -327,7 +338,14 @@ export function VaultPicker() {
   // Local recents backing a synced vault are folded into the remote row (by
   // path) so nothing shows twice.
   const entries = useMemo<PickerEntry[]>(() => {
-    const known = readKnownVaults();
+    // Signed in, the store's list is authoritative — reading the cache here
+    // would resurrect a vault deleted moments ago, because the cache is only
+    // rewritten by the next `refreshVault`. Signed out, the cache is the point:
+    // it is what lets this screen still offer your synced vaults.
+    const known =
+      authStatus === "signed-in"
+        ? organizations.map((o) => ({ id: o.id, name: o.name }))
+        : readKnownVaults(serverUrl);
     const orgVaults = readOrgVaults();
     const boundPaths = new Set(Object.values(orgVaults));
     const remote: PickerEntry[] = known.map((w) => ({
@@ -347,7 +365,7 @@ export function VaultPicker() {
         openedAt: r.openedAt,
       }));
     return [...remote, ...local];
-  }, [recents]);
+  }, [recents, organizations, authStatus, serverUrl]);
 
   // Show the 3 most recent by default; the rest hide behind "Load more".
   const RECENT_LIMIT = 3;

--- a/app/apps/desktop/src/lib/__tests__/serverUrl.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/serverUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveServerUrl,
+  DEFAULT_SERVER_URL,
+  LOCAL_SERVER_URL,
+  PRODUCTION_SERVER_URL,
+} from "../api";
+
+// Vitest runs with import.meta.env.DEV === true, which is exactly the mode
+// these rules are about: a dev build must never end up talking to production
+// just because the URL was persisted once.
+describe("resolveServerUrl (dev build)", () => {
+  it("defaults to the local stack when nothing is persisted", () => {
+    expect(DEFAULT_SERVER_URL).toBe(LOCAL_SERVER_URL);
+    expect(resolveServerUrl(null)).toBe(LOCAL_SERVER_URL);
+    expect(resolveServerUrl("")).toBe(LOCAL_SERVER_URL);
+    expect(resolveServerUrl("   ")).toBe(LOCAL_SERVER_URL);
+  });
+
+  it("ignores a persisted production URL", () => {
+    // The reported state: config.json held api.baalda.com, so every launch of
+    // `pnpm dev:desktop` was reading and writing real vaults.
+    expect(resolveServerUrl(PRODUCTION_SERVER_URL)).toBe(LOCAL_SERVER_URL);
+    expect(resolveServerUrl("https://api.baalda.com/")).toBe(LOCAL_SERVER_URL);
+  });
+
+  it("honours any other persisted server", () => {
+    // Staging / LAN / self-host overrides must keep working from Settings.
+    expect(resolveServerUrl("https://staging.example.com")).toBe(
+      "https://staging.example.com",
+    );
+    expect(resolveServerUrl("http://192.168.1.20:3010/")).toBe(
+      "http://192.168.1.20:3010",
+    );
+    expect(resolveServerUrl("http://localhost:4000")).toBe("http://localhost:4000");
+  });
+});

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -24,9 +24,40 @@
 // localhost:3010 meant a fresh install could only ever report "Load failed"
 // until the user found Server settings on their own. Self-hosters override it
 // there; nothing here is pinned at build time beyond this default.
-export const DEFAULT_SERVER_URL = import.meta.env.DEV
-  ? "http://localhost:3010"
-  : "https://api.baalda.com";
+/** The managed instance. Named so the dev guard below can recognise it. */
+export const PRODUCTION_SERVER_URL = "https://api.baalda.com";
+export const LOCAL_SERVER_URL = "http://localhost:3010";
+
+/** Explicit opt-out of everything below: `VITE_SERVER_URL=… pnpm dev:desktop`. */
+const ENV_SERVER_URL =
+  (import.meta.env.VITE_SERVER_URL as string | undefined)?.trim() || null;
+
+export const DEFAULT_SERVER_URL =
+  ENV_SERVER_URL ?? (import.meta.env.DEV ? LOCAL_SERVER_URL : PRODUCTION_SERVER_URL);
+
+/**
+ * The server to actually talk to, given whatever URL was persisted in the app
+ * config (Settings → Connection writes it, and it survives across launches).
+ *
+ * A dev build IGNORES a persisted production URL. That combination is not a
+ * preference, it's an accident with real consequences: `pnpm dev:desktop`
+ * pointed at the managed instance reads and WRITES real users' vaults, and
+ * because the URL is persisted per-device it silently stays that way across
+ * every later launch — you only notice when local changes fail to appear in
+ * a local Postgres that was never being used.
+ *
+ * Any OTHER persisted URL is honoured, so switching a dev build to a staging or
+ * LAN server from Settings still works; only "dev build → production" is
+ * refused, and `VITE_SERVER_URL=https://api.baalda.com` re-enables even that.
+ */
+export function resolveServerUrl(persisted: string | null | undefined): string {
+  const clean = stripTrailingSlash((persisted ?? "").trim());
+  if (!clean) return DEFAULT_SERVER_URL;
+  if (import.meta.env.DEV && !ENV_SERVER_URL && clean === PRODUCTION_SERVER_URL) {
+    return DEFAULT_SERVER_URL;
+  }
+  return clean;
+}
 
 // ---- Types (mirror the server's JSON) -------------------------------------
 

--- a/app/apps/desktop/src/lib/auth/authManager.ts
+++ b/app/apps/desktop/src/lib/auth/authManager.ts
@@ -5,7 +5,13 @@
 // Session tokens are captured from Better Auth's `set-auth-token` header and
 // stored ONLY in the OS keychain — never localStorage/plaintext.
 
-import { ApiClient, DEFAULT_SERVER_URL, type AuthUser, type SessionInfo } from "../api";
+import {
+  ApiClient,
+  DEFAULT_SERVER_URL,
+  resolveServerUrl,
+  type AuthUser,
+  type SessionInfo,
+} from "../api";
 import * as ipc from "../ipc";
 
 /**
@@ -55,11 +61,12 @@ export class AuthManager {
    */
   async init(): Promise<SessionInfo | null> {
     try {
-      const url = await ipc.getServerUrl();
-      if (url) {
-        this.serverUrl = stripSlash(url);
-        this.api.setBaseUrl(this.serverUrl);
-      }
+      // `resolveServerUrl` — not the raw persisted value — so a dev build that
+      // was once pointed at the managed instance doesn't silently keep talking
+      // to production on every later launch.
+      const url = resolveServerUrl(await ipc.getServerUrl());
+      this.serverUrl = stripSlash(url);
+      this.api.setBaseUrl(this.serverUrl);
     } catch {
       /* config unavailable — fall back to the default URL */
     }

--- a/app/apps/desktop/src/lib/vault/__tests__/landing.test.ts
+++ b/app/apps/desktop/src/lib/vault/__tests__/landing.test.ts
@@ -13,7 +13,6 @@ const base: LandingInput = {
   orgVaults: {},
   activeOrganizationId: null,
   rememberedOrgId: null,
-  createIfNone: false,
 };
 const plan = (over: Partial<LandingInput>) => planLanding({ ...base, ...over });
 
@@ -73,7 +72,6 @@ describe("planLanding — a folder is already open", () => {
         orgVaults: { a: "/v/a" },
         activeOrganizationId: "a",
         rememberedOrgId: "b",
-        createIfNone: true,
       }),
     ).toEqual({ kind: "stay-local" });
   });
@@ -122,18 +120,21 @@ describe("planLanding — nothing open", () => {
 });
 
 describe("planLanding — an account with no vaults", () => {
-  it("creates the first vault when the caller allows it", () => {
-    expect(plan({ createIfNone: true })).toEqual({ kind: "create-first-vault" });
+  it("lands on the welcome screen rather than inventing a vault", () => {
+    // Regression: this used to answer `create-first-vault` for an explicit
+    // sign-in, so deleting every vault and signing in again silently conjured
+    // "My Vault" and dropped the user inside it — the deletion looked like it
+    // had failed. The welcome screen offers New vault / Open existing / Join a
+    // team, so landing there is a destination, not a dead end.
+    expect(plan({})).toEqual({ kind: "nothing" });
   });
 
   it("does nothing on a silent session restore at launch", () => {
-    // `createIfNone` is false there on purpose: "I just signed in" earns a
-    // vault, "the app reopened" does not.
-    expect(plan({ createIfNone: false })).toEqual({ kind: "nothing" });
+    expect(plan({})).toEqual({ kind: "nothing" });
   });
 
   it("never creates a vault while a local folder is open", () => {
-    expect(plan({ openPath: "/somewhere/local", createIfNone: true })).toEqual({
+    expect(plan({ openPath: "/somewhere/local" })).toEqual({
       kind: "stay-local",
     });
   });
@@ -142,13 +143,13 @@ describe("planLanding — an account with no vaults", () => {
     // Falls through the restore chain with no vault to restore. Creating one
     // here would swap out the files the user is looking at.
     expect(
-      plan({ openPath: "/v/gone", orgVaults: { gone: "/v/gone" }, createIfNone: true }),
+      plan({ openPath: "/v/gone", orgVaults: { gone: "/v/gone" } }),
     ).toEqual({ kind: "nothing" });
   });
 
   it("never creates a vault when the user asked for one they're a member of", () => {
     expect(
-      plan({ orgIds: ["a"], requestedOrgId: "a", createIfNone: true }),
+      plan({ orgIds: ["a"], requestedOrgId: "a" }),
     ).toEqual({ kind: "switch", orgId: "a" });
   });
 });
@@ -160,7 +161,7 @@ describe("planLanding — an account with no vaults", () => {
 // route is for and who would be handed an auto-created "My Vault" instead.
 describe("planLanding — mid join-with-code", () => {
   it("does nothing for a brand-new account that would otherwise get one made", () => {
-    expect(plan({ joiningWithCode: true, createIfNone: true })).toEqual({
+    expect(plan({ joiningWithCode: true })).toEqual({
       kind: "nothing",
     });
   });
@@ -172,7 +173,6 @@ describe("planLanding — mid join-with-code", () => {
         orgIds: ["a", "b"],
         activeOrganizationId: "a",
         rememberedOrgId: "b",
-        createIfNone: true,
       }),
     ).toEqual({ kind: "nothing" });
   });

--- a/app/apps/desktop/src/lib/vault/__tests__/turnOnSync.test.ts
+++ b/app/apps/desktop/src/lib/vault/__tests__/turnOnSync.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { planTurnOnSync } from "../turnOnSync";
+
+describe("planTurnOnSync", () => {
+  it("creates a vault for a folder nothing is bound to", () => {
+    expect(
+      planTurnOnSync({
+        openPath: "/vaults/notes",
+        activeOrganizationId: null,
+        orgIds: [],
+        orgVaults: {},
+      }),
+    ).toEqual({ kind: "create-vault" });
+  });
+
+  it("retries the active vault when the open folder is its own folder", () => {
+    // Sync is off for a folder that IS the active vault's — enabling it failed,
+    // so this is a recovery, not a creation.
+    expect(
+      planTurnOnSync({
+        openPath: "/vaults/team",
+        activeOrganizationId: "org-a",
+        orgIds: ["org-a"],
+        orgVaults: { "org-a": "/vaults/team" },
+      }),
+    ).toEqual({ kind: "retry-active", orgId: "org-a" });
+  });
+
+  it("switches instead of creating when another vault owns the open folder", () => {
+    // Adopting this folder for a new vault would evict org-a's binding.
+    expect(
+      planTurnOnSync({
+        openPath: "/vaults/a",
+        activeOrganizationId: "org-b",
+        orgIds: ["org-a", "org-b"],
+        orgVaults: { "org-a": "/vaults/a", "org-b": "/vaults/b" },
+      }),
+    ).toEqual({ kind: "switch", orgId: "org-a" });
+  });
+
+  it("creates a vault for a folder bound to a vault we were removed from", () => {
+    // A stale binding must not pin the folder to a vault that can never sync.
+    expect(
+      planTurnOnSync({
+        openPath: "/vaults/old",
+        activeOrganizationId: "org-b",
+        orgIds: ["org-b"],
+        orgVaults: { "org-gone": "/vaults/old", "org-b": "/vaults/b" },
+      }),
+    ).toEqual({ kind: "create-vault" });
+  });
+
+  /**
+   * The reported bug, as a sequence: make a vault, then make another, then a
+   * third. `activeOrganizationId` survives opening each new local folder, so
+   * the old account-level guard matched every time from vault 2 onward and
+   * re-synced each new folder into vault 1 — orphaning the previous folder and
+   * never putting the new vault on the account.
+   */
+  it("creates a distinct vault for each new folder in a row", () => {
+    const orgVaults: Record<string, string> = {};
+    const orgIds: string[] = [];
+    let activeOrganizationId: string | null = null;
+
+    for (const [i, openPath] of ["/vaults/one", "/vaults/two", "/vaults/three"].entries()) {
+      const plan = planTurnOnSync({ openPath, activeOrganizationId, orgIds, orgVaults });
+      expect(plan, `vault ${i + 1} must be created, not folded into an existing one`).toEqual({
+        kind: "create-vault",
+      });
+      // What the store does on a create: new org, bound to this folder, now active.
+      const orgId = `org-${i + 1}`;
+      orgIds.push(orgId);
+      orgVaults[orgId] = openPath;
+      activeOrganizationId = orgId;
+    }
+
+    // Three vaults, three folders, no binding overwritten.
+    expect(orgVaults).toEqual({
+      "org-1": "/vaults/one",
+      "org-2": "/vaults/two",
+      "org-3": "/vaults/three",
+    });
+    expect(new Set(Object.values(orgVaults)).size).toBe(3);
+  });
+
+  it("still retries after a failed sync on the vault just created", () => {
+    // Immediately after the create above: same folder, now bound and active.
+    expect(
+      planTurnOnSync({
+        openPath: "/vaults/three",
+        activeOrganizationId: "org-3",
+        orgIds: ["org-1", "org-2", "org-3"],
+        orgVaults: {
+          "org-1": "/vaults/one",
+          "org-2": "/vaults/two",
+          "org-3": "/vaults/three",
+        },
+      }),
+    ).toEqual({ kind: "retry-active", orgId: "org-3" });
+  });
+});

--- a/app/apps/desktop/src/lib/vault/landing.ts
+++ b/app/apps/desktop/src/lib/vault/landing.ts
@@ -17,8 +17,6 @@ export type LandingAction =
   | { kind: "switch"; orgId: string }
   /** A local-only folder is open; leave the user in it. */
   | { kind: "stay-local" }
-  /** The account has no vaults — create its first one and open that. */
-  | { kind: "create-first-vault" }
   /** Nothing to do (and nothing we're allowed to invent). */
   | { kind: "nothing" };
 
@@ -35,8 +33,6 @@ export interface LandingInput {
   activeOrganizationId: string | null;
   /** The last vault used on this device. */
   rememberedOrgId: string | null;
-  /** May we create a vault for an account that has none? */
-  createIfNone: boolean;
   /**
    * The user is part-way through "join a team with a code" on the welcome
    * screen, which runs sign-in/sign-up first and then comes back for the code.
@@ -105,11 +101,16 @@ export function planLanding(input: LandingInput): LandingAction {
   //    than none. The first, matching that single-vault auto-activation.
   if (input.orgIds.length > 0) return { kind: "switch", orgId: input.orgIds[0] };
 
-  // 6) Signed in with no vaults at all — a brand-new account. Nothing can be
-  //    restored, so make the vault the account obviously needs. Only when the
-  //    screen is genuinely empty: creating a vault swaps the open folder for a
-  //    new one, which is never right while the user is looking at files.
-  return input.createIfNone && !input.openPath
-    ? { kind: "create-first-vault" }
-    : { kind: "nothing" };
+  // 6) Signed in with no vaults at all. Land NOWHERE, which means the welcome
+  //    screen — "New vault", "Open existing" and "Join a team" are all there,
+  //    so it is a real destination, not a dead end.
+  //
+  //    This used to auto-create a vault called "My Vault" whenever the caller
+  //    was an explicit sign-in/sign-up. That reads as the app inventing a vault
+  //    behind your back: delete every vault you have, and the next sign-in
+  //    silently conjures one and drops you inside it — the deletion looks like
+  //    it failed, and the phantom then persists in the welcome screen's cached
+  //    vault list. Making a vault is a decision with a name attached, so it
+  //    belongs to the button the user presses.
+  return { kind: "nothing" };
 }

--- a/app/apps/desktop/src/lib/vault/turnOnSync.ts
+++ b/app/apps/desktop/src/lib/vault/turnOnSync.ts
@@ -1,0 +1,71 @@
+// What "Turn on sync" should actually do for the folder that's open right now.
+//
+// This used to be an inline guard in `store.turnOnSyncForCurrentVault` that
+// asked "does the account have an active vault I'm a member of?" and, if so,
+// re-synced the open folder into it. That question is right for exactly one
+// case and wrong for the common one: `activeOrganizationId` is an ACCOUNT-level
+// pointer that survives opening a plain local folder (nothing in the local-open
+// path clears it), so from the second vault onward the answer was always yes.
+// Creating a second vault therefore synced its folder into the FIRST vault and
+// re-pointed that vault's folder binding at it — the first vault's folder was
+// orphaned back into the "Local" list, the new vault never reached the account,
+// and by the third round three folders had been reconciled into one server
+// vault with three colliding `Welcome.md`s.
+//
+// The question that distinguishes the cases is about the FOLDER, not the
+// account: is the folder I'm looking at already some vault's folder? That is
+// the same signal `planLanding` uses (branches 2 and 3), and the two should be
+// read together — they answer "which vault does this folder belong to?" for the
+// launch path and the turn-on-sync path respectively.
+//
+// Pure: no store, no IPC.
+
+/** What the caller should do. */
+export type TurnOnSyncAction =
+  /**
+   * The open folder is already the ACTIVE vault's folder, so sync is off
+   * because enabling it failed — retry that vault. Creating a vault must never
+   * be the recovery path for a failed sync: an invited user whose sync fell
+   * through a stale/error path would otherwise click the only affordance on
+   * screen and silently land in a brand-new empty vault of their own instead of
+   * the one they were invited to.
+   */
+  | { kind: "retry-active"; orgId: string }
+  /**
+   * The open folder belongs to a vault that isn't the active one — switch to
+   * it rather than creating anything. Without this, adopting the folder for a
+   * new vault would evict the binding of the vault that already owns it, which
+   * is the same defect in a different disguise.
+   */
+  | { kind: "switch"; orgId: string }
+  /** The folder belongs to no vault — this is a genuinely new vault. */
+  | { kind: "create-vault" };
+
+export interface TurnOnSyncInput {
+  /** The local folder open right now. */
+  openPath: string;
+  /** `session.activeOrganizationId` — an account-level pointer, not a folder one. */
+  activeOrganizationId: string | null;
+  /** Vaults we are currently a member of. */
+  orgIds: readonly string[];
+  /** Persisted { orgId → local folder } bindings. */
+  orgVaults: Readonly<Record<string, string>>;
+}
+
+export function planTurnOnSync(input: TurnOnSyncInput): TurnOnSyncAction {
+  // Which vault, if any, already calls this folder its own.
+  const boundOrg =
+    Object.entries(input.orgVaults).find(([, p]) => p === input.openPath)?.[0] ??
+    null;
+
+  // A binding to a vault we've since been REMOVED from is stale and must not
+  // pin the folder to a vault that can never sync again — fall through and let
+  // the folder become a new vault, exactly as `planLanding` branch 3 does.
+  if (boundOrg && input.orgIds.includes(boundOrg)) {
+    return boundOrg === input.activeOrganizationId
+      ? { kind: "retry-active", orgId: boundOrg }
+      : { kind: "switch", orgId: boundOrg };
+  }
+
+  return { kind: "create-vault" };
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -40,6 +40,7 @@ import {
 import type { TreeSort } from "./lib/tree/sort";
 import { seedWelcomeContent, vaultIsEmpty, WELCOME_NOTE_PATH } from "./lib/vault/seed";
 import { planLanding } from "./lib/vault/landing";
+import { planTurnOnSync } from "./lib/vault/turnOnSync";
 import { playJoinChime } from "./lib/celebrate/celebrate";
 import { viewingDocId } from "./lib/presence/viewingDocId";
 
@@ -209,7 +210,7 @@ interface AppStore {
   /**
    * Run the post-sign-in landing on demand, for a flow that deliberately
    * suppressed it and then fell through (abandoning "join a team" after the
-   * sign-up it required). Same rules as signing in, `createIfNone` included.
+   * sign-up it required). Same rules as signing in.
    */
   landAfterAuth: () => Promise<void>;
   setServerUrl: (url: string) => Promise<void>;
@@ -382,17 +383,36 @@ function forgetOrgVault(orgId: string): void {
 // folder to reopen + resync) instead of only local folders. Refreshed on every
 // refreshVault and — deliberately — KEPT across sign-out (that's the whole
 // point: you can pick a synced vault to sign back into).
+// Namespaced by server: vault ids and names belong to ONE instance, so a cache
+// shared across servers shows the managed instance's vaults while the app is
+// pointed at localhost (offering to open vaults that don't exist there, under
+// ids that will never resolve). The un-suffixed key is read once as a fallback
+// so an existing install doesn't lose its list on upgrade.
 const KNOWN_VAULTS_KEY = "context.knownVaults";
+const knownVaultsKey = (serverUrl: string) => `${KNOWN_VAULTS_KEY}:${serverUrl}`;
 
 export interface KnownVault {
   id: string;
   name: string;
 }
 
-export function readKnownVaults(): KnownVault[] {
+export function readKnownVaults(serverUrl = authManager.getServerUrl()): KnownVault[] {
+  const parse = (raw: string | null): KnownVault[] | null => {
+    try {
+      const v = JSON.parse(raw ?? "");
+      return Array.isArray(v) ? (v as KnownVault[]) : null;
+    } catch {
+      return null;
+    }
+  };
   try {
-    const raw = JSON.parse(localStorage.getItem(KNOWN_VAULTS_KEY) ?? "[]");
-    return Array.isArray(raw) ? (raw as KnownVault[]) : [];
+    return (
+      parse(localStorage.getItem(knownVaultsKey(serverUrl))) ??
+      // Pre-namespacing installs kept one list; adopt it rather than showing an
+      // empty welcome screen on the upgrade launch.
+      parse(localStorage.getItem(KNOWN_VAULTS_KEY)) ??
+      []
+    );
   } catch {
     return [];
   }
@@ -400,7 +420,7 @@ export function readKnownVaults(): KnownVault[] {
 
 function writeKnownVaults(list: KnownVault[]): void {
   try {
-    localStorage.setItem(KNOWN_VAULTS_KEY, JSON.stringify(list));
+    localStorage.setItem(knownVaultsKey(authManager.getServerUrl()), JSON.stringify(list));
   } catch {
     /* quota/unavailable — the cache is a convenience only */
   }
@@ -472,16 +492,12 @@ function forgetLastVault(orgId?: string): void {
  * back to syncing the open local vault when there's nothing to restore.
  *
  * The choice itself is `planLanding` (pure, unit-tested in `lib/vault/landing`);
- * this is only its dispatcher. Signing in must ALWAYS end somewhere — never
- * back on the signed-out welcome screen — so `createIfNone` is passed by the
- * explicit auth actions (sign-in / sign-up / Google) but NOT by silent session
- * restore at launch: "I just signed in" is a good reason to be given a vault,
- * "the app reopened" is not.
+ * this is only its dispatcher. An account with no vaults lands on the welcome
+ * screen — it offers "New vault", "Open existing" and "Join a team", so it is a
+ * destination rather than a dead end, and the app never invents a vault the
+ * user didn't ask for.
  */
-async function landInLastVault(
-  get: () => AppStore,
-  opts: { createIfNone?: boolean } = {},
-): Promise<void> {
+async function landInLastVault(get: () => AppStore): Promise<void> {
   const action = planLanding({
     orgIds: get().organizations.map((o) => o.id),
     // Consumed even when the join flow is about to override it: the join
@@ -492,7 +508,6 @@ async function landInLastVault(
     orgVaults: readOrgVaults(),
     activeOrganizationId: get().session?.activeOrganizationId ?? null,
     rememberedOrgId: readLastVault(),
-    createIfNone: opts.createIfNone ?? false,
   });
   // Only the two actions that end with a vault on screen raise the flag, and
   // only while they run: `stay-local`/`nothing` change nothing, so claiming to
@@ -507,31 +522,11 @@ async function landInLastVault(
       case "switch":
         await get().setActiveOrganization(action.orgId);
         return;
-      case "create-first-vault":
-        // `createOrganization` routes through the switch path, so the new vault
-        // gets a folder under the vaults root, turns sync on, and the reconcile
-        // seeds welcome content into it. Failure is not fatal — the vault cap
-        // (402) or an offline server just leaves the picker up, where "New vault"
-        // still works — so it must never reject out of the sign-in itself.
-        try {
-          await get().createOrganization(FIRST_VAULT_NAME);
-        } catch (e) {
-          console.warn("[vault] could not create a first vault on sign-in", e);
-        }
-        return;
     }
   } finally {
     useStore.setState({ landingVault: false });
   }
 }
-
-/**
- * Name for the vault auto-created on a first sign-in. Deliberately not derived
- * from the user's name: the display name becomes the folder slug
- * (`uniqueFolderSlug`), and "Naveed's Vault" lands on disk as `naveed-s-vault`.
- * Renaming a vault is one click in Vault Settings.
- */
-const FIRST_VAULT_NAME = "My Vault";
 
 /** Auto-dismiss timer for the member-joined celebration (module-scoped so a
  *  repeat join resets it rather than stacking). */
@@ -967,7 +962,7 @@ export const useStore = create<AppStore>((set, get) => ({
         // Open the vault they last used, rather than making them pick one — and
         // if the account has none yet, make one. Signing in never dead-ends back
         // on the welcome screen.
-        await landInLastVault(get, { createIfNone: true });
+        await landInLastVault(get);
         await get().refreshOrgBilling();
         await get().openWelcomeIfPresent();
       }
@@ -990,7 +985,7 @@ export const useStore = create<AppStore>((set, get) => ({
       await get().refreshBillingConfig();
       // Same as email sign-in: land in a vault, creating the first one if the
       // account has none.
-      await landInLastVault(get, { createIfNone: true });
+      await landInLastVault(get);
       await get().refreshOrgBilling();
       await get().openWelcomeIfPresent();
     }
@@ -1009,7 +1004,7 @@ export const useStore = create<AppStore>((set, get) => ({
         // creates their first vault and opens it. Sign-up used to skip landing
         // entirely, which is why signing up from the welcome screen returned you
         // to the welcome screen.
-        await landInLastVault(get, { createIfNone: true });
+        await landInLastVault(get);
         await get().refreshOrgBilling();
         await get().openWelcomeIfPresent();
       }
@@ -1059,7 +1054,7 @@ export const useStore = create<AppStore>((set, get) => ({
   landAfterAuth: async () => {
     // Callers reach here only after disarming whatever suppressed the landing
     // in the first place — otherwise planLanding still answers "nothing".
-    await landInLastVault(get, { createIfNone: true });
+    await landInLastVault(get);
     await get().openWelcomeIfPresent();
   },
 
@@ -1205,24 +1200,31 @@ export const useStore = create<AppStore>((set, get) => ({
   turnOnSyncForCurrentVault: async (name) => {
     const vault = get().vault;
     if (!vault) throw new Error("Open a vault first.");
-    // Already a member of an active vault? Then sync is off because enabling it
-    // FAILED, not because there's nowhere to sync to — so retry that vault
-    // instead of creating a new one.
-    //
-    // This guard exists because the alternative is the worst bug in the join
-    // flow: an invited user whose `enableSyncForVault` fell through one of its
-    // stale/error paths sees "Turn on sync", clicks the only affordance
-    // offered, and silently lands in a brand-new empty vault of their own
-    // rather than the one they were invited to. Creating an org must be a
-    // deliberate act, never the recovery path for a failed sync.
-    const activeOrgId = get().session?.activeOrganizationId;
-    if (activeOrgId && get().organizations.some((o) => o.id === activeOrgId)) {
+    // Which vault this folder belongs to (if any) decides what happens — NOT
+    // whether the account happens to have an active vault. See `planTurnOnSync`
+    // for why: `activeOrganizationId` survives opening a plain local folder, so
+    // an account-level test matched from the second vault onward and folded
+    // every new folder into the first vault.
+    const plan = planTurnOnSync({
+      openPath: vault.path,
+      activeOrganizationId: get().session?.activeOrganizationId ?? null,
+      orgIds: get().organizations.map((o) => o.id),
+      orgVaults: readOrgVaults(),
+    });
+    if (plan.kind === "retry-active") {
       await get().enableSyncForVault();
       if (!get().syncEnabled) {
         throw new Error(
           "Couldn't connect to this vault. Check your connection and try again.",
         );
       }
+      return;
+    }
+    if (plan.kind === "switch") {
+      // The folder is another vault's. Activating that vault re-opens this same
+      // folder and syncs it, which is what the user asked for; creating a vault
+      // here would steal the folder from the one that already owns it.
+      await get().setActiveOrganization(plan.orgId);
       return;
     }
     // This binds the folder you're ALREADY in, so every step below has to stay


### PR DESCRIPTION
Ships as **0.1.22**. Three user-reported bugs, each with a pure, unit-tested decision function rather than another inline guard.

## Creating several vaults folded them all into the first one

Reported as: make three vaults in a row, turn sync on for each, and they "disappear, stay local, or just don't work".

`turnOnSyncForCurrentVault` asked an **account-level** question — *does the account have an active vault I'm a member of?* — when the question that decides this is about the **folder**: *is this folder already some vault's folder?* Since `activeOrganizationId` survives opening a plain local folder (nothing on that path clears it), the check matched from vault 2 onward: each new folder was synced into vault 1 and `rememberOrgVault` re-pointed vault 1's binding at it. The previous folder was orphaned back into the "Local" list, the new vault never reached the account, and by the third round three folders had been reconciled into one server vault with three colliding `Welcome.md`s. The name typed into "Turn on sync" was discarded outright — it is only used on the branch the guard skipped.

Now `planTurnOnSync` (`lib/vault/turnOnSync.ts`):

- folder bound to the **active** vault → retry it. This preserves what the old guard existed for: an invited user whose sync failed must not silently get a vault of their own. `applyVaultFolder` binds the folder *before* enabling sync, so that case still lands here.
- folder bound to **another** vault you're in → switch to it. Creating would steal the folder and evict that vault's binding — the same defect wearing a different hat.
- folder bound to **nothing** → create a vault.

Six tests, including the reported three-in-a-row sequence asserting three distinct vaults and no overwritten binding. It fails against the old logic.

## Signing in invented a vault

Confirmed against the local database: the `My Vault` org row was created **275 ms after** the user row — `planLanding` branch 6 firing `createOrganization("My Vault")`.

Delete every vault, sign in again, and the app silently conjured one and dropped you inside it, so the deletion looked like it had failed — and the phantom then persisted in the welcome screen's cached list. `create-first-vault` and `createIfNone` are removed; an account with no vaults lands on the welcome screen, which offers New vault / Open existing / Join a team and is therefore a destination, not a dead end. Making a vault is a decision with a name attached, so it belongs to the button the user presses.

## The welcome screen kept showing deleted vaults

Three causes:

- **Never refreshed.** Recents loaded in a mount-only effect, and the row list was a `useMemo` keyed on `[recents]` that read `localStorage` imperatively — localStorage is not reactive. Deleting your last vaults leaves this screen mounted throughout, so nothing re-ran until an app reload.
- **Signed in, it read the cache instead of the truth.** It now uses the store's live `organizations` when signed in, falling back to the cache only when signed out, which is what the cache is for.
- **Not namespaced per server.** `context.knownVaults` was one shared list, so a client pointed at localhost still listed the managed instance's vaults under ids that can never resolve there. Now keyed `context.knownVaults:<serverUrl>`, with a one-time read of the old key so existing installs keep their list.

## A dev build could silently talk to production

`DEFAULT_SERVER_URL` already preferred localhost in dev, but a **persisted** `server_url` in the app config overrode it — and being per-device it stayed that way every launch, reading and writing real vaults from `pnpm dev:desktop`. `resolveServerUrl` now makes a dev build ignore a persisted *production* URL. Any other URL (staging, LAN, self-host) is still honoured from Settings, and `VITE_SERVER_URL=https://api.baalda.com` re-enables even that.

## Verification

- Desktop TS: 498 passed, 12 skipped — stable across three consecutive runs.
- Desktop Rust: 80 tests green.
- `tsc --noEmit` clean.
- The auto-created vault was confirmed from the local Postgres timestamps, not inferred.

Not covered here: the turn-on-sync fix is proven by unit test, not by a live multi-vault run against a server.
