### PR TITLE
Note version history, vault checkpoints, last-edited-by and silent auto-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,25 @@ jobs:
           echo "notarize=$want" >> "$GITHUB_OUTPUT"
           echo "Notarization: $want"
 
+      # The GitHub release body doubles as the in-app "what's new": the updater
+      # feeds it back as latest.json's `notes`, and the desktop shows those
+      # one-liners in the post-update banner. Keep docs/RELEASE_NOTES.md fresh
+      # alongside every version bump; the fallback keeps releases shippable if
+      # it's ever missing.
+      - name: Release notes
+        id: relnotes
+        shell: bash
+        run: |
+          {
+            echo 'body<<RELNOTES_EOF'
+            if [ -f docs/RELEASE_NOTES.md ]; then
+              cat docs/RELEASE_NOTES.md
+            else
+              echo 'See the assets below to download and install this version.'
+            fi
+            echo 'RELNOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       # Two steps rather than one with conditional env, deliberately. Blanking
       # APPLE_ID/PASSWORD/TEAM_ID does not reliably disable notarization — a GitHub
       # expression yields an EMPTY STRING, not an unset variable, and "set but
@@ -286,7 +305,7 @@ jobs:
           projectPath: app/apps/desktop
           tagName: v__VERSION__
           releaseName: 'Baalda v__VERSION__'
-          releaseBody: 'See the assets below to download and install this version.'
+          releaseBody: ${{ steps.relnotes.outputs.body }}
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}
@@ -311,7 +330,7 @@ jobs:
           projectPath: app/apps/desktop
           tagName: v__VERSION__
           releaseName: 'Baalda v__VERSION__'
-          releaseBody: 'See the assets below to download and install this version.'
+          releaseBody: ${{ steps.relnotes.outputs.body }}
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.22"
+version = "0.1.23"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1847,7 +1847,210 @@ body:has(.sidebar-resizer.dragging) {
   background: var(--bg-surface);
   border-top-left-radius: var(--radius-xl);
   box-shadow: var(--shadow-md);
+  /* Plain `hidden`, NOT `clip`: clip triggered a WKWebView compositing bug
+     that blanked sibling layers (the sidebar footer vanished when a synced
+     note's editor layers came up). Programmatic focus-scroll into the
+     off-screen version panel is prevented at the source instead — the panel
+     focuses with preventScroll and skips its mount-time scrollIntoView. */
   overflow: hidden;
+  /* Anchors the version-history panel, which slides in over the editor. */
+  position: relative;
+}
+
+/* ============================================================
+   Version history panel — slides in from the right, OVER the
+   editor rather than beside it: the list is read against the
+   note (hover previews in place), so the note must stay put.
+   ============================================================ */
+.version-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(320px, 85vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  z-index: 120; /* over the editor + backlinks, under overlays/modals (200+) */
+  outline: none;
+}
+.version-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-4) var(--sp-4) var(--sp-2);
+}
+.version-panel-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.version-panel-title strong {
+  font-size: var(--fs-md);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.version-panel-hint {
+  margin: 0;
+  padding: 0 var(--sp-4) var(--sp-2);
+  font-size: var(--fs-xs);
+}
+.version-panel-empty {
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-sm);
+}
+.version-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--sp-2);
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.version-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-md);
+}
+.version-row.active {
+  background: var(--bg-hover);
+}
+/* Current-buffer pseudo-row: an accent dot where the others carry a face. */
+.version-dot {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.version-dot::after {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.version-avatar {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  overflow: hidden;
+}
+.version-avatar svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.version-row-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.version-row-title {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.version-row-sub {
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.version-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--success-soft);
+  color: var(--success);
+}
+/* Revert whispers in like .tree-more: an answer for the row you're on. */
+.version-revert {
+  margin-left: auto;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--t-fast) var(--ease);
+}
+.version-row:hover .version-revert,
+.version-row.active .version-revert {
+  opacity: 1;
+}
+.version-revert:disabled {
+  opacity: 0.45;
+}
+
+/* Settings → Versioning: the vault checkpoint list. */
+.checkpoint-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.checkpoint-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2) 0;
+  border-bottom: 1px solid var(--border);
+}
+.checkpoint-row:last-child {
+  border-bottom: none;
+}
+.checkpoint-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  margin-right: auto;
+}
+.checkpoint-title {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.checkpoint-sub {
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+}
+.checkpoint-note {
+  margin-top: var(--sp-3);
+  font-size: var(--fs-xs);
+}
+
+/* Post-auto-update "what's new" banner. */
+.updated-banner-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+.updated-banner-notes {
+  margin: 0;
+  padding-left: var(--sp-5);
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 .main-header {
   display: flex;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -15,11 +15,18 @@ import { SidebarHeader } from "./components/SidebarHeader";
 import { SidebarResizer } from "./components/SidebarResizer";
 import { Toasts } from "./components/Toasts";
 import { VaultPicker } from "./components/VaultPicker";
+import { VersionPanel } from "./components/VersionPanel";
 import { bridgeManager } from "./lib/bridge";
 import { BRAND_NAME } from "./lib/brand";
 import * as ipc from "./lib/ipc";
 import { syncManager } from "./lib/sync/docSession";
-import { checkForUpdate, installUpdate, useUpdateState } from "./lib/updater";
+import {
+  autoUpdate,
+  clearJustUpdated,
+  justUpdatedTo,
+  releaseNoteLines,
+  useUpdateState,
+} from "./lib/updater";
 import { runConfetti } from "./lib/celebrate/celebrate";
 import { previewKind } from "./lib/preview";
 import { useSidebarWidth } from "./lib/useSidebarWidth";
@@ -239,32 +246,11 @@ function VaultFolderPrompt() {
  * only surface when the user checks manually from Settings → Updates.
  */
 function UpdateBanner() {
-  const [dismissed, setDismissed] = useState(false);
   const update = useUpdateState();
 
-  if (update.phase === "available" && dismissed) {
-    return null;
-  }
-
-  if (update.phase === "available") {
-    return (
-      <Banner show className="update-banner">
-        <span>
-          A new version of {BRAND_NAME} (<strong>{update.version}</strong>) is
-          available.
-        </span>
-        <div className="banner-actions">
-          <AsyncButton className="primary" onClick={() => installUpdate()}>
-            Install &amp; Restart
-          </AsyncButton>
-          <button className="secondary" onClick={() => setDismissed(true)}>
-            Later
-          </button>
-        </div>
-      </Banner>
-    );
-  }
-
+  // Updates apply themselves (see autoUpdate at launch) — the only live chrome
+  // is the progress strip while the new bytes come down, and the app restarts
+  // on its own when they're in. The post-restart story is UpdatedBanner's.
   if (update.phase === "downloading" || update.phase === "installing") {
     const pct =
       update.phase === "downloading" && update.total > 0
@@ -300,21 +286,78 @@ function UpdateBanner() {
   return null;
 }
 
+/**
+ * "You're on the new version" — shown on the first launch after a silent
+ * auto-update, with the release's one-liners. Stays until crossed out (the
+ * stash survives a quit), so an update never lands completely unannounced.
+ */
+function UpdatedBanner() {
+  const [updated, setUpdated] = useState<{ version: string; notes: string[] } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void justUpdatedTo().then((stash) => {
+      if (cancelled || !stash) return;
+      setUpdated({ version: stash.version, notes: releaseNoteLines(stash.notes) });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <Banner show={updated != null} className="updated-banner" role="status">
+      <div className="updated-banner-body">
+        <span>
+          🎉 {BRAND_NAME} updated to <strong>v{updated?.version}</strong>
+        </span>
+        {updated != null && updated.notes.length > 0 && (
+          <ul className="updated-banner-notes">
+            {updated.notes.map((line, i) => (
+              <li key={i}>{line}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="banner-actions">
+        <button
+          className="icon-btn"
+          aria-label="Dismiss"
+          title="Dismiss"
+          onClick={() => {
+            clearJustUpdated();
+            setUpdated(null);
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </Banner>
+  );
+}
+
 function SaveIndicator() {
   // The CRDT bridge autosaves to disk on a debounce, so the note is always
   // being persisted; there is no "unsaved" state to surface anymore.
   return <span className="save-indicator saved">Auto-saved</span>;
 }
 
-function SyncIndicator() {
+function SyncIndicator({ noteOpen }: { noteOpen: boolean }) {
   // Per-note sync status (offline / connecting / synced / read-only) PLUS the
   // vault's bulk-run progress, so a vault that is still uploading 380 of its 500
   // notes says so instead of claiming "Synced · just now" off a live socket.
+  // With no note open the pill goes vault-wide: it appears whenever a bulk run
+  // has something to report and stays put afterwards ("Synced ✓" / "N not
+  // synced"), so a fresh hydration is never invisible.
   const status = useStore((s) => s.syncStatus);
   const syncEnabled = useStore((s) => s.syncEnabled);
   const lastSyncedAt = useStore((s) => s.lastSyncedAt);
   const pending = useStore((s) => s.syncPending);
   const progress = useStore((s) => s.syncProgress);
+  // "idle" is the reporter's pre-start value — nothing to report yet.
+  if (!noteOpen && (progress == null || progress.phase === "idle")) return null;
   return (
     <SyncBadge
       status={status}
@@ -322,6 +365,7 @@ function SyncIndicator() {
       lastSyncedAt={lastSyncedAt}
       pending={pending}
       progress={progress}
+      noteOpen={noteOpen}
     />
   );
 }
@@ -330,6 +374,13 @@ export default function App() {
   const vault = useStore((s) => s.vault);
   const openNote = useStore((s) => s.openNote);
   const switchingVault = useStore((s) => s.switchingVault);
+  // Version history is a synced-vault feature: it needs the note's docId on the
+  // server. No mapping (local vault, unregistered note) → no history button.
+  const versionDocId = useStore((s) => {
+    const path = s.openNote?.path;
+    return path && s.syncEnabled ? (s.docIdByPath[path] ?? null) : null;
+  });
+  const versionPanelOpen = useStore((s) => s.versionPanelDocId != null);
   // An open image/PDF preview isn't a synced note — hide the save/sync chrome.
   const isPreview = openNote != null && previewKind(openNote.path) != null;
   const [booting, setBooting] = useState(true);
@@ -338,6 +389,12 @@ export default function App() {
   const { width: sidebarWidth, setWidth: setSidebarWidth } = useSidebarWidth();
   // Guards the launch auto-reopen against StrictMode's double-invoke (dev).
   const didAutoReopenRef = useRef(false);
+
+  // The history panel is about ONE note; switching notes under it would leave a
+  // list of versions that no longer belong to what's in the editor.
+  useEffect(() => {
+    useStore.getState().closeVersionPanel();
+  }, [openNote?.path]);
 
   // Auto-reopen the last vault on launch, then restore the session (spec 04 §7)
   // and enable sync. Vault first so `enableSyncForVault` (called inside initAuth)
@@ -381,10 +438,12 @@ export default function App() {
       } finally {
         setBooting(false);
       }
-      // Check for app updates once on launch. Failures (e.g. offline, or a
-      // non-bundled dev build) are swallowed by the updater store — the banner
-      // only appears when an update is genuinely available.
-      void checkForUpdate();
+      // Self-update on launch, silently: found → download → install → relaunch,
+      // no click required (notes are autosaved continuously, so a restart loses
+      // nothing). The user hears about it AFTER the fact, via the "Updated to
+      // vX" banner on the next boot. Failures (offline, non-bundled dev build)
+      // are swallowed by the updater store — surfaced only in Settings → Updates.
+      void autoUpdate();
     })();
   }, []);
 
@@ -566,7 +625,12 @@ export default function App() {
           <FileTree />
         </div>
         <div className="sidebar-footer">
-          <AccountMenu />
+          {/* Boundary so a crash here degrades to a visible fallback instead of
+              silently emptying the corner — the identity bar must never just
+              vanish. */}
+          <ErrorBoundary label="Account">
+            <AccountMenu />
+          </ErrorBoundary>
         </div>
       </aside>
       <SidebarResizer width={sidebarWidth} onWidth={setSidebarWidth} />
@@ -574,6 +638,7 @@ export default function App() {
       <main className="main">
         <MemberJoinedBanner />
         <UpdateBanner />
+        <UpdatedBanner />
         {/* Sits flush against the top of the window now that there's no system
             title bar above it (`titleBarStyle: "Overlay"`), which is where the
             reclaimed ~28px comes from — and that makes it the strip you'd expect
@@ -582,9 +647,35 @@ export default function App() {
         <header className="main-header" data-tauri-drag-region="deep">
           <span className="note-title">{openNote?.title ?? "No note open"}</span>
           {openNote && !isPreview && <SaveIndicator />}
-          {openNote && !isPreview && <SyncIndicator />}
+          <SyncIndicator noteOpen={openNote != null && !isPreview} />
           {/* Vault-wide, so it sits in the header regardless of the open note. */}
           <TalkButton />
+          {versionDocId && !isPreview && (
+            <button
+              className={`icon-btn history-btn${versionPanelOpen ? " active" : ""}`}
+              title="Version history"
+              aria-label="Version history"
+              aria-pressed={versionPanelOpen}
+              onClick={() => {
+                if (versionPanelOpen) useStore.getState().closeVersionPanel();
+                else void useStore.getState().openVersionPanel(versionDocId);
+              }}
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M3 12a9 9 0 1 0 2.6-6.4" />
+                <path d="M3 4v4h4" />
+                <path d="M12 8v4l3 2" />
+              </svg>
+            </button>
+          )}
           <button
             className="icon-btn search-btn"
             title="Search notes (⌘F)"
@@ -634,6 +725,8 @@ export default function App() {
           <Editor />
         </div>
         <BacklinksPanel />
+        {/* Slides in over the editor from the right; anchored to .main. */}
+        <VersionPanel />
       </main>
 
       {graphOpen && (

--- a/app/apps/desktop/src/__tests__/versionStore.test.ts
+++ b/app/apps/desktop/src/__tests__/versionStore.test.ts
@@ -1,0 +1,320 @@
+// The versioning view-state: the nine actions the UI is built against, and the
+// invariant that every one of the five new fields is vault-scoped (a version list
+// or checkpoint list from the vault we left would offer a revert that writes the
+// wrong content into the wrong note).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({
+  listNoteVersions: vi.fn(async (_docId: string) => [] as unknown[]),
+  getNoteVersion: vi.fn(async (_docId: string, _id: number) => ({ content: "" }) as unknown),
+  revertNoteToVersion: vi.fn(async (_docId: string, _id: number) => ({
+    ok: true,
+    preRevertVersionId: 9,
+  })),
+  listCheckpoints: vi.fn(async (_vaultId: string) => [] as unknown[]),
+  createCheckpoint: vi.fn(async (_vaultId: string, _label?: string) => ({}) as unknown),
+  deleteCheckpoint: vi.fn(async (_vaultId: string, _id: string) => {}),
+  revertToCheckpoint: vi.fn(async (_vaultId: string, _id: string) => ({
+    ok: true,
+    docsChanged: 2,
+    docsRestored: 1,
+    docsDeleted: 0,
+    foldersCreated: 1,
+    preRevertCheckpointId: "cp-0",
+  })),
+}));
+
+vi.mock("../lib/auth/authManager", () => ({
+  authManager: { api, getServerUrl: () => "http://localhost:3010" },
+  api,
+}));
+
+const sync = vi.hoisted(() => ({
+  registry: { vaultId: null as string | null, getMapping: () => null },
+  disable: vi.fn(),
+  setViewing: vi.fn(),
+  handleRegistryChanged: vi.fn(),
+  setStatusListener: vi.fn(),
+  setActivityListeners: vi.fn(),
+  setRegistryListener: vi.fn(),
+  setInboundListeners: vi.fn(),
+  setMemberJoinedListener: vi.fn(),
+  setVaultPresenceListener: vi.fn(),
+  setVoiceListener: vi.fn(),
+  setSyncProgressListener: vi.fn(),
+  setDocStateListener: vi.fn(),
+  setRegistryMapListener: vi.fn(),
+  setNoteMetaListener: vi.fn(),
+}));
+
+vi.mock("../lib/sync/docSession", () => ({ syncManager: sync }));
+
+import { useStore } from "../store";
+
+const VERSION = {
+  id: 7,
+  createdAt: "2026-08-11T10:00:00.000Z",
+  cause: "idle" as const,
+  authorId: "u1",
+  authorName: "Ada",
+  sha256: "abc",
+  size: 12,
+};
+
+const CHECKPOINT = {
+  id: "cp-1",
+  kind: "manual" as const,
+  label: null,
+  createdAt: "2026-08-11T10:00:00.000Z",
+  createdBy: "u1",
+  createdByName: "Ada",
+  noteCount: 2,
+};
+
+/** Pretend a synced vault is open (what every server-backed action needs). */
+function synced(): void {
+  sync.registry.vaultId = "vault-1";
+  useStore.setState({ syncEnabled: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.listNoteVersions.mockResolvedValue([]);
+  api.listCheckpoints.mockResolvedValue([]);
+  sync.registry.vaultId = null;
+  useStore.setState({
+    syncEnabled: false,
+    noteLastEdited: {},
+    versionPanelDocId: null,
+    noteVersions: null,
+    versionPreview: null,
+    checkpoints: null,
+  });
+});
+
+describe("version panel actions", () => {
+  it("opens a panel, loads the note's versions, and closes cleanly", async () => {
+    synced();
+    api.listNoteVersions.mockResolvedValue([VERSION]);
+
+    await useStore.getState().openVersionPanel("doc-a");
+
+    expect(api.listNoteVersions).toHaveBeenCalledWith("doc-a");
+    expect(useStore.getState().versionPanelDocId).toBe("doc-a");
+    expect(useStore.getState().noteVersions).toEqual([VERSION]);
+
+    useStore.getState().closeVersionPanel();
+    expect(useStore.getState()).toMatchObject({
+      versionPanelDocId: null,
+      noteVersions: null,
+      versionPreview: null,
+    });
+  });
+
+  it("clears the previous note's list before the new one loads", async () => {
+    synced();
+    useStore.setState({ versionPanelDocId: "doc-a", noteVersions: [VERSION] });
+    let duringLoad: unknown = "unset";
+    api.listNoteVersions.mockImplementation(async () => {
+      duringLoad = useStore.getState().noteVersions;
+      return [];
+    });
+
+    await useStore.getState().openVersionPanel("doc-b");
+
+    // A stale list of the same shape reads as this note's history.
+    expect(duringLoad).toBeNull();
+  });
+
+  it("drops a late response for a note whose panel has since been replaced", async () => {
+    synced();
+    api.listNoteVersions.mockImplementation(async (docId: string) => {
+      if (docId === "doc-a") useStore.setState({ versionPanelDocId: "doc-b" });
+      return [VERSION];
+    });
+
+    await useStore.getState().openVersionPanel("doc-a");
+
+    expect(useStore.getState().versionPanelDocId).toBe("doc-b");
+    expect(useStore.getState().noteVersions).toBeNull();
+  });
+
+  it("does not call the server for a local vault (versions are server-side)", async () => {
+    await useStore.getState().openVersionPanel("doc-a");
+    expect(api.listNoteVersions).not.toHaveBeenCalled();
+    expect(useStore.getState().noteVersions).toEqual([]);
+  });
+
+  it("shows an empty list rather than an endless spinner when the list fails", async () => {
+    synced();
+    api.listNoteVersions.mockRejectedValue(new Error("offline"));
+    await useStore.getState().openVersionPanel("doc-a");
+    expect(useStore.getState().noteVersions).toEqual([]);
+  });
+});
+
+describe("version preview", () => {
+  it("loads a version's markdown for the read-only overlay", async () => {
+    synced();
+    useStore.setState({ versionPanelDocId: "doc-a" });
+    api.getNoteVersion.mockResolvedValue({ ...VERSION, content: "# old" });
+
+    await useStore.getState().previewVersion(7);
+
+    expect(api.getNoteVersion).toHaveBeenCalledWith("doc-a", 7);
+    expect(useStore.getState().versionPreview).toEqual({ versionId: 7, content: "# old" });
+
+    useStore.getState().clearVersionPreview();
+    expect(useStore.getState().versionPreview).toBeNull();
+  });
+
+  it("does nothing when no panel is open", async () => {
+    await useStore.getState().previewVersion(7);
+    expect(api.getNoteVersion).not.toHaveBeenCalled();
+  });
+
+  it("leaves no preview behind when the fetch fails", async () => {
+    synced();
+    useStore.setState({ versionPanelDocId: "doc-a" });
+    api.getNoteVersion.mockRejectedValue(new Error("403"));
+    await useStore.getState().previewVersion(7);
+    expect(useStore.getState().versionPreview).toBeNull();
+  });
+});
+
+describe("revertToVersion", () => {
+  it("exits the preview, reverts the panel's note, and refreshes the list", async () => {
+    synced();
+    useStore.setState({
+      versionPanelDocId: "doc-a",
+      versionPreview: { versionId: 7, content: "# old" },
+      noteVersions: [VERSION],
+    });
+    const previewAtRevert: unknown[] = [];
+    api.revertNoteToVersion.mockImplementation(async () => {
+      previewAtRevert.push(useStore.getState().versionPreview);
+      return { ok: true as const, preRevertVersionId: 9 };
+    });
+    api.listNoteVersions.mockResolvedValue([{ ...VERSION, id: 9, cause: "pre-revert" }, VERSION]);
+
+    await useStore.getState().revertToVersion(7);
+
+    // The overlay must be gone before the write lands — the editor the user is
+    // looking at has to be the live one that is about to change.
+    expect(previewAtRevert).toEqual([null]);
+    expect(api.revertNoteToVersion).toHaveBeenCalledWith("doc-a", 7);
+    expect(useStore.getState().noteVersions).toHaveLength(2);
+  });
+
+  it("propagates the failure (a locked share 403s) instead of silently no-oping", async () => {
+    synced();
+    useStore.setState({ versionPanelDocId: "doc-a" });
+    api.revertNoteToVersion.mockRejectedValue(new Error("Read-only"));
+    await expect(useStore.getState().revertToVersion(7)).rejects.toThrow("Read-only");
+  });
+
+  it("throws when no note is open", async () => {
+    synced();
+    await expect(useStore.getState().revertToVersion(7)).rejects.toThrow(/no note/i);
+  });
+});
+
+describe("checkpoints", () => {
+  it("stays null (the sync gate) for a vault that isn't synced", async () => {
+    useStore.setState({ checkpoints: [CHECKPOINT] });
+    await useStore.getState().refreshCheckpoints();
+    expect(useStore.getState().checkpoints).toBeNull();
+    expect(api.listCheckpoints).not.toHaveBeenCalled();
+  });
+
+  it("lists the collection's checkpoints", async () => {
+    synced();
+    api.listCheckpoints.mockResolvedValue([CHECKPOINT]);
+    await useStore.getState().refreshCheckpoints();
+    expect(api.listCheckpoints).toHaveBeenCalledWith("vault-1");
+    expect(useStore.getState().checkpoints).toEqual([CHECKPOINT]);
+  });
+
+  it("drops a response for a collection that is no longer the open one", async () => {
+    synced();
+    api.listCheckpoints.mockImplementation(async () => {
+      sync.registry.vaultId = "vault-2";
+      return [CHECKPOINT];
+    });
+    await useStore.getState().refreshCheckpoints();
+    expect(useStore.getState().checkpoints).toBeNull();
+  });
+
+  it("creates a checkpoint, trimming the label, then refreshes", async () => {
+    synced();
+    await useStore.getState().createCheckpoint("  Before the rewrite  ");
+    expect(api.createCheckpoint).toHaveBeenCalledWith("vault-1", "Before the rewrite");
+    expect(api.listCheckpoints).toHaveBeenCalled();
+  });
+
+  it("treats a blank label as no label", async () => {
+    synced();
+    await useStore.getState().createCheckpoint("   ");
+    expect(api.createCheckpoint).toHaveBeenCalledWith("vault-1", undefined);
+  });
+
+  it("deletes a checkpoint, then refreshes", async () => {
+    synced();
+    await useStore.getState().deleteCheckpoint("cp-1");
+    expect(api.deleteCheckpoint).toHaveBeenCalledWith("vault-1", "cp-1");
+    expect(api.listCheckpoints).toHaveBeenCalled();
+  });
+
+  it("refuses the write actions without a synced vault", async () => {
+    await expect(useStore.getState().createCheckpoint()).rejects.toThrow(/sync/i);
+    await expect(useStore.getState().deleteCheckpoint("cp-1")).rejects.toThrow(/sync/i);
+    await expect(useStore.getState().revertVaultToCheckpoint("cp-1")).rejects.toThrow(/sync/i);
+    expect(api.createCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("reverts the vault, returns the tally, and pulls the new structure locally", async () => {
+    synced();
+    const result = await useStore.getState().revertVaultToCheckpoint("cp-1");
+
+    expect(api.revertToCheckpoint).toHaveBeenCalledWith("vault-1", "cp-1");
+    expect(result).toMatchObject({ docsChanged: 2, preRevertCheckpointId: "cp-0" });
+    // The pre-revert checkpoint the server just took has to show up in the list…
+    expect(api.listCheckpoints).toHaveBeenCalled();
+    // …and the restored/tombstoned notes have to converge on this device without
+    // waiting for the server's own registry broadcast to come back to us.
+    expect(sync.handleRegistryChanged).toHaveBeenCalled();
+  });
+});
+
+describe("vault scoping", () => {
+  it("closing the vault clears every versioning field", () => {
+    synced();
+    useStore.setState({
+      noteLastEdited: { "doc-a": { userId: "u1", name: "Ada", at: "2026-08-11T10:00:00.000Z" } },
+      versionPanelDocId: "doc-a",
+      noteVersions: [VERSION],
+      versionPreview: { versionId: 7, content: "# old" },
+      checkpoints: [CHECKPOINT],
+    });
+
+    useStore.getState().closeLocalVault();
+
+    expect(useStore.getState()).toMatchObject({
+      noteLastEdited: {},
+      versionPanelDocId: null,
+      noteVersions: null,
+      versionPreview: null,
+      checkpoints: null,
+      syncEnabled: false,
+    });
+  });
+
+  it("hands out a fresh noteLastEdited object per reset (no shared mutable map)", () => {
+    useStore.getState().closeLocalVault();
+    const first = useStore.getState().noteLastEdited;
+    first["leaked"] = { userId: "u1", name: "Ada", at: "2026-08-11T10:00:00.000Z" };
+    useStore.getState().closeLocalVault();
+    expect(useStore.getState().noteLastEdited).toEqual({});
+  });
+});

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { type McpToolInfo, type McpTokenRow, type Member } from "../lib/api";
+import {
+  type McpToolInfo,
+  type McpTokenRow,
+  type Member,
+  type VaultCheckpoint,
+} from "../lib/api";
+import { toast } from "../lib/toast";
+import { agoFromIso, checkpointTitle, noteCountLabel } from "./versionFormat";
 import { ITEM_COLORS, itemColorValue } from "../lib/appearance";
 import { authManager } from "../lib/auth/authManager";
 import { classifyLimitError, type LimitKind, limitFromError } from "../lib/billing";
@@ -961,13 +968,20 @@ type SettingsTab =
   | "billing"
   | "access"
   | "mcp"
+  | "versioning"
   | "import-export"
   | "appearance"
   | "updates";
 
 // Sections that only make sense once the vault is synced to an org. On a
 // local vault they're shown but locked, with a "Turn on sync" gate.
-const TEAM_TABS = new Set<SettingsTab>(["members", "billing", "access", "mcp"]);
+const TEAM_TABS = new Set<SettingsTab>([
+  "members",
+  "billing",
+  "access",
+  "mcp",
+  "versioning",
+]);
 
 /** General tab: name, folder, and sync state (incl. the Turn-on-sync CTA). */
 const GENERAL_TAB: { id: SettingsTab; label: string; icon: React.ReactNode } = {
@@ -1022,6 +1036,17 @@ const SETTINGS_TABS: Array<{ id: SettingsTab; label: string; icon: React.ReactNo
       <MenuIcon>
         <path d="M4 17l6-6-6-6" />
         <path d="M12 19h8" />
+      </MenuIcon>
+    ),
+  },
+  {
+    id: "versioning",
+    label: "Versioning",
+    icon: (
+      <MenuIcon>
+        <path d="M3 12a9 9 0 1 0 2.6-6.4" />
+        <path d="M3 4v4h4" />
+        <path d="M12 8v4l3 2" />
       </MenuIcon>
     ),
   },
@@ -1198,6 +1223,11 @@ function VaultSettingsDialog({
             <AccessPanel canManage={canManage} />
           ) : tab === "mcp" ? (
             <McpTab />
+          ) : tab === "versioning" ? (
+            <VersioningTab
+              canManage={canManage}
+              isOwner={myMember?.role === "owner"}
+            />
           ) : tab === "import-export" ? (
             <ImportExportTab />
           ) : tab === "updates" ? (
@@ -2221,6 +2251,173 @@ function LimitNudge({
       <button className="link-btn" onClick={onUpgrade}>
         Upgrade →
       </button>
+    </div>
+  );
+}
+
+/**
+ * Versioning: the vault-wide safety net. Lists the vault's checkpoints (max 5 —
+ * a daily automatic one plus manual ones), lets owners/admins take one on
+ * demand, and lets the OWNER roll the whole vault back to one. Per-note history
+ * lives in the editor's version panel; this page is for the blast-radius case
+ * ("the reorg went wrong, put everything back").
+ */
+function VersioningTab({
+  canManage,
+  isOwner,
+}: {
+  canManage: boolean;
+  isOwner: boolean;
+}) {
+  const checkpoints = useStore((s) => s.checkpoints);
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<VaultCheckpoint | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    void useStore.getState().refreshCheckpoints();
+    const id = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const create = async () => {
+    setError(null);
+    try {
+      await useStore.getState().createCheckpoint(label);
+      setLabel("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const remove = async (id: string) => {
+    setError(null);
+    try {
+      await useStore.getState().deleteCheckpoint(id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const revert = async (cp: VaultCheckpoint) => {
+    setError(null);
+    try {
+      const result = await useStore.getState().revertVaultToCheckpoint(cp.id);
+      setConfirming(null);
+      toast(
+        `Vault reverted — ${result.docsChanged} notes changed, ` +
+          `${result.docsRestored} restored, ${result.docsDeleted} removed`,
+        "success",
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div className="versioning-tab">
+      <div className="muted">
+        A checkpoint captures every note in this vault — content and folder
+        structure. One is taken automatically each day the vault changes; the
+        vault keeps its 5 most recent. Reverting rolls every member's vault back
+        and broadcasts live.
+      </div>
+      <div className="menu-sep" />
+      {canManage && (
+        <>
+          <div className="subhead">Create checkpoint</div>
+          <div className="row invite-bar">
+            <input
+              type="text"
+              placeholder="Label (optional) — e.g. Before the big reorg"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+            <AsyncButton className="primary sm" onClick={create}>
+              Create
+            </AsyncButton>
+          </div>
+          <div className="menu-sep" />
+        </>
+      )}
+      <div className="subhead">Checkpoints</div>
+      {error && <div className="auth-error">{error}</div>}
+      {checkpoints == null ? (
+        <div className="muted perm-empty">Loading…</div>
+      ) : checkpoints.length === 0 ? (
+        <div className="muted perm-empty">
+          No checkpoints yet. One is captured automatically within a day of the
+          vault changing{canManage ? ", or create one above" : ""}.
+        </div>
+      ) : (
+        <ul className="checkpoint-list">
+          {checkpoints.map((cp) => (
+            <li key={cp.id} className="checkpoint-row">
+              <span className="checkpoint-main">
+                <span className="checkpoint-title">
+                  {checkpointTitle(cp.label, cp.kind, cp.createdAt, now)}
+                </span>
+                <span className="checkpoint-sub">
+                  {agoFromIso(cp.createdAt, now)} · {noteCountLabel(cp.noteCount)}
+                  {cp.createdByName ? ` · by ${cp.createdByName}` : ""}
+                </span>
+              </span>
+              {isOwner && (
+                <button className="link-btn" onClick={() => setConfirming(cp)}>
+                  Revert
+                </button>
+              )}
+              {canManage && (
+                <AsyncButton className="link-btn danger" onClick={() => remove(cp.id)}>
+                  Delete
+                </AsyncButton>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {!isOwner && (
+        <div className="muted checkpoint-note">
+          Only the vault owner can revert to a checkpoint.
+        </div>
+      )}
+      {confirming && (
+        <div className="modal-backdrop" onClick={() => setConfirming(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>Revert the entire vault?</h2>
+            </div>
+            <p className="muted">
+              Every note goes back to{" "}
+              <strong>
+                {checkpointTitle(
+                  confirming.label,
+                  confirming.kind,
+                  confirming.createdAt,
+                  now,
+                )}
+              </strong>{" "}
+              ({agoFromIso(confirming.createdAt, now)}) — content, names and
+              folders — for every member, live. Notes created since then are
+              moved to trash. Attachments are not reverted. A checkpoint of the
+              current state is taken first, so this can be undone.
+            </p>
+            <div className="banner-actions">
+              <button className="secondary" onClick={() => setConfirming(null)}>
+                Cancel
+              </button>
+              <AsyncButton
+                className="primary danger"
+                spinnerTone="on-accent"
+                onClick={() => revert(confirming)}
+              >
+                Revert vault
+              </AsyncButton>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/apps/desktop/src/components/Editor.tsx
+++ b/app/apps/desktop/src/components/Editor.tsx
@@ -21,6 +21,7 @@ import { HtmlView } from "./HtmlView";
 import { FilePreview } from "./FilePreview";
 import { previewKind } from "../lib/preview";
 import { relativeAgo, characterSvg } from "./Identity";
+import { agoFromIso, lastEditedTooltip } from "./versionFormat";
 
 interface Peer {
   id: string;
@@ -138,6 +139,35 @@ function PresenceAvatar({
 }
 
 /**
+ * "Recent activity" section of the roster popover: who last touched this note
+ * (stamped server-side, so it covers teammates and AI writes alike). Lives
+ * INSIDE the presence dropdown rather than as its own chrome: presence answers
+ * "who is here now", this answers "who was here", and stacking them in one
+ * popover keeps history visibly subordinate — smaller, dimmer faces.
+ */
+function RosterRecent({ notePath, now }: { notePath: string; now: number }) {
+  const docId = syncManager.registry.getMapping(notePath)?.docId ?? null;
+  const name = useStore((s) => (docId ? (s.noteLastEdited[docId]?.name ?? null) : null));
+  const at = useStore((s) => (docId ? (s.noteLastEdited[docId]?.at ?? null) : null));
+  const svg = useMemo(() => (name ? characterSvg(name) : null), [name]);
+  if (!svg || !at) return null;
+  return (
+    <>
+      <div className="peer-roster-title roster-recent-title">Recent activity</div>
+      <div className="roster-recent-row" title={lastEditedTooltip(name, at, now)}>
+        <span
+          className="roster-recent-avatar"
+          aria-hidden="true"
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+        <span className="roster-recent-name">{name}</span>
+        <span className="roster-recent-when">edited {agoFromIso(at, now)}</span>
+      </div>
+    </>
+  );
+}
+
+/**
  * "Who's in this note" avatar stack (spec 04 §5). Avatars overlap; anything past
  * MAX_AVATARS collapses into a "+N" chip. The roster popover opens on hover/focus
  * of the stack; a click (or keyboard activation) opens it too, for touch and
@@ -246,10 +276,13 @@ function PeerRoster({
   peers,
   selfId,
   onPing,
+  notePath,
 }: {
   peers: Peer[];
   selfId: string | null;
   onPing: (peer: Peer) => void;
+  /** When set, the popover ends with the note's "Recent activity" section. */
+  notePath?: string | null;
 }) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -270,6 +303,7 @@ function PeerRoster({
           onPing={onPing}
         />
       ))}
+      {notePath && <RosterRecent notePath={notePath} now={now} />}
     </div>
   );
 }
@@ -292,6 +326,11 @@ export function Editor() {
   const session = useStore((s) => s.session);
   const tree = useStore((s) => s.tree);
   const syncStatus = useStore((s) => s.syncStatus);
+  // A version the user is hovering in the history panel, rendered over the live
+  // editor. The live view stays mounted and synced underneath — this is a look,
+  // not a mode.
+  const versionPreview = useStore((s) => s.versionPreview);
+  const noteVersions = useStore((s) => s.noteVersions);
   const notePath = openNote?.path ?? null;
 
   const [peers, setPeers] = useState<Peer[]>([]);
@@ -302,6 +341,7 @@ export function Editor() {
   // Editability is held in a Compartment so a lock applied while the note is
   // open can flip the live view read-only without rebuilding it.
   const editableRef = useRef<Compartment | null>(null);
+  const previewHostRef = useRef<HTMLDivElement | null>(null);
   const [rosterOpen, setRosterOpen] = useState(false);
   // Wraps the presence stack + its roster popover so an outside click can be
   // told apart from a click on the controls themselves.
@@ -524,6 +564,30 @@ export function Editor() {
     if (!readOnly) view.focus();
   }, [readOnly]);
 
+  // Hover preview of a past version: a SECOND, throwaway CodeMirror over the
+  // host. It is deliberately not the live view reconfigured — that view is bound
+  // to the Y.Text, and pushing old text through it would be an edit, i.e. the
+  // exact "replace state backwards" mistake the revert path exists to avoid.
+  // This one is read-only, unbound, and destroyed the moment the pointer leaves.
+  const previewVersionId = versionPreview?.versionId ?? null;
+  const previewContent = versionPreview?.content ?? null;
+  useEffect(() => {
+    if (previewContent == null || !previewHostRef.current || notePath == null) return;
+    const state = createEditorState({
+      doc: previewContent,
+      collab: false,
+      getTitles: () => useStore.getState().titles,
+      onNavigate: () => {},
+      resolveAsset: makeResolveAsset(
+        useStore.getState().vault?.path ?? null,
+        notePath,
+      ),
+      extraExtensions: [EditorState.readOnly.of(true), EditorView.editable.of(false)],
+    });
+    const view = new EditorView({ state, parent: previewHostRef.current });
+    return () => view.destroy();
+  }, [previewVersionId, previewContent, notePath]);
+
   if (notePath == null) {
     return (
       <div className="editor-empty">
@@ -554,6 +618,12 @@ export function Editor() {
   };
 
   const showToolbar = peers.length > 0;
+  // "from 2h ago" for the pill. The panel holds the metadata; the preview state
+  // carries only the id + text, so look the timestamp back up here.
+  const previewedAt =
+    previewVersionId != null
+      ? (noteVersions?.find((v) => v.id === previewVersionId)?.createdAt ?? null)
+      : null;
 
   return (
     <div className="editor-column">
@@ -615,7 +685,12 @@ export function Editor() {
                   }
                 />
                 {rosterOpen && (
-                  <PeerRoster peers={peers} selfId={myId} onPing={sendPing} />
+                  <PeerRoster
+                    peers={peers}
+                    selfId={myId}
+                    onPing={sendPing}
+                    notePath={notePath}
+                  />
                 )}
               </div>
               {pingFrom && (
@@ -629,8 +704,20 @@ export function Editor() {
       )}
       {/* The host must stay mounted whether or not the view exists — the effect
           above needs `hostRef.current` to attach CodeMirror to — so the skeleton
-          overlays it rather than replacing it. */}
-      <div className="editor-host" ref={hostRef} />
+          overlays it rather than replacing it. The wrapper is the positioning
+          context for the version-preview overlay, which covers the live text
+          without unmounting it. */}
+      <div className="editor-host-wrap">
+        <div className="editor-host" ref={hostRef} />
+        {previewContent != null && (
+          <div className="version-preview">
+            <div className="version-preview-host" ref={previewHostRef} />
+            <span className="version-preview-pill" role="status">
+              Viewing version from {agoFromIso(previewedAt, Date.now())} — read-only
+            </span>
+          </div>
+        )}
+      </div>
       {!viewMounted && <EditorSkeleton />}
     </div>
   );

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createAvatar } from "@dicebear/core";
 import { notionists } from "@dicebear/collection";
 import { PRESENCE_PALETTE } from "../lib/presence/color";
+import { CheckMark } from "./Spinner";
 import type { SyncProgress } from "../lib/sync/vaultScope";
 
 /* ============================================================
@@ -101,6 +102,10 @@ export function syncRunPercent(progress: SyncProgress | null | undefined): numbe
  * socket can be perfectly "synced" while 380 of 500 notes have never reached the
  * server, and reporting "Synced · just now" there is precisely the lie this
  * progress exists to kill.
+ *
+ * `noteOpen: false` puts the pill in vault-wide mode: `status` belongs to a
+ * socket that doesn't exist, so the label is derived from `progress` alone —
+ * counter while running, "Synced" once done, the failure count on error.
  */
 export function syncBadgeLabel(args: {
   status: string;
@@ -110,21 +115,35 @@ export function syncBadgeLabel(args: {
   enabled?: boolean;
   /** The open vault's bulk sync run, when one is in flight. */
   progress?: SyncProgress | null;
+  /** False when the pill stands for the vault, not an open note. */
+  noteOpen?: boolean;
 }): string {
-  const { status, pending, lastSyncedAt, now, enabled, progress } = args;
+  const { status, pending, lastSyncedAt, now, enabled, progress, noteOpen } = args;
   // A grant fact about the open note outranks everything else: there is no point
   // reporting upload progress on a doc we are not allowed to write.
-  if (status === "no-access") return "No access";
-  if (status === "read-only") return "Read-only";
+  if (noteOpen !== false) {
+    if (status === "no-access") return "No access";
+    if (status === "read-only") return "Read-only";
+  }
   if (progress && isSyncRunActive(progress)) {
-    return progress.total > 0
-      ? `Syncing ${progress.done}/${progress.total}`
-      : "Syncing…";
+    if (progress.total <= 0) return "Syncing…";
+    // Name the direction: a freshly invited teammate watching their vault arrive
+    // should read "Downloading", not a generic "Syncing".
+    const verb =
+      progress.phase === "downloading"
+        ? "Downloading"
+        : progress.phase === "uploading"
+          ? "Uploading"
+          : "Syncing";
+    return `${verb} ${progress.done}/${progress.total}`;
   }
   // A run that finished with failures must not read "Synced". `failed` is the
   // number of notes that are still only on this device.
   if (progress?.phase === "error") {
     return progress.failed > 0 ? `${progress.failed} not synced` : "Sync incomplete";
+  }
+  if (noteOpen === false) {
+    return progress?.phase === "done" ? "Synced" : "Syncing…";
   }
   if (status === "synced") {
     if (pending) return "Saving…";
@@ -143,11 +162,18 @@ export function syncBadgeLabel(args: {
 export function syncBadgeTone(args: {
   status: string;
   progress?: SyncProgress | null;
+  /** False when the pill stands for the vault, not an open note. */
+  noteOpen?: boolean;
 }): string {
-  const { status, progress } = args;
-  if (status === "no-access" || status === "read-only") return status;
+  const { status, progress, noteOpen } = args;
+  if (noteOpen !== false && (status === "no-access" || status === "read-only")) {
+    return status;
+  }
   if (isSyncRunActive(progress)) return "connecting";
   if (progress?.phase === "error") return "error";
+  if (noteOpen === false) {
+    return progress?.phase === "done" ? "synced" : "connecting";
+  }
   return status;
 }
 
@@ -167,6 +193,7 @@ export function SyncBadge({
   lastSyncedAt,
   pending,
   progress,
+  noteOpen,
 }: {
   status: string;
   enabled?: boolean;
@@ -177,6 +204,9 @@ export function SyncBadge({
   /** The open vault's bulk sync run — turns the pill into "Syncing 128/500"
    *  with a determinate bar. Omit for a pill that only tracks the connection. */
   progress?: SyncProgress | null;
+  /** False when the pill stands for the vault, not an open note: socket-derived
+   *  states are skipped and the label comes from `progress` alone. */
+  noteOpen?: boolean;
 }) {
   const running = isSyncRunActive(progress);
   // Only tick the relative clock once we're settled (synced, nothing pending, no
@@ -184,13 +214,26 @@ export function SyncBadge({
   const now = useNowTick(
     status === "synced" && !pending && lastSyncedAt != null && !running,
   );
-  const label = syncBadgeLabel({ status, pending, lastSyncedAt, now, enabled, progress });
-  const tone = syncBadgeTone({ status, progress });
+  const label = syncBadgeLabel({
+    status,
+    pending,
+    lastSyncedAt,
+    now,
+    enabled,
+    progress,
+    noteOpen,
+  });
+  const tone = syncBadgeTone({ status, progress, noteOpen });
   // A determinate fill whenever the run knows its own size; the pre-existing
   // indeterminate slide covers "working, size unknown" (connecting, saving).
   const percent = running ? syncRunPercent(progress) : null;
+  // Hover answers "how far along?" in the same shape as the folder tooltips.
+  const title =
+    running && progress && percent != null
+      ? `${progress.done} of ${progress.total} notes · ${percent}%`
+      : undefined;
   return (
-    <span className={`sync-badge ${tone}${pending ? " pending" : ""}`}>
+    <span className={`sync-badge ${tone}${pending ? " pending" : ""}`} title={title}>
       {tone === "connecting" || (tone === "synced" && pending) ? (
         <span
           className={`sync-progress${percent != null ? " determinate" : ""}`}
@@ -215,6 +258,10 @@ export function SyncBadge({
           <rect x="4" y="11" width="16" height="10" rx="2" />
           <path d="M8 11V7a4 4 0 0 1 8 0v4" />
         </svg>
+      ) : tone === "synced" ? (
+        // Settled and safe reads as a tick, not just a green dot — the same
+        // "this completed" glyph AsyncButton uses.
+        <CheckMark size="xs" />
       ) : (
         <span className="sync-dot" aria-hidden="true" />
       )}

--- a/app/apps/desktop/src/components/VersionPanel.tsx
+++ b/app/apps/desktop/src/components/VersionPanel.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { AsyncButton } from "./AsyncButton";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { characterSvg } from "./Identity";
+import {
+  agoFromIso,
+  formatVersionSize,
+  nextActiveIndex,
+  revertToastText,
+  versionAuthorLabel,
+  versionCauseLabel,
+} from "./versionFormat";
+import type { NoteVersion } from "../lib/api";
+import { bridgeManager } from "../lib/bridge";
+import { sha256Hex } from "../lib/bridge/adapter";
+import { toast } from "../lib/toast";
+import { useStore } from "../store";
+
+/**
+ * How long the preview survives the pointer leaving a row. Same 140ms the
+ * editor's presence roster uses: long enough to cross the gap to the next row
+ * (or to the Revert button) without the underlying editor flashing back to the
+ * live text and then away again.
+ */
+const PREVIEW_GRACE_MS = 140;
+
+/**
+ * Version history for the open note — a slide-in over the main pane rather than
+ * a modal, because the point of it is to be read *against* the editor: hovering
+ * a row previews that version in place, and the live note is still there
+ * underneath, still syncing, the moment the pointer leaves.
+ *
+ * Wrapped in an ErrorBoundary (as the graph view is): a panel that throws while
+ * formatting one bad row must not take the editor down with it.
+ */
+export function VersionPanel() {
+  const docId = useStore((s) => s.versionPanelDocId);
+  return (
+    <AnimatePresence>
+      {docId && (
+        <ErrorBoundary
+          label="Version history"
+          resetKeys={[docId]}
+          onError={() => useStore.getState().closeVersionPanel()}
+        >
+          <VersionPanelBody key={docId} docId={docId} />
+        </ErrorBoundary>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function VersionPanelBody({ docId }: { docId: string }) {
+  const versions = useStore((s) => s.noteVersions);
+  const noteTitle = useStore((s) => s.openNote?.title ?? null);
+  const reduceMotion = useReducedMotion();
+
+  // Row 0 is the "Current" pseudo-entry; version i lives at index i + 1.
+  const [active, setActive] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
+  // sha256 of the live buffer, so a stored version that still matches what's on
+  // screen can say so instead of inviting a revert that would change nothing.
+  const [liveSha, setLiveSha] = useState<string | null>(null);
+
+  const asideRef = useRef<HTMLElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const graceRef = useRef<number | null>(null);
+
+  const rows = versions ?? [];
+  const rowCount = rows.length + 1;
+
+  // Take focus so the arrow keys and Escape work without a second click.
+  // preventScroll is load-bearing: at this moment the panel is still translated
+  // off-screen right, and a plain focus() makes the browser scroll `.main`
+  // sideways to reveal it — the whole page lurches, then snaps back.
+  useEffect(() => {
+    asideRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  // Relative times stay honest while the panel sits open.
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  // Click anywhere outside → close, same convention as every popover here
+  // (AccountMenu, PeerRoster). The header's history button is exempt: it is a
+  // toggle, and closing on its pointerdown would make its click re-open the
+  // panel it just closed.
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (asideRef.current?.contains(target)) return;
+      if (target instanceof Element && target.closest(".history-btn")) return;
+      useStore.getState().closeVersionPanel();
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => window.removeEventListener("pointerdown", onPointerDown);
+  }, []);
+
+  // Track the live text's hash. Re-hashing on every keystroke would be silly, so
+  // it settles for a beat first; the badge is a hint, not a lock.
+  useEffect(() => {
+    const bridge = bridgeManager.currentBridge();
+    if (!bridge) return;
+    let cancelled = false;
+    let timer: number | null = null;
+    const recompute = () => {
+      const text = bridge.text.toString();
+      void sha256Hex(text).then((hash) => {
+        if (!cancelled) setLiveSha(hash);
+      });
+    };
+    const onChange = () => {
+      if (timer != null) window.clearTimeout(timer);
+      timer = window.setTimeout(recompute, 250);
+    };
+    recompute();
+    bridge.text.observe(onChange);
+    return () => {
+      cancelled = true;
+      if (timer != null) window.clearTimeout(timer);
+      bridge.text.unobserve(onChange);
+    };
+  }, [docId, versions]);
+
+  // Keep the keyboard selection visible when it walks off the viewport. Skipped
+  // on mount: scrollIntoView scrolls every scrollable ancestor, and doing that
+  // while the panel is still sliding in drags `.main` sideways mid-animation.
+  const didMountScroll = useRef(false);
+  useEffect(() => {
+    if (!didMountScroll.current) {
+      didMountScroll.current = true;
+      return;
+    }
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-idx="${active}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [active]);
+
+  const cancelGrace = () => {
+    if (graceRef.current != null) {
+      window.clearTimeout(graceRef.current);
+      graceRef.current = null;
+    }
+  };
+
+  // Leaving the panel must always drop the preview, including when the panel is
+  // closed mid-hover — otherwise the editor is left showing a frozen old
+  // version with nothing on screen explaining why.
+  useEffect(
+    () => () => {
+      cancelGrace();
+      useStore.getState().clearVersionPreview();
+    },
+    [],
+  );
+
+  const versionAt = (idx: number): NoteVersion | null => rows[idx - 1] ?? null;
+
+  const previewRow = (idx: number) => {
+    cancelGrace();
+    const v = versionAt(idx);
+    if (!v) {
+      // Row 0 ("Current") is the way back to the live buffer.
+      useStore.getState().clearVersionPreview();
+      return;
+    }
+    void useStore.getState().previewVersion(v.id);
+  };
+
+  const scheduleClearPreview = () => {
+    cancelGrace();
+    graceRef.current = window.setTimeout(() => {
+      graceRef.current = null;
+      useStore.getState().clearVersionPreview();
+    }, PREVIEW_GRACE_MS);
+  };
+
+  const close = () => {
+    cancelGrace();
+    useStore.getState().closeVersionPanel();
+  };
+
+  const doRevert = async (v: NoteVersion) => {
+    // Leave preview first: the revert lands in the LIVE editor as a forward
+    // CRDT edit, and watching it apply under a read-only overlay would read as
+    // nothing having happened.
+    cancelGrace();
+    useStore.getState().clearVersionPreview();
+    try {
+      await useStore.getState().revertToVersion(v.id);
+      toast(revertToastText(v.createdAt, Date.now()), "success");
+    } catch (e) {
+      toast(e instanceof Error ? e.message : String(e), "error");
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      close();
+      e.preventDefault();
+      return;
+    }
+    const next = nextActiveIndex(e.key, active, rowCount);
+    if (next != null) {
+      setActive(next);
+      previewRow(next);
+      e.preventDefault();
+      return;
+    }
+    if (e.key === "Enter") {
+      const v = versionAt(active);
+      if (v) {
+        void doRevert(v);
+        e.preventDefault();
+      }
+    }
+  };
+
+  return (
+    <motion.aside
+      ref={asideRef}
+      className="version-panel"
+      tabIndex={-1}
+      role="dialog"
+      aria-label="Version history"
+      onKeyDown={onKeyDown}
+      initial={reduceMotion ? { opacity: 0 } : { x: "100%" }}
+      animate={reduceMotion ? { opacity: 1 } : { x: 0 }}
+      exit={reduceMotion ? { opacity: 0 } : { x: "100%" }}
+      // A deceleration tween, not a spring: the panel slides over a live
+      // CodeMirror, where a spring's overshoot + settling frames read as jitter.
+      // Pure transform (no opacity ramp) keeps it compositor-only and smooth.
+      transition={
+        reduceMotion
+          ? { duration: 0.12 }
+          : { duration: 0.28, ease: [0.32, 0.72, 0, 1] }
+      }
+    >
+      <header className="version-panel-head">
+        <div className="version-panel-title">
+          <span className="settings-eyebrow">Version history</span>
+          <strong>{noteTitle ?? "This note"}</strong>
+        </div>
+        <button
+          className="icon-btn"
+          onClick={close}
+          aria-label="Close version history"
+          title="Close (Esc)"
+        >
+          ✕
+        </button>
+      </header>
+
+      <p className="muted version-panel-hint">
+        Hover a version to preview it here. Reverting keeps a copy of the current
+        text first, so you can always come back.
+      </p>
+
+      {versions == null ? (
+        <div className="muted version-panel-empty">Loading…</div>
+      ) : (
+        <ul className="version-list" ref={listRef} onMouseLeave={scheduleClearPreview}>
+          <li
+            data-idx={0}
+            className={`version-row current-row${active === 0 ? " active" : ""}`}
+            onMouseEnter={() => {
+              setActive(0);
+              previewRow(0);
+            }}
+          >
+            <span className="version-dot" aria-hidden="true" />
+            <span className="version-row-main">
+              <span className="version-row-title">Current</span>
+              <span className="version-row-sub">What’s in the editor right now</span>
+            </span>
+          </li>
+          {rows.map((v, i) => (
+            <VersionRow
+              key={v.id}
+              version={v}
+              idx={i + 1}
+              active={active === i + 1}
+              isCurrent={liveSha != null && liveSha === v.sha256}
+              now={now}
+              onHover={() => {
+                setActive(i + 1);
+                previewRow(i + 1);
+              }}
+              onRevert={() => doRevert(v)}
+            />
+          ))}
+          {rows.length === 0 && (
+            <li className="muted version-panel-empty">
+              No versions yet. One is captured automatically a few minutes after
+              you stop editing, and always just before a revert.
+            </li>
+          )}
+        </ul>
+      )}
+    </motion.aside>
+  );
+}
+
+function VersionRow({
+  version,
+  idx,
+  active,
+  isCurrent,
+  now,
+  onHover,
+  onRevert,
+}: {
+  version: NoteVersion;
+  idx: number;
+  active: boolean;
+  /** This stored version's text is byte-identical to the live buffer. */
+  isCurrent: boolean;
+  now: number;
+  onHover: () => void;
+  onRevert: () => Promise<void>;
+}) {
+  const author = versionAuthorLabel(version.authorName);
+  const svg = useMemo(
+    () => characterSvg(version.authorName || version.authorId || "?"),
+    [version.authorName, version.authorId],
+  );
+  const size = formatVersionSize(version.size);
+  return (
+    <li
+      data-idx={idx}
+      className={`version-row${active ? " active" : ""}${isCurrent ? " is-current" : ""}`}
+      onMouseEnter={onHover}
+    >
+      <span
+        className="version-avatar"
+        aria-hidden="true"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+      <span className="version-row-main">
+        <span className="version-row-title">
+          {agoFromIso(version.createdAt, now)}
+          {isCurrent && <span className="version-badge">Current</span>}
+        </span>
+        <span className="version-row-sub">
+          {author} · {versionCauseLabel(version.cause)}
+          {size && ` · ${size}`}
+        </span>
+      </span>
+      <AsyncButton
+        className="link-btn version-revert"
+        disabled={isCurrent}
+        title={
+          isCurrent
+            ? "This is already what the note says"
+            : "Replace the note with this version"
+        }
+        onClick={onRevert}
+      >
+        Revert
+      </AsyncButton>
+    </li>
+  );
+}

--- a/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
+++ b/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
@@ -67,10 +67,10 @@ describe("syncBadgeLabel with a bulk sync run", () => {
         now,
         progress: run({ phase: "uploading", done: 128, total: 500 }),
       }),
-    ).toBe("Syncing 128/500");
+    ).toBe("Uploading 128/500");
   });
 
-  it("counts the registering and downloading phases too", () => {
+  it("counts the registering and downloading phases too, named by direction", () => {
     expect(
       syncBadgeLabel({
         status: "connecting",
@@ -78,13 +78,14 @@ describe("syncBadgeLabel with a bulk sync run", () => {
         progress: run({ phase: "registering", done: 3, total: 40 }),
       }),
     ).toBe("Syncing 3/40");
+    // A freshly invited teammate watching their vault arrive reads "Downloading".
     expect(
       syncBadgeLabel({
         status: "synced",
         now,
         progress: run({ phase: "downloading", done: 9, total: 10 }),
       }),
-    ).toBe("Syncing 9/10");
+    ).toBe("Downloading 9/10");
   });
 
   it("falls back to the indeterminate label when the run has no total yet", () => {
@@ -155,6 +156,71 @@ describe("syncBadgeLabel with a bulk sync run", () => {
     for (const phase of ["registering", "uploading", "downloading"] as const) {
       expect(isSyncRunActive(run({ phase }))).toBe(true);
     }
+  });
+
+  it("stays honest with no note open: the label comes from the run alone", () => {
+    // The header pill is now mounted vault-wide. With no note open, `status`
+    // belongs to a socket that doesn't exist — it must never leak into the label.
+    expect(
+      syncBadgeLabel({
+        status: "offline",
+        now,
+        noteOpen: false,
+        progress: run({ phase: "downloading", done: 128, total: 500 }),
+      }),
+    ).toBe("Downloading 128/500");
+    expect(
+      syncBadgeLabel({
+        status: "offline",
+        now,
+        noteOpen: false,
+        progress: run({ phase: "done", done: 500, total: 500 }),
+      }),
+    ).toBe("Synced");
+    expect(
+      syncBadgeLabel({
+        status: "synced",
+        now,
+        noteOpen: false,
+        progress: run({ phase: "error", done: 480, total: 500, failed: 20 }),
+      }),
+    ).toBe("20 not synced");
+    // Stale grant facts from the last open note don't apply either.
+    expect(
+      syncBadgeLabel({
+        status: "no-access",
+        now,
+        noteOpen: false,
+        progress: run({ phase: "uploading", done: 1, total: 9 }),
+      }),
+    ).toBe("Uploading 1/9");
+  });
+
+  it("keeps the vault-wide tone consistent with the vault-wide words", () => {
+    expect(
+      syncBadgeTone({
+        status: "offline",
+        noteOpen: false,
+        progress: run({ done: 1, total: 9 }),
+      }),
+    ).toBe("connecting");
+    expect(
+      syncBadgeTone({ status: "offline", noteOpen: false, progress: run({ phase: "done" }) }),
+    ).toBe("synced");
+    expect(
+      syncBadgeTone({
+        status: "synced",
+        noteOpen: false,
+        progress: run({ phase: "error", failed: 3 }),
+      }),
+    ).toBe("error");
+    expect(
+      syncBadgeTone({
+        status: "no-access",
+        noteOpen: false,
+        progress: run({ done: 1, total: 9 }),
+      }),
+    ).toBe("connecting");
   });
 
   it("floors the bar's percentage and clamps it", () => {

--- a/app/apps/desktop/src/components/editor.css
+++ b/app/apps/desktop/src/components/editor.css
@@ -94,6 +94,50 @@
 /* No backing plate — hovering the stack grows the faces and reveals the roster
    (see .presence-bar:hover .presence-avatar); a box behind them read as a shadow. */
 
+/* "Recent activity" — the roster's history section. Faces half the size of the
+   live rows above and dimmed, so past never reads as present. */
+.roster-recent-title {
+  margin-top: var(--sp-2);
+  padding-top: var(--sp-2);
+  border-top: 1px solid var(--border);
+}
+.roster-recent-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  /* Same inset as .peer-row so the section breathes like the live rows above. */
+  padding: var(--sp-1) var(--sp-2);
+  opacity: 0.75;
+}
+.roster-recent-avatar {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  /* Center the 16px face inside the 24px avatar column of the rows above. */
+  margin: 0 4px;
+  border-radius: 50%;
+  overflow: hidden;
+  filter: grayscale(0.4);
+}
+.roster-recent-avatar svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.roster-recent-name {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.roster-recent-when {
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
 .presence-avatar {
   position: relative;
   width: 34px;
@@ -165,9 +209,9 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  min-width: 224px;
-  max-width: 300px;
-  padding: var(--sp-2);
+  min-width: 192px;
+  max-width: 256px;
+  padding: var(--sp-1) var(--sp-2) var(--sp-2);
   /* Compact translucent glass panel. */
   background: color-mix(in srgb, var(--bg-surface) 82%, transparent);
   backdrop-filter: blur(16px) saturate(1.3);
@@ -197,8 +241,8 @@
   background: var(--bg-hover);
 }
 .presence-avatar.sm {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   margin-left: 0;
   font-size: var(--fs-xs);
 }
@@ -503,6 +547,57 @@
 @media (prefers-reduced-motion: reduce) {
   /* Keep the shape and the delay, drop the travelling highlight. */
   .skel-line {
+    animation: none;
+  }
+}
+
+/* ============================================================
+   Version preview — a read-only past version laid over the live
+   editor while a row in the history panel is hovered.
+
+   The live CodeMirror stays mounted and syncing underneath (see
+   Editor.tsx): this is an overlay, not a mode, so letting go of
+   the row returns to a note that never stopped being edited.
+   ============================================================ */
+.editor-host-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+.version-preview {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-surface);
+  animation: fade-in var(--t-fast) var(--ease) both;
+}
+.version-preview-host {
+  height: 100%;
+  overflow: hidden;
+}
+/* Bottom-centred rather than top-right: this is the answer to "what am I
+   looking at?", and it must not sit under the presence avatars or get lost in
+   the same corner as the sync pill. */
+.version-preview-pill {
+  position: absolute;
+  bottom: var(--sp-5);
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-4);
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  white-space: nowrap;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .version-preview {
     animation: none;
   }
 }

--- a/app/apps/desktop/src/components/versionFormat.test.ts
+++ b/app/apps/desktop/src/components/versionFormat.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  agoFromIso,
+  checkpointTitle,
+  formatVersionSize,
+  lastEditedTooltip,
+  nextActiveIndex,
+  noteCountLabel,
+  parseIsoMs,
+  revertToastText,
+  versionAuthorLabel,
+  versionCauseLabel,
+} from "./versionFormat";
+
+// Every helper here renders a row the user is about to act on — reverting a
+// note or a whole vault — so the interesting cases are the degenerate ones the
+// server is allowed to send: a null author, a version with no size, a
+// checkpoint with no label.
+
+const NOW = Date.parse("2026-08-11T12:00:00.000Z");
+
+describe("parseIsoMs / agoFromIso", () => {
+  it("reads a server ISO timestamp", () => {
+    expect(parseIsoMs("2026-08-11T11:00:00.000Z")).toBe(NOW - 3_600_000);
+  });
+
+  it("returns null rather than NaN for junk", () => {
+    expect(parseIsoMs("not a date")).toBeNull();
+    expect(parseIsoMs(null)).toBeNull();
+    expect(parseIsoMs(undefined)).toBeNull();
+  });
+
+  it("degrades to a dash instead of 'NaNm ago'", () => {
+    expect(agoFromIso("nope", NOW)).toBe("—");
+    expect(agoFromIso("2026-08-11T11:00:00.000Z", NOW)).toBe("1h ago");
+    expect(agoFromIso("2026-08-11T11:59:50.000Z", NOW)).toBe("just now");
+  });
+});
+
+describe("versionCauseLabel", () => {
+  it("names the pre-revert safety copy distinctly", () => {
+    expect(versionCauseLabel("pre-revert")).toBe("Before revert");
+  });
+
+  it("treats anything else as the ordinary idle capture", () => {
+    expect(versionCauseLabel("idle")).toBe("Auto-saved");
+    // A cause added server-side later must not render blank.
+    expect(versionCauseLabel("something-new")).toBe("Auto-saved");
+  });
+});
+
+describe("versionAuthorLabel", () => {
+  it("falls back when the author was deleted or never recorded", () => {
+    expect(versionAuthorLabel(null)).toBe("Unknown");
+    expect(versionAuthorLabel("   ")).toBe("Unknown");
+    expect(versionAuthorLabel("Ada")).toBe("Ada");
+  });
+});
+
+describe("formatVersionSize", () => {
+  it("uses bytes, then one decimal of KB/MB, then whole units", () => {
+    expect(formatVersionSize(0)).toBe("0 B");
+    expect(formatVersionSize(812)).toBe("812 B");
+    expect(formatVersionSize(1024)).toBe("1.0 KB");
+    expect(formatVersionSize(4198)).toBe("4.1 KB");
+    expect(formatVersionSize(1024 * 200)).toBe("200 KB");
+    expect(formatVersionSize(1024 * 1024 * 1.25)).toBe("1.3 MB");
+  });
+
+  it("renders nothing for a size the server didn't send", () => {
+    expect(formatVersionSize(Number.NaN)).toBe("");
+    expect(formatVersionSize(-1)).toBe("");
+  });
+});
+
+describe("nextActiveIndex", () => {
+  it("wraps in both directions", () => {
+    expect(nextActiveIndex("ArrowDown", 2, 3)).toBe(0);
+    expect(nextActiveIndex("ArrowUp", 0, 3)).toBe(2);
+    expect(nextActiveIndex("ArrowDown", 0, 3)).toBe(1);
+  });
+
+  it("jumps to the ends", () => {
+    expect(nextActiveIndex("Home", 2, 3)).toBe(0);
+    expect(nextActiveIndex("End", 0, 3)).toBe(2);
+  });
+
+  it("declines keys it doesn't own, so they aren't swallowed", () => {
+    expect(nextActiveIndex("Enter", 0, 3)).toBeNull();
+    expect(nextActiveIndex("a", 0, 3)).toBeNull();
+  });
+
+  it("declines everything when there are no rows", () => {
+    expect(nextActiveIndex("ArrowDown", 0, 0)).toBeNull();
+  });
+});
+
+describe("revertToastText", () => {
+  it("says which version landed", () => {
+    expect(revertToastText("2026-08-11T09:00:00.000Z", NOW)).toBe(
+      "Reverted to the version from 3h ago",
+    );
+  });
+});
+
+describe("lastEditedTooltip", () => {
+  it("accepts either a timestamp or an ISO string", () => {
+    expect(lastEditedTooltip("Ada", NOW - 120_000, NOW)).toBe("Edited by Ada · 2m ago");
+    expect(lastEditedTooltip("Ada", "2026-08-11T11:58:00.000Z", NOW)).toBe(
+      "Edited by Ada · 2m ago",
+    );
+  });
+
+  it("drops the time when there isn't one, and names an unknown editor", () => {
+    expect(lastEditedTooltip("Ada", null, NOW)).toBe("Edited by Ada");
+    expect(lastEditedTooltip(null, NOW, NOW)).toBe("Edited by Someone · just now");
+  });
+});
+
+describe("checkpointTitle", () => {
+  it("prefers the user's own label", () => {
+    expect(checkpointTitle("Before the big refactor", "manual", "", NOW)).toBe(
+      "Before the big refactor",
+    );
+  });
+
+  it("describes an unlabelled checkpoint by kind and age", () => {
+    expect(checkpointTitle(null, "auto", "2026-08-10T12:00:00.000Z", NOW)).toBe(
+      "Daily checkpoint · 1d ago",
+    );
+    expect(checkpointTitle("  ", "manual", "2026-08-11T11:00:00.000Z", NOW)).toBe(
+      "Manual checkpoint · 1h ago",
+    );
+  });
+});
+
+describe("noteCountLabel", () => {
+  it("pluralises", () => {
+    expect(noteCountLabel(1)).toBe("1 note");
+    expect(noteCountLabel(0)).toBe("0 notes");
+    expect(noteCountLabel(12)).toBe("12 notes");
+  });
+});

--- a/app/apps/desktop/src/components/versionFormat.ts
+++ b/app/apps/desktop/src/components/versionFormat.ts
@@ -1,0 +1,110 @@
+// Pure formatting + keyboard-nav helpers for the version history UI.
+//
+// They live outside `VersionPanel.tsx` so they can be unit-tested in the plain
+// Node vitest environment (the panel itself pulls in motion/react, the store and
+// the bridge). Every one of them is total: a row must render even when the
+// server sent a null author or an unparseable timestamp.
+
+import { relativeAgo } from "./Identity";
+
+/** Why a version exists, as the server records it. */
+export type VersionCause = "idle" | "pre-revert";
+
+/** Millis for a server ISO timestamp; `null` when it can't be parsed. */
+export function parseIsoMs(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** "2h ago" for an ISO timestamp; "—" when it isn't a usable date. */
+export function agoFromIso(iso: string | null | undefined, now: number): string {
+  const ms = parseIsoMs(iso);
+  return ms == null ? "—" : relativeAgo(ms, now);
+}
+
+/**
+ * The row's one-word provenance. "Auto-saved" is the overwhelmingly common
+ * case (a version is captured when a note goes quiet); "Before revert" marks
+ * the safety copy taken on the way into a revert, which is the entry people
+ * come looking for when they want to undo one.
+ */
+export function versionCauseLabel(cause: string): string {
+  return cause === "pre-revert" ? "Before revert" : "Auto-saved";
+}
+
+/** Display name for a version's author; anonymous when the server had none. */
+export function versionAuthorLabel(authorName: string | null | undefined): string {
+  return authorName?.trim() || "Unknown";
+}
+
+/** Compact byte size for a version row: "812 B", "4.1 KB", "1.2 MB". */
+export function formatVersionSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb < 10 ? kb.toFixed(1) : Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  return `${mb < 10 ? mb.toFixed(1) : Math.round(mb)} MB`;
+}
+
+/**
+ * Keyboard navigation over the panel's rows, as arithmetic rather than as an
+ * event handler, so the wrap-around is testable. Returns the index to move to,
+ * or `null` when the key isn't ours (the caller must then NOT preventDefault —
+ * swallowing every keystroke in a focused panel breaks tab-out and copy).
+ */
+export function nextActiveIndex(
+  key: string,
+  active: number,
+  count: number,
+): number | null {
+  if (count <= 0) return null;
+  switch (key) {
+    case "ArrowDown":
+      return (active + 1) % count;
+    case "ArrowUp":
+      return (active - 1 + count) % count;
+    case "Home":
+      return 0;
+    case "End":
+      return count - 1;
+    default:
+      return null;
+  }
+}
+
+/** Toast copy after a successful per-note revert. */
+export function revertToastText(createdAt: string, now: number): string {
+  return `Reverted to the version from ${agoFromIso(createdAt, now)}`;
+}
+
+/** Tooltip for a sidebar row's last-edited-by tag. */
+export function lastEditedTooltip(
+  name: string | null | undefined,
+  at: number | string | null | undefined,
+  now: number,
+): string {
+  const who = name?.trim() || "Someone";
+  const ms = typeof at === "string" ? parseIsoMs(at) : typeof at === "number" ? at : null;
+  return ms == null ? `Edited by ${who}` : `Edited by ${who} · ${relativeAgo(ms, now)}`;
+}
+
+/** A checkpoint's headline: its label if it has one, else its kind + age. */
+export function checkpointTitle(
+  label: string | null | undefined,
+  kind: string,
+  createdAt: string,
+  now: number,
+): string {
+  const trimmed = label?.trim();
+  if (trimmed) return trimmed;
+  return kind === "manual"
+    ? `Manual checkpoint · ${agoFromIso(createdAt, now)}`
+    : `Daily checkpoint · ${agoFromIso(createdAt, now)}`;
+}
+
+/** "12 notes" / "1 note" — a checkpoint's size, in the unit users think in. */
+export function noteCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "note" : "notes"}`;
+}

--- a/app/apps/desktop/src/lib/__tests__/noteMetaListener.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/noteMetaListener.test.ts
@@ -1,0 +1,122 @@
+// SyncManager's half of the last-edited plumbing: it forwards the registry's
+// {docId → last-edit} map to the UI, and it applies the same vault-scope gate as
+// the path→docId mirror — a pull that lands after a vault switch describes the
+// vault we left, and the honest answer there is an empty map.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.hoisted` because importing the module under test evaluates its
+// `syncManager` singleton, which constructs a VaultRegistry at module-eval time.
+const fakeRegistry = vi.hoisted(() => {
+  const reg = {
+    vaultId: null as string | null,
+    reconcile: vi.fn(async () => ({ seeded: false })),
+    pull: vi.fn(async () => {}),
+    reset: vi.fn(),
+    getMapping: vi.fn(() => null),
+    pathForDocId: vi.fn(() => null),
+    allDocIds: vi.fn((): string[] => []),
+    setProgressSink: vi.fn(),
+    setMapListener: vi.fn(),
+    noteMetaListener: null as
+      | ((meta: Record<string, { userId: string | null; name: string | null; at: string }>) => void)
+      | null,
+    setNoteMetaListener: vi.fn(
+      (
+        cb:
+          | ((
+              meta: Record<string, { userId: string | null; name: string | null; at: string }>,
+            ) => void)
+          | null,
+      ) => {
+        reg.noteMetaListener = cb;
+      },
+    ),
+    setInboundHost: vi.fn(),
+    mappedNotes: vi.fn((): Array<{ docId: string; relPath: string }> => []),
+    isPushed: vi.fn(() => false),
+    markPushed: vi.fn(),
+    flushCheckpoint: vi.fn(async () => {}),
+    failures: vi.fn((): unknown[] => []),
+    hasFailures: vi.fn(() => false),
+    limitCode: vi.fn((): string | null => null),
+  };
+  return reg;
+});
+
+vi.mock("../sync/registry", () => ({
+  VaultRegistry: class {
+    constructor() {
+      return fakeRegistry;
+    }
+  },
+}));
+
+import type { NoteLastEdited, SessionInfo } from "../api";
+import { SyncManager } from "../sync/docSession";
+import { vaultScopes } from "../sync/vaultScope";
+
+const AT = "2026-08-11T10:00:00.000Z";
+const META: Record<string, NoteLastEdited> = { "doc-a": { userId: "u1", name: "Ada", at: AT } };
+
+function session(orgId = "org-a"): SessionInfo {
+  return {
+    user: { id: "u1", name: "Ann", email: "ann@example.com" },
+    activeOrganizationId: orgId,
+  } as unknown as SessionInfo;
+}
+
+async function enabled(orgId = "org-a"): Promise<SyncManager> {
+  const sm = new SyncManager();
+  await sm.enable(session(orgId), { orgId, name: orgId, path: `/vaults/${orgId}`, epoch: 1 });
+  return sm;
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  fakeRegistry.reconcile.mockClear().mockImplementation(async () => ({ seeded: false }));
+  fakeRegistry.mappedNotes.mockReturnValue([]);
+  vaultScopes.end();
+});
+
+describe("SyncManager — note last-edit forwarding", () => {
+  it("subscribes to the registry on construction and forwards its map", async () => {
+    const sm = await enabled();
+    const seen: Array<Record<string, NoteLastEdited>> = [];
+    sm.setNoteMetaListener((meta) => seen.push(meta));
+
+    fakeRegistry.noteMetaListener?.(META);
+
+    expect(seen).toEqual([META]);
+  });
+
+  it("publishes an EMPTY map for a pull that lands after a vault switch", async () => {
+    const sm = await enabled("org-a");
+    const seen: Array<Record<string, NoteLastEdited>> = [];
+    sm.setNoteMetaListener((meta) => seen.push(meta));
+
+    // Another vault becomes current without this manager tearing down — the exact
+    // shape of the historical cross-vault leak.
+    vaultScopes.begin({ orgId: "org-b", vaultPath: "/vaults/org-b", vaultEpoch: 2 });
+    fakeRegistry.noteMetaListener?.(META);
+
+    expect(seen).toEqual([{}]);
+  });
+
+  it("clears the UI's stamps on disable, rather than going silent", async () => {
+    const sm = await enabled();
+    const seen: Array<Record<string, NoteLastEdited>> = [];
+    sm.setNoteMetaListener((meta) => seen.push(meta));
+    fakeRegistry.noteMetaListener?.(META);
+
+    sm.disable();
+
+    expect(seen[seen.length - 1]).toEqual({});
+  });
+
+  it("is a no-op with no subscriber", async () => {
+    const sm = await enabled();
+    sm.setNoteMetaListener(undefined);
+    expect(() => fakeRegistry.noteMetaListener?.(META)).not.toThrow();
+  });
+});

--- a/app/apps/desktop/src/lib/__tests__/registryNoteMeta.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/registryNoteMeta.test.ts
@@ -1,0 +1,125 @@
+// "Last edited by" reaches the UI on the registry pull, not on a channel of its
+// own (the server already re-triggers that pull when it stamps an edit). These
+// tests pin the two halves of that: the registry publishes a docId-keyed map
+// from the note rows it just fetched, and it publishes the FINAL list.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../ipc", () => ({
+  getVaultConfig: vi.fn(async () => null),
+  setVaultConfig: vi.fn(async () => {}),
+  listTree: vi.fn(async () => ({
+    id: "root",
+    name: "",
+    path: "",
+    isDir: true,
+    children: [],
+    childrenLoaded: true,
+  })),
+  listNoteTitles: vi.fn(async () => []),
+  writeNote: vi.fn(async () => {}),
+  writeNoteIfMissing: vi.fn(async () => true),
+}));
+vi.mock("../vault/seed", () => ({ seedWelcomeContent: vi.fn(async () => {}) }));
+
+import type { ApiClient, NoteLastEdited, RegisteredNote } from "../api";
+import * as ipc from "../ipc";
+import type { TreeNode } from "../ipc";
+import { VaultRegistry } from "../sync/registry";
+
+const ORG = "org-1";
+const VAULT = { id: "vault-1", name: "V", organization_id: ORG };
+
+const AT = "2026-08-11T10:00:00.000Z";
+
+function fakeApi(notes: RegisteredNote[]) {
+  return {
+    listVaults: vi.fn(async () => [VAULT]),
+    createVault: vi.fn(async () => VAULT),
+    listFolders: vi.fn(async () => []),
+    createFolder: vi.fn(async (input: { path: string }) => ({ id: `folder-${input.path}` })),
+    listNotes: vi.fn(async () => notes),
+    listNoteRegistry: vi.fn(async () => ({ notes, tombstones: [] as string[] })),
+    createNote: vi.fn(async (input: { relPath: string }) => ({
+      id: `note-${input.relPath}`,
+      rel_path: input.relPath,
+    })),
+  } as unknown as ApiClient;
+}
+
+function emptyTree(): TreeNode {
+  return { id: "root", name: "vault", path: "", isDir: true, children: [], childrenLoaded: true };
+}
+
+beforeEach(() => {
+  vi.mocked(ipc.listTree).mockResolvedValue(emptyTree());
+  vi.mocked(ipc.getVaultConfig).mockResolvedValue(null);
+  vi.mocked(ipc.listNoteTitles).mockResolvedValue([]);
+  vi.mocked(ipc.writeNoteIfMissing).mockClear().mockResolvedValue(true);
+});
+
+describe("VaultRegistry — note last-edit metadata", () => {
+  it("publishes a docId-keyed map from the pulled note rows", async () => {
+    const api = fakeApi([
+      {
+        id: "doc-a",
+        title: "A",
+        rel_path: "A.md",
+        last_edited_by: "u1",
+        last_edited_by_name: "Ada",
+        last_edited_at: AT,
+      },
+    ]);
+    const reg = new VaultRegistry(api);
+    const seen: Array<Record<string, NoteLastEdited>> = [];
+    reg.setNoteMetaListener((meta) => seen.push(meta));
+
+    await reg.reconcile({ organizationId: ORG, vaultName: "V" });
+
+    expect(seen).toHaveLength(1);
+    // Keyed by doc_id — never by path, which renames and collides across vaults.
+    expect(seen[0]).toEqual({ "doc-a": { userId: "u1", name: "Ada", at: AT } });
+  });
+
+  it("omits notes the server has no stamp for, rather than inventing one", async () => {
+    const api = fakeApi([
+      { id: "doc-a", title: "A", rel_path: "A.md", last_edited_at: AT },
+      { id: "doc-b", title: "B", rel_path: "B.md" },
+    ]);
+    const reg = new VaultRegistry(api);
+    let meta: Record<string, NoteLastEdited> = {};
+    reg.setNoteMetaListener((m) => {
+      meta = m;
+    });
+
+    await reg.reconcile({ organizationId: ORG, vaultName: "V" });
+
+    expect(Object.keys(meta)).toEqual(["doc-a"]);
+    expect(meta["doc-a"].name).toBeNull();
+  });
+
+  it("re-publishes on every pull, so an edit converges on the existing round trip", async () => {
+    const notes: RegisteredNote[] = [{ id: "doc-a", title: "A", rel_path: "A.md" }];
+    const api = fakeApi(notes);
+    const reg = new VaultRegistry(api);
+    const seen: Array<Record<string, NoteLastEdited>> = [];
+    reg.setNoteMetaListener((meta) => seen.push(meta));
+
+    await reg.reconcile({ organizationId: ORG, vaultName: "V" });
+    expect(seen[0]).toEqual({});
+
+    // A teammate edits the note; the server stamps it and pings `registry`.
+    notes[0].last_edited_by = "u2";
+    notes[0].last_edited_by_name = "Grace";
+    notes[0].last_edited_at = AT;
+    await reg.pull();
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toEqual({ "doc-a": { userId: "u2", name: "Grace", at: AT } });
+  });
+
+  it("survives having no listener at all (unit tests, teardown)", async () => {
+    const reg = new VaultRegistry(fakeApi([{ id: "doc-a", title: "A", rel_path: "A.md" }]));
+    await expect(reg.reconcile({ organizationId: ORG, vaultName: "V" })).resolves.toBeDefined();
+  });
+});

--- a/app/apps/desktop/src/lib/__tests__/updater.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/updater.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { releaseNoteLines } from "../updater";
+
+// The post-update banner's one-liners come straight from the GitHub release
+// body (docs/RELEASE_NOTES.md at ship time). These lock in the cleanup rules:
+// bullets lose their markers, headings/blanks/the legacy placeholder vanish,
+// and a long list is capped rather than scrolling the banner.
+describe("releaseNoteLines", () => {
+  it("strips bullet markers and drops headings and blank lines", () => {
+    const body = [
+      "# v0.2.0",
+      "",
+      "- Version history for every note",
+      "* Vault checkpoints",
+      "• Sync indicator",
+      "plain line stays",
+      "",
+    ].join("\n");
+    expect(releaseNoteLines(body)).toEqual([
+      "Version history for every note",
+      "Vault checkpoints",
+      "Sync indicator",
+      "plain line stays",
+    ]);
+  });
+
+  it("drops the legacy placeholder body entirely", () => {
+    expect(
+      releaseNoteLines("See the assets below to download and install this version."),
+    ).toEqual([]);
+  });
+
+  it("caps the list and tolerates null/undefined", () => {
+    const body = Array.from({ length: 10 }, (_, i) => `- line ${i}`).join("\n");
+    expect(releaseNoteLines(body, 6)).toHaveLength(6);
+    expect(releaseNoteLines(null)).toEqual([]);
+    expect(releaseNoteLines(undefined)).toEqual([]);
+  });
+});

--- a/app/apps/desktop/src/lib/__tests__/versionsApi.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/versionsApi.test.ts
@@ -1,0 +1,194 @@
+// The versioning half of the HTTP boundary: URLs, methods, and the shapes the
+// desktop actually depends on. These are contract tests against the server's
+// documented responses — every expectation here mirrors one in the server's
+// `tests/versions.test.ts` / `tests/checkpoints.test.ts`.
+
+import { describe, expect, it } from "vitest";
+import { ApiClient, ApiError, noteLastEdited, type RegisteredNote } from "../api";
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+function fakeFetch(script: (call: Call) => { status?: number; json?: unknown; text?: string }) {
+  const calls: Call[] = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call: Call = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    };
+    calls.push(call);
+    const r = script(call);
+    const status = r.status ?? 200;
+    const text = r.text ?? (r.json !== undefined ? JSON.stringify(r.json) : "");
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: () => null },
+      text: async () => text,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+function client(script: Parameters<typeof fakeFetch>[0]) {
+  const { impl, calls } = fakeFetch(script);
+  return {
+    api: new ApiClient({ baseUrl: "http://localhost:3010", token: "t", fetchImpl: impl }),
+    calls,
+  };
+}
+
+const VERSION = {
+  id: 7,
+  createdAt: "2026-08-11T10:00:00.000Z",
+  cause: "idle" as const,
+  authorId: "u1",
+  authorName: "Ada",
+  sha256: "abc",
+  size: 12,
+};
+
+describe("ApiClient — per-note versions", () => {
+  it("lists versions newest-first and unwraps the envelope", async () => {
+    const { api, calls } = client(() => ({ json: { versions: [VERSION] } }));
+    const versions = await api.listNoteVersions("doc 1");
+    expect(versions).toEqual([VERSION]);
+    // The docId is path-encoded, not interpolated raw.
+    expect(calls[0].url).toBe("http://localhost:3010/api/notes/doc%201/versions");
+    expect(calls[0].method).toBe("GET");
+  });
+
+  it("returns [] when the server omits the versions array", async () => {
+    const { api } = client(() => ({ json: {} }));
+    expect(await api.listNoteVersions("d1")).toEqual([]);
+  });
+
+  it("fetches one version WITH content (the preview payload)", async () => {
+    const { api, calls } = client(() => ({ json: { ...VERSION, content: "# hi" } }));
+    const detail = await api.getNoteVersion("d1", 7);
+    expect(detail.content).toBe("# hi");
+    expect(detail.sha256).toBe("abc");
+    expect(calls[0].url).toBe("http://localhost:3010/api/notes/d1/versions/7");
+  });
+
+  it("reverts and surfaces a null preRevertVersionId (live text already stored)", async () => {
+    const { api, calls } = client(() => ({ json: { ok: true, preRevertVersionId: null } }));
+    expect(await api.revertNoteToVersion("d1", 7)).toEqual({
+      ok: true,
+      preRevertVersionId: null,
+    });
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("http://localhost:3010/api/notes/d1/versions/7/revert");
+  });
+
+  it("surfaces the 403 a locked share produces on revert", async () => {
+    const { api } = client(() => ({ status: 403, json: { error: "Read-only" } }));
+    await expect(api.revertNoteToVersion("d1", 7)).rejects.toMatchObject({
+      name: "ApiError",
+      status: 403,
+    });
+  });
+});
+
+const CHECKPOINT = {
+  id: "cp-1",
+  kind: "manual" as const,
+  label: "Before the rewrite",
+  createdAt: "2026-08-11T10:00:00.000Z",
+  createdBy: "u1",
+  createdByName: "Ada",
+  noteCount: 3,
+};
+
+describe("ApiClient — vault checkpoints", () => {
+  it("lists checkpoints for a note collection", async () => {
+    const { api, calls } = client(() => ({ json: { checkpoints: [CHECKPOINT] } }));
+    expect(await api.listCheckpoints("v1")).toEqual([CHECKPOINT]);
+    expect(calls[0].url).toBe("http://localhost:3010/api/vaults/v1/checkpoints");
+  });
+
+  it("creates a checkpoint and reads the summary UNWRAPPED from the 201", async () => {
+    const { api, calls } = client(() => ({ status: 201, json: CHECKPOINT }));
+    expect(await api.createCheckpoint("v1", "  Before the rewrite  ".trim())).toEqual(CHECKPOINT);
+    expect(calls[0].body).toEqual({ label: "Before the rewrite" });
+  });
+
+  it("omits the label entirely when none is given", async () => {
+    const { api, calls } = client(() => ({ status: 201, json: { ...CHECKPOINT, label: null } }));
+    await api.createCheckpoint("v1");
+    expect(calls[0].body).toEqual({});
+  });
+
+  it("maps the 409 taken while the vault lock is held", async () => {
+    const { api } = client(() => ({ status: 409, json: { error: "Vault is busy" } }));
+    await expect(api.createCheckpoint("v1")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("deletes a checkpoint via a 204 with an EMPTY body (nothing to parse)", async () => {
+    const { api, calls } = client(() => ({ status: 204, text: "" }));
+    await expect(api.deleteCheckpoint("v1", "cp 1")).resolves.toBeUndefined();
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].url).toBe("http://localhost:3010/api/vaults/v1/checkpoints/cp%201");
+  });
+
+  it("returns the whole-vault revert tally", async () => {
+    const result = {
+      ok: true as const,
+      docsChanged: 2,
+      docsRestored: 1,
+      docsDeleted: 1,
+      foldersCreated: 0,
+      preRevertCheckpointId: "cp-0",
+    };
+    const { api, calls } = client(() => ({ json: result }));
+    expect(await api.revertToCheckpoint("v1", "cp-1")).toEqual(result);
+    expect(calls[0].url).toBe("http://localhost:3010/api/vaults/v1/checkpoints/cp-1/revert");
+    expect(calls[0].method).toBe("POST");
+  });
+});
+
+describe("noteLastEdited — dual-casing normalization", () => {
+  const base: RegisteredNote = { id: "n1", title: "A" };
+
+  it("reads the server's snake_case row", () => {
+    expect(
+      noteLastEdited({
+        ...base,
+        last_edited_by: "u1",
+        last_edited_by_name: "Ada",
+        last_edited_at: "2026-08-11T10:00:00.000Z",
+      }),
+    ).toEqual({ userId: "u1", name: "Ada", at: "2026-08-11T10:00:00.000Z" });
+  });
+
+  it("reads camelCase too, and prefers it when both are present", () => {
+    expect(
+      noteLastEdited({
+        ...base,
+        lastEditedBy: "u2",
+        last_edited_by: "u1",
+        lastEditedAt: "2026-08-11T11:00:00.000Z",
+        last_edited_at: "2026-08-11T10:00:00.000Z",
+      })?.userId,
+    ).toBe("u2");
+  });
+
+  it("is null for a note that has never been edited (no timestamp)", () => {
+    // The absence of `last_edited_at` is what the whole UI branches on — a note
+    // with an author but no time is not a stamp, it's a half-written row.
+    expect(noteLastEdited(base)).toBeNull();
+    expect(noteLastEdited({ ...base, last_edited_by: "u1" })).toBeNull();
+  });
+
+  it("keeps a stamp whose author has been deleted (name/id null, time real)", () => {
+    expect(noteLastEdited({ ...base, last_edited_at: "2026-08-11T10:00:00.000Z" })).toEqual({
+      userId: null,
+      name: null,
+      at: "2026-08-11T10:00:00.000Z",
+    });
+  });
+});

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -118,6 +118,23 @@ export interface RegisteredNote {
   title: string | null;
   relPath?: string;
   rel_path?: string;
+  /** Who last *edited* the note's content (never a rename/move), server-stamped
+   *  from the authenticated editor — a teammate or an AI over MCP. Null until
+   *  the note has been edited at least once since versioning shipped. */
+  lastEditedBy?: string | null;
+  last_edited_by?: string | null;
+  lastEditedByName?: string | null;
+  last_edited_by_name?: string | null;
+  lastEditedAt?: string | null;
+  last_edited_at?: string | null;
+}
+
+/** The normalized "last edited by" fact for one note (see {@link noteLastEdited}). */
+export interface NoteLastEdited {
+  userId: string | null;
+  name: string | null;
+  /** ISO timestamp from the server. */
+  at: string;
 }
 
 export interface RegisteredFolder {
@@ -198,6 +215,57 @@ export interface BlobMeta {
   filename?: string | null;
   /** True when the upload deduped to an existing row (server-set). */
   deduped?: boolean;
+}
+
+// ---- Versioning (per-note history + vault checkpoints) --------------------
+
+/**
+ * One stored state of a note. Content is deliberately absent — the list is
+ * fetched constantly (every panel open) and a version is the full markdown, so
+ * the body only travels when someone actually previews or reverts
+ * ({@link NoteVersionDetail}).
+ *
+ * `id` is a JS number (the server narrows its BIGSERIAL), `size` is bytes.
+ */
+export interface NoteVersion {
+  id: number;
+  createdAt: string;
+  /** `idle` = captured at the end of an edit session; `pre-revert` = the state
+   *  that was replaced, captured so a revert is itself undoable. */
+  cause: "idle" | "pre-revert";
+  authorId: string | null;
+  authorName: string | null;
+  sha256: string;
+  size: number;
+}
+
+export interface NoteVersionDetail extends NoteVersion {
+  content: string;
+}
+
+/** A vault-wide snapshot (structure + content of every note at one moment). */
+export interface VaultCheckpoint {
+  id: string;
+  kind: "auto" | "manual";
+  label: string | null;
+  createdAt: string;
+  createdBy: string | null;
+  createdByName: string | null;
+  noteCount: number;
+}
+
+/** What a whole-vault revert did. Attachments/blobs are never touched. */
+export interface VaultRevertResult {
+  ok: true;
+  docsChanged: number;
+  docsRestored: number;
+  docsDeleted: number;
+  foldersCreated: number;
+  /** Notes kept as-is because the snapshot was empty while the live note had
+   *  text — the revert's data-loss firewall refusing to bulldoze content. */
+  docsKeptOverEmpty?: number;
+  /** The auto checkpoint taken just before the revert — this is the undo. */
+  preRevertCheckpointId: string;
 }
 
 export interface SyncTokenResponse {
@@ -834,6 +902,80 @@ export class ApiClient {
     await this.request<unknown>("DELETE", `/api/notes/${encodeURIComponent(id)}`);
   }
 
+  // ---- Versioning ---------------------------------------------------------
+
+  /** A note's stored versions, newest first (no content). Needs `view`. */
+  async listNoteVersions(docId: string): Promise<NoteVersion[]> {
+    const { data } = await this.request<{ versions: NoteVersion[] }>(
+      "GET",
+      `/api/notes/${encodeURIComponent(docId)}/versions`,
+    );
+    return data.versions ?? [];
+  }
+
+  /** One version *with* its markdown — the preview/revert payload. */
+  async getNoteVersion(docId: string, versionId: number): Promise<NoteVersionDetail> {
+    const { data } = await this.request<NoteVersionDetail>(
+      "GET",
+      `/api/notes/${encodeURIComponent(docId)}/versions/${encodeURIComponent(String(versionId))}`,
+    );
+    return data;
+  }
+
+  /**
+   * Restore a version as a forward CRDT edit (never a backwards state merge, which
+   * would resurrect deleted text). The server captures the pre-revert state first
+   * unless the live text already matches the newest stored version — that's when
+   * `preRevertVersionId` comes back null. Needs `edit`; a locked share 403s.
+   */
+  async revertNoteToVersion(
+    docId: string,
+    versionId: number,
+  ): Promise<{ ok: true; preRevertVersionId: number | null }> {
+    const { data } = await this.request<{ ok: true; preRevertVersionId: number | null }>(
+      "POST",
+      `/api/notes/${encodeURIComponent(docId)}/versions/${encodeURIComponent(String(versionId))}/revert`,
+    );
+    return data;
+  }
+
+  /** A note collection's checkpoints, newest first (any vault member). */
+  async listCheckpoints(vaultId: string): Promise<VaultCheckpoint[]> {
+    const { data } = await this.request<{ checkpoints: VaultCheckpoint[] }>(
+      "GET",
+      `/api/vaults/${encodeURIComponent(vaultId)}/checkpoints`,
+    );
+    return data.checkpoints ?? [];
+  }
+
+  /** Take a manual checkpoint (owner/admin). Throws ApiError(409) while another
+   *  checkpoint/revert holds the vault's lock. */
+  async createCheckpoint(vaultId: string, label?: string): Promise<VaultCheckpoint> {
+    const { data } = await this.request<VaultCheckpoint>(
+      "POST",
+      `/api/vaults/${encodeURIComponent(vaultId)}/checkpoints`,
+      { body: label ? { label } : {} },
+    );
+    return data;
+  }
+
+  async deleteCheckpoint(vaultId: string, checkpointId: string): Promise<void> {
+    await this.request<unknown>(
+      "DELETE",
+      `/api/vaults/${encodeURIComponent(vaultId)}/checkpoints/${encodeURIComponent(checkpointId)}`,
+    );
+  }
+
+  /** Revert the whole vault to a checkpoint (**owner only**; admins 403).
+   *  Synchronous and convergent — re-running it lands in the same place. */
+  async revertToCheckpoint(vaultId: string, checkpointId: string): Promise<VaultRevertResult> {
+    const { data } = await this.request<VaultRevertResult>(
+      "POST",
+      `/api/vaults/${encodeURIComponent(vaultId)}/checkpoints/${encodeURIComponent(checkpointId)}/revert`,
+    );
+    return data;
+  }
+
   // ---- Shares -------------------------------------------------------------
 
   async listShares(
@@ -988,6 +1130,20 @@ export function noteVaultId(n: RegisteredNote): string | undefined {
 }
 export function noteRelPath(n: RegisteredNote): string | undefined {
   return n.relPath ?? n.rel_path;
+}
+/**
+ * The note's last-edit stamp, or null when it has never been edited (or the
+ * server predates versioning). Null is the honest answer — a row with no
+ * `last_edited_at` must show no "edited by" tag rather than a bare avatar.
+ */
+export function noteLastEdited(n: RegisteredNote): NoteLastEdited | null {
+  const at = n.lastEditedAt ?? n.last_edited_at ?? null;
+  if (!at) return null;
+  return {
+    userId: n.lastEditedBy ?? n.last_edited_by ?? null,
+    name: n.lastEditedByName ?? n.last_edited_by_name ?? null,
+    at,
+  };
 }
 export function vaultOrgId(v: Vault): string | undefined {
   return v.organizationId ?? v.organization_id;

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionVaultScope.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionVaultScope.test.ts
@@ -34,6 +34,8 @@ const fakeRegistry = vi.hoisted(() => {
     setMapListener: vi.fn((cb: (() => void) | null) => {
       reg.mapListener = cb;
     }),
+    // Versioning: the manager also mirrors {docId → last-edit} out of the pull.
+    setNoteMetaListener: vi.fn(),
     // Inbound reconciliation: the manager hands itself over as the host that can
     // make the editor/doc-store let go of a doc before its file moves.
     inboundHost: null as unknown,

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -13,7 +13,7 @@
 import { Awareness } from "y-protocols/awareness";
 import type { NoteBridge } from "../bridge";
 import { bridgeManager, createTauriBridgeIO } from "../bridge/adapter";
-import type { SessionInfo } from "../api";
+import type { NoteLastEdited, SessionInfo } from "../api";
 import * as ipc from "../ipc";
 import { api } from "../auth/authManager";
 import { colorForUser, presenceUser } from "../presence/color";
@@ -99,6 +99,9 @@ export class SyncManager implements InboundHost {
     // reactively — coalesced — instead of letting the UI read it imperatively
     // during render, which never re-rendered when the mapping changed.
     this.registry.setMapListener(() => this.scheduleRegistryMapPublish());
+    // Who last edited each note, refreshed by the same registry pull. Not
+    // coalesced like the map above: it fires once per pull, not once per note.
+    this.registry.setNoteMetaListener((meta) => this.publishNoteMeta(meta));
     // Inbound reconciliation mutates files the editor and the background doc store
     // may be holding, so it has to be able to make them let go first.
     this.registry.setInboundHost(this);
@@ -122,6 +125,8 @@ export class SyncManager implements InboundHost {
   private onMemberJoined?: (name: string) => void;
   /** Mirrors the registry's {relPath → docId} map to the UI (coalesced). */
   private onRegistryMap?: (map: Record<string, string>) => void;
+  /** Mirrors the registry's {docId → last-edit} stamps to the UI. */
+  private onNoteMeta?: (meta: Record<string, NoteLastEdited>) => void;
   private mapPublishTimer: ReturnType<typeof setTimeout> | null = null;
   private registryPullTimer: ReturnType<typeof setTimeout> | null = null;
   private attachments: AttachmentSync | null = null;
@@ -348,6 +353,27 @@ export class SyncManager implements InboundHost {
       for (const { docId, relPath } of this.registry.mappedNotes()) map[relPath] = docId;
     }
     cb(map);
+  }
+
+  /**
+   * UI subscribes here for the open vault's {docId → last-edit} stamps
+   * (`store.noteLastEdited`) — who last changed each note's *content*, and when.
+   *
+   * Refreshed by the registry pull, which the server already triggers when it
+   * stamps an edit, so the sidebar's "edited by" tags converge on the existing
+   * `registry-changed` round trip rather than a channel of their own.
+   */
+  setNoteMetaListener(cb: ((meta: Record<string, NoteLastEdited>) => void) | undefined): void {
+    this.onNoteMeta = cb;
+  }
+
+  /**
+   * Push per-note last-edit stamps out. Same scope gate as
+   * {@link publishRegistryMap}: a pull that lands after a vault switch describes
+   * the vault we left, and an empty map is the honest answer there.
+   */
+  private publishNoteMeta(meta: Record<string, NoteLastEdited>): void {
+    this.onNoteMeta?.(this.scope?.isCurrent() ? meta : {});
   }
 
   /**
@@ -769,8 +795,9 @@ export class SyncManager implements InboundHost {
     vaultScopes.end();
     // Now that no scope is current, this publishes an EMPTY path→docId map (and
     // clears the coalescing timer, so nothing from the vault we left arrives
-    // 100ms into the next one).
+    // 100ms into the next one). The last-edit stamps go the same way.
     this.publishRegistryMap();
+    this.publishNoteMeta({});
   }
 
   /** UI subscribes here for the vault-wide background-sync indicator. */

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -25,8 +25,10 @@ import {
   ApiClient,
   ApiError,
   noteDocId,
+  noteLastEdited,
   noteRelPath,
   vaultOrgId,
+  type NoteLastEdited,
   type RegisteredFolder,
   type RegisteredNote,
 } from "../api";
@@ -282,6 +284,19 @@ export class VaultRegistry {
    */
   private onMapChanged: (() => void) | null = null;
 
+  /**
+   * Notified with the {docId → last-edit} map every time a pull tells us who
+   * last touched each note.
+   *
+   * Liveness rides the registry re-pull rather than a protocol frame of its own:
+   * the server already fires `registry-changed` when it stamps an edit, and that
+   * pull is coalesced (120ms/250ms), so "edited by X just now" converges on the
+   * same round trip that moves/renames use. Owned for the process lifetime like
+   * {@link onMapChanged} — a vault switch must *publish* an empty map, not go
+   * silent.
+   */
+  private onNoteMeta: ((meta: Record<string, NoteLastEdited>) => void) | null = null;
+
   constructor(
     private readonly api: ApiClient,
     /** Where the current VaultScope comes from; injectable for tests. */
@@ -304,6 +319,11 @@ export class VaultRegistry {
     this.onMapChanged = cb;
   }
 
+  /** Subscribe to per-note last-edit metadata (see {@link onNoteMeta}). */
+  setNoteMetaListener(cb: ((meta: Record<string, NoteLastEdited>) => void) | null): void {
+    this.onNoteMeta = cb;
+  }
+
   /** Provide the editor/doc-store coupling inbound reconciliation needs. Without
    *  a host, inbound still runs but nothing is released — safe only in tests,
    *  where no bridge is open. */
@@ -315,6 +335,23 @@ export class VaultRegistry {
    *  created note); the listener is responsible for coalescing. */
   private notifyMapChanged(): void {
     this.onMapChanged?.();
+  }
+
+  /**
+   * Publish the last-edit stamps carried by a registry pull, keyed by **docId**
+   * (the sidebar joins it back to a row through the path→docId map). Notes the
+   * server has no stamp for are simply absent, so the whole map replaces the
+   * previous one rather than merging into it.
+   */
+  private publishNoteMeta(serverNotes: RegisteredNote[]): void {
+    const cb = this.onNoteMeta;
+    if (!cb) return;
+    const meta: Record<string, NoteLastEdited> = {};
+    for (const n of serverNotes) {
+      const edited = noteLastEdited(n);
+      if (edited) meta[noteDocId(n)] = edited;
+    }
+    cb(meta);
   }
 
   /**
@@ -926,6 +963,11 @@ export class VaultRegistry {
     } else {
       this.inboundSuppressed = new Set();
     }
+
+    // Published from the FINAL note list (the inbound branch above may have
+    // re-read it), so the "edited by" tags reflect the same rows the rest of this
+    // pass reconciles against.
+    this.publishNoteMeta(serverNotes);
 
     // Drop anything belonging to a different collection before we start adding:
     // the maps are written into incrementally from here on (so a mid-run

--- a/app/apps/desktop/src/lib/updater.ts
+++ b/app/apps/desktop/src/lib/updater.ts
@@ -112,3 +112,93 @@ export async function installUpdate(): Promise<void> {
 export function currentVersion(): Promise<string> {
   return getVersion();
 }
+
+// ---------------------------------------------------------------------------
+// Silent auto-update + the post-restart "Updated to vX" banner.
+//
+// The handoff problem: by the time the new version is running, the Update
+// object (and its release notes) died with the old process. So the stash below
+// is written just before download/relaunch, and read back on the next boot —
+// if the running version matches the stashed one, the update landed and the
+// banner shows its notes; if not (install failed, or a newer hop), it's stale
+// and dropped.
+// ---------------------------------------------------------------------------
+
+const JUST_UPDATED_KEY = "context.justUpdated";
+
+interface JustUpdated {
+  version: string;
+  notes: string | null;
+}
+
+/**
+ * Fully automatic update: check, and when a newer version exists, download +
+ * install + relaunch without asking. Callers should treat this as fire-and-
+ * forget from launch; every failure lands in the shared state's `error` phase
+ * (surfaced only in Settings → Updates — an offline launch is not an event).
+ */
+export async function autoUpdate(): Promise<void> {
+  const found = await checkForUpdate();
+  if (!found || !pending) return;
+  try {
+    localStorage.setItem(
+      JUST_UPDATED_KEY,
+      JSON.stringify({ version: pending.version, notes: pending.body ?? null }),
+    );
+  } catch {
+    // Storage full/blocked: the update still proceeds, only the banner is lost.
+  }
+  await installUpdate();
+}
+
+/**
+ * The update we just restarted into, if that is what happened — else null.
+ * Non-destructive: the banner clears the stash on dismiss via
+ * {@link clearJustUpdated}, so an un-dismissed banner survives a quit.
+ */
+export async function justUpdatedTo(): Promise<JustUpdated | null> {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(JUST_UPDATED_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const stash = JSON.parse(raw) as JustUpdated;
+    if (!stash?.version) throw new Error("bad stash");
+    const running = await getVersion();
+    if (running === stash.version) return stash;
+    // Stale: the install never landed, or we've since hopped past it.
+    clearJustUpdated();
+    return null;
+  } catch {
+    clearJustUpdated();
+    return null;
+  }
+}
+
+/** Forget the just-updated stash (the banner was dismissed). */
+export function clearJustUpdated(): void {
+  try {
+    localStorage.removeItem(JUST_UPDATED_KEY);
+  } catch {
+    // Nothing to do — worst case the banner shows once more.
+  }
+}
+
+/**
+ * Release notes → the banner's one-liners. Keeps markdown bullet lines (and
+ * plain lines) as-is minus the bullet, drops headings/blanks and the historic
+ * placeholder body, and caps the list so a long release stays a glance.
+ */
+export function releaseNoteLines(notes: string | null | undefined, max = 6): string[] {
+  if (!notes) return [];
+  return notes
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .filter((line) => !line.startsWith("See the assets below"))
+    .map((line) => line.replace(/^[-*•]\s+/, ""))
+    .slice(0, max);
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -14,10 +14,14 @@ import {
   type BillingConfig,
   type Invitation,
   type Member,
+  type NoteLastEdited,
+  type NoteVersion,
   type OrgBilling,
   type Organization,
   type SessionInfo,
   type Share,
+  type VaultCheckpoint,
+  type VaultRevertResult,
 } from "./lib/api";
 import { authManager } from "./lib/auth/authManager";
 import { syncManager } from "./lib/sync/docSession";
@@ -147,6 +151,21 @@ interface AppStore {
   docIdByPath: Record<string, string>;
   /** Locks (read-only overlays) in the synced vault — drives tree badges. */
   locks: Share[];
+  /**
+   * Who last edited each note's CONTENT, keyed by **docId** (never by path, and
+   * dropped on every vault switch — two vaults both have a `Welcome.md`).
+   * Refreshed by the registry pull; empty when sync is off.
+   */
+  noteLastEdited: Record<string, NoteLastEdited>;
+  /** The note whose version panel is open (docId), or null when it's closed. */
+  versionPanelDocId: string | null;
+  /** The open panel's versions, newest first. `null` = still loading. */
+  noteVersions: NoteVersion[] | null;
+  /** The version being hovered/previewed in the editor overlay (read-only). */
+  versionPreview: { versionId: number; content: string } | null;
+  /** The active vault's checkpoints, newest first. `null` = unknown (not synced,
+   *  or not fetched yet). */
+  checkpoints: VaultCheckpoint[] | null;
   /** Live "who's viewing what" roster (teammates only) — drives the sidebar
    *  presence dots on notes/folders. Empty when sync is off or disconnected. */
   vaultPresence: VaultPeer[];
@@ -292,6 +311,22 @@ interface AppStore {
     principalId: string | null,
   ) => Promise<void>;
   removeLock: (shareId: string) => Promise<void>;
+
+  // Versioning (per-note history + vault checkpoints)
+  /** Open the history panel for a note and load its versions. */
+  openVersionPanel: (docId: string) => Promise<void>;
+  closeVersionPanel: () => void;
+  /** Load one version's markdown for the read-only editor overlay. */
+  previewVersion: (versionId: number) => Promise<void>;
+  clearVersionPreview: () => void;
+  /** Restore a version (forward CRDT edit server-side); refreshes the list. */
+  revertToVersion: (versionId: number) => Promise<void>;
+  refreshCheckpoints: () => Promise<void>;
+  /** Take a manual checkpoint of the active vault (owner/admin). */
+  createCheckpoint: (label?: string) => Promise<void>;
+  deleteCheckpoint: (id: string) => Promise<void>;
+  /** Roll the whole vault back to a checkpoint (owner only). */
+  revertVaultToCheckpoint: (id: string) => Promise<VaultRevertResult>;
 
   // Billing
   /** Re-probe server billing capability (on start/sign-in/server change). */
@@ -592,6 +627,11 @@ function sameVault(get: () => AppStore, epoch: number | null | undefined): boole
  * previous vault's results; `docIdByPath` is keyed by path, which two vaults
  * share outright (both have a `Welcome.md`); and a stale `syncProgress` would
  * report the vault we left as still uploading.
+ *
+ * The versioning fields are here for exactly the same reason: `noteLastEdited`
+ * is docId-keyed, and a version list / checkpoint list belongs to ONE vault —
+ * showing the previous vault's history against the new vault's notes would offer
+ * a revert that writes the wrong content into the wrong note.
  */
 function vaultScopedSyncReset() {
   // A fresh object each call: handing out one shared `{}`/`[]` would let any
@@ -604,6 +644,11 @@ function vaultScopedSyncReset() {
     docSyncState: {} as Record<string, DocSyncState>,
     docIdByPath: {} as Record<string, string>,
     locks: [] as Share[],
+    noteLastEdited: {} as Record<string, NoteLastEdited>,
+    versionPanelDocId: null,
+    noteVersions: null,
+    versionPreview: null,
+    checkpoints: null,
   } satisfies Partial<AppStore>;
 }
 
@@ -933,6 +978,10 @@ export const useStore = create<AppStore>((set, get) => ({
     // The path→docId index the sidebar needs to attach a docId-keyed sync state
     // to a path-keyed row. Coalesced by SyncManager on the same ~10/second budget.
     syncManager.setRegistryMapListener((map) => get().setDocIdByPath(map));
+    // Who last edited each note, from the same registry pull — drives the
+    // "edited by" tag on sidebar rows. Replaced wholesale, never merged: a note
+    // can lose its stamp (restored from a checkpoint, access revoked).
+    syncManager.setNoteMetaListener((meta) => set({ noteLastEdited: meta }));
     try {
       const session = await authManager.init();
       set({ serverUrl: authManager.getServerUrl() });
@@ -1661,6 +1710,113 @@ export const useStore = create<AppStore>((set, get) => ({
     await get().refreshLocks();
   },
 
+  // ---- Versioning ----
+
+  openVersionPanel: async (docId) => {
+    // Clear first so the panel never shows the previous note's history while the
+    // new one loads (they are the same shape, so a stale list looks plausible).
+    set({ versionPanelDocId: docId, noteVersions: null, versionPreview: null });
+    if (!get().syncEnabled) {
+      // Versions live on the server; a local vault has none. The panel says so.
+      set({ noteVersions: [] });
+      return;
+    }
+    try {
+      const versions = await authManager.api.listNoteVersions(docId);
+      // A different note (or no note) is open now — that panel owns the state.
+      if (get().versionPanelDocId !== docId) return;
+      set({ noteVersions: versions });
+    } catch (e) {
+      console.warn("[versions] list failed", e);
+      if (get().versionPanelDocId !== docId) return;
+      set({ noteVersions: [] });
+    }
+  },
+
+  closeVersionPanel: () =>
+    set({ versionPanelDocId: null, noteVersions: null, versionPreview: null }),
+
+  previewVersion: async (versionId) => {
+    const docId = get().versionPanelDocId;
+    if (!docId) return;
+    try {
+      const version = await authManager.api.getNoteVersion(docId, versionId);
+      // Hover previews race each other constantly; only the newest hover may
+      // paint, and only while its own panel is still open.
+      if (get().versionPanelDocId !== docId) return;
+      set({ versionPreview: { versionId, content: version.content } });
+    } catch (e) {
+      console.warn("[versions] preview failed", e);
+      if (get().versionPreview?.versionId === versionId) set({ versionPreview: null });
+    }
+  },
+
+  clearVersionPreview: () => set({ versionPreview: null }),
+
+  revertToVersion: async (versionId) => {
+    const docId = get().versionPanelDocId;
+    if (!docId) throw new Error("No note is open.");
+    // Leave the read-only overlay before the write lands, so the editor the user
+    // is looking at is the live one that's about to change.
+    set({ versionPreview: null });
+    await authManager.api.revertNoteToVersion(docId, versionId);
+    // The revert usually captures a pre-revert version of its own, so the list
+    // the user is looking at is already out of date.
+    try {
+      const versions = await authManager.api.listNoteVersions(docId);
+      if (get().versionPanelDocId !== docId) return;
+      set({ noteVersions: versions });
+    } catch (e) {
+      console.warn("[versions] refresh after revert failed", e);
+    }
+  },
+
+  refreshCheckpoints: async () => {
+    const vaultId = syncManager.registry.vaultId;
+    if (!vaultId || !get().syncEnabled) {
+      // `null`, not `[]`: a local vault has no checkpoints to *have*, which the
+      // tab renders as a sync gate rather than "no checkpoints yet".
+      set({ checkpoints: null });
+      return;
+    }
+    try {
+      const checkpoints = await authManager.api.listCheckpoints(vaultId);
+      // Checkpoints are per-vault; publishing another vault's set would offer a
+      // revert that rewrites the wrong notes.
+      if (syncManager.registry.vaultId !== vaultId) return;
+      set({ checkpoints });
+    } catch (e) {
+      console.warn("[checkpoints] refresh failed", e);
+      if (syncManager.registry.vaultId !== vaultId) return;
+      set({ checkpoints: [] });
+    }
+  },
+
+  createCheckpoint: async (label) => {
+    const vaultId = requireSyncedVaultId(get);
+    await authManager.api.createCheckpoint(vaultId, label?.trim() || undefined);
+    await get().refreshCheckpoints();
+  },
+
+  deleteCheckpoint: async (id) => {
+    const vaultId = requireSyncedVaultId(get);
+    await authManager.api.deleteCheckpoint(vaultId, id);
+    await get().refreshCheckpoints();
+  },
+
+  revertVaultToCheckpoint: async (id) => {
+    const vaultId = requireSyncedVaultId(get);
+    const result = await authManager.api.revertToCheckpoint(vaultId, id);
+    // The revert took a pre-revert checkpoint, so the list has grown.
+    await get().refreshCheckpoints();
+    // Structure changed server-side (notes restored, re-pathed, tombstoned). The
+    // server broadcasts `registry-changed` to everyone including us, but pulling
+    // here means the vault we just reverted converges on this device without
+    // waiting for that round trip.
+    syncManager.handleRegistryChanged();
+    return result;
+  },
+
   // ---- Billing ----
 
   refreshBillingConfig: async () => {
@@ -1778,6 +1934,19 @@ export const useStore = create<AppStore>((set, get) => ({
     }
   },
 }));
+
+/**
+ * The server note-collection id for the open vault, for the checkpoint calls
+ * that cannot be a no-op. Throws (rather than returning null) because every
+ * caller is a user-initiated write whose failure must be visible.
+ */
+function requireSyncedVaultId(get: () => AppStore): string {
+  const vaultId = syncManager.registry.vaultId;
+  if (!vaultId || !get().syncEnabled) {
+    throw new Error("Turn on sync for this vault to use checkpoints.");
+  }
+  return vaultId;
+}
 
 function errMsg(e: unknown): string {
   if (e instanceof ApiError) return e.message;

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -29,6 +29,10 @@ SYNC_TOKEN_TTL_SECONDS=600
 # Compaction threshold: merge doc_updates into a snapshot when the log exceeds this.
 COMPACTION_THRESHOLD=50
 
+# Quiet time after a note's last edit before a version is auto-captured (ms).
+# Default 600000 (10 minutes). Lower it in local dev to test version history.
+# VERSION_IDLE_MS=600000
+
 # --- Vault sync engine (spec 05) ---
 
 # Cross-instance fanout for the vault replication channel. LEAVE UNSET for

--- a/app/apps/server/migrations/016_versioning.sql
+++ b/app/apps/server/migrations/016_versioning.sql
@@ -1,0 +1,45 @@
+-- Version history: per-note versions + vault-wide checkpoints.
+--
+-- Versions store MARKDOWN TEXT + sha256, not Yjs bytes. The CRDT update log is
+-- destroyed by compaction and a Y.Doc with gc on cannot reconstruct a past
+-- state anyway; text is also what a preview and a forward diff need. Reverting
+-- never replaces state backwards — the stored text is the TARGET, applied as a
+-- forward transaction through the doc writer.
+
+CREATE TABLE note_versions (
+  id         BIGSERIAL PRIMARY KEY,
+  -- No FK on doc_id: a note is soft-deleted (and can be restored by a vault
+  -- revert), so its versions must outlive any churn in the notes table.
+  doc_id     TEXT NOT NULL,
+  vault_id   TEXT NOT NULL REFERENCES vaults (id) ON DELETE CASCADE,
+  content    TEXT NOT NULL,
+  sha256     TEXT NOT NULL,
+  cause      TEXT NOT NULL CHECK (cause IN ('idle', 'pre-revert')),
+  author_id  TEXT REFERENCES "user" (id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- Newest-first listing + "what is the latest version of this doc" (the dedupe
+-- check on every idle capture) are the only two reads.
+CREATE INDEX note_versions_doc_idx ON note_versions (doc_id, id DESC);
+
+-- A checkpoint is a whole-vault snapshot: the folder/note STRUCTURE as JSONB
+-- plus one row per note body in vault_checkpoint_docs.
+CREATE TABLE vault_checkpoints (
+  id         TEXT PRIMARY KEY,
+  vault_id   TEXT NOT NULL REFERENCES vaults (id) ON DELETE CASCADE,
+  kind       TEXT NOT NULL CHECK (kind IN ('auto', 'manual')),
+  label      TEXT,
+  created_by TEXT REFERENCES "user" (id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- { notes: [{id, rel_path, folder_id, title}], folders: [{id, parent_id, name, path, sort}] }
+  structure  JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX vault_checkpoints_vault_idx ON vault_checkpoints (vault_id, created_at DESC);
+
+CREATE TABLE vault_checkpoint_docs (
+  checkpoint_id TEXT NOT NULL REFERENCES vault_checkpoints (id) ON DELETE CASCADE,
+  doc_id        TEXT NOT NULL,
+  sha256        TEXT NOT NULL,
+  content       TEXT NOT NULL,
+  PRIMARY KEY (checkpoint_id, doc_id)
+);

--- a/app/apps/server/migrations/017_last_edited_by.sql
+++ b/app/apps/server/migrations/017_last_edited_by.sql
@@ -1,0 +1,10 @@
+-- Who last EDITED a note's content, stamped server-side from the authenticated
+-- editor (a human over sync, or an AI over MCP).
+--
+-- Separate from updated_at deliberately: updated_at is bumped by renames and
+-- moves and is NOT bumped by ordinary human sync edits, so it answers a
+-- different question than "who typed in here last, and when".
+
+ALTER TABLE notes
+  ADD COLUMN IF NOT EXISTS last_edited_by TEXT REFERENCES "user" (id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS last_edited_at TIMESTAMPTZ;

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -73,6 +73,9 @@ export const config = {
   hocuspocusPort: int("HOCUSPOCUS_PORT", 3011),
   syncTokenTtlSeconds: int("SYNC_TOKEN_TTL_SECONDS", 600),
   compactionThreshold: int("COMPACTION_THRESHOLD", 50),
+  /** Quiet time after a note's last edit before a version is captured.
+   *  Lower it locally to test the history panel without the 10-minute wait. */
+  versionIdleMs: int("VERSION_IDLE_MS", 10 * 60_000),
   invitationExpiresInSeconds: 48 * 60 * 60, // 48h per spec 04 §2
   // ---- Vault sync engine (spec 05) ----
   /** Redis connection string. Unset ⇒ in-memory pub/sub, single instance.

--- a/app/apps/server/src/http/app.ts
+++ b/app/apps/server/src/http/app.ts
@@ -13,6 +13,7 @@ import { createShareRoutes, type ShareDeps } from "./routes/shares.js";
 import { createOrgRoutes } from "./routes/orgs.js";
 import { graphRoutes } from "./routes/graph.js";
 import { createMcpRoutes } from "./routes/mcp.js";
+import { createVersionRoutes } from "./routes/versions.js";
 import { createBillingRoutes } from "./routes/billing.js";
 import { PolarBillingProvider } from "../billing/polar.js";
 import type { BillingProvider } from "../billing/provider.js";
@@ -79,6 +80,7 @@ function allowedOrigins(): string[] {
  *  - /api/sync-token → mint per-doc sync JWTs
  *  - /api/{vaults,folders,notes,files} → registry
  *  - /api/vaults/:id/blobs, /api/blobs/:id → attachment blob store
+ *  - /api/notes/:id/versions, /api/vaults/:id/checkpoints → version history
  *  - /api/shares → folder/file ACL management
  *  - /api/orgs/join-code, /api/orgs/join → vault join codes
  *  - /api/vaults/:id/graph, /api/vaults/:id/search → note index (links+vectors)
@@ -144,6 +146,13 @@ export function createApp(deps: AppDeps): Hono {
     }),
   );
   app.route("/api", blobRoutes);
+  app.route(
+    "/api",
+    createVersionRoutes({
+      docWriter: deps.docWriter,
+      onRegistryChanged: deps.onRegistryChanged,
+    }),
+  );
   app.route("/api", createShareRoutes(deps));
   const billingProvider = deps.billingProvider ?? new PolarBillingProvider();
   app.route(

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -316,9 +316,17 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     if (!org || !(await orgRole(org, session.userId))) {
       return c.json({ error: "Not a member of this vault" }, 403);
     }
+    // last_edited_* rides this pull deliberately: the file rows that show
+    // "edited by X" are already re-fetched on every `registry` frame, so
+    // attribution stays live without a second endpoint or a new wire frame.
     const { rows } = await pool.query(
-      `SELECT id, vault_id, folder_id, title, rel_path, doc_id, created_by, created_at, updated_at
-         FROM notes WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path`,
+      `SELECT n.id, n.vault_id, n.folder_id, n.title, n.rel_path, n.doc_id, n.created_by,
+              n.created_at, n.updated_at,
+              n.last_edited_by, u.name AS last_edited_by_name, n.last_edited_at
+         FROM notes n
+         LEFT JOIN "user" u ON u.id = n.last_edited_by
+        WHERE n.vault_id = $1 AND n.deleted_at IS NULL
+        ORDER BY n.rel_path`,
       [vaultId],
     );
     // Private-by-default: hide notes the caller can't read (leaks title/path and

--- a/app/apps/server/src/http/routes/sync-token.ts
+++ b/app/apps/server/src/http/routes/sync-token.ts
@@ -48,6 +48,8 @@ syncTokenRoutes.post("/sync-token", async (c) => {
   }
 
   const readOnly = permission === "view";
-  const token = await mintSyncToken({ docId, vaultId, readOnly });
+  // userId travels in the token so the sync server can attribute the edits that
+  // arrive on this connection ("last edited by" + version authorship).
+  const token = await mintSyncToken({ docId, vaultId, readOnly, userId: session.userId });
   return c.json({ token, docId, vaultId, readOnly, permission });
 });

--- a/app/apps/server/src/http/routes/versions.ts
+++ b/app/apps/server/src/http/routes/versions.ts
@@ -1,0 +1,266 @@
+import { Hono } from "hono";
+import { pool } from "../../db/pool.js";
+import { canEditDoc } from "../../permissions/http-gates.js";
+import { orgRole, vaultOrg } from "../../permissions/lookup.js";
+import { effectivePermission } from "../../permissions/resolver.js";
+import type { DocWriter } from "../../mcp/doc-writer.js";
+import { recordVersion, sha256Hex, stampLastEdited } from "../../versions/capture.js";
+import {
+  captureCheckpoint,
+  getCheckpointSummary,
+  listCheckpoints,
+  withVaultCheckpointLock,
+} from "../../versions/checkpoints.js";
+import { revertVaultToCheckpoint, RevertError } from "../../versions/revert.js";
+import { getSession } from "../session.js";
+
+/**
+ * Version history API (session-authenticated).
+ *
+ *   GET    /api/notes/:id/versions                    list (view)
+ *   GET    /api/notes/:id/versions/:versionId         one version + content (view)
+ *   POST   /api/notes/:id/versions/:versionId/revert  restore it (edit)
+ *   GET    /api/vaults/:vaultId/checkpoints           list (member)
+ *   POST   /api/vaults/:vaultId/checkpoints           create (owner/admin)
+ *   DELETE /api/vaults/:vaultId/checkpoints/:id       delete (owner/admin)
+ *   POST   /api/vaults/:vaultId/checkpoints/:id/revert  revert the vault (owner)
+ *
+ * Gates mirror the rest of the app: per-doc `effectivePermission` for note
+ * versions (so a `locked` share caps at view and a revert 403s), org role for
+ * vault-wide operations. Version CONTENT is served only from the per-version
+ * endpoint, never from a listing.
+ */
+
+export interface VersionRouteDeps {
+  docWriter: DocWriter;
+  /** Broadcast so open clients re-pull after a revert. */
+  onRegistryChanged: (vaultId: string, originId: string | null) => void;
+}
+
+interface VersionRow {
+  id: string;
+  doc_id: string;
+  created_at: Date;
+  cause: "idle" | "pre-revert";
+  author_id: string | null;
+  author_name: string | null;
+  sha256: string;
+  size: number;
+}
+
+function versionSummary(r: VersionRow) {
+  return {
+    id: Number(r.id),
+    createdAt: new Date(r.created_at).toISOString(),
+    cause: r.cause,
+    authorId: r.author_id,
+    authorName: r.author_name,
+    sha256: r.sha256,
+    size: r.size,
+  };
+}
+
+/** Live note → its collection id, or null when the note is gone. */
+async function noteVaultId(docId: string): Promise<string | null> {
+  const { rows } = await pool.query<{ vault_id: string }>(
+    "SELECT vault_id FROM notes WHERE id = $1 AND deleted_at IS NULL",
+    [docId],
+  );
+  return rows[0]?.vault_id ?? null;
+}
+
+export function createVersionRoutes(deps: VersionRouteDeps): Hono {
+  const routes = new Hono();
+
+  // ── per-note versions ──────────────────────────────────────────────────────
+
+  routes.get("/notes/:id/versions", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const docId = c.req.param("id");
+    if (!(await noteVaultId(docId))) return c.json({ error: "Unknown note" }, 404);
+    if ((await effectivePermission(session.userId, docId)) === "none") {
+      return c.json({ error: "No access to this note" }, 403);
+    }
+
+    const { rows } = await pool.query<VersionRow>(
+      `SELECT v.id, v.doc_id, v.created_at, v.cause, v.author_id,
+              u.name AS author_name, v.sha256, octet_length(v.content) AS size
+         FROM note_versions v
+         LEFT JOIN "user" u ON u.id = v.author_id
+        WHERE v.doc_id = $1
+        ORDER BY v.id DESC`,
+      [docId],
+    );
+    return c.json({ versions: rows.map(versionSummary) });
+  });
+
+  routes.get("/notes/:id/versions/:versionId", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const docId = c.req.param("id");
+    if (!(await noteVaultId(docId))) return c.json({ error: "Unknown note" }, 404);
+    if ((await effectivePermission(session.userId, docId)) === "none") {
+      return c.json({ error: "No access to this note" }, 403);
+    }
+
+    const versionId = Number.parseInt(c.req.param("versionId"), 10);
+    if (!Number.isFinite(versionId)) return c.json({ error: "Unknown version" }, 404);
+    const { rows } = await pool.query<VersionRow & { content: string }>(
+      `SELECT v.id, v.doc_id, v.created_at, v.cause, v.author_id,
+              u.name AS author_name, v.sha256, octet_length(v.content) AS size, v.content
+         FROM note_versions v
+         LEFT JOIN "user" u ON u.id = v.author_id
+        WHERE v.id = $1`,
+      [versionId],
+    );
+    const row = rows[0];
+    // A version id belongs to exactly one doc; asking for it under another note
+    // is a 404, not a peek at someone else's content.
+    if (!row || row.doc_id !== docId) return c.json({ error: "Unknown version" }, 404);
+    return c.json({ ...versionSummary(row), content: row.content });
+  });
+
+  routes.post("/notes/:id/versions/:versionId/revert", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const docId = c.req.param("id");
+    const vaultId = await noteVaultId(docId);
+    if (!vaultId) return c.json({ error: "Unknown note" }, 404);
+    if (!(await canEditDoc(session.userId, docId))) {
+      return c.json({ error: "You cannot edit this note" }, 403);
+    }
+
+    const versionId = Number.parseInt(c.req.param("versionId"), 10);
+    if (!Number.isFinite(versionId)) return c.json({ error: "Unknown version" }, 404);
+    const { rows } = await pool.query<{ doc_id: string; content: string }>(
+      "SELECT doc_id, content FROM note_versions WHERE id = $1",
+      [versionId],
+    );
+    const version = rows[0];
+    if (!version || version.doc_id !== docId) return c.json({ error: "Unknown version" }, 404);
+
+    // Capture where we are BEFORE overwriting it, so a revert is itself
+    // undoable. `recordVersion` dedupes against the newest stored version, so
+    // this is a no-op (null) when nothing has changed since the last capture.
+    const current = await deps.docWriter.readContent(vaultId, docId);
+    const preRevertVersionId = await recordVersion({
+      vaultId,
+      docId,
+      content: current,
+      cause: "pre-revert",
+      authorId: session.userId,
+    });
+
+    // Forward-only: set the target text as a normal transaction so live editors
+    // merge it. Never a state replace.
+    if (sha256Hex(current) !== sha256Hex(version.content)) {
+      await deps.docWriter.setContent(vaultId, docId, version.content, {
+        userId: session.userId,
+      });
+    }
+    await stampLastEdited(docId, session.userId);
+    deps.onRegistryChanged(vaultId, null);
+    return c.json({ ok: true, preRevertVersionId });
+  });
+
+  // ── vault checkpoints ──────────────────────────────────────────────────────
+
+  /** Caller's role in the vault's organization, or null when not a member. */
+  async function vaultRole(vaultId: string, userId: string): Promise<string | null | undefined> {
+    const org = await vaultOrg(vaultId);
+    if (!org) return undefined; // unknown vault
+    return orgRole(org, userId);
+  }
+
+  routes.get("/vaults/:vaultId/checkpoints", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.param("vaultId");
+    const role = await vaultRole(vaultId, session.userId);
+    if (role === undefined) return c.json({ error: "Unknown vault" }, 404);
+    if (!role) return c.json({ error: "Not a member of this vault" }, 403);
+    return c.json({ checkpoints: await listCheckpoints(pool, vaultId) });
+  });
+
+  routes.post("/vaults/:vaultId/checkpoints", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.param("vaultId");
+    const role = await vaultRole(vaultId, session.userId);
+    if (role === undefined) return c.json({ error: "Unknown vault" }, 404);
+    if (role !== "owner" && role !== "admin") {
+      return c.json({ error: "Only a vault owner/admin can create checkpoints" }, 403);
+    }
+    const body = await c.req.json().catch(() => ({}));
+    const label = typeof body.label === "string" && body.label.trim() ? body.label.trim() : null;
+
+    const outcome = await withVaultCheckpointLock(vaultId, (db) =>
+      captureCheckpoint({
+        db,
+        docWriter: deps.docWriter,
+        vaultId,
+        kind: "manual",
+        label,
+        createdBy: session.userId,
+      }),
+    );
+    // Busy: another checkpoint or a revert is running on this vault right now.
+    if (!outcome.acquired) return c.json({ error: "Vault is busy, try again" }, 409);
+
+    const summary = await getCheckpointSummary(pool, vaultId, outcome.value.id);
+    return c.json(summary ?? { id: outcome.value.id }, 201);
+  });
+
+  routes.delete("/vaults/:vaultId/checkpoints/:id", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.param("vaultId");
+    const role = await vaultRole(vaultId, session.userId);
+    if (role === undefined) return c.json({ error: "Unknown vault" }, 404);
+    if (role !== "owner" && role !== "admin") {
+      return c.json({ error: "Only a vault owner/admin can delete checkpoints" }, 403);
+    }
+    const { rowCount } = await pool.query(
+      "DELETE FROM vault_checkpoints WHERE id = $1 AND vault_id = $2",
+      [c.req.param("id"), vaultId],
+    );
+    if (!rowCount) return c.json({ error: "Unknown checkpoint" }, 404);
+    return c.body(null, 204);
+  });
+
+  routes.post("/vaults/:vaultId/checkpoints/:id/revert", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.param("vaultId");
+    const role = await vaultRole(vaultId, session.userId);
+    if (role === undefined) return c.json({ error: "Unknown vault" }, 404);
+    // Owner only: this rewrites every note in the vault at once.
+    if (role !== "owner") {
+      return c.json({ error: "Only the vault owner can revert a vault" }, 403);
+    }
+    const checkpointId = c.req.param("id");
+    const { rows } = await pool.query<{ id: string }>(
+      "SELECT id FROM vault_checkpoints WHERE id = $1 AND vault_id = $2",
+      [checkpointId, vaultId],
+    );
+    if (!rows[0]) return c.json({ error: "Unknown checkpoint" }, 404);
+
+    try {
+      const outcome = await revertVaultToCheckpoint({
+        vaultId,
+        checkpointId,
+        userId: session.userId,
+        docWriter: deps.docWriter,
+        onRegistryChanged: deps.onRegistryChanged,
+      });
+      if (!outcome.acquired) return c.json({ error: "Vault is busy, try again" }, 409);
+      return c.json({ ok: true, ...outcome.result });
+    } catch (err) {
+      if (err instanceof RevertError) return c.json({ error: err.message }, 404);
+      throw err;
+    }
+  });
+
+  return routes;
+}

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -9,6 +9,8 @@ import { VaultChannel } from "./sync/vault-channel.js";
 import { setMemberJoinedPublisher } from "./sync/member-events.js";
 import { backfillIndex } from "./index/indexer.js";
 import { createDocWriter } from "./mcp/doc-writer.js";
+import { createVersionCapture, type VersionCapture } from "./versions/capture.js";
+import { maybeDailyCheckpoint } from "./versions/checkpoints.js";
 
 /**
  * Entry point. Runs two listeners in one Node process:
@@ -44,11 +46,45 @@ async function main() {
     void vaultChannel.publishMemberJoined(vaultId, name).catch(broadcastFailed("member-joined"));
   });
 
+  // Version capture is created below (it needs the doc writer, which needs the
+  // sync server, which needs this hook) — hence the late binding. Every edit,
+  // however it arrived, ends up in exactly one place.
+  let versionCapture: VersionCapture | null = null;
+  const noteEdited = (vaultId: string, docId: string, userId: string | null) =>
+    versionCapture?.touch(vaultId, docId, userId);
+
   // Every persisted doc change is fanned out to background vault subscribers.
-  const sync = createSyncServer(config.hocuspocusPort, (vaultId, docId, update) => {
-    void vaultChannel.publishDocUpdate(vaultId, docId, update).catch(broadcastFailed("doc-update"));
-  });
+  const sync = createSyncServer(
+    config.hocuspocusPort,
+    (vaultId, docId, update) => {
+      void vaultChannel
+        .publishDocUpdate(vaultId, docId, update)
+        .catch(broadcastFailed("doc-update"));
+    },
+    noteEdited,
+  );
   await sync.listen();
+
+  const onRegistryChanged = (vaultId: string, originId: string | null) =>
+    void vaultChannel
+      .publishRegistryChanged(vaultId, originId)
+      .catch(broadcastFailed("registry-changed"));
+
+  // The detached write path never reaches Hocuspocus, so it reports edits here.
+  const docWriter = createDocWriter(
+    sync,
+    (vaultId, docId, update) => vaultChannel.publishDocUpdate(vaultId, docId, update),
+    noteEdited,
+  );
+
+  versionCapture = createVersionCapture({
+    docWriter,
+    onRegistryChanged,
+    idleMs: config.versionIdleMs,
+    // Activity-triggered daily checkpoint — no scheduler, and the freshness
+    // test runs under a per-vault advisory lock so instances don't stampede.
+    dailyCheckpoint: (vaultId) => maybeDailyCheckpoint({ vaultId, docWriter }),
+  });
 
   const app = createApp({
     disconnectDoc: (vaultId, docId) => disconnectDoc(sync, vaultId, docId),
@@ -58,10 +94,7 @@ async function main() {
     // Folder/note create/rename/move/delete → subscribers re-pull the registry.
     // Coalesced per vault inside the channel, and skipped for the client whose
     // own write caused it (`originId`).
-    onRegistryChanged: (vaultId, originId) =>
-      void vaultChannel
-        .publishRegistryChanged(vaultId, originId)
-        .catch(broadcastFailed("registry-changed")),
+    onRegistryChanged,
     // MCP tools write notes through the same sync server, so AI edits persist,
     // re-index, and broadcast exactly like a human edit — to open editors via
     // Hocuspocus when the doc is live, and to background subscribers via this
@@ -70,9 +103,7 @@ async function main() {
     //
     // Returned, not `void`ed: `DocUpdatePublisher` accepts a promise so the
     // doc-writer awaits and swallows a rejection on our behalf.
-    docWriter: createDocWriter(sync, (vaultId, docId, update) =>
-      vaultChannel.publishDocUpdate(vaultId, docId, update),
-    ),
+    docWriter,
   });
 
   const httpServer = serve({ fetch: app.fetch, port: config.port }, (info) => {
@@ -96,6 +127,7 @@ async function main() {
 
   const shutdown = async () => {
     console.log("Shutting down…");
+    versionCapture?.stop();
     syncWss.close();
     vaultWss.close();
     await pubsub.close();

--- a/app/apps/server/src/mcp/doc-writer.ts
+++ b/app/apps/server/src/mcp/doc-writer.ts
@@ -1,5 +1,5 @@
 import * as Y from "yjs";
-import type { Server } from "@hocuspocus/server";
+import type { LocalTransactionOrigin, Server } from "@hocuspocus/server";
 import { formatDocName } from "../sync/doc-name.js";
 import type { SyncContext } from "../sync/hocuspocus.js";
 import { appendUpdate, loadDocState } from "../yjs/persistence.js";
@@ -27,14 +27,48 @@ const CONTENT_FIELD = "content";
 /** Transaction origin tag for edits that originate from the MCP server. */
 export const MCP_ORIGIN = "mcp";
 
+/** Who is behind a server-side write, for attribution (versions, last-edited). */
+export interface DocActor {
+  userId?: string | null;
+}
+
 export interface DocWriter {
   /** Replace the whole note body. */
-  setContent(vaultId: string, docId: string, content: string): Promise<void>;
+  setContent(
+    vaultId: string,
+    docId: string,
+    content: string,
+    actor?: DocActor,
+  ): Promise<void>;
   /** Append text to the end of the note body. */
-  appendContent(vaultId: string, docId: string, text: string): Promise<void>;
+  appendContent(
+    vaultId: string,
+    docId: string,
+    text: string,
+    actor?: DocActor,
+  ): Promise<void>;
   /** Read the current note body (from the live doc if open, else from storage). */
   readContent(vaultId: string, docId: string): Promise<string>;
+  /**
+   * Like {@link readContent}, but `null` when the doc has NO live session and NO
+   * persisted CRDT state — i.e. the server has never seen this note's content
+   * (typical for a freshly-synced vault whose bulk upload is still running).
+   * Callers that snapshot content MUST use this: treating "not uploaded yet" as
+   * "empty note" is how a checkpoint ends up bulldozing real text with "".
+   */
+  peekContent(vaultId: string, docId: string): Promise<string | null>;
 }
+
+/**
+ * Called after a DETACHED write (no client connected), with the writer's
+ * identity. The live path needs no equivalent: it goes through Hocuspocus, whose
+ * `onChange` already reports the editor via the transaction origin's context.
+ */
+export type DocWrittenHook = (
+  vaultId: string,
+  docId: string,
+  userId: string | null,
+) => void;
 
 /**
  * Publishes a doc update to background vault subscribers — the same fan-out the
@@ -64,16 +98,29 @@ export type DocUpdatePublisher = (
 export function createDocWriter(
   server: Server<SyncContext>,
   publishUpdate?: DocUpdatePublisher,
+  onDocWritten?: DocWrittenHook,
 ): DocWriter {
   async function mutate(
     vaultId: string,
     docId: string,
     fn: (text: Y.Text) => void,
+    actor?: DocActor,
   ): Promise<void> {
+    const userId = actor?.userId ?? null;
     const live = server.hocuspocus.documents.get(formatDocName(vaultId, docId));
     if (live) {
       // Live path: the sync server's onChange persists + broadcasts for us.
-      live.transact(() => fn(live.getText(CONTENT_FIELD)), MCP_ORIGIN);
+      //
+      // The origin is a Hocuspocus `LocalTransactionOrigin` object rather than
+      // the old bare `MCP_ORIGIN` string, because that is the ONLY channel that
+      // carries an identity into `onChange`: Hocuspocus resolves
+      // `origin.source === "local" ? origin.context : {}`, so a string origin is
+      // permanently anonymous. `skipStoreHooks` stays unset — this write must
+      // persist exactly like a human's.
+      live.transact(() => fn(live.getText(CONTENT_FIELD)), {
+        source: "local",
+        context: { source: MCP_ORIGIN, userId },
+      } satisfies LocalTransactionOrigin);
       return;
     }
 
@@ -108,36 +155,62 @@ export function createDocWriter(
         }
         // Keep search/graph in sync (best-effort; never fail the write on it).
         await indexDoc(docId).catch(() => {});
+        // Attribution + version capture, the detached counterpart of the sync
+        // server's `onDocEdited`. Best-effort for the same reason the publish
+        // above is: the write is already durable.
+        try {
+          onDocWritten?.(vaultId, docId, userId);
+        } catch (err) {
+          console.warn(`[mcp] onDocWritten hook failed for ${docId}`, err);
+        }
       }
     } finally {
       doc.destroy();
     }
   }
 
+  // A plain closure, NOT a method using `this`: call sites hand these functions
+  // around detached (`readContent: docWriter.readContent`), where `this` dies.
+  async function peekContent(vaultId: string, docId: string): Promise<string | null> {
+    const live = server.hocuspocus.documents.get(formatDocName(vaultId, docId));
+    if (live) return live.getText(CONTENT_FIELD).toString();
+    const state = await loadDocState(docId);
+    // No state is NOT an empty note: it is a note whose content has never
+    // reached this server. The distinction is load-bearing for checkpoints.
+    if (!state) return null;
+    const doc = new Y.Doc();
+    try {
+      Y.applyUpdate(doc, state);
+      return doc.getText(CONTENT_FIELD).toString();
+    } finally {
+      doc.destroy();
+    }
+  }
+
   return {
-    setContent: (vaultId, docId, content) =>
-      mutate(vaultId, docId, (text) => {
-        if (text.length > 0) text.delete(0, text.length);
-        if (content) text.insert(0, content);
-      }),
+    setContent: (vaultId, docId, content, actor) =>
+      mutate(
+        vaultId,
+        docId,
+        (text) => {
+          if (text.length > 0) text.delete(0, text.length);
+          if (content) text.insert(0, content);
+        },
+        actor,
+      ),
 
-    appendContent: (vaultId, docId, appended) =>
-      mutate(vaultId, docId, (text) => {
-        text.insert(text.length, appended);
-      }),
+    appendContent: (vaultId, docId, appended, actor) =>
+      mutate(
+        vaultId,
+        docId,
+        (text) => {
+          text.insert(text.length, appended);
+        },
+        actor,
+      ),
 
-    async readContent(vaultId, docId) {
-      const live = server.hocuspocus.documents.get(formatDocName(vaultId, docId));
-      if (live) return live.getText(CONTENT_FIELD).toString();
-      const state = await loadDocState(docId);
-      if (!state) return "";
-      const doc = new Y.Doc();
-      try {
-        Y.applyUpdate(doc, state);
-        return doc.getText(CONTENT_FIELD).toString();
-      } finally {
-        doc.destroy();
-      }
-    },
+    readContent: async (vaultId, docId) => (await peekContent(vaultId, docId)) ?? "",
+
+    peekContent,
   };
 }

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -408,7 +408,9 @@ export async function createNote(
     if (input.content) {
       const current = await ctx.docWriter.readContent(input.vaultId, row.id);
       if (current.trim().length === 0) {
-        await ctx.docWriter.setContent(input.vaultId, row.id, input.content);
+        await ctx.docWriter.setContent(input.vaultId, row.id, input.content, {
+          userId: ctx.auth.userId,
+        });
         seeded = true;
       }
     }
@@ -430,7 +432,9 @@ export async function createNote(
     [docId, input.vaultId, folderId, input.title ?? null, input.relPath, ctx.auth.userId],
   );
   if (input.content) {
-    await ctx.docWriter.setContent(input.vaultId, docId, input.content);
+    await ctx.docWriter.setContent(input.vaultId, docId, input.content, {
+      userId: ctx.auth.userId,
+    });
   }
   // After the content, so a client that reacts to the announcement by pulling
   // the note finds it already written rather than briefly empty.
@@ -477,14 +481,16 @@ async function requireEditableNote(auth: McpAuth, docId: string) {
  */
 export async function updateNote(ctx: McpContext, docId: string, content: string) {
   const note = await requireEditableNote(ctx.auth, docId);
-  await ctx.docWriter.setContent(note.vault_id, docId, content);
+  // The actor rides along so the edit is attributed to the MCP token's user —
+  // an AI write shows up as "edited by <that user>" like any teammate's.
+  await ctx.docWriter.setContent(note.vault_id, docId, content, { userId: ctx.auth.userId });
   await pool.query("UPDATE notes SET updated_at = now() WHERE id = $1", [docId]);
   return { docId, bytes: content.length };
 }
 
 export async function appendNote(ctx: McpContext, docId: string, text: string) {
   const note = await requireEditableNote(ctx.auth, docId);
-  await ctx.docWriter.appendContent(note.vault_id, docId, text);
+  await ctx.docWriter.appendContent(note.vault_id, docId, text, { userId: ctx.auth.userId });
   await pool.query("UPDATE notes SET updated_at = now() WHERE id = $1", [docId]);
   return { docId, appended: text.length };
 }

--- a/app/apps/server/src/sync/hocuspocus.ts
+++ b/app/apps/server/src/sync/hocuspocus.ts
@@ -26,6 +26,15 @@ export interface SyncContext {
   docId: string;
   vaultId: string;
   readOnly: boolean;
+  /**
+   * The authenticated editor on this connection, from the sync token's `userId`
+   * claim — `null` for a token minted before the claim existed (still valid,
+   * just anonymous).
+   *
+   * Also the shape server-side writers put in a `LocalTransactionOrigin`'s
+   * `context`, so `onChange` can read one field regardless of who wrote.
+   */
+  userId: string | null;
 }
 
 /**
@@ -39,9 +48,23 @@ export type DocChangedHook = (
   update: Uint8Array,
 ) => void;
 
+/**
+ * Notified after each persisted doc change WITH the editor's identity, so the
+ * versioning layer can stamp "last edited by" and arm its idle capture.
+ *
+ * `userId` is null when the writer is unattributable (a pre-attribution token,
+ * or a server-side write with no actor). Best-effort, like {@link DocChangedHook}.
+ */
+export type DocEditedHook = (
+  vaultId: string,
+  docId: string,
+  userId: string | null,
+) => void;
+
 export function createSyncServer(
   port: number = config.hocuspocusPort,
   onDocChanged?: DocChangedHook,
+  onDocEdited?: DocEditedHook,
 ): Server<SyncContext> {
   return new Server<SyncContext>({
     name: "context-sync",
@@ -88,6 +111,7 @@ export function createSyncServer(
         docId: parsed.docId,
         vaultId: parsed.vaultId,
         readOnly: claims.readOnly,
+        userId: claims.userId ?? null,
       };
       return context;
     },
@@ -147,6 +171,19 @@ export function createSyncServer(
           onDocChanged(parsed.vaultId, parsed.docId, data.update);
         } catch (err) {
           console.error("onDocChanged hook failed:", err);
+        }
+      }
+      // Attribution. Hocuspocus resolves `data.context` for us: the CONNECTION's
+      // context for a client edit, and a `LocalTransactionOrigin`'s `context` for
+      // a server-side write (the doc writer's live path) — both of which carry
+      // `userId`. Anything else (a plain string origin, a Redis-replicated
+      // update) lands as `{}`, i.e. anonymous.
+      if (onDocEdited) {
+        try {
+          const editorId = (data.context as Partial<SyncContext> | undefined)?.userId ?? null;
+          onDocEdited(parsed.vaultId, parsed.docId, editorId);
+        } catch (err) {
+          console.error("onDocEdited hook failed:", err);
         }
       }
     },

--- a/app/apps/server/src/tokens/sync-token.ts
+++ b/app/apps/server/src/tokens/sync-token.ts
@@ -10,6 +10,15 @@ export interface SyncTokenClaims {
   docId: string;
   vaultId: string;
   readOnly: boolean;
+  /**
+   * Who the token was minted for — the attribution source for "last edited by".
+   *
+   * Optional, and `verifySyncToken` must keep it optional: tokens minted before
+   * this claim existed are still in flight (TTL ~10 min), and a client holding
+   * one has to keep syncing, just anonymously. Rejecting them would drop every
+   * open editor at deploy time to learn a name.
+   */
+  userId?: string;
 }
 
 const secret = new TextEncoder().encode(config.jwtSecret);
@@ -24,6 +33,7 @@ export async function mintSyncToken(
     docId: claims.docId,
     vaultId: claims.vaultId,
     readOnly: claims.readOnly,
+    ...(claims.userId ? { userId: claims.userId } : {}),
   })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
@@ -49,6 +59,8 @@ export async function verifySyncToken(token: string): Promise<SyncTokenClaims> {
     docId: payload.docId,
     vaultId: payload.vaultId,
     readOnly: payload.readOnly,
+    // Absent on tokens minted before attribution existed — anonymous, not invalid.
+    userId: typeof payload.userId === "string" ? payload.userId : undefined,
   };
 }
 

--- a/app/apps/server/src/versions/capture.ts
+++ b/app/apps/server/src/versions/capture.ts
@@ -1,0 +1,249 @@
+import { createHash } from "node:crypto";
+import type pg from "pg";
+import { pool as defaultPool } from "../db/pool.js";
+import type { DocWriter } from "../mcp/doc-writer.js";
+
+/**
+ * Automatic version capture + "last edited by" stamping.
+ *
+ * Both ride the same signal — a persisted doc change with an editor identity
+ * (`onDocEdited` from the sync server, `onDocWritten` from the detached doc
+ * writer) — but on very different clocks:
+ *
+ *  - **Versions** are captured at the END of an edit session: a per-doc idle
+ *    timer, re-armed on every edit, fires once the doc has been quiet for
+ *    {@link IDLE_CAPTURE_MS}. That gives one version per sitting instead of one
+ *    per keystroke, and no scheduler.
+ *  - **last_edited_by/at** is stamped eagerly but throttled (immediately when
+ *    the editor changes, else at most once a minute), because it is what a file
+ *    row in every open sidebar shows.
+ *
+ * Versions hold MARKDOWN TEXT + sha256, never Yjs bytes: the update log is
+ * compacted away, a gc'd Y.Doc can't reconstruct a past state, and both preview
+ * and revert-by-forward-diff need the text itself.
+ */
+
+type Queryable = Pick<pg.Pool, "query">;
+
+/** Doc inactivity that ends an "edit session" and triggers a capture. */
+export const IDLE_CAPTURE_MS = 10 * 60_000;
+/** Versions kept per note; the oldest beyond this are pruned on each capture. */
+export const MAX_VERSIONS_PER_NOTE = 50;
+/** Re-stamp last_edited_at at most this often for the same editor. */
+const STAMP_THROTTLE_MS = 60_000;
+/** Per-vault ceiling on how often the lazy daily-checkpoint check runs. */
+const CHECKPOINT_CHECK_INTERVAL_MS = 5 * 60_000;
+
+export type VersionCause = "idle" | "pre-revert";
+
+export function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/**
+ * Insert a version for a doc, unless its latest stored version already has the
+ * same sha256 (nothing changed since — this is the dedupe the whole capture
+ * strategy relies on). Returns the new version id, or null when deduped or when
+ * the doc has no live note row.
+ */
+export async function recordVersion(
+  input: {
+    vaultId: string;
+    docId: string;
+    content: string;
+    cause: VersionCause;
+    authorId: string | null;
+  },
+  db: Queryable = defaultPool,
+): Promise<number | null> {
+  const sha = sha256Hex(input.content);
+  const { rows: latest } = await db.query<{ sha256: string }>(
+    "SELECT sha256 FROM note_versions WHERE doc_id = $1 ORDER BY id DESC LIMIT 1",
+    [input.docId],
+  );
+  if (latest[0]?.sha256 === sha) return null;
+
+  const { rows } = await db.query<{ id: string }>(
+    `INSERT INTO note_versions (doc_id, vault_id, content, sha256, cause, author_id)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [input.docId, input.vaultId, input.content, sha, input.cause, input.authorId],
+  );
+  await pruneVersions(input.docId, db);
+  // BIGSERIAL arrives as a string from node-postgres; the API hands out numbers.
+  return Number(rows[0].id);
+}
+
+/** Drop everything older than the newest {@link MAX_VERSIONS_PER_NOTE} versions. */
+export async function pruneVersions(
+  docId: string,
+  db: Queryable = defaultPool,
+): Promise<number> {
+  const { rowCount } = await db.query(
+    `DELETE FROM note_versions
+      WHERE doc_id = $1
+        AND id NOT IN (
+          SELECT id FROM note_versions WHERE doc_id = $1 ORDER BY id DESC LIMIT $2
+        )`,
+    [docId, MAX_VERSIONS_PER_NOTE],
+  );
+  return rowCount ?? 0;
+}
+
+/**
+ * Stamp who last edited a note's CONTENT. Deliberately also bumps `updated_at`
+ * (human sync edits never did), and deliberately does NOT broadcast — callers
+ * coalesce that themselves. Returns false when there is no live note row.
+ */
+export async function stampLastEdited(
+  docId: string,
+  userId: string | null,
+  db: Queryable = defaultPool,
+): Promise<boolean> {
+  const { rowCount } = await db.query(
+    `UPDATE notes
+        SET last_edited_by = $2, last_edited_at = now(), updated_at = now()
+      WHERE id = $1 AND deleted_at IS NULL`,
+    [docId, userId],
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+export interface VersionCaptureDeps {
+  docWriter: Pick<DocWriter, "peekContent">;
+  /** Broadcast so open sidebars re-pull and show the new "edited by" line. */
+  onRegistryChanged?: (vaultId: string, originId: string | null) => void;
+  /**
+   * Lazy daily vault checkpoint, invoked (throttled) on vault activity. Injected
+   * rather than imported so this module stays free of the checkpoint machinery;
+   * `src/index.ts` wires it to `maybeDailyCheckpoint`.
+   */
+  dailyCheckpoint?: (vaultId: string) => Promise<unknown>;
+  db?: Queryable;
+  /** Override the idle window (tests). */
+  idleMs?: number;
+}
+
+export interface VersionCapture {
+  /** A doc was just edited by `userId` (null = unattributed). */
+  touch(vaultId: string, docId: string, userId: string | null): void;
+  /** Run a doc's pending idle capture NOW (test hook / shutdown). */
+  flush(docId: string): Promise<void>;
+  /** Drop every pending timer. */
+  stop(): void;
+}
+
+interface Session {
+  vaultId: string;
+  /** Last editor seen in this session — the version's author. */
+  userId: string | null;
+  timer?: ReturnType<typeof setTimeout>;
+  stampedUserId?: string | null;
+  stampedAt: number;
+}
+
+export function createVersionCapture(deps: VersionCaptureDeps): VersionCapture {
+  const db = deps.db ?? defaultPool;
+  const idleMs = deps.idleMs ?? IDLE_CAPTURE_MS;
+  const sessions = new Map<string, Session>();
+  const vaultChecked = new Map<string, number>();
+
+  async function captureIdle(docId: string): Promise<void> {
+    const session = sessions.get(docId);
+    if (!session) return;
+    // The session is over the moment we capture it: a later edit starts a new
+    // one (and re-stamps last_edited, since the throttle state goes with it).
+    sessions.delete(docId);
+    if (session.timer) clearTimeout(session.timer);
+    try {
+      // Only live notes get versions — a soft-deleted one has nothing to show
+      // them in, and its vault row may already be gone.
+      const { rows } = await db.query<{ id: string }>(
+        "SELECT id FROM notes WHERE id = $1 AND vault_id = $2 AND deleted_at IS NULL",
+        [docId, session.vaultId],
+      );
+      if (!rows[0]) return;
+      const content = await deps.docWriter.peekContent(session.vaultId, docId);
+      // No server-side state yet (content still uploading) — there is nothing
+      // truthful to version. The next edit re-arms the timer.
+      if (content == null) return;
+      await recordVersion(
+        {
+          vaultId: session.vaultId,
+          docId,
+          content,
+          cause: "idle",
+          authorId: session.userId,
+        },
+        db,
+      );
+    } catch (err) {
+      console.error(`[versions] idle capture failed for ${docId}:`, err);
+    }
+  }
+
+  async function stamp(session: Session, docId: string, userId: string): Promise<void> {
+    try {
+      if (await stampLastEdited(docId, userId, db)) {
+        deps.onRegistryChanged?.(session.vaultId, null);
+      }
+    } catch (err) {
+      console.error(`[versions] last-edited stamp failed for ${docId}:`, err);
+    }
+  }
+
+  return {
+    touch(vaultId, docId, userId) {
+      const now = Date.now();
+      let session = sessions.get(docId);
+      if (!session) {
+        session = { vaultId, userId, stampedAt: 0 };
+        sessions.set(docId, session);
+      }
+      session.vaultId = vaultId;
+      session.userId = userId;
+
+      if (session.timer) clearTimeout(session.timer);
+      const timer = setTimeout(() => void captureIdle(docId), idleMs);
+      // A pending capture must never hold the process open (mirrors scheduleIndex).
+      if (typeof timer.unref === "function") timer.unref();
+      session.timer = timer;
+
+      // Stamp immediately when the editor changes hands, else at most once a
+      // minute — this write lands in every open sidebar via a registry re-pull.
+      if (
+        userId &&
+        (session.stampedUserId !== userId || now - session.stampedAt > STAMP_THROTTLE_MS)
+      ) {
+        session.stampedUserId = userId;
+        session.stampedAt = now;
+        void stamp(session, docId, userId);
+      }
+
+      // Lazy daily checkpoint: activity-triggered, no scheduler. The real
+      // freshness test (and the cross-instance advisory lock) lives in
+      // `maybeDailyCheckpoint`; this only keeps us from asking every keystroke.
+      if (deps.dailyCheckpoint) {
+        const lastCheck = vaultChecked.get(vaultId) ?? 0;
+        if (now - lastCheck > CHECKPOINT_CHECK_INTERVAL_MS) {
+          vaultChecked.set(vaultId, now);
+          void deps.dailyCheckpoint(vaultId).catch((err) => {
+            console.error(`[versions] daily checkpoint check failed for ${vaultId}:`, err);
+          });
+        }
+      }
+    },
+
+    flush(docId) {
+      return captureIdle(docId);
+    },
+
+    stop() {
+      for (const session of sessions.values()) {
+        if (session.timer) clearTimeout(session.timer);
+      }
+      sessions.clear();
+      vaultChecked.clear();
+    },
+  };
+}

--- a/app/apps/server/src/versions/checkpoints.ts
+++ b/app/apps/server/src/versions/checkpoints.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "node:crypto";
+import type pg from "pg";
+import { pool as defaultPool } from "../db/pool.js";
+import type { DocWriter } from "../mcp/doc-writer.js";
+import { sha256Hex } from "./capture.js";
+
+/**
+ * Vault-wide checkpoints: a snapshot of the folder/note STRUCTURE (JSONB) plus
+ * one row per note body, taken automatically once a day and manually by an
+ * owner/admin. At most {@link MAX_CHECKPOINTS} are kept.
+ *
+ * Everything that mutates a vault's checkpoint set — auto capture, manual
+ * capture, and a vault revert — serializes on ONE Postgres advisory lock per
+ * vault, so two instances (or two impatient clicks) can't interleave a capture
+ * with a revert, or both decide the daily snapshot is due.
+ */
+
+type Queryable = Pick<pg.Pool, "query">;
+
+/** Checkpoints retained per vault (oldest `auto` pruned first, then `manual`). */
+export const MAX_CHECKPOINTS = 5;
+/** A pathological doc this size is skipped rather than snapshotted. */
+export const MAX_CHECKPOINT_DOC_BYTES = 20 * 1024 * 1024;
+/** How stale the newest `auto` checkpoint must be before another is taken. */
+export const DAILY_CHECKPOINT_MS = 24 * 60 * 60 * 1000;
+
+export type CheckpointKind = "auto" | "manual";
+
+export interface CheckpointNote {
+  id: string;
+  rel_path: string;
+  folder_id: string | null;
+  title: string | null;
+}
+
+export interface CheckpointFolder {
+  id: string;
+  parent_id: string | null;
+  name: string;
+  path: string;
+  sort: number;
+}
+
+export interface CheckpointStructure {
+  notes: CheckpointNote[];
+  folders: CheckpointFolder[];
+}
+
+/** The list-shape a client sees. Never carries note content. */
+export interface CheckpointSummary {
+  id: string;
+  kind: CheckpointKind;
+  label: string | null;
+  createdAt: string;
+  createdBy: string | null;
+  createdByName: string | null;
+  noteCount: number;
+}
+
+/**
+ * Run `fn` holding this vault's checkpoint lock, inside one transaction.
+ *
+ * `pg_try_advisory_xact_lock` — try, not wait: a second caller is told the vault
+ * is busy (409) instead of queueing behind a multi-second snapshot. The lock is
+ * transaction-scoped, so it is released by COMMIT/ROLLBACK even if the process
+ * dies mid-revert.
+ */
+export async function withVaultCheckpointLock<T>(
+  vaultId: string,
+  fn: (db: pg.PoolClient) => Promise<T>,
+  pool: pg.Pool = defaultPool,
+): Promise<{ acquired: false } | { acquired: true; value: T }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const { rows } = await client.query<{ ok: boolean }>(
+      "SELECT pg_try_advisory_xact_lock(hashtextextended($1, 0)) AS ok",
+      [`vault-checkpoint:${vaultId}`],
+    );
+    if (!rows[0]?.ok) {
+      await client.query("ROLLBACK");
+      return { acquired: false };
+    }
+    try {
+      const value = await fn(client);
+      await client.query("COMMIT");
+      return { acquired: true, value };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    }
+  } finally {
+    client.release();
+  }
+}
+
+/** Read a vault's live structure — the shape stored in `structure` JSONB. */
+export async function readVaultStructure(
+  db: Queryable,
+  vaultId: string,
+): Promise<CheckpointStructure> {
+  const { rows: notes } = await db.query<CheckpointNote>(
+    `SELECT id, rel_path, folder_id, title
+       FROM notes WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path`,
+    [vaultId],
+  );
+  const { rows: folders } = await db.query<CheckpointFolder>(
+    "SELECT id, parent_id, name, path, sort FROM folders WHERE vault_id = $1 ORDER BY path",
+    [vaultId],
+  );
+  return { notes, folders };
+}
+
+export interface CaptureCheckpointOptions {
+  db: Queryable;
+  docWriter: Pick<DocWriter, "peekContent">;
+  vaultId: string;
+  kind: CheckpointKind;
+  label?: string | null;
+  createdBy?: string | null;
+  /** Checkpoint ids the prune must not touch (a revert's target, e.g.). */
+  excludeFromPrune?: string[];
+}
+
+/**
+ * Snapshot a vault: structure first, then each note body sequentially (one doc
+ * at a time — a vault can hold thousands, and the point is durability, not
+ * speed). Prunes afterwards so the set never exceeds {@link MAX_CHECKPOINTS}.
+ */
+export async function captureCheckpoint(
+  opts: CaptureCheckpointOptions,
+): Promise<{ id: string; noteCount: number }> {
+  const { db, vaultId } = opts;
+  const structure = await readVaultStructure(db, vaultId);
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO vault_checkpoints (id, vault_id, kind, label, created_by, structure)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+    [id, vaultId, opts.kind, opts.label ?? null, opts.createdBy ?? null, JSON.stringify(structure)],
+  );
+
+  let noteCount = 0;
+  for (const note of structure.notes) {
+    const content = await opts.docWriter.peekContent(vaultId, note.id);
+    // `null` = the server has never seen this note's content (registered, but
+    // its CRDT is still on its way up from a freshly-synced client). Recording
+    // "" for it would make a later revert bulldoze the real text — the exact
+    // data-loss this feature exists to prevent. Structure keeps the note; the
+    // revert leaves its content alone.
+    if (content == null) {
+      console.warn(`[checkpoints] no server content yet for ${note.id}; structure-only`);
+      continue;
+    }
+    if (Buffer.byteLength(content, "utf8") > MAX_CHECKPOINT_DOC_BYTES) {
+      console.warn(`[checkpoints] skipping oversized doc ${note.id} in vault ${vaultId}`);
+      continue;
+    }
+    await db.query(
+      `INSERT INTO vault_checkpoint_docs (checkpoint_id, doc_id, sha256, content)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (checkpoint_id, doc_id) DO NOTHING`,
+      [id, note.id, sha256Hex(content), content],
+    );
+    noteCount++;
+  }
+
+  await pruneCheckpoints(db, vaultId, [id, ...(opts.excludeFromPrune ?? [])]);
+  return { id, noteCount };
+}
+
+/**
+ * Keep at most {@link MAX_CHECKPOINTS} per vault. Automatic snapshots go first
+ * (oldest first) — they cost the user nothing to lose, since another one is due
+ * within a day — and only then the oldest manual ones, which someone chose to
+ * take. `excludeIds` protects checkpoints that are mid-flight (a revert's target
+ * and the pre-revert snapshot that is its undo).
+ */
+export async function pruneCheckpoints(
+  db: Queryable,
+  vaultId: string,
+  excludeIds: string[] = [],
+): Promise<string[]> {
+  const { rows } = await db.query<{ id: string; kind: CheckpointKind }>(
+    "SELECT id, kind FROM vault_checkpoints WHERE vault_id = $1 ORDER BY created_at ASC, id ASC",
+    [vaultId],
+  );
+  const overflow = rows.length - MAX_CHECKPOINTS;
+  if (overflow <= 0) return [];
+
+  const excluded = new Set(excludeIds);
+  const candidates = [
+    ...rows.filter((r) => r.kind === "auto"),
+    ...rows.filter((r) => r.kind === "manual"),
+  ].filter((r) => !excluded.has(r.id));
+  const victims = candidates.slice(0, overflow).map((r) => r.id);
+  if (victims.length === 0) return [];
+  await db.query("DELETE FROM vault_checkpoints WHERE id = ANY($1::text[])", [victims]);
+  return victims;
+}
+
+/** Checkpoint list for a vault, newest first. */
+export async function listCheckpoints(
+  db: Queryable,
+  vaultId: string,
+): Promise<CheckpointSummary[]> {
+  const { rows } = await db.query<{
+    id: string;
+    kind: CheckpointKind;
+    label: string | null;
+    created_at: Date;
+    created_by: string | null;
+    created_by_name: string | null;
+    note_count: number;
+  }>(
+    `SELECT c.id, c.kind, c.label, c.created_at, c.created_by,
+            u.name AS created_by_name,
+            (SELECT count(*) FROM vault_checkpoint_docs d WHERE d.checkpoint_id = c.id)::int
+              AS note_count
+       FROM vault_checkpoints c
+       LEFT JOIN "user" u ON u.id = c.created_by
+      WHERE c.vault_id = $1
+      ORDER BY c.created_at DESC, c.id DESC`,
+    [vaultId],
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    kind: r.kind,
+    label: r.label,
+    createdAt: new Date(r.created_at).toISOString(),
+    createdBy: r.created_by,
+    createdByName: r.created_by_name,
+    noteCount: r.note_count,
+  }));
+}
+
+/** One checkpoint's summary row (after a create), or null if it's gone. */
+export async function getCheckpointSummary(
+  db: Queryable,
+  vaultId: string,
+  checkpointId: string,
+): Promise<CheckpointSummary | null> {
+  const all = await listCheckpoints(db, vaultId);
+  return all.find((c) => c.id === checkpointId) ?? null;
+}
+
+/**
+ * Take the daily automatic checkpoint if one is due. Called on vault activity
+ * (throttled in-process by the capture layer), so there is no scheduler.
+ *
+ * The age test is made twice: once cheaply outside the lock, and again INSIDE
+ * it, because "is a snapshot due?" is exactly the question two instances answer
+ * simultaneously at midnight. Returns null when not due or when another caller
+ * holds the lock.
+ */
+export async function maybeDailyCheckpoint(opts: {
+  vaultId: string;
+  docWriter: Pick<DocWriter, "peekContent">;
+  pool?: pg.Pool;
+  now?: () => number;
+}): Promise<{ id: string; noteCount: number } | null> {
+  const pool = opts.pool ?? defaultPool;
+  const now = opts.now?.() ?? Date.now();
+
+  const due = async (db: Queryable): Promise<boolean> => {
+    const { rows } = await db.query<{ at: Date | null }>(
+      "SELECT max(created_at) AS at FROM vault_checkpoints WHERE vault_id = $1 AND kind = 'auto'",
+      [opts.vaultId],
+    );
+    const at = rows[0]?.at;
+    return !at || now - new Date(at).getTime() >= DAILY_CHECKPOINT_MS;
+  };
+
+  if (!(await due(pool))) return null;
+
+  const outcome = await withVaultCheckpointLock(
+    opts.vaultId,
+    async (db) => {
+      if (!(await due(db))) return null;
+      return captureCheckpoint({
+        db,
+        docWriter: opts.docWriter,
+        vaultId: opts.vaultId,
+        kind: "auto",
+        createdBy: null,
+      });
+    },
+    pool,
+  );
+  return outcome.acquired ? outcome.value : null;
+}

--- a/app/apps/server/src/versions/revert.ts
+++ b/app/apps/server/src/versions/revert.ts
@@ -1,0 +1,252 @@
+import type pg from "pg";
+import { pool as defaultPool } from "../db/pool.js";
+import { purgeNoteIndex } from "../index/indexer.js";
+import type { DocWriter } from "../mcp/doc-writer.js";
+import { sha256Hex, stampLastEdited } from "./capture.js";
+import {
+  captureCheckpoint,
+  withVaultCheckpointLock,
+  type CheckpointStructure,
+} from "./checkpoints.js";
+
+/**
+ * Revert a whole vault to a checkpoint.
+ *
+ * Two rules shape everything here:
+ *
+ *  1. **Never move CRDT state backwards.** Restoring a note is not "replace the
+ *     Y.Doc with the old one" (that resurrects deleted text and forks history);
+ *     it is `docWriter.setContent(target)`, a FORWARD transaction that every
+ *     connected editor merges like any other edit.
+ *  2. **Convergent, not transactional-across-docs.** Structure lives in
+ *     Postgres, content lives in the CRDT store, so the two cannot commit
+ *     together. Instead every step is idempotent: re-running a revert converges
+ *     on the same state, and the pre-revert checkpoint taken at the top is the
+ *     undo for the whole operation.
+ *
+ * Attachments/blobs are deliberately untouched — out of scope for v1, and the
+ * UI says so before the user confirms.
+ */
+
+/** The checkpoint disappeared (pruned/deleted) between the request and the lock. */
+export class RevertError extends Error {}
+
+export interface VaultRevertOutcome {
+  docsChanged: number;
+  docsRestored: number;
+  docsDeleted: number;
+  foldersCreated: number;
+  /** Docs whose snapshot was empty while the live note has text — left alone. */
+  docsKeptOverEmpty: number;
+  preRevertCheckpointId: string;
+}
+
+export interface VaultRevertDeps {
+  docWriter: Pick<DocWriter, "peekContent" | "setContent">;
+  onRegistryChanged?: (vaultId: string, originId: string | null) => void;
+  pool?: pg.Pool;
+}
+
+/** Root-first, so a parent folder exists before its children are re-created. */
+function byDepth(a: { path: string }, b: { path: string }): number {
+  const depth = (p: string) => p.split("/").length;
+  return depth(a.path) - depth(b.path) || a.path.localeCompare(b.path);
+}
+
+export async function revertVaultToCheckpoint(
+  opts: {
+    vaultId: string;
+    checkpointId: string;
+    userId: string;
+  } & VaultRevertDeps,
+): Promise<{ acquired: false } | { acquired: true; result: VaultRevertOutcome }> {
+  const pool = opts.pool ?? defaultPool;
+  const { vaultId, checkpointId, userId, docWriter } = opts;
+
+  const outcome = await withVaultCheckpointLock(
+    vaultId,
+    async (db): Promise<VaultRevertOutcome> => {
+      const { rows: cpRows } = await db.query<{ structure: CheckpointStructure }>(
+        "SELECT structure FROM vault_checkpoints WHERE id = $1 AND vault_id = $2",
+        [checkpointId, vaultId],
+      );
+      if (!cpRows[0]) throw new RevertError("Unknown checkpoint");
+      const structure: CheckpointStructure = {
+        notes: cpRows[0].structure?.notes ?? [],
+        folders: cpRows[0].structure?.folders ?? [],
+      };
+
+      const { rows: docRows } = await db.query<{
+        doc_id: string;
+        sha256: string;
+        content: string;
+      }>(
+        "SELECT doc_id, sha256, content FROM vault_checkpoint_docs WHERE checkpoint_id = $1",
+        [checkpointId],
+      );
+      const contentByDoc = new Map(docRows.map((r) => [r.doc_id, r]));
+
+      // The undo for this whole operation, taken BEFORE anything moves. Excluded
+      // from its own prune along with the checkpoint we are restoring.
+      const preRevert = await captureCheckpoint({
+        db,
+        docWriter,
+        vaultId,
+        kind: "auto",
+        label: "Before revert",
+        createdBy: userId,
+        excludeFromPrune: [checkpointId],
+      });
+
+      // ── folders ────────────────────────────────────────────────────────────
+      // Ids are preserved where possible; a folder that was deleted comes back
+      // with its ORIGINAL id so the notes' folder_id references still resolve.
+      // When the id is gone but a folder already sits at that path, the two are
+      // the same folder for our purposes and we map old id → existing id.
+      const folderIdMap = new Map<string, string>();
+      let foldersCreated = 0;
+      for (const folder of [...structure.folders].sort(byDepth)) {
+        const parentId = folder.parent_id
+          ? (folderIdMap.get(folder.parent_id) ?? folder.parent_id)
+          : null;
+
+        const { rows: byId } = await db.query<{ id: string }>(
+          "SELECT id FROM folders WHERE id = $1 AND vault_id = $2",
+          [folder.id, vaultId],
+        );
+        if (byId[0]) {
+          await db.query(
+            "UPDATE folders SET parent_id = $2, name = $3, path = $4, sort = $5 WHERE id = $1",
+            [folder.id, parentId, folder.name, folder.path, folder.sort],
+          );
+          continue;
+        }
+
+        const { rows: byPath } = await db.query<{ id: string }>(
+          "SELECT id FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+          [vaultId, folder.path],
+        );
+        if (byPath[0]) {
+          folderIdMap.set(folder.id, byPath[0].id);
+          await db.query("UPDATE folders SET parent_id = $2, name = $3, sort = $4 WHERE id = $1", [
+            byPath[0].id,
+            parentId,
+            folder.name,
+            folder.sort,
+          ]);
+          continue;
+        }
+
+        await db.query(
+          `INSERT INTO folders (id, vault_id, parent_id, name, path, sort)
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [folder.id, vaultId, parentId, folder.name, folder.path, folder.sort],
+        );
+        foldersCreated++;
+      }
+
+      // ── notes ──────────────────────────────────────────────────────────────
+      let docsChanged = 0;
+      let docsRestored = 0;
+      let docsKeptOverEmpty = 0;
+      for (const note of structure.notes) {
+        const folderId = note.folder_id
+          ? (folderIdMap.get(note.folder_id) ?? note.folder_id)
+          : null;
+
+        const { rows: existing } = await db.query<{
+          rel_path: string;
+          title: string | null;
+          folder_id: string | null;
+          deleted_at: Date | null;
+        }>(
+          "SELECT rel_path, title, folder_id, deleted_at FROM notes WHERE id = $1 AND vault_id = $2",
+          [note.id, vaultId],
+        );
+        const row = existing[0];
+        if (!row) {
+          // Hard-gone (or never existed on this server): re-create with the
+          // original doc_id so its CRDT history and backlinks reattach.
+          await db.query(
+            `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id)
+             VALUES ($1, $2, $3, $4, $5, $1)
+             ON CONFLICT (id) DO NOTHING`,
+            [note.id, vaultId, folderId, note.title, note.rel_path],
+          );
+          docsRestored++;
+        } else {
+          const moved =
+            row.rel_path !== note.rel_path ||
+            row.title !== note.title ||
+            row.folder_id !== folderId;
+          if (row.deleted_at) docsRestored++;
+          if (moved || row.deleted_at) {
+            // The first `deleted_at = NULL` in the codebase: a soft-deleted note
+            // comes back rather than being re-created, keeping its doc_id, its
+            // Yjs history and every share row pointing at it.
+            await db.query(
+              `UPDATE notes
+                  SET deleted_at = NULL, rel_path = $2, title = $3, folder_id = $4,
+                      updated_at = now()
+                WHERE id = $1`,
+              [note.id, note.rel_path, note.title, folderId],
+            );
+          }
+        }
+
+        const snapshot = contentByDoc.get(note.id);
+        if (!snapshot) continue; // structure-only (doc skipped at capture time)
+        const current = (await docWriter.peekContent(vaultId, note.id)) ?? "";
+        if (sha256Hex(current) === snapshot.sha256) continue;
+        // The data-loss firewall (same philosophy as the bridge's everHadContent
+        // guard): a revert may rewrite text, but it must never bulldoze a note
+        // that HAS text with emptiness. An empty snapshot row against a
+        // non-empty live doc is far more likely a capture that ran before the
+        // note's content reached the server than a note someone truly blanked —
+        // and the cost of being wrong here is the user's words, unrecoverably.
+        if (snapshot.content.length === 0 && current.length > 0) {
+          console.warn(
+            `[revert] keeping ${note.id}: checkpoint says empty, live doc has content`,
+          );
+          docsKeptOverEmpty++;
+          continue;
+        }
+        await docWriter.setContent(vaultId, note.id, snapshot.content, { userId });
+        await stampLastEdited(note.id, userId, db);
+        docsChanged++;
+      }
+
+      // ── notes created after the checkpoint ─────────────────────────────────
+      // Soft-deleted, exactly as a user delete would: the row and the CRDT doc
+      // survive, so a later revert to a newer checkpoint brings them back.
+      const keepIds = structure.notes.map((n) => n.id);
+      const { rows: removed } = await db.query<{ id: string }>(
+        `UPDATE notes SET deleted_at = now()
+          WHERE vault_id = $1 AND deleted_at IS NULL AND NOT (id = ANY($2::text[]))
+        RETURNING id`,
+        [vaultId, keepIds],
+      );
+      if (removed.length > 0) {
+        await purgeNoteIndex(
+          removed.map((r) => r.id),
+          db,
+        );
+      }
+
+      return {
+        docsChanged,
+        docsRestored,
+        docsDeleted: removed.length,
+        foldersCreated,
+        docsKeptOverEmpty,
+        preRevertCheckpointId: preRevert.id,
+      };
+    },
+    pool,
+  );
+
+  if (!outcome.acquired) return outcome;
+  // After COMMIT, so a client that re-pulls on the broadcast sees the new tree.
+  opts.onRegistryChanged?.(vaultId, null);
+  return { acquired: true, result: outcome.value };
+}

--- a/app/apps/server/tests/checkpoints.test.ts
+++ b/app/apps/server/tests/checkpoints.test.ts
@@ -1,0 +1,436 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import {
+  MAX_CHECKPOINTS,
+  maybeDailyCheckpoint,
+  pruneCheckpoints,
+  withVaultCheckpointLock,
+} from "../src/versions/checkpoints.js";
+import { sha256Hex } from "../src/versions/capture.js";
+import { recordingAppDeps, type RecordingAppDeps } from "./helpers/app.js";
+import { signUp, type TestUser } from "./helpers/auth.js";
+import { resetDb } from "./helpers/db.js";
+import { seedFolder, seedMember, seedNote, seedOrg, seedVault } from "./helpers/seed.js";
+
+/**
+ * Vault-wide checkpoints and the vault revert.
+ *
+ * The revert is the sharp end of the feature: it un-deletes notes (the first
+ * `deleted_at = NULL` in the codebase), re-creates folders with their original
+ * ids, and rewrites content FORWARD through the doc writer. It is convergent
+ * rather than transactional, so "run it twice" is a test, not a hazard.
+ */
+
+let rec: RecordingAppDeps;
+let app: ReturnType<typeof createApp>;
+
+function api(user: TestUser | null, path: string, init: RequestInit = {}) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (user) headers.authorization = `Bearer ${user.token}`;
+  return app.fetch(new Request(`http://local${path}`, { ...init, headers }));
+}
+
+async function seedCheckpoint(
+  vaultId: string,
+  kind: "auto" | "manual",
+  createdAt: string,
+): Promise<string> {
+  const id = randomUUID();
+  await pool.query(
+    `INSERT INTO vault_checkpoints (id, vault_id, kind, label, created_at, structure)
+     VALUES ($1, $2, $3, $4, $5, '{}'::jsonb)`,
+    [id, vaultId, kind, `${kind}@${createdAt}`, createdAt],
+  );
+  return id;
+}
+
+async function checkpointIds(vaultId: string): Promise<string[]> {
+  const { rows } = await pool.query<{ id: string }>(
+    "SELECT id FROM vault_checkpoints WHERE vault_id = $1 ORDER BY created_at ASC",
+    [vaultId],
+  );
+  return rows.map((r) => r.id);
+}
+
+describe("vault checkpoints", () => {
+  beforeEach(async () => {
+    await resetDb();
+    rec = recordingAppDeps();
+    app = createApp(rec.deps);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // ── CRUD + gates ─────────────────────────────────────────────────────────
+
+  it("owner creates a checkpoint of every note; members can list it", async () => {
+    const owner = await signUp("cp-owner@t.com");
+    const member = await signUp("cp-member@t.com");
+    const org = await seedOrg("Acme", "acme-c1");
+    await seedMember(org, owner.userId, "owner");
+    await seedMember(org, member.userId, "member");
+    const vault = await seedVault(org);
+    const a = await seedNote(vault, null, "a.md", owner.userId);
+    const b = await seedNote(vault, null, "b.md", owner.userId);
+    rec.docWriter.store.set(a, "alpha");
+    rec.docWriter.store.set(b, "beta");
+
+    const res = await api(owner, `/api/vaults/${vault}/checkpoints`, {
+      method: "POST",
+      body: JSON.stringify({ label: "Before the big refactor" }),
+    });
+    expect(res.status).toBe(201);
+    const created = (await res.json()) as { id: string; kind: string; noteCount: number };
+    expect(created.kind).toBe("manual");
+    expect(created.noteCount).toBe(2);
+
+    const list = await api(member, `/api/vaults/${vault}/checkpoints`);
+    expect(list.status).toBe(200);
+    const body = (await list.json()) as {
+      checkpoints: Array<Record<string, unknown>>;
+    };
+    expect(body.checkpoints).toHaveLength(1);
+    expect(body.checkpoints[0]).toMatchObject({
+      id: created.id,
+      kind: "manual",
+      label: "Before the big refactor",
+      createdBy: owner.userId,
+      createdByName: "cp-owner",
+      noteCount: 2,
+    });
+    // Bodies never ride a listing.
+    expect(JSON.stringify(body)).not.toContain("alpha");
+  });
+
+  it("gates create/delete to owner+admin and revert to the owner alone", async () => {
+    const owner = await signUp("g-owner@t.com");
+    const admin = await signUp("g-admin@t.com");
+    const member = await signUp("g-member@t.com");
+    const outsider = await signUp("g-out@t.com");
+    const org = await seedOrg("Acme", "acme-c2");
+    await seedMember(org, owner.userId, "owner");
+    await seedMember(org, admin.userId, "admin");
+    await seedMember(org, member.userId, "member");
+    const vault = await seedVault(org);
+
+    expect(
+      (await api(member, `/api/vaults/${vault}/checkpoints`, { method: "POST", body: "{}" }))
+        .status,
+    ).toBe(403);
+    expect((await api(outsider, `/api/vaults/${vault}/checkpoints`)).status).toBe(403);
+    expect((await api(owner, "/api/vaults/no-such-vault/checkpoints")).status).toBe(404);
+    expect((await api(null, `/api/vaults/${vault}/checkpoints`)).status).toBe(401);
+
+    const created = await api(admin, `/api/vaults/${vault}/checkpoints`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(created.status).toBe(201);
+    const { id } = (await created.json()) as { id: string };
+
+    // Admins may take and delete checkpoints, but reverting the whole vault is
+    // the owner's call alone.
+    expect(
+      (await api(admin, `/api/vaults/${vault}/checkpoints/${id}/revert`, { method: "POST" }))
+        .status,
+    ).toBe(403);
+    expect(
+      (await api(member, `/api/vaults/${vault}/checkpoints/${id}`, { method: "DELETE" })).status,
+    ).toBe(403);
+    expect(
+      (await api(admin, `/api/vaults/${vault}/checkpoints/${id}`, { method: "DELETE" })).status,
+    ).toBe(204);
+    expect(
+      (await api(admin, `/api/vaults/${vault}/checkpoints/${id}`, { method: "DELETE" })).status,
+    ).toBe(404);
+  });
+
+  // ── prune ────────────────────────────────────────────────────────────────
+
+  it("prunes the oldest automatic checkpoints first, then the oldest manual ones", async () => {
+    const org = await seedOrg("Acme", "acme-c3");
+    const vault = await seedVault(org);
+    const oldAuto = await seedCheckpoint(vault, "auto", "2026-01-01T00:00:00Z");
+    const newAuto = await seedCheckpoint(vault, "auto", "2026-01-02T00:00:00Z");
+    const m1 = await seedCheckpoint(vault, "manual", "2026-01-03T00:00:00Z");
+    const m2 = await seedCheckpoint(vault, "manual", "2026-01-04T00:00:00Z");
+    const m3 = await seedCheckpoint(vault, "manual", "2026-01-05T00:00:00Z");
+    const m4 = await seedCheckpoint(vault, "manual", "2026-01-06T00:00:00Z");
+
+    expect(await pruneCheckpoints(pool, vault)).toEqual([oldAuto]);
+    expect(await checkpointIds(vault)).toEqual([newAuto, m1, m2, m3, m4]);
+
+    // No autos left: the oldest manual goes instead.
+    const m5 = await seedCheckpoint(vault, "manual", "2026-01-07T00:00:00Z");
+    await pool.query("DELETE FROM vault_checkpoints WHERE id = $1", [newAuto]);
+    const m6 = await seedCheckpoint(vault, "manual", "2026-01-08T00:00:00Z");
+    expect(await pruneCheckpoints(pool, vault)).toEqual([m1]);
+    expect(await checkpointIds(vault)).toEqual([m2, m3, m4, m5, m6]);
+  });
+
+  it("never prunes a checkpoint that is mid-flight", async () => {
+    const org = await seedOrg("Acme", "acme-c4");
+    const vault = await seedVault(org);
+    const target = await seedCheckpoint(vault, "auto", "2026-01-01T00:00:00Z");
+    const second = await seedCheckpoint(vault, "auto", "2026-01-02T00:00:00Z");
+    for (let i = 3; i <= 7; i++) {
+      await seedCheckpoint(vault, "manual", `2026-01-0${i}T00:00:00Z`);
+    }
+
+    // 7 rows, 2 over the cap: the two oldest autos would go — but the revert
+    // target is being restored right now, so the prune has to skip it.
+    const pruned = await pruneCheckpoints(pool, vault, [target]);
+    expect(pruned).toContain(second);
+    expect(pruned).not.toContain(target);
+    expect(await checkpointIds(vault)).toContain(target);
+    expect(await checkpointIds(vault)).toHaveLength(MAX_CHECKPOINTS);
+  });
+
+  // ── lazy daily capture ───────────────────────────────────────────────────
+
+  it("takes the daily checkpoint once, and not again within the day", async () => {
+    const org = await seedOrg("Acme", "acme-c5");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md");
+    rec.docWriter.store.set(docId, "daily");
+
+    const first = await maybeDailyCheckpoint({ vaultId: vault, docWriter: rec.docWriter });
+    expect(first?.noteCount).toBe(1);
+    const second = await maybeDailyCheckpoint({ vaultId: vault, docWriter: rec.docWriter });
+    expect(second).toBeNull();
+
+    // A day later it is due again.
+    await pool.query(
+      "UPDATE vault_checkpoints SET created_at = now() - interval '25 hours' WHERE vault_id = $1",
+      [vault],
+    );
+    expect(await maybeDailyCheckpoint({ vaultId: vault, docWriter: rec.docWriter })).not.toBeNull();
+    expect(await checkpointIds(vault)).toHaveLength(2);
+  });
+
+  it("two simultaneous daily checks produce ONE checkpoint (advisory lock)", async () => {
+    const org = await seedOrg("Acme", "acme-c6");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md");
+    rec.docWriter.store.set(docId, "stampede");
+
+    const [a, b] = await Promise.all([
+      maybeDailyCheckpoint({ vaultId: vault, docWriter: rec.docWriter }),
+      maybeDailyCheckpoint({ vaultId: vault, docWriter: rec.docWriter }),
+    ]);
+    expect([a, b].filter(Boolean)).toHaveLength(1);
+    expect(await checkpointIds(vault)).toHaveLength(1);
+  });
+
+  it("409s a manual create while the vault's lock is held", async () => {
+    const owner = await signUp("busy@t.com");
+    const org = await seedOrg("Acme", "acme-c7");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const holding = withVaultCheckpointLock(vault, async () => {
+      await held;
+    });
+    // Give the lock holder a moment to actually take it.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await api(owner, `/api/vaults/${vault}/checkpoints`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(res.status).toBe(409);
+
+    release();
+    await holding;
+    expect((await api(owner, `/api/vaults/${vault}/checkpoints`, { method: "POST", body: "{}" }))
+      .status).toBe(201);
+  });
+
+  // ── vault revert ─────────────────────────────────────────────────────────
+
+  it("restores content, un-deletes notes, re-creates folders and tombstones new ones", async () => {
+    const owner = await signUp("rv-owner@t.com");
+    const org = await seedOrg("Acme", "acme-c8");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Docs", "Docs");
+    const kept = await seedNote(vault, folder, "Docs/kept.md", owner.userId);
+    const removed = await seedNote(vault, null, "gone.md", owner.userId);
+    rec.docWriter.store.set(kept, "original body");
+    rec.docWriter.store.set(removed, "will be deleted");
+
+    const create = await api(owner, `/api/vaults/${vault}/checkpoints`, {
+      method: "POST",
+      body: JSON.stringify({ label: "good state" }),
+    });
+    const checkpoint = (await create.json()) as { id: string };
+
+    // …then the vault drifts: a rewrite, a delete, a folder removal, a new note.
+    rec.docWriter.store.set(kept, "a bad rewrite");
+    await pool.query("UPDATE notes SET deleted_at = now() WHERE id = $1", [removed]);
+    await pool.query("DELETE FROM folders WHERE id = $1", [folder]); // notes.folder_id → NULL
+    const fresh = await seedNote(vault, null, "fresh.md", owner.userId);
+    rec.registryBroadcasts.length = 0;
+
+    const res = await api(owner, `/api/vaults/${vault}/checkpoints/${checkpoint.id}/revert`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const result = (await res.json()) as {
+      ok: boolean;
+      docsChanged: number;
+      docsRestored: number;
+      docsDeleted: number;
+      foldersCreated: number;
+      preRevertCheckpointId: string;
+    };
+    expect(result).toMatchObject({
+      ok: true,
+      docsChanged: 1,
+      docsRestored: 1,
+      docsDeleted: 1,
+      foldersCreated: 1,
+    });
+    expect(result.preRevertCheckpointId).toBeTypeOf("string");
+
+    // Content came back as a FORWARD write, attributed to the reverter.
+    expect(rec.docWriter.store.get(kept)).toBe("original body");
+    expect(rec.docWriter.writes.at(-1)).toMatchObject({
+      docId: kept,
+      actor: { userId: owner.userId },
+    });
+
+    const { rows } = await pool.query<{
+      id: string;
+      folder_id: string | null;
+      rel_path: string;
+      deleted_at: Date | null;
+      last_edited_by: string | null;
+    }>("SELECT id, folder_id, rel_path, deleted_at, last_edited_by FROM notes WHERE vault_id = $1", [
+      vault,
+    ]);
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    expect(byId.get(kept)!.deleted_at).toBeNull();
+    expect(byId.get(kept)!.folder_id).toBe(folder); // folder re-created with its ORIGINAL id
+    expect(byId.get(kept)!.last_edited_by).toBe(owner.userId);
+    expect(byId.get(removed)!.deleted_at).toBeNull(); // un-deleted
+    expect(byId.get(fresh)!.deleted_at).not.toBeNull(); // created after the checkpoint
+    expect(rec.registryBroadcasts).toContainEqual({ vaultId: vault, originId: null });
+
+    // The undo of the revert itself.
+    const { rows: pre } = await pool.query<{ kind: string; created_by: string }>(
+      "SELECT kind, created_by FROM vault_checkpoints WHERE id = $1",
+      [result.preRevertCheckpointId],
+    );
+    expect(pre[0]).toMatchObject({ kind: "auto", created_by: owner.userId });
+
+    // Convergent: running it again changes nothing.
+    const again = await api(owner, `/api/vaults/${vault}/checkpoints/${checkpoint.id}/revert`, {
+      method: "POST",
+    });
+    expect(again.status).toBe(200);
+    expect(await again.json()).toMatchObject({
+      docsChanged: 0,
+      docsRestored: 0,
+      docsDeleted: 0,
+      foldersCreated: 0,
+    });
+    expect(rec.docWriter.store.get(kept)).toBe("original body");
+  });
+
+  it("captures structure-only for notes whose content never reached the server", async () => {
+    // The freshly-synced-vault data-loss regression: registry rows exist the
+    // moment sync turns on, but content uploads lag. A checkpoint captured in
+    // that window must NOT record "" for the lagging notes — reverting to it
+    // later would bulldoze the real text.
+    const owner = await signUp("rv-lag@t.com");
+    const org = await seedOrg("Lag", "lag-c8");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const uploaded = await seedNote(vault, null, "uploaded.md", owner.userId);
+    const lagging = await seedNote(vault, null, "lagging.md", owner.userId);
+    rec.docWriter.store.set(uploaded, "made it up");
+    // `lagging` deliberately has NO server content: peekContent → null.
+
+    const create = await api(owner, `/api/vaults/${vault}/checkpoints`, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(create.status).toBe(201);
+    const checkpoint = (await create.json()) as { id: string; noteCount: number };
+    expect(checkpoint.noteCount).toBe(1); // uploaded only
+    const { rows: docRows } = await pool.query(
+      "SELECT doc_id FROM vault_checkpoint_docs WHERE checkpoint_id = $1",
+      [checkpoint.id],
+    );
+    expect(docRows.map((r) => r.doc_id)).toEqual([uploaded]);
+
+    // The upload finishes AFTER the checkpoint; a revert must leave it alone.
+    rec.docWriter.store.set(lagging, "arrived after the checkpoint");
+    const res = await api(owner, `/api/vaults/${vault}/checkpoints/${checkpoint.id}/revert`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    expect(rec.docWriter.store.get(lagging)).toBe("arrived after the checkpoint");
+    expect(rec.docWriter.store.get(uploaded)).toBe("made it up");
+  });
+
+  it("never bulldozes a note that has text with an empty snapshot row", async () => {
+    // Belt for pre-fix checkpoints that already stored "" (and any future bug
+    // that reintroduces one): the revert keeps the live text and reports it.
+    const owner = await signUp("rv-guard@t.com");
+    const org = await seedOrg("Guard", "guard-c8");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const doc = await seedNote(vault, null, "precious.md", owner.userId);
+    rec.docWriter.store.set(doc, "precious words");
+
+    const create = await api(owner, `/api/vaults/${vault}/checkpoints`, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    const checkpoint = (await create.json()) as { id: string };
+    // Simulate a legacy bad checkpoint: an empty content row for a real note.
+    await pool.query(
+      "UPDATE vault_checkpoint_docs SET content = '', sha256 = $2 WHERE checkpoint_id = $1",
+      [checkpoint.id, sha256Hex("")],
+    );
+
+    const res = await api(owner, `/api/vaults/${vault}/checkpoints/${checkpoint.id}/revert`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const result = (await res.json()) as { docsChanged: number; docsKeptOverEmpty: number };
+    expect(result.docsKeptOverEmpty).toBe(1);
+    expect(result.docsChanged).toBe(0);
+    expect(rec.docWriter.store.get(doc)).toBe("precious words");
+  });
+
+  it("404s a checkpoint from another vault", async () => {
+    const owner = await signUp("rv-cross@t.com");
+    const org = await seedOrg("Acme", "acme-c9");
+    await seedMember(org, owner.userId, "owner");
+    const vaultA = await seedVault(org, "A");
+    const vaultB = await seedVault(org, "B");
+    const created = await api(owner, `/api/vaults/${vaultA}/checkpoints`, {
+      method: "POST",
+      body: "{}",
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    expect(
+      (await api(owner, `/api/vaults/${vaultB}/checkpoints/${id}/revert`, { method: "POST" }))
+        .status,
+    ).toBe(404);
+    expect(
+      (await api(owner, `/api/vaults/${vaultB}/checkpoints/${id}`, { method: "DELETE" })).status,
+    ).toBe(404);
+  });
+});

--- a/app/apps/server/tests/helpers/app.ts
+++ b/app/apps/server/tests/helpers/app.ts
@@ -1,19 +1,43 @@
 import type { AppDeps } from "../../src/http/app.js";
-import type { DocWriter } from "../../src/mcp/doc-writer.js";
+import type { DocActor, DocWriter } from "../../src/mcp/doc-writer.js";
+
+/** One recorded write, so a test can assert WHO the server said wrote it. */
+export interface RecordedWrite {
+  vaultId: string;
+  docId: string;
+  content: string;
+  actor: DocActor | undefined;
+}
+
+export type MemoryDocWriter = DocWriter & {
+  store: Map<string, string>;
+  /** Every setContent/appendContent, in order. */
+  writes: RecordedWrite[];
+};
 
 /** A DocWriter that records writes in memory — for tests that don't run sync. */
-export function memoryDocWriter(): DocWriter & { store: Map<string, string> } {
+export function memoryDocWriter(): MemoryDocWriter {
   const store = new Map<string, string>();
+  const writes: RecordedWrite[] = [];
   return {
     store,
-    async setContent(_vaultId, docId, content) {
+    writes,
+    async setContent(vaultId, docId, content, actor) {
       store.set(docId, content);
+      writes.push({ vaultId, docId, content, actor });
     },
-    async appendContent(_vaultId, docId, text) {
-      store.set(docId, (store.get(docId) ?? "") + text);
+    async appendContent(vaultId, docId, text, actor) {
+      const next = (store.get(docId) ?? "") + text;
+      store.set(docId, next);
+      writes.push({ vaultId, docId, content: next, actor });
     },
     async readContent(_vaultId, docId) {
       return store.get(docId) ?? "";
+    },
+    // Mirrors production: null = the store has never seen this doc's content,
+    // which capture paths must treat as "skip", never as "empty note".
+    async peekContent(_vaultId, docId) {
+      return store.get(docId) ?? null;
     },
   };
 }
@@ -45,7 +69,7 @@ export interface RecordingAppDeps {
   aclBroadcasts: string[];
   /** Docs whose live sync sockets were force-closed. */
   disconnected: Array<{ vaultId: string; docId: string }>;
-  docWriter: DocWriter & { store: Map<string, string> };
+  docWriter: MemoryDocWriter;
   /** Clear all recordings (call from `beforeEach`). */
   reset(): void;
 }
@@ -71,6 +95,7 @@ export function recordingAppDeps(overrides: Partial<AppDeps> = {}): RecordingApp
       aclBroadcasts.length = 0;
       disconnected.length = 0;
       docWriter.store.clear();
+      docWriter.writes.length = 0;
     },
     deps: {
       docWriter,

--- a/app/apps/server/tests/helpers/db.ts
+++ b/app/apps/server/tests/helpers/db.ts
@@ -10,6 +10,9 @@ export async function ensureMigrated(): Promise<void> {
 }
 
 const TABLES = [
+  "note_versions",
+  "vault_checkpoint_docs",
+  "vault_checkpoints",
   "billing_events",
   "subscriptions",
   "mcp_tokens",

--- a/app/apps/server/tests/sync-e2e.test.ts
+++ b/app/apps/server/tests/sync-e2e.test.ts
@@ -7,7 +7,13 @@ import { createSyncServer, disconnectDoc, type SyncContext } from "../src/sync/h
 import { formatDocName } from "../src/sync/doc-name.js";
 import { mintSyncToken } from "../src/tokens/sync-token.js";
 import { countUpdates } from "../src/yjs/persistence.js";
+import { createDocWriter } from "../src/mcp/doc-writer.js";
+import { createApp } from "../src/http/app.js";
+import { recordVersion } from "../src/versions/capture.js";
 import { pool } from "../src/db/pool.js";
+import { testAppDeps } from "./helpers/app.js";
+import { authHeaders, signUp } from "./helpers/auth.js";
+import { seedMember, seedNote, seedOrg, seedVault } from "./helpers/seed.js";
 import { resetDb } from "./helpers/db.js";
 
 const PORT = 3987;
@@ -15,6 +21,8 @@ const URL = `ws://127.0.0.1:${PORT}`;
 const VAULT = "vault-e2e";
 
 let server: Server<SyncContext>;
+/** Every `onDocEdited` notification the sync server made, in order. */
+let edits: Array<{ vaultId: string; docId: string; userId: string | null }>;
 
 function waitFor(cond: () => boolean, timeoutMs = 8000, label = "condition"): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -34,12 +42,17 @@ interface Client {
   text: Y.Text;
 }
 
-async function connect(docId: string, readOnly: boolean): Promise<Client> {
-  const token = await mintSyncToken({ docId, vaultId: VAULT, readOnly });
+async function connect(
+  docId: string,
+  readOnly: boolean,
+  userId?: string,
+  vaultId: string = VAULT,
+): Promise<Client> {
+  const token = await mintSyncToken({ docId, vaultId, readOnly, userId });
   const doc = new Y.Doc();
   const provider = new HocuspocusProvider({
     url: URL,
-    name: formatDocName(VAULT, docId),
+    name: formatDocName(vaultId, docId),
     token,
     document: doc,
     WebSocketPolyfill: WebSocket as unknown as typeof globalThis.WebSocket,
@@ -51,7 +64,10 @@ async function connect(docId: string, readOnly: boolean): Promise<Client> {
 describe("end-to-end Yjs sync through the server (spec 03 §3, 04 §4)", () => {
   beforeAll(async () => {
     await resetDb();
-    server = createSyncServer(PORT);
+    edits = [];
+    server = createSyncServer(PORT, undefined, (vaultId, docId, userId) =>
+      edits.push({ vaultId, docId, userId }),
+    );
     await server.listen();
   });
   afterAll(async () => {
@@ -60,6 +76,7 @@ describe("end-to-end Yjs sync through the server (spec 03 §3, 04 §4)", () => {
   });
   beforeEach(async () => {
     await resetDb();
+    edits = [];
   });
 
   it("two edit clients converge on one doc", async () => {
@@ -120,6 +137,103 @@ describe("end-to-end Yjs sync through the server (spec 03 §3, 04 §4)", () => {
     ).catch(() => {});
     // Best-effort: it should no longer report a live synced connection soon after.
     c.provider.disconnect();
+    c.provider.destroy();
+  });
+
+  // ── attribution (versioning / "last edited by") ─────────────────────────────
+
+  it("attributes a client edit to the token's userId", async () => {
+    const docId = "e2e-attrib-client";
+    const c = await connect(docId, false, "user-abc");
+    c.text.insert(0, "typed by a human");
+
+    await waitFor(() => edits.some((e) => e.docId === docId), 8000, "onDocEdited fired");
+    const mine = edits.filter((e) => e.docId === docId);
+    expect(mine[0].vaultId).toBe(VAULT);
+    expect(mine[0].userId).toBe("user-abc");
+
+    c.provider.destroy();
+  });
+
+  it("a pre-attribution token (no userId claim) still syncs, anonymously", async () => {
+    // Tokens minted before the claim existed are in flight for up to the TTL.
+    // They must verify and connect — just without a name attached.
+    const docId = "e2e-attrib-legacy";
+    const c = await connect(docId, false);
+    c.text.insert(0, "anonymous edit");
+
+    await waitFor(() => edits.some((e) => e.docId === docId), 8000, "onDocEdited fired");
+    expect(edits.find((e) => e.docId === docId)?.userId).toBeNull();
+
+    c.provider.destroy();
+  });
+
+  it("a doc-writer LIVE write reaches onChange with its actor (object origin)", async () => {
+    // The load-bearing one. The live path tags its transaction with a Hocuspocus
+    // `LocalTransactionOrigin` object; if Hocuspocus only string-compared origins
+    // (as `LOAD_ORIGIN` is), the context — and with it the whole attribution
+    // chain for MCP/AI and revert writes — would never arrive.
+    const docId = "e2e-attrib-local-origin";
+    const c = await connect(docId, false, "human");
+    await waitFor(() => c.provider.isSynced);
+
+    const writer = createDocWriter(server);
+    await writer.setContent(VAULT, docId, "written by the assistant", {
+      userId: "assistant-user",
+    });
+
+    // Reached the connected editor as an ordinary remote update…
+    await waitFor(
+      () => c.text.toString() === "written by the assistant",
+      8000,
+      "live write broadcast",
+    );
+    // …and was attributed to the actor, not to the connected human.
+    await waitFor(
+      () => edits.some((e) => e.docId === docId && e.userId === "assistant-user"),
+      8000,
+      "actor attribution",
+    );
+
+    c.provider.destroy();
+  });
+
+  it("a version revert over HTTP lands live in a connected editor", async () => {
+    // The whole point of reverting FORWARD through the doc writer: the client
+    // needs no revert protocol at all — the restored text arrives as an ordinary
+    // remote update and yCollab applies it like a teammate's keystroke.
+    const owner = await signUp("e2e-revert@t.com");
+    const org = await seedOrg("Acme", "acme-e2e-rv");
+    await seedMember(org, owner.userId, "owner");
+    const vaultId = await seedVault(org);
+    const docId = await seedNote(vaultId, null, "n.md", owner.userId);
+
+    const app = createApp(testAppDeps({ docWriter: createDocWriter(server) }));
+    const c = await connect(docId, false, owner.userId, vaultId);
+    c.text.insert(0, "text the user regrets");
+    await waitFor(() => c.text.toString() === "text the user regrets");
+
+    const versionId = await recordVersion({
+      vaultId,
+      docId,
+      content: "the good version",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+
+    const res = await app.fetch(
+      new Request(`http://local/api/notes/${docId}/versions/${versionId}/revert`, {
+        method: "POST",
+        headers: authHeaders(owner),
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    await waitFor(
+      () => c.text.toString() === "the good version",
+      8000,
+      "revert reached the editor",
+    );
     c.provider.destroy();
   });
 });

--- a/app/apps/server/tests/sync-token.test.ts
+++ b/app/apps/server/tests/sync-token.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../src/http/app.js";
 import { testAppDeps } from "./helpers/app.js";
-import { verifySyncToken } from "../src/tokens/sync-token.js";
+import { mintSyncToken, verifySyncToken } from "../src/tokens/sync-token.js";
 import { pool } from "../src/db/pool.js";
 import { resetDb } from "./helpers/db.js";
 import { authHeaders, signUp } from "./helpers/auth.js";
@@ -51,6 +51,19 @@ describe("POST /api/sync-token (spec 03 §7)", () => {
     expect(claims.docId).toBe(doc);
     expect(claims.vaultId).toBe(vault);
     expect(claims.readOnly).toBe(false);
+    // Attribution: the sync server reads this to stamp "last edited by" and to
+    // author auto-captured versions.
+    expect(claims.userId).toBe(owner.userId);
+  });
+
+  it("verifies a token minted WITHOUT a userId claim as anonymous", async () => {
+    // Tokens minted before attribution existed stay in flight for the whole TTL.
+    // They must keep syncing — nameless, not rejected — or a deploy drops every
+    // open editor just to learn who is typing.
+    const token = await mintSyncToken({ docId: "d", vaultId: "v", readOnly: false });
+    const claims = await verifySyncToken(token);
+    expect(claims.userId).toBeUndefined();
+    expect(claims.docId).toBe("d");
   });
 
   it("view grant -> 200 readOnly:true", async () => {

--- a/app/apps/server/tests/versions.test.ts
+++ b/app/apps/server/tests/versions.test.ts
@@ -1,0 +1,403 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import {
+  createVersionCapture,
+  MAX_VERSIONS_PER_NOTE,
+  recordVersion,
+  sha256Hex,
+} from "../src/versions/capture.js";
+import { recordingAppDeps, type RecordingAppDeps } from "./helpers/app.js";
+import { authHeaders, signUp, type TestUser } from "./helpers/auth.js";
+import { resetDb } from "./helpers/db.js";
+import {
+  seedFolder,
+  seedLock,
+  seedMember,
+  seedNote,
+  seedOrg,
+  seedShare,
+  seedVault,
+} from "./helpers/seed.js";
+
+/**
+ * Per-note version history: automatic capture at the end of an edit session,
+ * the "last edited by" stamp that rides the same signal, and the HTTP surface
+ * (which is gated by the SAME per-doc ACL as sync — a `locked` share caps at
+ * view, so listing works and reverting 403s).
+ */
+
+let rec: RecordingAppDeps;
+let app: ReturnType<typeof createApp>;
+
+function api(user: TestUser | null, path: string, init: RequestInit = {}) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (user) headers.authorization = `Bearer ${user.token}`;
+  return app.fetch(new Request(`http://local${path}`, { ...init, headers }));
+}
+
+describe("per-note versions", () => {
+  beforeEach(async () => {
+    await resetDb();
+    rec = recordingAppDeps();
+    app = createApp(rec.deps);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // ── capture ──────────────────────────────────────────────────────────────
+
+  it("captures one version when a doc's edit session goes idle", async () => {
+    const user = await signUp("cap@t.com");
+    const org = await seedOrg("Acme", "acme-v1");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+    rec.docWriter.store.set(docId, "# Draft\n\nbody");
+
+    const capture = createVersionCapture({
+      docWriter: rec.docWriter,
+      onRegistryChanged: rec.deps.onRegistryChanged,
+      // Long idle window: the flush hook is what ends the session here, exactly
+      // as the timer would 10 minutes later.
+      idleMs: 60_000,
+    });
+    capture.touch(vault, docId, user.userId);
+    capture.touch(vault, docId, user.userId);
+    await capture.flush(docId);
+    capture.stop();
+
+    const { rows } = await pool.query(
+      "SELECT doc_id, vault_id, content, sha256, cause, author_id FROM note_versions",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].doc_id).toBe(docId);
+    expect(rows[0].vault_id).toBe(vault);
+    expect(rows[0].content).toBe("# Draft\n\nbody");
+    expect(rows[0].sha256).toBe(sha256Hex("# Draft\n\nbody"));
+    expect(rows[0].cause).toBe("idle");
+    expect(rows[0].author_id).toBe(user.userId);
+  });
+
+  it("skips a capture whose content is identical to the newest version", async () => {
+    const user = await signUp("dedupe@t.com");
+    const org = await seedOrg("Acme", "acme-v2");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+    rec.docWriter.store.set(docId, "same text");
+
+    const capture = createVersionCapture({ docWriter: rec.docWriter, idleMs: 60_000 });
+    capture.touch(vault, docId, user.userId);
+    await capture.flush(docId);
+    capture.touch(vault, docId, user.userId);
+    await capture.flush(docId);
+    expect(await countVersions(docId)).toBe(1);
+
+    rec.docWriter.store.set(docId, "changed");
+    capture.touch(vault, docId, user.userId);
+    await capture.flush(docId);
+    capture.stop();
+    expect(await countVersions(docId)).toBe(2);
+  });
+
+  it("attributes an unauthenticated (pre-attribution token) edit to nobody", async () => {
+    const org = await seedOrg("Acme", "acme-v3");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md");
+    rec.docWriter.store.set(docId, "anonymous work");
+
+    const capture = createVersionCapture({ docWriter: rec.docWriter, idleMs: 60_000 });
+    capture.touch(vault, docId, null);
+    await capture.flush(docId);
+    capture.stop();
+
+    const { rows } = await pool.query("SELECT author_id FROM note_versions WHERE doc_id = $1", [
+      docId,
+    ]);
+    expect(rows[0].author_id).toBeNull();
+  });
+
+  it(`keeps at most ${MAX_VERSIONS_PER_NOTE} versions per note, dropping the oldest`, async () => {
+    const org = await seedOrg("Acme", "acme-v4");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md");
+
+    for (let i = 0; i < MAX_VERSIONS_PER_NOTE + 7; i++) {
+      await recordVersion({ vaultId: vault, docId, content: `v${i}`, cause: "idle", authorId: null });
+    }
+    const { rows } = await pool.query<{ content: string }>(
+      "SELECT content FROM note_versions WHERE doc_id = $1 ORDER BY id ASC",
+      [docId],
+    );
+    expect(rows).toHaveLength(MAX_VERSIONS_PER_NOTE);
+    expect(rows[0].content).toBe("v7");
+    expect(rows[rows.length - 1].content).toBe(`v${MAX_VERSIONS_PER_NOTE + 6}`);
+  });
+
+  it("stamps last_edited_by/at on the first touch and broadcasts it", async () => {
+    const user = await signUp("stamp@t.com");
+    const org = await seedOrg("Acme", "acme-v5");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+    rec.docWriter.store.set(docId, "hello");
+
+    const capture = createVersionCapture({
+      docWriter: rec.docWriter,
+      onRegistryChanged: rec.deps.onRegistryChanged,
+      idleMs: 60_000,
+    });
+    capture.touch(vault, docId, user.userId);
+    // The stamp is fire-and-forget inside touch(); let it land.
+    await new Promise((r) => setTimeout(r, 100));
+    capture.stop();
+
+    const { rows } = await pool.query<{ last_edited_by: string; last_edited_at: Date | null }>(
+      "SELECT last_edited_by, last_edited_at FROM notes WHERE id = $1",
+      [docId],
+    );
+    expect(rows[0].last_edited_by).toBe(user.userId);
+    expect(rows[0].last_edited_at).not.toBeNull();
+    expect(rec.registryBroadcasts).toContainEqual({ vaultId: vault, originId: null });
+  });
+
+  it("surfaces the stamp on GET /api/notes (name joined in)", async () => {
+    const user = await signUp("surf@t.com");
+    const org = await seedOrg("Acme", "acme-v6");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+    await pool.query(
+      "UPDATE notes SET last_edited_by = $2, last_edited_at = now() WHERE id = $1",
+      [docId, user.userId],
+    );
+
+    const res = await api(user, `/api/notes?vaultId=${vault}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      notes: Array<{
+        id: string;
+        last_edited_by: string | null;
+        last_edited_by_name: string | null;
+        last_edited_at: string | null;
+      }>;
+    };
+    const note = body.notes.find((n) => n.id === docId)!;
+    expect(note.last_edited_by).toBe(user.userId);
+    expect(note.last_edited_by_name).toBe("surf");
+    expect(note.last_edited_at).not.toBeNull();
+  });
+
+  // ── HTTP surface ─────────────────────────────────────────────────────────
+
+  it("lists versions newest-first, without content", async () => {
+    const owner = await signUp("list@t.com");
+    const org = await seedOrg("Acme", "acme-v7");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", owner.userId);
+    const first = await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "one",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+    const second = await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "two",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+
+    const res = await api(owner, `/api/notes/${docId}/versions`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      versions: Array<Record<string, unknown>>;
+    };
+    expect(body.versions.map((v) => v.id)).toEqual([second, first]);
+    expect(body.versions[0]).toMatchObject({
+      cause: "idle",
+      authorId: owner.userId,
+      authorName: "list",
+      sha256: sha256Hex("two"),
+      size: 3,
+    });
+    expect(body.versions[0].content).toBeUndefined();
+
+    const detail = await api(owner, `/api/notes/${docId}/versions/${second}`);
+    expect(detail.status).toBe(200);
+    expect(((await detail.json()) as { content: string }).content).toBe("two");
+  });
+
+  it("404s a version id that belongs to another note", async () => {
+    const owner = await signUp("cross@t.com");
+    const org = await seedOrg("Acme", "acme-v8");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const a = await seedNote(vault, null, "a.md", owner.userId);
+    const b = await seedNote(vault, null, "b.md", owner.userId);
+    const versionOfA = await recordVersion({
+      vaultId: vault,
+      docId: a,
+      content: "secret",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+
+    const res = await api(owner, `/api/notes/${b}/versions/${versionOfA}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("a viewer may list versions but may not revert; a stranger sees nothing", async () => {
+    const owner = await signUp("owner8@t.com");
+    const viewer = await signUp("viewer8@t.com");
+    const stranger = await signUp("stranger8@t.com");
+    const org = await seedOrg("Acme", "acme-v9");
+    await seedMember(org, owner.userId, "owner");
+    await seedMember(org, viewer.userId, "member");
+    await seedMember(org, stranger.userId, "member");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Shared", "Shared");
+    const docId = await seedNote(vault, folder, "Shared/n.md", owner.userId);
+    await seedShare(org, "folder", folder, viewer.userId, "view");
+    const version = await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "old",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+    rec.docWriter.store.set(docId, "new");
+
+    expect((await api(viewer, `/api/notes/${docId}/versions`)).status).toBe(200);
+    expect((await api(stranger, `/api/notes/${docId}/versions`)).status).toBe(403);
+    const revert = await api(viewer, `/api/notes/${docId}/versions/${version}/revert`, {
+      method: "POST",
+    });
+    expect(revert.status).toBe(403);
+    expect(rec.docWriter.store.get(docId)).toBe("new");
+  });
+
+  it("a locked share caps an editor at view, so revert 403s", async () => {
+    const owner = await signUp("owner9@t.com");
+    const editor = await signUp("editor9@t.com");
+    const org = await seedOrg("Acme", "acme-v10");
+    await seedMember(org, owner.userId, "owner");
+    await seedMember(org, editor.userId, "member");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Locked", "Locked");
+    const docId = await seedNote(vault, folder, "Locked/n.md", owner.userId);
+    await seedShare(org, "folder", folder, editor.userId, "edit");
+    await seedLock(org, "folder", folder, { type: "org" });
+    const version = await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "old",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+
+    expect((await api(editor, `/api/notes/${docId}/versions`)).status).toBe(200);
+    const revert = await api(editor, `/api/notes/${docId}/versions/${version}/revert`, {
+      method: "POST",
+    });
+    expect(revert.status).toBe(403);
+  });
+
+  it("reverting captures a pre-revert version, writes forward, and re-stamps", async () => {
+    const owner = await signUp("revert@t.com");
+    const org = await seedOrg("Acme", "acme-v11");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", owner.userId);
+    const version = await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "the good version",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+    // Live text has moved on since that version — so it must be saved first.
+    rec.docWriter.store.set(docId, "a regrettable rewrite");
+    rec.registryBroadcasts.length = 0;
+
+    const res = await api(owner, `/api/notes/${docId}/versions/${version}/revert`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; preRevertVersionId: number | null };
+    expect(body.ok).toBe(true);
+    expect(body.preRevertVersionId).toBeTypeOf("number");
+
+    const pre = await pool.query<{ content: string; cause: string; author_id: string }>(
+      "SELECT content, cause, author_id FROM note_versions WHERE id = $1",
+      [body.preRevertVersionId],
+    );
+    expect(pre.rows[0]).toMatchObject({
+      content: "a regrettable rewrite",
+      cause: "pre-revert",
+      author_id: owner.userId,
+    });
+
+    // Forward write, attributed to the reverter.
+    expect(rec.docWriter.store.get(docId)).toBe("the good version");
+    expect(rec.docWriter.writes.at(-1)).toMatchObject({
+      docId,
+      actor: { userId: owner.userId },
+    });
+    const stamped = await pool.query<{ last_edited_by: string }>(
+      "SELECT last_edited_by FROM notes WHERE id = $1",
+      [docId],
+    );
+    expect(stamped.rows[0].last_edited_by).toBe(owner.userId);
+    expect(rec.registryBroadcasts).toContainEqual({ vaultId: vault, originId: null });
+  });
+
+  it("skips the pre-revert version when the live text is already the newest one", async () => {
+    const owner = await signUp("nopre@t.com");
+    const org = await seedOrg("Acme", "acme-v12");
+    await seedMember(org, owner.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", owner.userId);
+    const older = await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "older",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+    await recordVersion({
+      vaultId: vault,
+      docId,
+      content: "current",
+      cause: "idle",
+      authorId: owner.userId,
+    });
+    rec.docWriter.store.set(docId, "current");
+
+    const res = await api(owner, `/api/notes/${docId}/versions/${older}/revert`, {
+      method: "POST",
+    });
+    const body = (await res.json()) as { preRevertVersionId: number | null };
+    expect(body.preRevertVersionId).toBeNull();
+    expect(rec.docWriter.store.get(docId)).toBe("older");
+  });
+
+  it("401s without a session and 404s an unknown note", async () => {
+    const owner = await signUp("gate@t.com");
+    expect((await api(null, "/api/notes/whatever/versions")).status).toBe(401);
+    expect((await api(owner, "/api/notes/no-such-note/versions")).status).toBe(404);
+  });
+});
+
+async function countVersions(docId: string): Promise<number> {
+  const { rows } = await pool.query<{ n: string }>(
+    "SELECT count(*)::text AS n FROM note_versions WHERE doc_id = $1",
+    [docId],
+  );
+  return Number(rows[0].n);
+}

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+- Version history for every note — open the clock icon to browse, preview and revert past versions
+- Vault checkpoints in Settings → Versioning — automatic daily snapshots plus manual ones, with owner-only full-vault revert
+- See who last edited a note in the presence menu, and "edited … ago" at a glance
+- Persistent sync indicator in the header — live download/upload progress that settles to a checkmark
+- Updates now install themselves; this banner is the new way you hear about them


### PR DESCRIPTION
## What's in here

**Per-note version history** (synced vaults)
- Versions auto-capture when a note goes idle after edits (`VERSION_IDLE_MS`, default 10 min), sha-deduped, 50/note cap, plus a safety version before every revert
- New header clock button opens a right slide-in panel: hover previews a version read-only over the live editor, click reverts (as a forward CRDT edit that broadcasts live), keyboard nav, outside-click closes

**Vault checkpoints** (Settings → Versioning)
- Automatic daily (lazy, activity-triggered) + manual capture (owner/admin), max 5 with auto-first pruning
- Owner-only full-vault revert: restores content, un-deletes notes (first `deleted_at = NULL` in the codebase), re-creates folders with original ids, tombstones post-checkpoint notes; convergent and idempotent, undone via the auto pre-revert checkpoint
- **Data-loss firewall:** capture skips notes whose content never reached the server (`peekContent` distinguishes "not uploaded" from "empty"), and a revert refuses to overwrite a note that has text with an empty snapshot (`docsKeptOverEmpty`) — regression-tested against the freshly-synced-vault wipe scenario

**Last edited by**
- Sync tokens now carry `userId` (old tokens verify as anonymous); Hocuspocus `onChange` and MCP writes stamp `notes.last_edited_by/at`, throttled ~1/min/doc
- Shown in the editor's presence dropdown as a "Recent activity" section (dimmer, smaller faces than live presence)

**Sync progress badge**
- The header sync pill is now vault-wide and persistent: "Downloading 128/500" with a determinate bar during hydration (no note open needed), settles to "Synced ✓", failures stay visible

**Silent auto-updates**
- On launch: check → download → install → relaunch, no click; after restart a dismissible "Updated to vX" banner lists the release one-liners
- Release body now comes from `docs/RELEASE_NOTES.md` (updater feeds it back as `latest.json` notes); older app versions keep their manual Install & Restart flow until their one last click

## Migrations
`016_versioning.sql` (note_versions, vault_checkpoints, vault_checkpoint_docs) and `017_last_edited_by.sql` — purely additive.

## Tests
Server: 240 passing (versions, checkpoints incl. both data-loss regressions, sync-token round-trip, revert-broadcast e2e). Desktop: 565 passing. Both workspaces typecheck clean.

Version bumped to 0.1.23 → merging releases.