### PR TITLE
Install updates in the background while the app is running

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.25"
+version = "0.1.26"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -32,6 +32,10 @@ import { previewKind } from "./lib/preview";
 import { useSidebarWidth } from "./lib/useSidebarWidth";
 import { useStore } from "./store";
 
+/** How often a running app re-checks for a new release (it also checks at
+ *  launch). The check is one GET of the release's static `latest.json`. */
+const UPDATE_POLL_MS = 30 * 60 * 1000;
+
 /**
  * Every banner in the app slides down out of the chrome it belongs to and
  * collapses its own height on the way out.
@@ -446,12 +450,21 @@ export default function App() {
       } finally {
         setBooting(false);
       }
-      // Self-update on launch, silently: found → download → install → relaunch,
-      // no click required (notes are autosaved continuously, so a restart loses
+      // Self-update, silently: found → download → install → relaunch, no click
+      // required (notes are autosaved continuously, and the updater flushes the
+      // open note's pending write before relaunching, so a restart loses
       // nothing). The user hears about it AFTER the fact, via the "Updated to
       // vX" banner on the next boot. Failures (offline, non-bundled dev build)
       // are swallowed by the updater store — surfaced only in Settings → Updates.
+      //
+      // Checked at launch AND on a background poll: a long-running app used to
+      // learn about a release only when it happened to restart, so updates
+      // reached users days late. `autoUpdate` skips a tick that fires while a
+      // previous check/download is still in flight. App-lifetime interval —
+      // never cleared, and the launch guard above keeps it single in dev
+      // StrictMode.
       void autoUpdate();
+      setInterval(() => void autoUpdate(), UPDATE_POLL_MS);
     })();
   }, []);
 

--- a/app/apps/desktop/src/lib/updater.ts
+++ b/app/apps/desktop/src/lib/updater.ts
@@ -13,6 +13,8 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { useSyncExternalStore } from "react";
 
+import { bridgeManager } from "./bridge";
+
 export type UpdateState =
   | { phase: "idle" }
   | { phase: "checking" }
@@ -100,6 +102,14 @@ export async function installUpdate(): Promise<void> {
           break;
       }
     });
+    // The background poll can land this relaunch mid-session with a note open,
+    // so flush the bridge's debounced disk write first — same rule as the ⌘R
+    // reload path. A no-op when nothing is open (the launch-time update).
+    try {
+      await bridgeManager.currentBridge()?.flushEgest();
+    } catch (e) {
+      console.error("flush before update relaunch failed", e);
+    }
     // New bytes are in place; restart into them. On macOS this quits and
     // relaunches; on Windows the installer hands off to the new process.
     await relaunch();
@@ -134,10 +144,21 @@ interface JustUpdated {
 /**
  * Fully automatic update: check, and when a newer version exists, download +
  * install + relaunch without asking. Callers should treat this as fire-and-
- * forget from launch; every failure lands in the shared state's `error` phase
- * (surfaced only in Settings → Updates — an offline launch is not an event).
+ * forget from launch AND from the background poll; every failure lands in the
+ * shared state's `error` phase (surfaced only in Settings → Updates — an
+ * offline launch is not an event).
  */
 export async function autoUpdate(): Promise<void> {
+  // Re-entrancy guard for the background poll: a tick that fires while a
+  // check/download/install is already in flight must not start a second one
+  // (two concurrent downloadAndInstall calls race on the same staged bundle).
+  if (
+    state.phase === "checking" ||
+    state.phase === "downloading" ||
+    state.phase === "installing"
+  ) {
+    return;
+  }
   const found = await checkForUpdate();
   if (!found || !pending) return;
   try {


### PR DESCRIPTION
## Problem

The update check ran exactly once, at launch. An app left open for days never noticed a new release — updates only reached users when they happened to restart or reload, which contradicts the "ships to every running app on its next updater poll" intent.

## Fix

- **Background poll**: the launch-time silent `autoUpdate()` now also runs every 30 minutes. Same behavior as launch — found → download → install → relaunch, no click — and the existing "Updated to vX" release-notes banner greets the user on the boot into the new version.
- **Re-entrancy guard**: a poll tick that fires while a check/download/install is in flight is skipped, so two `downloadAndInstall` calls can never race on the staged bundle.
- **Flush before relaunch**: a background relaunch can land mid-typing, so `installUpdate` flushes the open note's debounced disk write before `relaunch()` — the same rule as the ⌘R reload path.

Bumps version to 0.1.26.

## Tests

Desktop vitest 584 passed, typecheck clean.