### PR TITLE
Let owners and admins change member roles in place

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.26",
+  "version": "0.1.27",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.26"
+version = "0.1.27"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1785,6 +1785,92 @@ body:has(.sidebar-resizer.dragging) {
   min-width: 210px;
 }
 
+/* ---- Role picker (Members tab) ----
+   Button-anchored like the sort popover. Right-aligned because it sits at the
+   row's right edge; opening left keeps it over the dialog, not off its side. */
+.role-select-wrap {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+.context-menu.role-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 150px;
+}
+.context-menu.role-menu li {
+  text-transform: capitalize;
+}
+.role-caret {
+  color: var(--text-tertiary);
+  font-size: 0.75em;
+  line-height: 1;
+}
+/* Pill variant: keeps the badge's shape and role-colored text but sits on a
+   bordered surface chip — visibly a control, unlike the static tinted badge
+   on rows the caller can't change. (Scoped under the wrap so these beat the
+   .member-role.admin/.owner background rules that appear later in the file.) */
+.role-select-wrap .member-role.role-trigger {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: inherit;
+  transition:
+    border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease);
+}
+.role-select-wrap .member-role.role-trigger .role-caret {
+  color: var(--text-tertiary);
+  font-size: 0.8em;
+}
+.role-select-wrap .member-role.role-trigger:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+.role-select-wrap .member-role.role-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+.role-select-wrap .member-role.role-trigger:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+/* Field variant: dressed like the settings inputs beside it (invite bar). */
+.role-field-trigger {
+  background: var(--bg-subtle);
+  border: 1px solid transparent;
+  color: var(--text-primary);
+  border-radius: var(--radius-md);
+  padding: var(--sp-2) var(--sp-3);
+  font: inherit;
+  font-size: var(--fs-md);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  cursor: pointer;
+  white-space: nowrap;
+  text-transform: capitalize;
+  transition:
+    border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease);
+}
+.role-field-trigger:hover {
+  border-color: var(--border-strong);
+}
+.role-field-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+  background: var(--bg-surface);
+}
+
 /* Color swatch row inside the ⋯ menu (Finder-tag style) */
 .context-menu li.menu-swatches {
   display: flex;

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -24,6 +24,8 @@ import { statusTone } from "../lib/presence/color";
 import { AccessPanel } from "./AccessPanel";
 import { AccountSettings } from "./AccountSettings";
 import { AsyncButton } from "./AsyncButton";
+import { canActOnMember } from "./memberRoles";
+import { RoleSelect } from "./RoleSelect";
 import { Avatar, SyncBadge } from "./Identity";
 import { Spinner } from "./Spinner";
 import { ThemeToggle } from "./ThemeToggle";
@@ -1954,15 +1956,22 @@ function MembersTab({ canManage }: { canManage: boolean }) {
   const [removeBusy, setRemoveBusy] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
 
+  // Role changes: no confirm step (reversible, unlike remove), one busy row
+  // at a time so a slow server can't interleave two changes.
+  const [roleBusyId, setRoleBusyId] = useState<string | null>(null);
+  const [roleError, setRoleError] = useState<string | null>(null);
+
   // The caller's own role in this vault, so we mirror the server's rules and
-  // only show a Remove button where it would actually succeed: owners can remove
-  // anyone but themselves and the (single) owner; admins can remove plain members.
+  // only offer Remove / role changes where they would actually succeed
+  // (see memberRoles.ts for the shared matrix).
   const myRole = members.find((m) => m.userId === session?.user.id)?.role;
-  const canRemove = (m: Member): boolean =>
-    canManage &&
-    m.userId !== session?.user.id &&
-    m.role !== "owner" &&
-    (myRole === "owner" || m.role === "member");
+  const canAct = (m: Member): boolean =>
+    canActOnMember({
+      canManage,
+      myUserId: session?.user.id,
+      myRole,
+      target: { userId: m.userId, role: m.role },
+    });
 
   const doRemove = async (userId: string) => {
     setRemoveBusy(true);
@@ -1974,6 +1983,18 @@ function MembersTab({ canManage }: { canManage: boolean }) {
       setRemoveError(e instanceof Error ? e.message : String(e));
     } finally {
       setRemoveBusy(false);
+    }
+  };
+
+  const doChangeRole = async (userId: string, role: "member" | "admin") => {
+    setRoleBusyId(userId);
+    setRoleError(null);
+    try {
+      await useStore.getState().updateMemberRole(userId, role);
+    } catch (e) {
+      setRoleError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRoleBusyId(null);
     }
   };
 
@@ -2051,13 +2072,12 @@ function MembersTab({ canManage }: { canManage: boolean }) {
               if (e.key === "Enter") void invite();
             }}
           />
-          <select
+          <RoleSelect
+            variant="field"
             value={inviteRole}
-            onChange={(e) => setInviteRole(e.target.value as "member" | "admin")}
-          >
-            <option value="member">Member</option>
-            <option value="admin">Admin</option>
-          </select>
+            onSelect={setInviteRole}
+            ariaLabel="Invite role"
+          />
           <button className="primary" disabled={busy} onClick={() => void invite()}>
             Invite
           </button>
@@ -2083,8 +2103,18 @@ function MembersTab({ canManage }: { canManage: boolean }) {
                 {label}
                 {m.userId === session?.user.id && <span className="muted"> (you)</span>}
               </span>
-              <span className={`member-role ${m.role}`}>{m.role}</span>
-              {canRemove(m) &&
+              {canAct(m) && (m.role === "member" || m.role === "admin") ? (
+                <RoleSelect
+                  variant="pill"
+                  value={m.role}
+                  disabled={roleBusyId !== null}
+                  ariaLabel={`Change role of ${label}`}
+                  onSelect={(r) => void doChangeRole(m.userId, r)}
+                />
+              ) : (
+                <span className={`member-role ${m.role}`}>{m.role}</span>
+              )}
+              {canAct(m) &&
                 (confirmRemoveId === m.userId ? (
                   <>
                     <AsyncButton
@@ -2118,6 +2148,7 @@ function MembersTab({ canManage }: { canManage: boolean }) {
         })}
       </ul>
       {removeError && <div className="auth-error">{removeError}</div>}
+      {roleError && <div className="auth-error">{roleError}</div>}
 
       {pendingInvitations.length > 0 && (
         <>

--- a/app/apps/desktop/src/components/RoleSelect.tsx
+++ b/app/apps/desktop/src/components/RoleSelect.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import { ASSIGNABLE_ROLES, type AssignableRole } from "./memberRoles";
+
+/**
+ * Role picker used by the Members tab — the invite bar ("field" variant) and
+ * each member row ("pill" variant, styled like the static role badge it
+ * replaces so unchangeable rows and changeable ones read as the same thing).
+ *
+ * Same popover anatomy as the file-tree sort menu: a trigger button with
+ * aria-haspopup/aria-expanded and a button-anchored `.context-menu` of
+ * menuitemradio items. Unlike FileTree (which owns a window-level dismiss),
+ * this is self-contained: outside-mousedown and Escape close it.
+ */
+export function RoleSelect({
+  value,
+  onSelect,
+  disabled,
+  ariaLabel,
+  variant,
+}: {
+  value: AssignableRole;
+  onSelect: (role: AssignableRole) => void | Promise<void>;
+  disabled?: boolean;
+  ariaLabel: string;
+  variant: "field" | "pill";
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const triggerClass =
+    variant === "pill" ? `member-role ${value} role-trigger` : "role-field-trigger";
+
+  return (
+    // Swallow clicks so a dialog-level dismiss can't eat the opening click.
+    <div className="role-select-wrap" ref={wrapRef} onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        className={triggerClass}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="role-trigger-label">{value}</span>
+        <span className="role-caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {open && (
+        <ul className="context-menu role-menu" role="menu">
+          {ASSIGNABLE_ROLES.map((r) => (
+            <li
+              key={r}
+              role="menuitemradio"
+              aria-checked={value === r}
+              className={value === r ? "is-on" : undefined}
+              onClick={() => {
+                setOpen(false);
+                if (r !== value) void onSelect(r);
+              }}
+            >
+              <span className="menu-tick" aria-hidden="true">
+                {value === r ? "✓" : ""}
+              </span>
+              <span className="role-option-label">{r}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/apps/desktop/src/components/memberRoles.test.ts
+++ b/app/apps/desktop/src/components/memberRoles.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { assignableRoles, canActOnMember } from "./memberRoles";
+
+const ME = "user-me";
+const THEM = "user-them";
+
+function args(myRole: string | undefined, targetRole: string, opts?: { self?: boolean; canManage?: boolean }) {
+  return {
+    canManage: opts?.canManage ?? (myRole === "owner" || myRole === "admin"),
+    myUserId: ME,
+    myRole,
+    target: { userId: opts?.self ? ME : THEM, role: targetRole },
+  };
+}
+
+describe("canActOnMember / assignableRoles", () => {
+  it("owner may act on admins and members", () => {
+    expect(canActOnMember(args("owner", "member"))).toBe(true);
+    expect(canActOnMember(args("owner", "admin"))).toBe(true);
+    expect(assignableRoles(args("owner", "admin"))).toEqual(["member", "admin"]);
+  });
+
+  it("nobody acts on the owner or on themselves", () => {
+    expect(canActOnMember(args("owner", "owner"))).toBe(false);
+    expect(canActOnMember(args("admin", "owner"))).toBe(false);
+    expect(canActOnMember(args("owner", "owner", { self: true }))).toBe(false);
+    expect(canActOnMember(args("admin", "admin", { self: true }))).toBe(false);
+  });
+
+  it("admin may act on plain members only (promote allowed, admins off-limits)", () => {
+    expect(canActOnMember(args("admin", "member"))).toBe(true);
+    expect(assignableRoles(args("admin", "member"))).toEqual(["member", "admin"]);
+    expect(canActOnMember(args("admin", "admin"))).toBe(false);
+    expect(assignableRoles(args("admin", "admin"))).toEqual([]);
+  });
+
+  it("plain members and signed-out callers get nothing", () => {
+    expect(canActOnMember(args("member", "member"))).toBe(false);
+    expect(canActOnMember(args(undefined, "member"))).toBe(false);
+    // canManage=false wins even if a stale role claims otherwise.
+    expect(canActOnMember(args("owner", "member", { canManage: false }))).toBe(false);
+  });
+});

--- a/app/apps/desktop/src/components/memberRoles.ts
+++ b/app/apps/desktop/src/components/memberRoles.ts
@@ -1,0 +1,39 @@
+/**
+ * Who may do what to whom in the members list. Pure — mirrors the server's
+ * authz matrix (orgs.ts remove + role-change handlers) so the UI only offers
+ * actions that would actually succeed:
+ *
+ *   - owner: may change/remove any admin or member, never themselves or
+ *     another owner;
+ *   - admin: may change/remove plain members only (promoting one to admin is
+ *     allowed — admins can already invite admins), never another admin;
+ *   - member: nothing.
+ *
+ * `owner` is never assignable — ownership transfer is a separate, deliberate
+ * operation the product doesn't support yet.
+ */
+
+export const ASSIGNABLE_ROLES = ["member", "admin"] as const;
+export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
+
+export interface MemberRoleArgs {
+  canManage: boolean;
+  myUserId: string | undefined;
+  myRole: string | undefined;
+  target: { userId: string; role: string };
+}
+
+/** The single predicate both actions share: may the caller act on this row? */
+export function canActOnMember({ canManage, myUserId, myRole, target }: MemberRoleArgs): boolean {
+  return (
+    canManage &&
+    target.userId !== myUserId &&
+    target.role !== "owner" &&
+    (myRole === "owner" || target.role === "member")
+  );
+}
+
+/** Roles the caller may set on this member; empty ⇒ show a static badge. */
+export function assignableRoles(args: MemberRoleArgs): AssignableRole[] {
+  return canActOnMember(args) ? [...ASSIGNABLE_ROLES] : [];
+}

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -711,6 +711,24 @@ export class ApiClient {
     );
   }
 
+  /**
+   * Change a member's role (owner/admin). Same authz shape as removeMember:
+   * an admin may only change plain members; nobody touches the owner or
+   * themselves. The server force-closes the member's live sync sockets so the
+   * new role applies immediately, not at token expiry.
+   */
+  async updateMemberRole(
+    organizationId: string,
+    userId: string,
+    role: "member" | "admin",
+  ): Promise<void> {
+    await this.request<{ updated: boolean }>(
+      "PATCH",
+      `/api/orgs/${encodeURIComponent(organizationId)}/members/${encodeURIComponent(userId)}`,
+      { body: { role } },
+    );
+  }
+
   // ---- MCP tokens ---------------------------------------------------------
 
   /** The MCP endpoint URL for this server (what an AI client connects to). */

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -274,6 +274,8 @@ interface AppStore {
   inviteMember: (email: string, role: "member" | "admin") => Promise<void>;
   /** Remove a member from the active vault (owner/admin), then refresh. */
   removeMember: (userId: string) => Promise<void>;
+  /** Change a member's role in the active vault (owner/admin), then refresh. */
+  updateMemberRole: (userId: string, role: "member" | "admin") => Promise<void>;
   acceptInvitation: (invitationId: string) => Promise<void>;
   joinVault: (code: string) => Promise<void>;
   /** Detach a vault from THIS device (forget its folder, stop syncing it).
@@ -1616,6 +1618,13 @@ export const useStore = create<AppStore>((set, get) => ({
     const activeOrgId = get().session?.activeOrganizationId;
     if (!activeOrgId) throw new Error("No active vault");
     await authManager.api.removeMember(activeOrgId, userId);
+    await get().refreshVault();
+  },
+
+  updateMemberRole: async (userId, role) => {
+    const activeOrgId = get().session?.activeOrganizationId;
+    if (!activeOrgId) throw new Error("No active vault");
+    await authManager.api.updateMemberRole(activeOrgId, userId, role);
     await get().refreshVault();
   },
 

--- a/app/apps/server/src/auth/auth.ts
+++ b/app/apps/server/src/auth/auth.ts
@@ -137,6 +137,16 @@ export const auth = betterAuth({
           const name = data.user.name?.trim() || data.user.email;
           await announceMemberJoined(data.organization.id, name);
         },
+        // Role changes must go through PATCH /api/orgs/:orgId/members/:userId,
+        // which enforces our stricter matrix (an admin may not touch another
+        // admin) and force-closes live sockets so the new role applies now.
+        // Better Auth's own update-member-role endpoint does neither, so it's
+        // closed off entirely.
+        beforeUpdateMemberRole: async () => {
+          throw new APIError("FORBIDDEN", {
+            message: "role_change_not_supported_here",
+          });
+        },
       },
     }),
     // OAuth 2.1 authorization server for MCP clients (spec: MCP integration).

--- a/app/apps/server/src/http/routes/orgs.ts
+++ b/app/apps/server/src/http/routes/orgs.ts
@@ -347,5 +347,77 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
     return c.json({ removed: true });
   });
 
+  // Change a member's role (owner/admin). Same authz shape as removal: owner
+  // may set any non-owner (but not themselves) to member/admin; an admin may
+  // only touch plain members (promoting one to admin is allowed — admins can
+  // already *invite* admins). `owner` is never grantable here; ownership
+  // transfer is a different, deliberate operation we don't support yet.
+  orgRoutes.patch("/orgs/:orgId/members/:userId", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+
+    const orgId = c.req.param("orgId");
+    const targetUserId = c.req.param("userId");
+
+    const callerRole = await orgRole(orgId, session.userId);
+    if (!callerRole) return c.json({ error: "Unknown vault" }, 404);
+    if (callerRole !== "owner" && callerRole !== "admin") {
+      return c.json({ error: "Only the vault owner or an admin can change roles" }, 403);
+    }
+    if (targetUserId === session.userId) {
+      return c.json({ error: "You can't change your own role" }, 400);
+    }
+
+    const targetRole = await orgRole(orgId, targetUserId);
+    if (!targetRole) return c.json({ error: "That person isn't a member of this vault" }, 404);
+    if (targetRole === "owner") {
+      return c.json({ error: "The vault owner's role can't be changed" }, 403);
+    }
+    if (targetRole === "admin" && callerRole !== "owner") {
+      return c.json({ error: "Only the owner can change an admin's role" }, 403);
+    }
+
+    const body = await c.req.json().catch(() => null);
+    const role = body && typeof body.role === "string" ? body.role : null;
+    if (role !== "member" && role !== "admin") {
+      return c.json({ error: "Role must be 'member' or 'admin'" }, 400);
+    }
+    // No-op guard before any side effects, so repeated clicks don't churn
+    // sockets for a change that changes nothing.
+    if (role === targetRole) return c.json({ updated: false, role });
+
+    // Snapshot the org's docs BEFORE flipping the role so we can kick the
+    // member's live sockets afterwards (same rationale as removal above).
+    const vaults = await pool.query<{ id: string }>(
+      "SELECT id FROM vaults WHERE organization_id = $1",
+      [orgId],
+    );
+    const vaultIds = vaults.rows.map((r) => r.id);
+    const docs = vaultIds.length
+      ? await pool.query<{ id: string; vault_id: string }>(
+          `SELECT id, vault_id FROM notes WHERE vault_id = ANY($1)
+           UNION ALL
+           SELECT id, vault_id FROM files WHERE vault_id = ANY($1)`,
+          [vaultIds],
+        )
+      : { rows: [] as Array<{ id: string; vault_id: string }> };
+
+    await pool.query(`UPDATE member SET role = $1 WHERE "organizationId" = $2 AND "userId" = $3`, [
+      role,
+      orgId,
+      targetUserId,
+    ]);
+
+    // A role change flips effective permissions in BOTH directions, but the
+    // `readOnly` flag is baked into the sync token and only checked at connect
+    // time — a demoted admin keeps edit sockets, a promoted member keeps
+    // read-only ones. Kick every live socket AFTER the update so reconnects
+    // mint tokens against the new role, then tell the vault channels.
+    for (const d of docs.rows) deps.disconnectDoc(d.vault_id, d.id);
+    for (const vaultId of vaultIds) deps.onAclChanged(vaultId);
+
+    return c.json({ updated: true, role });
+  });
+
   return orgRoutes;
 }

--- a/app/apps/server/tests/orgs-update-member-role.test.ts
+++ b/app/apps/server/tests/orgs-update-member-role.test.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { recordingAppDeps } from "./helpers/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { createOrg, signUp } from "./helpers/auth.js";
+import { seedNote, seedVault } from "./helpers/seed.js";
+
+const rec = recordingAppDeps();
+const app = createApp(rec.deps);
+
+function changeRole(token: string | null, orgId: string, userId: string, body: unknown) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  return app.fetch(
+    new Request(
+      `http://local/api/orgs/${encodeURIComponent(orgId)}/members/${encodeURIComponent(userId)}`,
+      { method: "PATCH", headers, body: JSON.stringify(body) },
+    ),
+  );
+}
+
+async function addMember(orgId: string, userId: string, role: "member" | "admin" = "member") {
+  await pool.query(
+    `INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+     VALUES ($1, $2, $3, $4, now())`,
+    [randomUUID(), orgId, userId, role],
+  );
+}
+
+async function roleOf(orgId: string, userId: string): Promise<string | null> {
+  const { rows } = await pool.query<{ role: string }>(
+    `SELECT role FROM member WHERE "organizationId" = $1 AND "userId" = $2`,
+    [orgId, userId],
+  );
+  return rows[0]?.role ?? null;
+}
+
+describe("change a member's role", () => {
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("owner promotes a member to admin and demotes them back", async () => {
+    const owner = await signUp("owner@role.com");
+    const org = await createOrg(owner, "Acme", "acme-role1");
+    const member = await signUp("member@role.com");
+    await addMember(org.id, member.userId);
+
+    let res = await changeRole(owner.token, org.id, member.userId, { role: "admin" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: true, role: "admin" });
+    expect(await roleOf(org.id, member.userId)).toBe("admin");
+
+    res = await changeRole(owner.token, org.id, member.userId, { role: "member" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: true, role: "member" });
+    expect(await roleOf(org.id, member.userId)).toBe("member");
+  });
+
+  it("rejects anon (401), a plain member (403), self (400), and the owner as target (403)", async () => {
+    const owner = await signUp("owner@role2.com");
+    const org = await createOrg(owner, "Acme", "acme-role2");
+    const member = await signUp("member@role2.com");
+    await addMember(org.id, member.userId);
+    const admin = await signUp("admin@role2.com");
+    await addMember(org.id, admin.userId, "admin");
+
+    expect((await changeRole(null, org.id, member.userId, { role: "admin" })).status).toBe(401);
+    // A plain member can't change anyone.
+    expect((await changeRole(member.token, org.id, member.userId, { role: "admin" })).status).toBe(
+      403,
+    );
+    // Nobody changes their own role via this route.
+    expect((await changeRole(owner.token, org.id, owner.userId, { role: "admin" })).status).toBe(
+      400,
+    );
+    // The owner's role can't be touched — by the owner's admins or anyone else.
+    expect((await changeRole(admin.token, org.id, owner.userId, { role: "member" })).status).toBe(
+      403,
+    );
+    // Everything is as it was.
+    expect(await roleOf(org.id, owner.userId)).toBe("owner");
+    expect(await roleOf(org.id, member.userId)).toBe("member");
+  });
+
+  it("rejects an outsider and an unknown target with 404", async () => {
+    const owner = await signUp("owner@role3.com");
+    const org = await createOrg(owner, "Acme", "acme-role3");
+    const member = await signUp("member@role3.com");
+    await addMember(org.id, member.userId);
+    const outsider = await signUp("outsider@role3.com");
+
+    expect((await changeRole(outsider.token, org.id, member.userId, { role: "admin" })).status).toBe(
+      404,
+    );
+    expect((await changeRole(owner.token, org.id, outsider.userId, { role: "admin" })).status).toBe(
+      404,
+    );
+    expect(await roleOf(org.id, member.userId)).toBe("member");
+  });
+
+  it("admin may promote a plain member but not touch another admin", async () => {
+    const owner = await signUp("owner@role4.com");
+    const org = await createOrg(owner, "Acme", "acme-role4");
+    const admin = await signUp("admin@role4.com");
+    await addMember(org.id, admin.userId, "admin");
+    const other = await signUp("other@role4.com");
+    await addMember(org.id, other.userId);
+    const admin2 = await signUp("admin2@role4.com");
+    await addMember(org.id, admin2.userId, "admin");
+
+    // Admin promotes a plain member — allowed (parity with inviting admins).
+    expect((await changeRole(admin.token, org.id, other.userId, { role: "admin" })).status).toBe(
+      200,
+    );
+    expect(await roleOf(org.id, other.userId)).toBe("admin");
+
+    // Admin can't demote another admin — only the owner can.
+    expect((await changeRole(admin.token, org.id, admin2.userId, { role: "member" })).status).toBe(
+      403,
+    );
+    expect(await roleOf(org.id, admin2.userId)).toBe("admin");
+    expect((await changeRole(owner.token, org.id, admin2.userId, { role: "member" })).status).toBe(
+      200,
+    );
+    expect(await roleOf(org.id, admin2.userId)).toBe("member");
+  });
+
+  it("rejects invalid roles and malformed bodies with 400", async () => {
+    const owner = await signUp("owner@role5.com");
+    const org = await createOrg(owner, "Acme", "acme-role5");
+    const member = await signUp("member@role5.com");
+    await addMember(org.id, member.userId);
+
+    // `owner` is never grantable here (ownership transfer is out of scope).
+    expect((await changeRole(owner.token, org.id, member.userId, { role: "owner" })).status).toBe(
+      400,
+    );
+    expect(
+      (await changeRole(owner.token, org.id, member.userId, { role: "superuser" })).status,
+    ).toBe(400);
+    expect((await changeRole(owner.token, org.id, member.userId, {})).status).toBe(400);
+    expect(await roleOf(org.id, member.userId)).toBe("member");
+  });
+
+  it("same-role no-op returns updated:false and fires no side effects", async () => {
+    const owner = await signUp("owner@role6.com");
+    const org = await createOrg(owner, "Acme", "acme-role6");
+    const member = await signUp("member@role6.com");
+    await addMember(org.id, member.userId);
+    await seedVault(org.id, "A");
+
+    const res = await changeRole(owner.token, org.id, member.userId, { role: "member" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: false, role: "member" });
+    expect(rec.aclBroadcasts).toEqual([]);
+    expect(rec.disconnected).toEqual([]);
+  });
+
+  // The `readOnly` flag is baked into the sync token and only checked at
+  // connect time, so a role change must kick live sockets and re-announce the
+  // ACL — in BOTH directions — or the old permissions live on until the
+  // socket happens to drop.
+  it("success broadcasts acl-changed per collection and force-closes the org's doc sockets", async () => {
+    const owner = await signUp("owner@role7.com");
+    const org = await createOrg(owner, "Acme", "acme-role7");
+    const admin = await signUp("admin@role7.com");
+    await addMember(org.id, admin.userId, "admin");
+    const vaultA = await seedVault(org.id, "A");
+    const vaultB = await seedVault(org.id, "B");
+    const note = await seedNote(vaultA, null, "team.md", owner.userId);
+
+    expect((await changeRole(owner.token, org.id, admin.userId, { role: "member" })).status).toBe(
+      200,
+    );
+    expect(rec.aclBroadcasts.sort()).toEqual([vaultA, vaultB].sort());
+    expect(rec.disconnected).toContainEqual({ vaultId: vaultA, docId: note });
+  });
+
+  it("broadcasts nothing when the change was refused", async () => {
+    const owner = await signUp("owner@role8.com");
+    const org = await createOrg(owner, "Acme", "acme-role8");
+    const member = await signUp("member@role8.com");
+    await addMember(org.id, member.userId);
+    await seedVault(org.id, "A");
+
+    expect((await changeRole(member.token, org.id, owner.userId, { role: "member" })).status).toBe(
+      403,
+    );
+    expect(rec.aclBroadcasts).toEqual([]);
+    expect(rec.disconnected).toEqual([]);
+  });
+
+  // Better Auth's own update-member-role endpoint is mounted via /api/auth/*
+  // with weaker rules (an admin may demote another admin) and no socket/ACL
+  // handling; the beforeUpdateMemberRole hook closes it so our route is the
+  // only way to change roles.
+  it("the parallel Better Auth update-member-role endpoint is closed off", async () => {
+    const owner = await signUp("owner@role9.com");
+    const org = await createOrg(owner, "Acme", "acme-role9");
+    const member = await signUp("member@role9.com");
+    await addMember(org.id, member.userId);
+    const { rows } = await pool.query<{ id: string }>(
+      `SELECT id FROM member WHERE "organizationId" = $1 AND "userId" = $2`,
+      [org.id, member.userId],
+    );
+
+    const res = await app.fetch(
+      new Request("http://local/api/auth/organization/update-member-role", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${owner.token}`,
+        },
+        body: JSON.stringify({ memberId: rows[0].id, role: "admin", organizationId: org.id }),
+      }),
+    );
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(await roleOf(org.id, member.userId)).toBe("member");
+  });
+});


### PR DESCRIPTION
Owners and admins can now change a teammate's role after they've joined, from Vault Settings → Members — no more remove-and-reinvite.

- New `PATCH /api/orgs/:orgId/members/:userId` with the same authz matrix as removal: owners may set any non-owner to member/admin; admins may promote plain members but can't touch other admins; nobody changes the owner or themselves. Same-role requests are a no-op.
- A role change force-closes the member's live sync sockets and broadcasts `acl-changed`, so the new permissions apply immediately in both directions (the readOnly flag is baked into sync tokens at mint).
- Better Auth's built-in `update-member-role` endpoint (mounted via the `/api/auth/*` proxy, with weaker rules and no socket handling) is blocked via a `beforeUpdateMemberRole` hook.
- New `RoleSelect` dropdown (built on the existing `.context-menu` pattern) replaces the native `<select>` in the invite bar and renders each changeable member row's role as a bordered clickable chip; unchangeable rows keep the static badge.
- Tests: new server suite covering the full authz matrix, broadcasts, socket disconnects and the closed bypass; new pure-predicate test for the shared UI matrix.
- Bumps version to 0.1.27 (ships via the release workflow on merge).