### PR TITLE
Bring back the manual update banner as a global top strip

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.27"
+version = "0.1.28"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -677,6 +677,21 @@ button.primary.hero:hover:not(:disabled) {
 /* ============================================================
    App shell — canvas + floating editor sheet
    ============================================================ */
+/* Column wrapper so the window-global update banner can slide in ABOVE the
+   sidebar+main grid (and above the vault picker) and push it down, instead of
+   living inside one pane. */
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.app-shell > .app,
+.app-shell > .vault-picker {
+  height: auto;
+  flex: 1;
+  min-height: 0;
+}
+
 .app {
   display: grid;
   /* Width is user-set (see SidebarResizer); the fallback is the default so the
@@ -2286,6 +2301,19 @@ body:has(.sidebar-resizer.dragging) {
    it reads as informational rather than a warning. */
 .update-banner {
   background: var(--accent-soft, var(--warning-soft));
+}
+
+/* The update banner sits at the very top of the WINDOW (see .app-shell), so it
+   trades the floating-card look for a flush full-width strip. Content is
+   centered and the side padding is wide enough that nothing lands under the
+   macOS traffic lights, which float over the top-left corner when the strip
+   becomes the topmost thing on screen. */
+.global-banner {
+  margin: 0;
+  border-radius: 0;
+  border-bottom: 1px solid var(--border);
+  justify-content: center;
+  padding: var(--sp-3) 96px;
 }
 
 /* Member-joined celebration: same banner shape, an accent tint, and a gentle

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -21,8 +21,9 @@ import { BRAND_NAME } from "./lib/brand";
 import * as ipc from "./lib/ipc";
 import { syncManager } from "./lib/sync/docSession";
 import {
-  autoUpdate,
+  backgroundUpdateCheck,
   clearJustUpdated,
+  installUpdate,
   justUpdatedTo,
   releaseNoteLines,
   useUpdateState,
@@ -33,8 +34,10 @@ import { useSidebarWidth } from "./lib/useSidebarWidth";
 import { useStore } from "./store";
 
 /** How often a running app re-checks for a new release (it also checks at
- *  launch). The check is one GET of the release's static `latest.json`. */
-const UPDATE_POLL_MS = 30 * 60 * 1000;
+ *  launch). The check is one cheap GET of the release's static `latest.json`
+ *  off GitHub's CDN; 15 minutes keeps a long-running app reasonably current
+ *  without pinging GitHub all day. */
+const UPDATE_POLL_MS = 15 * 60 * 1000;
 
 /**
  * Every banner in the app slides down out of the chrome it belongs to and
@@ -258,18 +261,44 @@ function VaultFolderPrompt() {
  * only surface when the user checks manually from Settings → Updates.
  */
 function UpdateBanner() {
+  // Dismissal is per-version: "Later" on v0.1.27 must not also swallow the
+  // v0.1.28 banner when the background poll finds it hours later.
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
   const update = useUpdateState();
 
-  // Updates apply themselves (see autoUpdate at launch) — the only live chrome
-  // is the progress strip while the new bytes come down, and the app restarts
-  // on its own when they're in. The post-restart story is UpdatedBanner's.
+  if (update.phase === "available") {
+    if (update.version === dismissedVersion) return null;
+    return (
+      <Banner show className="update-banner global-banner">
+        <span>
+          A new version of {BRAND_NAME} (<strong>v{update.version}</strong>) is
+          available.
+        </span>
+        <div className="banner-actions">
+          <AsyncButton className="primary" onClick={() => installUpdate()}>
+            Install &amp; Restart
+          </AsyncButton>
+          <button
+            className="secondary"
+            onClick={() => setDismissedVersion(update.version)}
+          >
+            Later
+          </button>
+        </div>
+      </Banner>
+    );
+  }
+
+  // Once the user clicks Install & Restart the banner becomes the progress
+  // strip while the new bytes come down, and the app restarts when they're in.
+  // The post-restart story is UpdatedBanner's.
   if (update.phase === "downloading" || update.phase === "installing") {
     const pct =
       update.phase === "downloading" && update.total > 0
         ? Math.round((update.downloaded / update.total) * 100)
         : null;
     return (
-      <Banner show className="update-banner" role="status">
+      <Banner show className="update-banner global-banner" role="status">
         <span>
           {update.phase === "installing"
             ? "Installing update — the app will restart…"
@@ -299,9 +328,9 @@ function UpdateBanner() {
 }
 
 /**
- * "You're on the new version" — shown on the first launch after a silent
- * auto-update, with the release's one-liners. Stays until crossed out (the
- * stash survives a quit), so an update never lands completely unannounced.
+ * "You're on the new version" — shown on the first launch after an update,
+ * with the release's one-liners. Stays until crossed out (the stash survives
+ * a quit), so an update never lands completely unannounced.
  */
 function UpdatedBanner() {
   const [updated, setUpdated] = useState<{ version: string; notes: string[] } | null>(
@@ -450,21 +479,15 @@ export default function App() {
       } finally {
         setBooting(false);
       }
-      // Self-update, silently: found → download → install → relaunch, no click
-      // required (notes are autosaved continuously, and the updater flushes the
-      // open note's pending write before relaunching, so a restart loses
-      // nothing). The user hears about it AFTER the fact, via the "Updated to
-      // vX" banner on the next boot. Failures (offline, non-bundled dev build)
-      // are swallowed by the updater store — surfaced only in Settings → Updates.
-      //
-      // Checked at launch AND on a background poll: a long-running app used to
-      // learn about a release only when it happened to restart, so updates
-      // reached users days late. `autoUpdate` skips a tick that fires while a
-      // previous check/download is still in flight. App-lifetime interval —
+      // Check for updates at launch AND on a background poll, but never install
+      // uninvited: a found release only raises the UpdateBanner, and the
+      // download/relaunch waits for the user's "Install & Restart" click.
+      // Failures (offline, non-bundled dev build) are swallowed by the updater
+      // store — surfaced only in Settings → Updates. App-lifetime interval —
       // never cleared, and the launch guard above keeps it single in dev
       // StrictMode.
-      void autoUpdate();
-      setInterval(() => void autoUpdate(), UPDATE_POLL_MS);
+      void backgroundUpdateCheck();
+      setInterval(() => void backgroundUpdateCheck(), UPDATE_POLL_MS);
     })();
   }, []);
 
@@ -621,66 +644,91 @@ export default function App() {
     // that has no local folder yet (e.g. clicked from the welcome screen) asks
     // the user to choose/create one before its folder opens.
     return (
-      <>
+      <div className="app-shell">
+        <UpdateBanner />
         <VaultPicker />
         <VaultFolderPrompt />
-      </>
+      </div>
     );
   }
 
   return (
-    <div
-      className="app"
-      style={{ "--sidebar-w": `${sidebarWidth}px` } as React.CSSProperties}
-    >
-      {/* Centered overlay, not a sidebar panel — it searches the whole vault
-          and its button lives in the main header. */}
-      {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
-      <aside className="sidebar">
-        <SidebarHeader />
-        {/* The tree still lists the OUTGOING vault's files until the folder
-            swaps, so a switch fades it and stops taking clicks — opening a note
-            from a vault you're leaving would be cancelled by the epoch guard
-            anyway, and a row that highlights then does nothing reads as a bug. */}
-        <div className={`sidebar-tree-wrap${switchingVault ? " is-switching" : ""}`}>
-          <FileTree />
-        </div>
-        <div className="sidebar-footer">
-          {/* Boundary so a crash here degrades to a visible fallback instead of
-              silently emptying the corner — the identity bar must never just
-              vanish. */}
-          <ErrorBoundary label="Account">
-            <AccountMenu />
-          </ErrorBoundary>
-        </div>
-      </aside>
-      <SidebarResizer width={sidebarWidth} onWidth={setSidebarWidth} />
-
-      <main className="main">
-        <MemberJoinedBanner />
-        <UpdateBanner />
-        <UpdatedBanner />
-        {/* Sits flush against the top of the window now that there's no system
-            title bar above it (`titleBarStyle: "Overlay"`), which is where the
-            reclaimed ~28px comes from — and that makes it the strip you'd expect
-            to drag the window by. "deep" hands the whole row over as a drag
-            region; Tauri exempts the buttons on the right, so they still click. */}
-        <header className="main-header" data-tauri-drag-region="deep">
-          <span className="note-title">{openNote?.title ?? "No note open"}</span>
-          {openNote && !isPreview && <SaveIndicator />}
-          <SyncIndicator noteOpen={openNote != null && !isPreview} />
-          {/* Vault-wide, so it sits in the header regardless of the open note. */}
-          <TalkButton />
-          {versionDocId && !isPreview && (
+    <div className="app-shell">
+      {/* Window-global, above the sidebar+main split: a new release must be
+          visible the moment the poll finds it, whatever is on screen. */}
+      <UpdateBanner />
+      <div
+        className="app"
+        style={{ "--sidebar-w": `${sidebarWidth}px` } as React.CSSProperties}
+      >
+        {/* Centered overlay, not a sidebar panel — it searches the whole vault
+            and its button lives in the main header. */}
+        {searchOpen && <SearchPanel onClose={() => setSearchOpen(false)} />}
+        <aside className="sidebar">
+          <SidebarHeader />
+          {/* The tree still lists the OUTGOING vault's files until the folder
+              swaps, so a switch fades it and stops taking clicks — opening a note
+              from a vault you're leaving would be cancelled by the epoch guard
+              anyway, and a row that highlights then does nothing reads as a bug. */}
+          <div className={`sidebar-tree-wrap${switchingVault ? " is-switching" : ""}`}>
+            <FileTree />
+          </div>
+          <div className="sidebar-footer">
+            {/* Boundary so a crash here degrades to a visible fallback instead of
+                silently emptying the corner — the identity bar must never just
+                vanish. */}
+            <ErrorBoundary label="Account">
+              <AccountMenu />
+            </ErrorBoundary>
+          </div>
+        </aside>
+        <SidebarResizer width={sidebarWidth} onWidth={setSidebarWidth} />
+  
+        <main className="main">
+          <MemberJoinedBanner />
+          <UpdatedBanner />
+          {/* Sits flush against the top of the window now that there's no system
+              title bar above it (`titleBarStyle: "Overlay"`), which is where the
+              reclaimed ~28px comes from — and that makes it the strip you'd expect
+              to drag the window by. "deep" hands the whole row over as a drag
+              region; Tauri exempts the buttons on the right, so they still click. */}
+          <header className="main-header" data-tauri-drag-region="deep">
+            <span className="note-title">{openNote?.title ?? "No note open"}</span>
+            {openNote && !isPreview && <SaveIndicator />}
+            <SyncIndicator noteOpen={openNote != null && !isPreview} />
+            {/* Vault-wide, so it sits in the header regardless of the open note. */}
+            <TalkButton />
+            {versionDocId && !isPreview && (
+              <button
+                className={`icon-btn history-btn${versionPanelOpen ? " active" : ""}`}
+                title="Version history"
+                aria-label="Version history"
+                aria-pressed={versionPanelOpen}
+                onClick={() => {
+                  if (versionPanelOpen) useStore.getState().closeVersionPanel();
+                  else void useStore.getState().openVersionPanel(versionDocId);
+                }}
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M3 12a9 9 0 1 0 2.6-6.4" />
+                  <path d="M3 4v4h4" />
+                  <path d="M12 8v4l3 2" />
+                </svg>
+              </button>
+            )}
             <button
-              className={`icon-btn history-btn${versionPanelOpen ? " active" : ""}`}
-              title="Version history"
-              aria-label="Version history"
-              aria-pressed={versionPanelOpen}
-              onClick={() => {
-                if (versionPanelOpen) useStore.getState().closeVersionPanel();
-                else void useStore.getState().openVersionPanel(versionDocId);
-              }}
+              className="icon-btn search-btn"
+              title="Search notes (⌘F)"
+              aria-label="Search notes"
+              onClick={() => setSearchOpen((v) => !v)}
             >
               <svg
                 viewBox="0 0 24 24"
@@ -691,77 +739,57 @@ export default function App() {
                 strokeLinejoin="round"
                 aria-hidden="true"
               >
-                <path d="M3 12a9 9 0 1 0 2.6-6.4" />
-                <path d="M3 4v4h4" />
-                <path d="M12 8v4l3 2" />
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3.5-3.5" />
               </svg>
             </button>
-          )}
-          <button
-            className="icon-btn search-btn"
-            title="Search notes (⌘F)"
-            aria-label="Search notes"
-            onClick={() => setSearchOpen((v) => !v)}
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
+            <button
+              className="icon-btn graph-btn"
+              title="Graph view (⌘G)"
+              aria-label="Open graph view"
+              onClick={() => setGraphOpen(true)}
             >
-              <circle cx="11" cy="11" r="7" />
-              <path d="m20 20-3.5-3.5" />
-            </svg>
-          </button>
-          <button
-            className="icon-btn graph-btn"
-            title="Graph view (⌘G)"
-            aria-label="Open graph view"
-            onClick={() => setGraphOpen(true)}
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="5.5" cy="6" r="2.5" />
+                <circle cx="18" cy="4.5" r="2" />
+                <circle cx="12.5" cy="13" r="2.5" />
+                <circle cx="6" cy="19" r="2" />
+                <circle cx="19.5" cy="18.5" r="2.5" />
+                <path d="M7.8 7.2 10.6 11M14.4 11.3 16.6 6M11 15 7.3 17.6M14.8 14.6l3 2.6" />
+              </svg>
+            </button>
+          </header>
+          <RemovedBanner />
+          <DeletedByTeammateBanner />
+          <div className="editor-wrap">
+            <Editor />
+          </div>
+          <BacklinksPanel />
+          {/* Slides in over the editor from the right; anchored to .main. */}
+          <VersionPanel />
+        </main>
+  
+        {graphOpen && (
+          <ErrorBoundary
+            label="Graph view"
+            resetKeys={[graphOpen]}
+            onError={() => setGraphOpen(false)}
           >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="5.5" cy="6" r="2.5" />
-              <circle cx="18" cy="4.5" r="2" />
-              <circle cx="12.5" cy="13" r="2.5" />
-              <circle cx="6" cy="19" r="2" />
-              <circle cx="19.5" cy="18.5" r="2.5" />
-              <path d="M7.8 7.2 10.6 11M14.4 11.3 16.6 6M11 15 7.3 17.6M14.8 14.6l3 2.6" />
-            </svg>
-          </button>
-        </header>
-        <RemovedBanner />
-        <DeletedByTeammateBanner />
-        <div className="editor-wrap">
-          <Editor />
-        </div>
-        <BacklinksPanel />
-        {/* Slides in over the editor from the right; anchored to .main. */}
-        <VersionPanel />
-      </main>
-
-      {graphOpen && (
-        <ErrorBoundary
-          label="Graph view"
-          resetKeys={[graphOpen]}
-          onError={() => setGraphOpen(false)}
-        >
-          <GraphView onClose={() => setGraphOpen(false)} />
-        </ErrorBoundary>
-      )}
-      <VaultFolderPrompt />
-      {/* Last child so it layers over everything without a z-index race. */}
-      <Toasts />
+            <GraphView onClose={() => setGraphOpen(false)} />
+          </ErrorBoundary>
+        )}
+        <VaultFolderPrompt />
+        {/* Last child so it layers over everything without a z-index race. */}
+        <Toasts />
+      </div>
     </div>
   );
 }

--- a/app/apps/desktop/src/lib/updater.ts
+++ b/app/apps/desktop/src/lib/updater.ts
@@ -83,6 +83,16 @@ export async function checkForUpdate(): Promise<boolean> {
 export async function installUpdate(): Promise<void> {
   const update = pending;
   if (!update) return;
+  // Stash the version/notes now — the Update object dies with this process, and
+  // the next boot reads the stash back to show the "Updated to vX" banner.
+  try {
+    localStorage.setItem(
+      JUST_UPDATED_KEY,
+      JSON.stringify({ version: update.version, notes: update.body ?? null }),
+    );
+  } catch {
+    // Storage full/blocked: the update still proceeds, only the banner is lost.
+  }
   let total = 0;
   let downloaded = 0;
   try {
@@ -102,9 +112,9 @@ export async function installUpdate(): Promise<void> {
           break;
       }
     });
-    // The background poll can land this relaunch mid-session with a note open,
-    // so flush the bridge's debounced disk write first — same rule as the ⌘R
-    // reload path. A no-op when nothing is open (the launch-time update).
+    // The user clicks Install & Restart mid-session with a note open, so flush
+    // the bridge's debounced disk write first — same rule as the ⌘R reload
+    // path. A no-op when nothing is open.
     try {
       await bridgeManager.currentBridge()?.flushEgest();
     } catch (e) {
@@ -124,14 +134,14 @@ export function currentVersion(): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
-// Silent auto-update + the post-restart "Updated to vX" banner.
+// The post-restart "Updated to vX" banner.
 //
 // The handoff problem: by the time the new version is running, the Update
-// object (and its release notes) died with the old process. So the stash below
-// is written just before download/relaunch, and read back on the next boot —
-// if the running version matches the stashed one, the update landed and the
-// banner shows its notes; if not (install failed, or a newer hop), it's stale
-// and dropped.
+// object (and its release notes) died with the old process. So installUpdate
+// writes the stash just before download/relaunch, and it's read back on the
+// next boot — if the running version matches the stashed one, the update
+// landed and the banner shows its notes; if not (install failed, or a newer
+// hop), it's stale and dropped.
 // ---------------------------------------------------------------------------
 
 const JUST_UPDATED_KEY = "context.justUpdated";
@@ -142,16 +152,18 @@ interface JustUpdated {
 }
 
 /**
- * Fully automatic update: check, and when a newer version exists, download +
- * install + relaunch without asking. Callers should treat this as fire-and-
- * forget from launch AND from the background poll; every failure lands in the
- * shared state's `error` phase (surfaced only in Settings → Updates — an
- * offline launch is not an event).
+ * Background check, no install: when a newer version exists it lands the shared
+ * state in `available`, which App's UpdateBanner renders as "Install & Restart".
+ * The install itself is always a user click (the banner or Settings → Updates) —
+ * a mid-session relaunch the user didn't ask for proved too disruptive. Callers
+ * treat this as fire-and-forget from launch AND from the poll; every failure
+ * lands in the `error` phase (surfaced only in Settings → Updates — an offline
+ * launch is not an event).
  */
-export async function autoUpdate(): Promise<void> {
-  // Re-entrancy guard for the background poll: a tick that fires while a
-  // check/download/install is already in flight must not start a second one
-  // (two concurrent downloadAndInstall calls race on the same staged bundle).
+export async function backgroundUpdateCheck(): Promise<void> {
+  // Skip a tick that fires while a check or a user-initiated download/install
+  // is in flight. An `available` state is NOT skipped: re-checking keeps a
+  // long-running app's banner current if an even newer version ships.
   if (
     state.phase === "checking" ||
     state.phase === "downloading" ||
@@ -159,17 +171,7 @@ export async function autoUpdate(): Promise<void> {
   ) {
     return;
   }
-  const found = await checkForUpdate();
-  if (!found || !pending) return;
-  try {
-    localStorage.setItem(
-      JUST_UPDATED_KEY,
-      JSON.stringify({ version: pending.version, notes: pending.body ?? null }),
-    );
-  } catch {
-    // Storage full/blocked: the update still proceeds, only the banner is lost.
-  }
-  await installUpdate();
+  await checkForUpdate();
 }
 
 /**


### PR DESCRIPTION
Silent background auto-install proved unreliable mid-session, so updates are manual again: the background poll (launch + every 15 minutes) only checks for a new release, and a found one raises a full-width banner at the very top of the window — above the sidebar and visible on the vault picker too — with Install & Restart / Later. Dismissal is per-version, the pre-relaunch note flush is kept, and the post-restart "Updated to vX" notes banner still works. Bumps version to 0.1.28.