### PR TITLE
Turn the post-update banner into a What's New modal and bump version to 0.1.29

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.28"
+version = "0.1.29"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -2186,21 +2186,113 @@ body:has(.sidebar-resizer.dragging) {
   font-size: var(--fs-xs);
 }
 
-/* Post-auto-update "what's new" banner. */
-.updated-banner-body {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-1);
-  min-width: 0;
+/* Post-auto-update "What's New" modal. Rides the shared .modal/.modal-backdrop
+   chrome; everything below is the celebratory dressing. */
+.whats-new {
+  width: 400px;
+  text-align: center;
+  padding: var(--sp-8) var(--sp-6) var(--sp-6);
+  /* A soft accent wash from the top so the moment reads as good news, not a
+     system dialog — same trick as the welcome screen's radial. */
+  background:
+    radial-gradient(320px 180px at 50% -30px, var(--accent-soft) 0%, transparent 70%),
+    var(--bg-surface);
 }
-.updated-banner-notes {
-  margin: 0;
-  padding-left: var(--sp-5);
-  font-size: var(--fs-xs);
-  color: var(--text-secondary);
+.whats-new-hero {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.whats-new-glyph {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-lg);
+  color: #fff;
+  background: var(--accent-gradient, var(--accent));
+  box-shadow: var(--shadow-md);
+  animation: whats-new-pop 420ms cubic-bezier(0.2, 0.9, 0.3, 1.3) both;
+}
+.whats-new-title {
+  margin: var(--sp-2) 0 0;
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+.whats-new-version {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: var(--radius-pill);
+  padding: 2px var(--sp-3);
+}
+.whats-new-sub {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+.whats-new-notes {
+  list-style: none;
+  margin: var(--sp-5) 0 0;
+  padding: var(--sp-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  text-align: left;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+.whats-new-notes li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+  line-height: 1.45;
+  /* Each line settles in a beat after the previous one (delay set inline). */
+  animation: whats-new-line 320ms var(--ease) both;
+}
+.whats-new-notes li svg {
+  flex: none;
+  margin-top: 3px;
+  color: var(--accent);
+}
+.whats-new-cta {
+  width: 100%;
+  margin-top: var(--sp-5);
+  padding: var(--sp-3) var(--sp-4);
+}
+@keyframes whats-new-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.5) rotate(-12deg);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) rotate(0);
+  }
+}
+@keyframes whats-new-line {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .whats-new-glyph,
+  .whats-new-notes li {
+    animation: none;
+  }
 }
 .main-header {
   display: flex;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -328,14 +328,17 @@ function UpdateBanner() {
 }
 
 /**
- * "You're on the new version" — shown on the first launch after an update,
- * with the release's one-liners. Stays until crossed out (the stash survives
- * a quit), so an update never lands completely unannounced.
+ * "What's New" — a centered modal shown on the first launch after an update,
+ * with the release's one-liners and a one-shot confetti burst. A modal rather
+ * than a banner: the old top strip pushed the whole page down, which read as
+ * the content jumping. Stays until dismissed (the stash survives a quit), so
+ * an update never lands completely unannounced.
  */
-function UpdatedBanner() {
+function WhatsNewModal() {
   const [updated, setUpdated] = useState<{ version: string; notes: string[] } | null>(
     null,
   );
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -348,34 +351,88 @@ function UpdatedBanner() {
     };
   }, []);
 
+  const open = updated != null;
+
+  useEffect(() => {
+    if (!open || !canvasRef.current) return;
+    return runConfetti(canvasRef.current);
+  }, [open]);
+
+  const close = () => {
+    clearJustUpdated();
+    setUpdated(null);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  if (!updated) return null;
   return (
-    <Banner show={updated != null} className="updated-banner" role="status">
-      <div className="updated-banner-body">
-        <span>
-          🎉 {BRAND_NAME} updated to <strong>v{updated?.version}</strong>
-        </span>
-        {updated != null && updated.notes.length > 0 && (
-          <ul className="updated-banner-notes">
-            {updated.notes.map((line, i) => (
-              <li key={i}>{line}</li>
-            ))}
-          </ul>
-        )}
-      </div>
-      <div className="banner-actions">
-        <button
-          className="icon-btn"
-          aria-label="Dismiss"
-          title="Dismiss"
-          onClick={() => {
-            clearJustUpdated();
-            setUpdated(null);
-          }}
+    <>
+      <canvas ref={canvasRef} className="celebrate-confetti" aria-hidden="true" />
+      <div className="modal-backdrop" onClick={close}>
+        <div
+          className="modal whats-new"
+          role="dialog"
+          aria-label="What's new"
+          onClick={(e) => e.stopPropagation()}
         >
-          ✕
-        </button>
+          <div className="whats-new-hero">
+            <div className="whats-new-glyph" aria-hidden="true">
+              <svg
+                width="26"
+                height="26"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9L12 3z" />
+                <path d="M19 15l.7 1.8L21.5 17.5l-1.8.7L19 20l-.7-1.8-1.8-.7 1.8-.7L19 15z" />
+              </svg>
+            </div>
+            <h2 className="whats-new-title">What&rsquo;s New</h2>
+            <span className="whats-new-version">v{updated.version}</span>
+            <p className="whats-new-sub">
+              {BRAND_NAME} just updated itself — here&rsquo;s what changed.
+            </p>
+          </div>
+          {updated.notes.length > 0 && (
+            <ul className="whats-new-notes">
+              {updated.notes.map((line, i) => (
+                <li key={i} style={{ animationDelay: `${120 + i * 70}ms` }}>
+                  <svg
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M20 6L9 17l-5-5" />
+                  </svg>
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <button className="primary whats-new-cta" autoFocus onClick={close}>
+            Nice — let&rsquo;s go
+          </button>
+        </div>
       </div>
-    </Banner>
+    </>
   );
 }
 
@@ -686,7 +743,7 @@ export default function App() {
   
         <main className="main">
           <MemberJoinedBanner />
-          <UpdatedBanner />
+          <WhatsNewModal />
           {/* Sits flush against the top of the window now that there's no system
               title bar above it (`titleBarStyle: "Overlay"`), which is where the
               reclaimed ~28px comes from — and that makes it the strip you'd expect


### PR DESCRIPTION
Replaces the post-update top strip (which pushed the whole page down) with a centered What's New modal: accent-gradient sparkle glyph, version pill, staggered release-note lines, confetti burst, and a single dismiss button. Bumps the version to 0.1.29 so the release ships on merge.