### PR TITLE
Access tree, per-member No access, frozen vault root, note share links, admin revert, synced colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,72 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   `SECURITY.md`, `CODE_OF_CONDUCT.md`, `TRADEMARK.md`, and GitHub issue/PR
   templates.
 
+## [0.1.30] - 2026-08-22
+
+Access control, and the vault's shape.
+
+### Added
+- **Shareable note links.** A share icon in the note header copies
+  `baalda://note/<vault>/<doc>`; opening it switches vault if needed and lands on
+  the note. The link carries ids only, resolved against whoever opens it, and is
+  keyed by `doc_id` so it survives every rename and move. Adds
+  `tauri-plugin-deep-link` plus `tauri-plugin-single-instance`, so a click on
+  Windows/Linux reaches the running app instead of starting a second one.
+- **Private, at two scales** (`shares.permission = 'denied'`, migration 018) —
+  the only row in the model that subtracts. Per-**member** it blocks one person
+  and beats everything, authorship included. Per-**item** it takes a folder or
+  note out of the team's reach, leaving only people shared with by name.
+- **Freeze vault root** (Settings → General): a structural latch that closes the
+  vault's top level to new folders and notes. Applies to everyone, lifted only by
+  an owner/admin, and enforced on the HTTP registry *and* the MCP tools.
+- **Reveal in Finder** on any note or folder in the sidebar (platform-labelled).
+- `GET /api/vaults/:id/access-tree` — the vault's whole structure for the Access
+  panel (owner/admin, ids and paths only, deliberately not ACL-filtered) so an
+  item you have made Private stays administrable after its file leaves your disk.
+- Item colours on the server (`folders.color` / `notes.color`), keyed by id.
+
+### Changed
+- **Access settings now apply to the person setting them.** The owner/admin and
+  note-creator branches were shortcuts that ran before any grant was consulted,
+  so a Read-only vault still let its owner edit and a Private folder still showed
+  up for its author. Both are skipped under item-Private and under a Read-only
+  vault. Managing shares stays role-gated, so an owner can always lift what they
+  applied to themselves.
+- **Losing access de-syncs the note from disk**, alongside the existing tombstone
+  path. It only fires when the server actually answered about deletions, it moves
+  the file to the vault's recoverable trash rather than destroying it, and it
+  refuses any doc whose content the device never confirmed upstream. Revocations
+  are capped separately from deletions and more loosely. Restoring access
+  re-materialises the file.
+- **Vault revert is owner *or* admin** — it is the recovery half of an action
+  admins could already take.
+- **Item colours sync to the team** and survive a rename; colours set before a
+  vault gained sync are adopted upward once.
+- The Access panel is a real tree: folders expand in place and pull their
+  contents in on demand, which is what made the notes *inside* a folder reachable
+  at all. Permission writes now say "Applying…" instead of appearing stuck.
+- One popover select everywhere (`MenuSelect`, which `RoleSelect` now wraps),
+  replacing the last native `<select>`; the freeze-root checkbox became an
+  animated `Switch`; the account menu leads with **Home** instead of repeating the
+  identity card its own trigger already shows.
+
+### Fixed
+- **Google sign-in failed with `account_not_linked` on any account created with a
+  password.** Better Auth's `accountLinking.requireLocalEmailVerified` defaults to
+  true and refuses to link while the local row is unverified — and with
+  `requireEmailVerification` off, every password sign-up is unverified forever,
+  which made the account-linking config dead code. Now set to false. Trade-off:
+  without verification at sign-up an address can be squatted, so email
+  verification remains the real fix and is still owed.
+- The "who can access" list resolved through different branches than the enforcer
+  and reported *No access* on a member's own note while the sync token granted
+  edit. They now mirror each other.
+- The Access panel's dropdown was clipped by the settings card, which becomes the
+  containing block for `position: fixed` children because its entry animation
+  keeps a `transform` applied. The menu is portalled to `<body>`.
+- The Access item list no longer nests its own scroll region inside the settings
+  page's, which sliced rows in half at the top edge.
+
 ## [0.1.0] - 2026-07-14
 
 ### Added
@@ -30,5 +96,6 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Local search (SQLite FTS5), backlinks, tags, and a graph view.
 - Semantic search via a dependency-free hashed embedder.
 
-[Unreleased]: https://github.com/naveedharri/baalda/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/naveedharri/baalda/compare/v0.1.30...HEAD
+[0.1.30]: https://github.com/naveedharri/baalda/releases/tag/v0.1.30
 [0.1.0]: https://github.com/naveedharri/baalda/releases/tag/v0.1.0

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -28,6 +28,7 @@
     "@lezer/highlight": "^1.2.3",
     "@lezer/markdown": "^1.7.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2",

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -506,6 +506,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +617,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -735,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "keyring",
  "notify",
@@ -748,10 +774,12 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tempfile",
  "trash",
@@ -834,6 +862,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2567,6 +2604,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3103,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -3913,6 +3970,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,6 +4062,23 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -4209,6 +4304,15 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5094,6 +5198,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.29"
+version = "0.1.30"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"
@@ -37,10 +37,14 @@ trash = "5"
 # OS keychain for session tokens (spec 04 §7). apple-native uses the macOS
 # Security framework; swap/add features for other platforms later.
 keyring = { version = "3", features = ["apple-native"] }
+tauri-plugin-deep-link = "2.4.9"
 
 # The updater is desktop-only — gate it so mobile targets don't try to build it.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
+
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = { version = "2.4.3", features = ["deep-link"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/app/apps/desktop/src-tauri/capabilities/default.json
+++ b/app/apps/desktop/src-tauri/capabilities/default.json
@@ -18,6 +18,16 @@
     "dialog:default",
     "fs:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    {
+      "identifier": "core:window:allow-set-focus",
+      "comment": "A `baalda://` note link has to bring the window forward — a link that navigates a window the user can't see is the same as a link that did nothing. `core:default` grants only read-only window commands, so the three commands the deep-link handler needs are listed explicitly rather than by widening it."
+    },
+    "core:window:allow-show",
+    "core:window:allow-unminimize",
+    {
+      "identifier": "deep-link:default",
+      "comment": "Registers the `baalda://` URL scheme and lets the webview subscribe to opens on it. This is how a shared note link gets from a teammate's chat window into this app; the payload is only ever a vault + note id, and the handler resolves it against the signed-in user's own access."
+    }
   ]
 }

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -20,16 +20,39 @@ use state::AppState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    // Single-instance FIRST, and only on desktop. Without it, clicking a
+    // `baalda://` link on Windows/Linux spawns a SECOND copy of the app with
+    // the URL as an argv entry — two windows, two vault locks, one confused
+    // user. With it the running instance is handed the URL and the duplicate
+    // exits. On macOS the OS already routes links to the running app; the
+    // plugin is harmless there and keeps one code path.
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|_app, _argv, _cwd| {}));
+
+    builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
+        // `baalda://` links. A teammate pastes one into chat; clicking it hands
+        // the URL to this app, which resolves it against the *recipient's* own
+        // account and access — the link carries ids, never content or a grant.
+        .plugin(tauri_plugin_deep_link::init())
         .setup(|app| {
             // Updater is desktop-only; register it here so mobile builds skip it.
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
+            // Dev/Linux need a runtime registration: on macOS and Windows the
+            // scheme comes from the bundle, which `tauri dev` never builds, so
+            // without this a link is unopenable in development.
+            #[cfg(any(windows, target_os = "linux"))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                let _ = app.deep_link().register_all();
+            }
             Ok(())
         })
         .manage(AppState::default())

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -53,6 +53,11 @@
       "endpoints": [
         "https://github.com/naveedharri/baalda/releases/latest/download/latest.json"
       ]
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": ["baalda"]
+      }
     }
   }
 }

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1825,6 +1825,13 @@ body:has(.sidebar-resizer.dragging) {
 .context-menu.role-menu {
   min-width: 150px;
 }
+/* Portalled to <body>, so it is no longer nested inside whatever opened it and
+   has to out-rank those layers by hand: the settings page is 200 and a modal
+   backdrop is 300. A popover always belongs above the surface it was opened
+   from. */
+.context-menu.menu-portal {
+  z-index: 400;
+}
 .context-menu.role-menu li {
   text-transform: capitalize;
 }

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -3797,11 +3797,65 @@ body:has(.sidebar-resizer.dragging) {
 .access-lv.no {
   color: var(--text-tertiary);
 }
-.access-choice {
-  width: auto !important;
+/* Per-member picker in the Access panel. Same popover as the Members page's
+   role picker (see MenuSelect) — the native <select> that used to sit here was
+   the last piece of OS chrome in the product and read as unfinished beside it.
+   Sized a notch smaller than the role field because it sits inside a list row. */
+.access-choice-trigger {
+  background: var(--bg-subtle);
+  border: 1px solid transparent;
+  color: var(--text-primary);
+  border-radius: var(--radius-md);
+  padding: 5px var(--sp-2) 5px var(--sp-3);
+  font: inherit;
+  font-size: var(--fs-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  cursor: pointer;
+  white-space: nowrap;
   flex-shrink: 0;
-  font-size: var(--fs-sm) !important;
-  padding: var(--sp-1) var(--sp-2) !important;
+  transition:
+    border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease);
+}
+.access-choice-trigger:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+.access-choice-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+  background: var(--bg-surface);
+}
+.access-choice-trigger:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+/* Wider than the role menu (these labels carry a hint line), and with the
+   role list's `capitalize` undone — that exists for "owner"/"admin", and would
+   turn "Can view" into "Can View". Specificity matches `.context-menu.role-menu`
+   so it actually overrides it. */
+.context-menu.role-menu.access-choice-menu {
+  right: 0;
+  left: auto;
+  min-width: 232px;
+}
+.context-menu.role-menu.access-choice-menu li {
+  text-transform: none;
+  align-items: flex-start;
+}
+/* Second line on an option — says what the choice does, so "Private" doesn't
+   have to be guessed at. */
+.menu-option-hint {
+  display: block;
+  font-size: var(--fs-xs);
+  color: var(--text-tertiary);
+  margin-top: 1px;
+}
+.role-menu li .role-option-label {
+  display: inline-block;
 }
 
 .theme-toggle {
@@ -4813,6 +4867,73 @@ button.secondary:disabled {
   width: auto;
   flex: none;
   cursor: pointer;
+}
+
+/* ── Switch ──────────────────────────────────────────────────────────────
+   A real checkbox, visually replaced. The input keeps its size and sits on
+   top at zero opacity so it stays the hit target and the focus owner — the
+   track below is pure paint. */
+.switch {
+  position: relative;
+  display: inline-flex;
+  flex: none;
+  width: 40px;
+  height: 24px;
+}
+.switch .switch-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+.switch.is-disabled .switch-input {
+  cursor: not-allowed;
+}
+.switch-track {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-pill);
+  background: var(--bg-subtle);
+  box-shadow: inset 0 0 0 1px var(--border);
+  transition:
+    background var(--t-med) var(--ease),
+    box-shadow var(--t-med) var(--ease);
+}
+.switch-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
+  /* The knob is what makes the change read as a decision rather than a blink,
+     so it gets a slight overshoot on the way across. */
+  transition: transform var(--t-med) cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+.switch.on .switch-track {
+  background: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+.switch.on .switch-knob {
+  transform: translateX(16px);
+}
+.switch.is-disabled {
+  opacity: 0.5;
+}
+.switch .switch-input:focus-visible + .switch-track {
+  box-shadow: var(--focus-ring);
+}
+@media (prefers-reduced-motion: reduce) {
+  .switch-knob,
+  .switch-track {
+    transition: none;
+  }
 }
 
 /* ============================================================

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1819,10 +1819,10 @@ body:has(.sidebar-resizer.dragging) {
   display: inline-flex;
   flex-shrink: 0;
 }
+/* Positioning is done in JS (`MenuSelect` → `placeMenu`) in viewport
+   coordinates, so the menu can flip above its trigger and can't be clipped by a
+   scrolling ancestor. Only the sizing belongs here. */
 .context-menu.role-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
   min-width: 150px;
 }
 .context-menu.role-menu li {
@@ -3316,12 +3316,15 @@ body:has(.sidebar-resizer.dragging) {
 }
 
 /* --- master list --- */
+/* No scroll of its own. The settings page already scrolls, and a second scroll
+   region nested inside it is what sliced rows in half at the top edge — you
+   could never tell whether a row was cut off or simply short. The list grows to
+   its content and the page carries it; folders start collapsed, so what's on
+   screen by default is the vault's top level, not everything in it. */
 .access-master {
   background: var(--bg-subtle);
   border-radius: var(--radius-lg);
   padding: var(--sp-2);
-  max-height: 360px;
-  overflow-y: auto;
 }
 .access-list {
   list-style: none;
@@ -3838,8 +3841,6 @@ body:has(.sidebar-resizer.dragging) {
    turn "Can view" into "Can View". Specificity matches `.context-menu.role-menu`
    so it actually overrides it. */
 .context-menu.role-menu.access-choice-menu {
-  right: 0;
-  left: auto;
   min-width: 232px;
 }
 .context-menu.role-menu.access-choice-menu li {

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -156,6 +156,17 @@ button.primary.hero:hover:not(:disabled) {
   width: 18px;
   height: 18px;
 }
+/* Copy-link button. Goes green on success rather than only toasting: the toast
+   is at the other end of the window, and the confirmation belongs where the
+   click happened. */
+.share-btn.copied {
+  color: var(--success);
+}
+.share-btn .checkmark {
+  width: 18px;
+  height: 18px;
+}
+
 /* Graph view toggle in the main header — nudge toward accent so it reads as a
    navigable affordance rather than a passive status glyph. */
 .graph-btn {
@@ -3344,6 +3355,77 @@ body:has(.sidebar-resizer.dragging) {
   background: var(--accent-soft);
   border-color: transparent;
 }
+/* One list line: twisty + row button, side by side. Indentation lives on the
+   line so the twisty indents with the row it belongs to. */
+.access-item {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding-right: var(--sp-2);
+}
+.access-item .access-row {
+  padding-left: 2px;
+}
+
+/* Folder twisty. Its own hit target beside the row button, so opening a folder
+   and selecting it stay separate intents. */
+.access-twisty {
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    transform var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease);
+}
+.access-twisty.spacer {
+  cursor: default;
+}
+.access-twisty:not(.spacer):hover {
+  color: var(--text-primary);
+}
+.access-twisty.open {
+  transform: rotate(90deg);
+}
+.access-twisty svg {
+  width: 100%;
+  height: 100%;
+}
+/* The twisty is a sibling of the row, so it takes its selected colour from the
+   line, not from a descendant selector. */
+.access-item:has(.access-row.sel) .access-twisty {
+  color: var(--accent);
+}
+
+/* "Applying…" / "Resolving…" beside a section label. Permission writes fan out
+   into several round trips and a socket kick, so the wait is real and has to be
+   narrated — otherwise the panel just looks stuck. */
+.access-applying {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: var(--sp-2);
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 500;
+  color: var(--text-tertiary);
+}
+.access-seg.busy {
+  opacity: 0.55;
+  pointer-events: none;
+}
+.access-seg {
+  transition: opacity var(--t-fast) var(--ease);
+}
+
 .access-glyph {
   width: 16px;
   height: 16px;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -30,6 +30,8 @@ import {
 } from "./lib/updater";
 import { runConfetti } from "./lib/celebrate/celebrate";
 import { previewKind } from "./lib/preview";
+import { ShareNoteButton } from "./components/ShareNoteButton";
+import { listenForNoteLinks } from "./lib/deepLink";
 import { useSidebarWidth } from "./lib/useSidebarWidth";
 import { useStore } from "./store";
 
@@ -494,6 +496,11 @@ export default function App() {
     useStore.getState().closeVersionPanel();
   }, [openNote?.path]);
 
+  // `baalda://` links, from a teammate's chat window into this app. Mounted for
+  // the app's whole life (not gated on a vault being open) because the very
+  // first thing a link may have to do is switch vaults.
+  useEffect(() => listenForNoteLinks(), []);
+
   // Auto-reopen the last vault on launch, then restore the session (spec 04 §7)
   // and enable sync. Vault first so `enableSyncForVault` (called inside initAuth)
   // sees the loaded tree.
@@ -755,6 +762,9 @@ export default function App() {
             <SyncIndicator noteOpen={openNote != null && !isPreview} />
             {/* Vault-wide, so it sits in the header regardless of the open note. */}
             <TalkButton />
+            {/* Same gate as history: a link is a doc_id, so it only exists for a
+                note the server knows about. */}
+            {versionDocId && !isPreview && <ShareNoteButton docId={versionDocId} />}
             {versionDocId && !isPreview && (
               <button
                 className={`icon-btn history-btn${versionPanelOpen ? " active" : ""}`}

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -346,7 +346,9 @@ function WhatsNewModal() {
     let cancelled = false;
     void justUpdatedTo().then((stash) => {
       if (cancelled || !stash) return;
-      setUpdated({ version: stash.version, notes: releaseNoteLines(stash.notes) });
+      // A wider cap than the banner's: this is a dialog with room, and a
+      // release that changed ten things should say so rather than stop at six.
+      setUpdated({ version: stash.version, notes: releaseNoteLines(stash.notes, 12) });
     });
     return () => {
       cancelled = true;

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -17,6 +17,7 @@ import { lockScopesByPath, resourceIdsByPath } from "../lib/locks";
 import { syncManager } from "../lib/sync/docSession";
 import { useStore } from "../store";
 import { Avatar } from "./Identity";
+import { MenuSelect, type MenuSelectOption } from "./MenuSelect";
 import { Spinner } from "./Spinner";
 
 /**
@@ -39,9 +40,11 @@ type Mode = "open" | "readonly" | "private";
 // only ever RAISE permission and a member already has edit under Open, "view"
 // must be a per-user LOCK (a cap), not a view grant — a view grant would leave
 // the member on edit. "default" clears the override (falls back to Open / the
-// folder's inherited setting). "none" is the deny: the only per-member row that
-// SUBTRACTS, and the only way to keep one person out of a folder in a vault
-// everyone else can read. One row per (resource, user): grant, lock, or deny.
+// folder's inherited setting). "none" is the deny — shown as **Private** — the
+// only per-member row that SUBTRACTS, and the only way to keep one person out of
+// a folder in a vault everyone else can read. It applies to owners and admins
+// too, which is what makes a restriction testable from the seat that set it.
+// One row per (resource, user): grant, lock, or deny.
 type MemberChoice = "default" | "none" | "view" | "edit";
 
 /** One row in the item list (see `lib/accessTree`). */
@@ -93,6 +96,30 @@ const ICON = {
     </svg>
   ),
 };
+
+/**
+ * The per-member picker's options.
+ *
+ * Owners are configurable like anyone else — the only row that isn't is *your
+ * own*, because a Private on yourself would take the item out of your tree and
+ * with it the row you'd need to undo it. Every other rule here is about not
+ * promising something the model won't honour.
+ */
+function memberOptions(everyoneReadonly: boolean): MenuSelectOption<MemberChoice>[] {
+  return [
+    { value: "default", label: "Default", hint: "Whatever this item's mode gives them" },
+    // An Everyone/parent lock already holds everyone at read-only, so offering
+    // "can view"/"can edit" would promise something the lock overrides.
+    // Private still works — a per-member block outranks a lock.
+    ...(everyoneReadonly
+      ? []
+      : ([
+          { value: "view", label: "Can view", hint: "Read-only" },
+          { value: "edit", label: "Can edit", hint: "Read & write" },
+        ] as MenuSelectOption<MemberChoice>[])),
+    { value: "none", label: "Private", hint: "Hidden from this person" },
+  ];
+}
 
 const MODE_LABEL: Record<Mode, string> = {
   open: "Open",
@@ -149,6 +176,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const session = useStore((s) => s.session);
   const members = useStore((s) => s.members);
   const locks = useStore((s) => s.locks);
+  const denies = useStore((s) => s.denies);
   const tree = useStore((s) => s.tree);
   const syncEnabled = useStore((s) => s.syncEnabled);
 
@@ -250,6 +278,32 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   };
 
   const lockMap = useMemo(() => buildLockMap(tree, locks), [tree, locks]);
+  /**
+   * Vault-relative paths carrying an ORG deny — an item set to Private.
+   *
+   * Read from the vault-wide overlay rather than the selected resource's own
+   * shares, because Private inherits: a note inside a Private folder is private
+   * too, and the panel has to be able to say which folder is deciding that.
+   */
+  const privatePaths = useMemo(() => {
+    const idToPath = resourceIdsByPath(tree);
+    const out = new Set<string>();
+    for (const d of denies) {
+      if (sharePrincipalType(d) !== "org") continue;
+      const path = idToPath.get(shareResId(d));
+      if (path) out.add(path);
+    }
+    return out;
+  }, [tree, denies]);
+  /** The nearest ANCESTOR of `path` that is Private, or null. */
+  const privateSourcePath = (path: string): string | null => {
+    const parts = path.split("/");
+    for (let i = parts.length - 1; i > 0; i--) {
+      const ancestor = parts.slice(0, i).join("/");
+      if (privatePaths.has(ancestor)) return ancestor;
+    }
+    return null;
+  };
   const directScopes = useMemo(
     () => lockScopesByPath(tree, locks, session?.user.id),
     [tree, locks, session?.user.id],
@@ -306,15 +360,23 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const ownOrgLock = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "locked");
   const ownOrgView = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "view");
   const ownOrgEdit = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "edit");
+  const ownOrgDeny = shares.find((s) => sharePrincipalType(s) === "org" && s.permission === "denied");
   const inheritedOrgLock = !!effLock?.org && !ownOrgLock;
-  // Resolve the resource's team mode: a direct lock/view → read-only; a direct
-  // edit grant → shared/open; nothing direct → inherit the vault posture.
+  // Private inherited from a parent folder: the nearest ancestor with an org
+  // deny governs this item, exactly as an ancestor lock does.
+  const privateSource = selected && !ownOrgDeny ? privateSourcePath(selected.path) : null;
+  // Resolve the resource's team mode. Private is checked FIRST because it is
+  // the only mode that can override an inherited grant — which is the whole
+  // reason it exists: with a Shared vault, clearing an item's own rows left the
+  // vault-wide grant reaching it, so Private silently snapped back to Shared.
   const generalMode: Mode =
-    ownOrgLock || inheritedOrgLock || ownOrgView
-      ? "readonly"
-      : ownOrgEdit
-        ? "open"
-        : wsPosture;
+    ownOrgDeny || privateSource
+      ? "private"
+      : ownOrgLock || inheritedOrgLock || ownOrgView
+        ? "readonly"
+        : ownOrgEdit
+          ? "open"
+          : wsPosture;
   // When an Everyone/org lock (direct or inherited) already makes the resource
   // read-only for all, a per-member "read-only" lock is redundant and makes
   // Unlock misleading — so the per-person controls are suppressed in favour of
@@ -334,6 +396,9 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const inheritSourceRes = inheritSource
     ? resources.find((r) => r.path === inheritSource)
     : null;
+  const privateSourceRes = privateSource
+    ? (resources.find((r) => r.path === privateSource) ?? null)
+    : null;
 
   // --- writes ---------------------------------------------------------------
 
@@ -352,7 +417,9 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
     }
   };
 
-  /** Clear every DIRECT org row (grant or lock) on the selected resource. */
+  /** Clear every DIRECT org row on the selected resource — grant, lock, or the
+   *  Private deny. One row per (resource, principal), so the new mode's row can
+   *  only be written once the old one is gone. */
   const clearResourceOrgRows = async () => {
     if (!selected) return;
     for (const s of shares) {
@@ -368,10 +435,24 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   // edit at view); a plain org view grant when the vault is Private (there
   // is no baseline edit to cap, and a grant is what GIVES the team read).
   const setGeneral = (mode: Mode) => {
-    if (!selected || mode === generalMode || inheritedOrgLock) return;
+    if (!selected || mode === generalMode || inheritedOrgLock || privateSource) return;
     void run(async () => {
       await clearResourceOrgRows();
-      if (mode === "open") {
+      if (mode === "private") {
+        // An explicit org DENY, not merely the absence of a grant. Clearing the
+        // rows was the old behaviour and it could not work: in a Shared vault
+        // the vault-wide grant still reached the item, so the segment snapped
+        // straight back to Shared. The deny removes the team's reach and
+        // nothing else — the creator, anyone shared with by name, and
+        // owners/admins keep it, which is what "only you and people you share
+        // it with" says on the button.
+        await authManager.api.createShare({
+          resourceType: selected.kind,
+          resourceId: selected.id,
+          principalType: "org",
+          permission: "denied",
+        });
+      } else if (mode === "open") {
         await authManager.api.createShare({
           resourceType: selected.kind,
           resourceId: selected.id,
@@ -390,7 +471,6 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
           await useStore.getState().createLock(selected.kind, selected.id, null);
         }
       }
-      // "private" = just the cleared state (no team row).
     });
   };
 
@@ -546,6 +626,9 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                   ? members.map((m) => m.userId)
                   : [...(lk?.users ?? [])];
                 const isOpen = expanded.has(r.path);
+                // Private wins the badge: it's the strongest statement a row
+                // can make, and an item can be Private *and* sit under a lock.
+                const isPrivate = privatePaths.has(r.path) || !!privateSourcePath(r.path);
                 return (
                   // The twisty is a SIBLING of the row button, not a child.
                   // Opening a folder and selecting it are different intents, and
@@ -577,7 +660,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                       <span className="access-glyph">{r.kind === "folder" ? ICON.folder : ICON.note}</span>
                       <span className="access-rname">{r.name}</span>
                       <span className="access-rright">
-                        {readOnly && affected.length > 0 && (
+                        {!isPrivate && readOnly && affected.length > 0 && (
                           <span className="access-avstack" aria-hidden="true">
                             {affected.slice(0, 3).map((uid) => (
                               <span className="access-av-wrap locked" key={uid}>
@@ -588,25 +671,29 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                         )}
                         <span
                           className={`access-badge ${
-                            readOnly ? "ro" : wsPosture === "private" ? "priv" : "open"
+                            isPrivate ? "priv" : readOnly ? "ro" : wsPosture === "private" ? "priv" : "open"
                           }`}
                         >
-                          {readOnly
-                            ? ICON.lock
-                            : wsPosture === "private"
-                              ? ICON.shield
-                              : wsPosture === "readonly"
-                                ? ICON.lock
-                                : ICON.open}
-                          {readOnly
-                            ? everyone
-                              ? "Read-only"
-                              : "Restricted"
-                            : wsPosture === "private"
-                              ? "Private"
-                              : wsPosture === "readonly"
+                          {isPrivate
+                            ? ICON.shield
+                            : readOnly
+                              ? ICON.lock
+                              : wsPosture === "private"
+                                ? ICON.shield
+                                : wsPosture === "readonly"
+                                  ? ICON.lock
+                                  : ICON.open}
+                          {isPrivate
+                            ? "Private"
+                            : readOnly
+                              ? everyone
                                 ? "Read-only"
-                                : "Shared"}
+                                : "Restricted"
+                              : wsPosture === "private"
+                                ? "Private"
+                                : wsPosture === "readonly"
+                                  ? "Read-only"
+                                  : "Shared"}
                         </span>
                       </span>
                     </button>
@@ -656,6 +743,25 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                   </span>
                 </div>
               )}
+              {privateSourceRes && (
+                <div className="access-banner">
+                  <span className="access-bico">{ICON.shield}</span>
+                  <span>
+                    <strong>{privateSourceRes.name}</strong> is private, so this{" "}
+                    {selected.kind === "folder" ? "folder" : "note"} is too — the team can't
+                    reach it.{" "}
+                    <button
+                      className="access-jump"
+                      onClick={() => {
+                        revealPath(privateSourceRes.path);
+                        setSelected(privateSourceRes);
+                      }}
+                    >
+                      Open {privateSourceRes.name} ›
+                    </button>
+                  </span>
+                </div>
+              )}
               {!inheritSource && generalMode === "readonly" && (
                 <div className="access-banner">
                   <span className="access-bico">{ICON.lock}</span>
@@ -689,7 +795,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                     type="button"
                     className={`access-segbtn${generalMode === m ? " active" : ""}`}
                     data-mode={m}
-                    disabled={!canManage || inheritedOrgLock || busy}
+                    disabled={!canManage || inheritedOrgLock || !!privateSource || busy}
                     onClick={() => setGeneral(m)}
                   >
                     <span className="access-st-top">
@@ -706,11 +812,11 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                   </button>
                 ))}
               </div>
-              {generalMode === "private" && wsPosture !== "private" && (
+              {generalMode === "private" && !privateSource && (
                 <div className="access-hint">
-                  This vault is <strong>{MODE_LABEL[wsPosture]}</strong>, so everything is
-                  visible to the team by default. To make individual items private, set the whole
-                  vault to <strong>Private</strong> above, then share the folders you want.
+                  The team can't reach this {selected.kind === "folder" ? "folder" : "note"}
+                  {wsPosture !== "private" && <> — even though the vault is <strong>{MODE_LABEL[wsPosture]}</strong></>}.
+                  You, anyone you share it with by name below, and vault admins still can.
                 </div>
               )}
 
@@ -755,22 +861,16 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                           </div>
                           <div className="access-prole">{sourceLabel(m, choice)}</div>
                         </div>
-                        {canManage && m.role !== "owner" ? (
-                          <select
-                            className="access-choice"
+                        {canManage && m.userId !== session?.user.id ? (
+                          <MenuSelect
                             value={choice}
+                            options={memberOptions(everyoneReadonly)}
+                            onSelect={(next) => setMember(m.userId, next)}
                             disabled={busy}
-                            onChange={(e) => setMember(m.userId, e.target.value as MemberChoice)}
-                          >
-                            <option value="default">Default</option>
-                            {/* An Everyone/parent lock already holds everyone at
-                                read-only, so offering "can view"/"can edit" here
-                                would promise something the lock overrides. "No
-                                access" still works — a deny outranks a lock. */}
-                            {!everyoneReadonly && <option value="view">Can view (read-only)</option>}
-                            {!everyoneReadonly && <option value="edit">Can edit</option>}
-                            <option value="none">No access (blocked)</option>
-                          </select>
+                            ariaLabel={`Access for ${m.name || m.email || m.userId}`}
+                            triggerClassName="access-choice-trigger"
+                            menuClassName="access-choice-menu"
+                          />
                         ) : (
                           <span className={`access-lv ${levelCls(m.permission)}`}>{levelLabel(m.permission)}</span>
                         )}
@@ -781,8 +881,8 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                   {otherMembers === 0 && (
                     <p className="access-hint">
                       You're the only member. Invite teammates in <strong>Members</strong>, then
-                      each one gets a per-person control here — <strong>Can edit</strong> or{" "}
-                      <strong>Can view (read-only)</strong> — so you can lock this{" "}
+                      each one gets a per-person control here — <strong>Can edit</strong>,{" "}
+                      <strong>Can view</strong>, or <strong>Private</strong> — so you can lock this{" "}
                       {selected.kind === "folder" ? "folder" : "note"} for some people while others
                       keep editing.
                     </p>
@@ -814,7 +914,7 @@ function claudeCls(p: "edit" | "view" | "none"): string {
 }
 
 function sourceLabel(m: ResolvedMemberAccess, choice: MemberChoice): string {
-  if (choice === "none" || m.denied) return "Blocked · no access";
+  if (choice === "none" || m.denied) return "Private · hidden from them";
   if (m.permission === "none") return "No access";
   if (m.capped) return "Read-only · locked";
   if (m.role === "owner") return "Owner · full access";

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -575,7 +575,8 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
       <p className="access-intro">
         Choose what the team can reach. Set the whole vault below, then override any folder or
         note — <strong>Shared</strong> (read &amp; write), <strong>Read-only</strong>, or{" "}
-        <strong>Private</strong> (just you). Folder settings flow down to everything inside.
+        <strong>Private</strong> (nobody until you name them — you included). Folder settings flow
+        down to everything inside.
       </p>
 
       {canManage && orgId && (
@@ -814,16 +815,22 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                         ? "The whole team can read & write."
                         : m === "readonly"
                           ? "The team can read, not edit. Claude reads only."
-                          : "Only you and people you share it with."}
+                          : "Nobody reaches it — including you — until you add them below."}
                     </span>
                   </button>
                 ))}
               </div>
               {generalMode === "private" && !privateSource && (
                 <div className="access-hint">
-                  The team can't reach this {selected.kind === "folder" ? "folder" : "note"}
-                  {wsPosture !== "private" && <> — even though the vault is <strong>{MODE_LABEL[wsPosture]}</strong></>}.
-                  You, anyone you share it with by name below, and vault admins still can.
+                  Nobody reaches this {selected.kind === "folder" ? "folder" : "note"}
+                  {wsPosture !== "private" && (
+                    <> — the vault being <strong>{MODE_LABEL[wsPosture]}</strong> doesn't override it</>
+                  )}
+                  . Not the team, not vault admins, and not you: add someone below by name to give
+                  them access, yourself included.{" "}
+                  <strong>Your local files are untouched</strong> — this stops the{" "}
+                  {selected.kind === "folder" ? "folder" : "note"} syncing and takes it out of every
+                  teammate's vault, but never deletes anything off a disk.
                 </div>
               )}
 
@@ -866,7 +873,9 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                             {m.name || m.email || m.userId}
                             {m.userId === session?.user.id && <span className="access-you"> (you)</span>}
                           </div>
-                          <div className="access-prole">{sourceLabel(m, choice)}</div>
+                          <div className="access-prole">
+                            {sourceLabel(m, choice, m.userId === session?.user.id)}
+                          </div>
                         </div>
                         {canManage && m.userId !== session?.user.id ? (
                           <MenuSelect
@@ -920,8 +929,10 @@ function claudeCls(p: "edit" | "view" | "none"): string {
   return p === "edit" ? "can" : p === "view" ? "view" : "no";
 }
 
-function sourceLabel(m: ResolvedMemberAccess, choice: MemberChoice): string {
-  if (choice === "none" || m.denied) return "Private · hidden from them";
+function sourceLabel(m: ResolvedMemberAccess, choice: MemberChoice, isYou = false): string {
+  if (choice === "none" || m.denied) {
+    return isYou ? "Private · hidden from you too" : "Private · hidden from them";
+  }
   if (m.permission === "none") return "No access";
   if (m.capped) return "Read-only · locked";
   if (m.role === "owner") return "Owner · full access";

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -6,11 +6,15 @@ import {
   sharePrincipalId,
   sharePrincipalType,
 } from "../lib/api";
+import type { AccessTreeResponse } from "../lib/api";
 import type { TreeNode } from "../lib/ipc";
 import {
   ancestorPaths,
+  entriesFromServer,
+  entriesFromTree,
   folderChildrenLoaded,
-  visibleAccessRows,
+  rowsFromEntries,
+  type AccessEntry,
   type AccessRow,
 } from "../lib/accessTree";
 import { lockScopesByPath, resourceIdsByPath } from "../lib/locks";
@@ -191,6 +195,8 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   /** Folder paths whose children are being fetched from Rust right now. */
   const [expanding, setExpanding] = useState<Set<string>>(() => new Set());
+  /** The vault's full structure, unfiltered by the ACL (owner/admin only). */
+  const [serverTree, setServerTree] = useState<AccessTreeResponse | null>(null);
   const [shares, setShares] = useState<Share[]>([]);
   const [access, setAccess] = useState<ResolvedMemberAccess[] | null>(null);
   const [wsShares, setWsShares] = useState<Share[]>([]);
@@ -206,12 +212,27 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const reloadVault = async () => {
     if (!canManage || !orgId) {
       setWsShares([]);
+      setServerTree(null);
       return;
     }
     try {
       setWsShares(await authManager.api.listVaultShares(orgId));
     } catch {
       setWsShares([]);
+    }
+    // The structure listing is what keeps a Private item administrable, so it is
+    // re-read after every write: setting something Private removes its file, and
+    // the row you would undo that from has to survive it.
+    const vaultId = syncManager.registry.vaultId;
+    if (!vaultId) {
+      setServerTree(null);
+      return;
+    }
+    try {
+      setServerTree(await authManager.api.listAccessTree(vaultId));
+    } catch {
+      // Older server, or a caller who can't manage — fall back to the local tree.
+      setServerTree(null);
     }
   };
   useEffect(() => {
@@ -225,18 +246,28 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const wsPosture: Mode = wsGrant ? (wsGrant.permission === "edit" ? "open" : "readonly") : "private";
 
   /**
-   * The rows currently on screen: the vault tree, indented, with a collapsed
-   * folder's contents left out. The rule that makes it work — an un-listed
-   * folder is expandable, not empty — lives in `lib/accessTree` where a test
-   * can hold it.
+   * The rows currently on screen: the vault's structure, indented, with a
+   * collapsed folder's contents left out.
+   *
+   * Sourced from the SERVER, not from this machine's disk. An item set to
+   * Private leaves the disk, and this panel is where you'd go to change your
+   * mind — drawing the list from the disk meant the row you needed disappeared
+   * the moment you needed it. The local tree is the fallback while that listing
+   * is in flight or if it was refused.
    */
-  const resources = useMemo<Resource[]>(
+  const entries = useMemo<AccessEntry[]>(
     () =>
-      visibleAccessRows(tree, expanded, {
-        folderId: (path) => syncManager.registry.getFolderId(path),
-        docId: (path) => syncManager.registry.getMapping(path)?.docId ?? null,
-      }),
-    [tree, expanded],
+      serverTree
+        ? entriesFromServer(serverTree)
+        : entriesFromTree(tree, {
+            folderId: (path) => syncManager.registry.getFolderId(path),
+            docId: (path) => syncManager.registry.getMapping(path)?.docId ?? null,
+          }),
+    [serverTree, tree],
+  );
+  const resources = useMemo<Resource[]>(
+    () => rowsFromEntries(entries, expanded),
+    [entries, expanded],
   );
 
   /**
@@ -255,7 +286,9 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
     }
     next.add(path);
     setExpanded(next);
-    if (loaded) return;
+    // The server listing is complete, so nothing has to be fetched to expand.
+    // Only the local fallback loads lazily.
+    if (serverTree || loaded) return;
     setExpanding((prev) => new Set(prev).add(path));
     try {
       await useStore.getState().loadChildren(path);

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -476,6 +476,13 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
 
   // Whole-vault posture (Open / Read-only / Private) = the org grant on the
   // vault resource. Private removes it, falling back to per-item sharing.
+  //
+  // The Read-only grant is a CEILING for everyone now, not just a floor for
+  // members: the resolver stops taking the owner/admin and note-creator
+  // shortcuts when it's set (`vaultBaseline`), so "Everyone can read
+  // everything, not edit" finally includes the person who chose it. It stays a
+  // single grant row rather than a grant plus a lock because both would want
+  // the same (resource, principal) key.
   const setVaultPosture = (mode: Mode) => {
     if (!orgId || mode === wsPosture) return;
     void run(async () => {

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -7,10 +7,17 @@ import {
   sharePrincipalType,
 } from "../lib/api";
 import type { TreeNode } from "../lib/ipc";
+import {
+  ancestorPaths,
+  folderChildrenLoaded,
+  visibleAccessRows,
+  type AccessRow,
+} from "../lib/accessTree";
 import { lockScopesByPath, resourceIdsByPath } from "../lib/locks";
 import { syncManager } from "../lib/sync/docSession";
 import { useStore } from "../store";
 import { Avatar } from "./Identity";
+import { Spinner } from "./Spinner";
 
 /**
  * Access — the unified locker. A vault-default posture (Shared · Read-only ·
@@ -32,17 +39,13 @@ type Mode = "open" | "readonly" | "private";
 // only ever RAISE permission and a member already has edit under Open, "view"
 // must be a per-user LOCK (a cap), not a view grant — a view grant would leave
 // the member on edit. "default" clears the override (falls back to Open / the
-// folder's inherited setting). One row per (resource, user): grant OR lock.
-type MemberChoice = "default" | "view" | "edit";
+// folder's inherited setting). "none" is the deny: the only per-member row that
+// SUBTRACTS, and the only way to keep one person out of a folder in a vault
+// everyone else can read. One row per (resource, user): grant, lock, or deny.
+type MemberChoice = "default" | "none" | "view" | "edit";
 
-interface Resource {
-  key: string;
-  kind: "folder" | "file";
-  id: string;
-  path: string;
-  name: string;
-  depth: number;
-}
+/** One row in the item list (see `lib/accessTree`). */
+type Resource = AccessRow;
 
 const ICON = {
   folder: (
@@ -71,6 +74,17 @@ const ICON = {
   shield: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12 3l7 3v6c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6z" />
+    </svg>
+  ),
+  chevron: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 6l6 6-6 6" />
+    </svg>
+  ),
+  block: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M5.6 5.6l12.8 12.8" />
     </svg>
   ),
   spark: (
@@ -138,7 +152,17 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   const tree = useStore((s) => s.tree);
   const syncEnabled = useStore((s) => s.syncEnabled);
 
-  const [selectedKey, setSelectedKey] = useState<string>("");
+  /**
+   * The item whose access is being edited. Held as the row itself, not just its
+   * key, so collapsing a folder doesn't blank the detail pane out from under
+   * someone who is halfway through configuring a note inside it.
+   */
+  const [selected, setSelected] = useState<Resource | null>(null);
+  const selectedKey = selected?.key ?? "";
+  /** Folder paths currently open in the list. */
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  /** Folder paths whose children are being fetched from Rust right now. */
+  const [expanding, setExpanding] = useState<Set<string>>(() => new Set());
   const [shares, setShares] = useState<Share[]>([]);
   const [access, setAccess] = useState<ResolvedMemberAccess[] | null>(null);
   const [wsShares, setWsShares] = useState<Share[]>([]);
@@ -172,30 +196,64 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   );
   const wsPosture: Mode = wsGrant ? (wsGrant.permission === "edit" ? "open" : "readonly") : "private";
 
-  // Flatten every synced folder + note into an indented list.
-  const resources = useMemo<Resource[]>(() => {
-    const out: Resource[] = [];
-    const walk = (n: TreeNode, depth: number) => {
-      if (n.isDir) {
-        const id = syncManager.registry.getFolderId(n.path);
-        if (id) out.push({ key: `folder:${id}`, kind: "folder", id, path: n.path, name: baseName(n.path), depth });
-      } else {
-        const m = syncManager.registry.getMapping(n.path);
-        if (m) out.push({ key: `file:${m.docId}`, kind: "file", id: m.docId, path: n.path, name: baseName(n.path, true), depth });
-      }
-      n.children?.forEach((c) => walk(c, depth + 1));
-    };
-    tree?.children?.forEach((c) => walk(c, 0));
-    return out;
-  }, [tree]);
+  /**
+   * The rows currently on screen: the vault tree, indented, with a collapsed
+   * folder's contents left out. The rule that makes it work — an un-listed
+   * folder is expandable, not empty — lives in `lib/accessTree` where a test
+   * can hold it.
+   */
+  const resources = useMemo<Resource[]>(
+    () =>
+      visibleAccessRows(tree, expanded, {
+        folderId: (path) => syncManager.registry.getFolderId(path),
+        docId: (path) => syncManager.registry.getMapping(path)?.docId ?? null,
+      }),
+    [tree, expanded],
+  );
+
+  /**
+   * Open/close a folder, pulling its children off disk the first time.
+   *
+   * `loadChildren` is the same lazy listing the sidebar uses, so expanding here
+   * populates the sidebar too — one tree, one cache, no second code path that
+   * could show a different vault.
+   */
+  const toggleFolder = async (path: string, loaded: boolean) => {
+    const next = new Set(expanded);
+    if (next.has(path)) {
+      next.delete(path);
+      setExpanded(next);
+      return;
+    }
+    next.add(path);
+    setExpanded(next);
+    if (loaded) return;
+    setExpanding((prev) => new Set(prev).add(path));
+    try {
+      await useStore.getState().loadChildren(path);
+    } catch {
+      /* a failed listing just leaves the folder looking empty */
+    } finally {
+      setExpanding((prev) => {
+        const s2 = new Set(prev);
+        s2.delete(path);
+        return s2;
+      });
+    }
+  };
+
+  /** Reveal a path in the list by opening every folder above it. */
+  const revealPath = (path: string) => {
+    const above = ancestorPaths(path);
+    if (above.length === 0) return;
+    setExpanded((prev) => new Set([...prev, ...above]));
+  };
 
   const lockMap = useMemo(() => buildLockMap(tree, locks), [tree, locks]);
   const directScopes = useMemo(
     () => lockScopesByPath(tree, locks, session?.user.id),
     [tree, locks, session?.user.id],
   );
-
-  const selected = resources.find((r) => r.key === selectedKey) ?? null;
 
   const memberByUser = (userId: string) => members.find((m) => m.userId === userId);
   const displayName = (userId: string, fallback?: string | null) => {
@@ -354,6 +412,14 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   };
 
   const memberChoice = (userId: string): MemberChoice => {
+    // Deny first — it's the row that outranks every other, here as on the server.
+    const denied = shares.find(
+      (s) =>
+        sharePrincipalType(s) === "user" &&
+        sharePrincipalId(s) === userId &&
+        s.permission === "denied",
+    );
+    if (denied) return "none";
     // A per-user lock reads back as read-only ("view"); an edit grant as "edit".
     // A legacy view grant also maps to "view" (it will be rewritten as a lock
     // the next time the member is set, so it actually takes effect).
@@ -362,7 +428,11 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
     );
     if (lock) return "view";
     const grant = shares.find(
-      (s) => sharePrincipalType(s) === "user" && sharePrincipalId(s) === userId && s.permission !== "locked",
+      (s) =>
+        sharePrincipalType(s) === "user" &&
+        sharePrincipalId(s) === userId &&
+        s.permission !== "locked" &&
+        s.permission !== "denied",
     );
     if (grant?.permission === "edit") return "edit";
     if (grant?.permission === "view") return "view";
@@ -376,11 +446,23 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
       // unique (resource, principal) key means only one can exist at a time.
       for (const s of shares) {
         if (sharePrincipalType(s) === "user" && sharePrincipalId(s) === userId) {
+          // Locks go through the store so the sidebar's badge cache stays in
+          // step; grants and denies are plain share rows.
           if (s.permission === "locked") await useStore.getState().removeLock(s.id);
           else await authManager.api.revokeShare(s.id);
         }
       }
-      if (choice === "edit") {
+      if (choice === "none") {
+        // The one subtractive row. It beats the vault's Open grant, an admin's
+        // blanket edit, and even "you created this note" — which is the point:
+        // "not for Sam" has to mean it on the notes Sam wrote too.
+        await authManager.api.createShare({
+          resourceType: selected.kind,
+          resourceId: selected.id,
+          principalId: userId,
+          permission: "denied",
+        });
+      } else if (choice === "edit") {
         await authManager.api.createShare({
           resourceType: selected.kind,
           resourceId: selected.id,
@@ -411,8 +493,15 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
 
       {canManage && orgId && (
         <div className="access-ws">
-          <div className="access-seclabel">This vault, by default</div>
-          <div className="access-seg" aria-disabled={busy}>
+          <div className="access-seclabel">
+            This vault, by default
+            {busy && (
+              <span className="access-applying">
+                <Spinner size="xs" /> Applying…
+              </span>
+            )}
+          </div>
+          <div className={`access-seg${busy ? " busy" : ""}`} aria-busy={busy} aria-disabled={busy}>
             {(["open", "readonly", "private"] as Mode[]).map((m) => (
               <button
                 key={m}
@@ -456,13 +545,34 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                 const affected = everyone
                   ? members.map((m) => m.userId)
                   : [...(lk?.users ?? [])];
+                const isOpen = expanded.has(r.path);
                 return (
-                  <li key={r.key}>
+                  // The twisty is a SIBLING of the row button, not a child.
+                  // Opening a folder and selecting it are different intents, and
+                  // an interactive element nested inside a button is both wrong
+                  // for assistive tech and unreachable by keyboard.
+                  <li
+                    key={r.key}
+                    className="access-item"
+                    style={{ paddingLeft: `${10 + r.depth * 16}px` }}
+                  >
+                    {r.kind === "folder" && r.expandable ? (
+                      <button
+                        type="button"
+                        className={`access-twisty${isOpen ? " open" : ""}`}
+                        aria-label={isOpen ? `Collapse ${r.name}` : `Expand ${r.name}`}
+                        aria-expanded={isOpen}
+                        onClick={() => void toggleFolder(r.path, folderChildrenLoaded(tree, r.path))}
+                      >
+                        {expanding.has(r.path) ? <Spinner size="xs" /> : ICON.chevron}
+                      </button>
+                    ) : (
+                      <span className="access-twisty spacer" aria-hidden="true" />
+                    )}
                     <button
                       type="button"
                       className={`access-row${r.key === selectedKey ? " sel" : ""}`}
-                      style={{ paddingLeft: `${10 + r.depth * 16}px` }}
-                      onClick={() => setSelectedKey(r.key)}
+                      onClick={() => setSelected(r)}
                     >
                       <span className="access-glyph">{r.kind === "folder" ? ICON.folder : ICON.note}</span>
                       <span className="access-rname">{r.name}</span>
@@ -533,7 +643,13 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                     Access is managed by <strong>{inheritSourceRes?.name ?? inheritSource}</strong> — this{" "}
                     {selected.kind === "folder" ? "folder" : "note"} is read-only.{" "}
                     {inheritSourceRes && (
-                      <button className="access-jump" onClick={() => setSelectedKey(inheritSourceRes.key)}>
+                      <button
+                        className="access-jump"
+                        onClick={() => {
+                          revealPath(inheritSourceRes.path);
+                          setSelected(inheritSourceRes);
+                        }}
+                      >
                         Open {inheritSourceRes.name} ›
                       </button>
                     )}
@@ -552,8 +668,21 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
 
               <div className="access-seclabel">
                 {selected.kind === "folder" ? "Access for this folder & everything inside" : "Access mode"}
+                {/* Applying a mode is several round trips (revoke the old rows,
+                    write the new one, re-resolve every member) and it kicks live
+                    sockets, so it is genuinely slow. Saying so is the difference
+                    between "working" and "broken". */}
+                {busy && (
+                  <span className="access-applying">
+                    <Spinner size="xs" /> Applying…
+                  </span>
+                )}
               </div>
-              <div className="access-seg" aria-disabled={!canManage || inheritedOrgLock}>
+              <div
+                className={`access-seg${busy ? " busy" : ""}`}
+                aria-busy={busy}
+                aria-disabled={!canManage || inheritedOrgLock}
+              >
                 {(["open", "readonly", "private"] as Mode[]).map((m) => (
                   <button
                     key={m}
@@ -586,7 +715,12 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
               )}
 
               <div className="access-seclabel">
-                Who can access{loading ? " · resolving…" : ""}
+                Who can access
+                {loading && (
+                  <span className="access-applying">
+                    <Spinner size="xs" /> Resolving…
+                  </span>
+                )}
               </div>
 
               {!canManage ? (
@@ -621,7 +755,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                           </div>
                           <div className="access-prole">{sourceLabel(m, choice)}</div>
                         </div>
-                        {canManage && m.role !== "owner" && !everyoneReadonly ? (
+                        {canManage && m.role !== "owner" ? (
                           <select
                             className="access-choice"
                             value={choice}
@@ -629,8 +763,13 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                             onChange={(e) => setMember(m.userId, e.target.value as MemberChoice)}
                           >
                             <option value="default">Default</option>
-                            <option value="view">Can view (read-only)</option>
-                            <option value="edit">Can edit</option>
+                            {/* An Everyone/parent lock already holds everyone at
+                                read-only, so offering "can view"/"can edit" here
+                                would promise something the lock overrides. "No
+                                access" still works — a deny outranks a lock. */}
+                            {!everyoneReadonly && <option value="view">Can view (read-only)</option>}
+                            {!everyoneReadonly && <option value="edit">Can edit</option>}
+                            <option value="none">No access (blocked)</option>
                           </select>
                         ) : (
                           <span className={`access-lv ${levelCls(m.permission)}`}>{levelLabel(m.permission)}</span>
@@ -660,10 +799,6 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
 
 // --- small pure helpers ------------------------------------------------------
 
-function baseName(path: string, stripMd = false): string {
-  const last = path.split("/").pop() ?? path;
-  return stripMd ? last.replace(/\.md$/i, "") : last;
-}
 
 function levelLabel(p: "edit" | "view" | "none"): string {
   return p === "edit" ? "Full access" : p === "view" ? "Can view" : "No access";
@@ -679,6 +814,7 @@ function claudeCls(p: "edit" | "view" | "none"): string {
 }
 
 function sourceLabel(m: ResolvedMemberAccess, choice: MemberChoice): string {
+  if (choice === "none" || m.denied) return "Blocked · no access";
   if (m.permission === "none") return "No access";
   if (m.capped) return "Read-only · locked";
   if (m.role === "owner") return "Owner · full access";

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -27,6 +27,7 @@ import { AsyncButton } from "./AsyncButton";
 import { canActOnMember } from "./memberRoles";
 import { RoleSelect } from "./RoleSelect";
 import { Avatar, SyncBadge } from "./Identity";
+import { Switch } from "./Switch";
 import { Spinner } from "./Spinner";
 import { ThemeToggle } from "./ThemeToggle";
 import { UpgradeDialog } from "./UpgradeDialog";
@@ -534,7 +535,6 @@ function AccountPopover({
   if (!session) return null;
   const rows = splitVaultRows(organizations.length, locals.length);
   const activeOrgId = session.activeOrganizationId;
-  const userLabel = session.user.name || session.user.email;
   // "Current" tracks the vault whose folder is actually OPEN right now —
   // not merely the account's active org. After signing in you can be viewing a
   // local folder while an org is active; only one row may read "Current".
@@ -558,14 +558,14 @@ function AccountPopover({
   };
 
   return (
+    // No identity card at the top. The trigger this popover opens from IS the
+    // identity card — name, email and avatar, permanently on screen in the
+    // sidebar footer — so repeating it here spent the most valuable row in the
+    // menu saying something the user was already looking at. Home takes that
+    // row instead: it's the one destination, and it was previously buried
+    // below the fold on an account with several vaults.
     <div className="account-popover" role="menu">
-      <div className="menu-account">
-        <Avatar label={userLabel} image={session.user.image} />
-        <span className="identity-meta">
-          <span className="identity-line1">{session.user.name || "—"}</span>
-          <span className="identity-line2">{session.user.email}</span>
-        </span>
-      </div>
+      {vault && <HomeButton onClose={onClose} />}
 
       {userInvitations.length > 0 && (
         <div className="invite-inbox">
@@ -591,7 +591,6 @@ function AccountPopover({
       )}
 
       <div className="menu-sep" />
-      {vault && <HomeButton onClose={onClose} />}
       <div className="menu-label">Remote vaults</div>
 
       {/* Active vault pinned to the top — it's the one you're working in.
@@ -1499,12 +1498,12 @@ function FreezeRootRow({ canManage }: { canManage: boolean }) {
             Nothing already at the root is moved, renamed, or hidden.
           </span>
         </span>
-        <input
-          type="checkbox"
+        <Switch
           checked={rootFrozen}
           disabled={!canManage || busy}
+          ariaLabel="Freeze vault root"
           title={canManage ? undefined : "Only an owner or admin can change this"}
-          onChange={(e) => void flip(e.target.checked)}
+          onChange={(next) => void flip(next)}
         />
       </label>
       {!canManage && (

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1280,6 +1280,7 @@ function VaultSettingsDialog({
           {tab === "general" ? (
             <GeneralTab
               isSynced={isSynced}
+              canManage={canManage}
               activeOrgName={activeOrg?.name ?? null}
               onRequestSignIn={onRequestSignIn}
             />
@@ -1296,10 +1297,7 @@ function VaultSettingsDialog({
           ) : tab === "mcp" ? (
             <McpTab />
           ) : tab === "versioning" ? (
-            <VersioningTab
-              canManage={canManage}
-              isOwner={myMember?.role === "owner"}
-            />
+            <VersioningTab canManage={canManage} />
           ) : tab === "import-export" ? (
             <ImportExportTab />
           ) : tab === "updates" ? (
@@ -1320,10 +1318,13 @@ function VaultSettingsDialog({
  */
 function GeneralTab({
   isSynced,
+  canManage,
   activeOrgName,
   onRequestSignIn,
 }: {
   isSynced: boolean;
+  /** Owner/admin — the only roles that may flip a vault-wide latch. */
+  canManage: boolean;
   activeOrgName: string | null;
   onRequestSignIn?: () => void;
 }) {
@@ -1439,6 +1440,8 @@ function GeneralTab({
         </>
       )}
 
+      {isSynced && <FreezeRootRow canManage={canManage} />}
+
       <div className="menu-sep" />
       <div className="subhead">Folder on disk</div>
       <div className="join-code-row">
@@ -1448,6 +1451,70 @@ function GeneralTab({
       </div>
 
       {upgradeOpen && <UpgradeDialog onClose={() => setUpgradeOpen(false)} />}
+    </>
+  );
+}
+
+/**
+ * The "Freeze vault root" latch.
+ *
+ * A vault's top level is the one place where a stray note or folder is most
+ * visible and least recoverable — everyone sees it, and nobody is sure whose it
+ * is. Once a team has agreed the top-level shape, this closes it: new notes and
+ * folders have to go inside an existing folder.
+ *
+ * Deliberately applies to EVERYONE, owners and admins included, because the
+ * accidental root folder is almost always created by someone who does have
+ * permission. Only an owner/admin can lift it; everyone else sees the switch in
+ * its real state, disabled, so the rule is visible rather than mysterious.
+ */
+function FreezeRootRow({ canManage }: { canManage: boolean }) {
+  const rootFrozen = useStore((s) => s.rootFrozen);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const flip = async (next: boolean) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await useStore.getState().setRootFrozen(next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="menu-sep" />
+      <div className="subhead">Vault structure</div>
+      <label className="menu-row toggle-row">
+        <span className="menu-row-label">
+          Freeze vault root
+          <span className="field-hint">
+            Stops anything new being created at the top level of this vault —
+            new notes and folders have to go inside an existing folder. Applies
+            to everyone, including you; only an owner or admin can turn it off.
+            Nothing already at the root is moved, renamed, or hidden.
+          </span>
+        </span>
+        <input
+          type="checkbox"
+          checked={rootFrozen}
+          disabled={!canManage || busy}
+          title={canManage ? undefined : "Only an owner or admin can change this"}
+          onChange={(e) => void flip(e.target.checked)}
+        />
+      </label>
+      {!canManage && (
+        <div className="muted">
+          {rootFrozen
+            ? "This vault's root is frozen. Ask an owner or admin to unfreeze it."
+            : "Only an owner or admin can freeze this vault's root."}
+        </div>
+      )}
+      {error && <div className="auth-error">{error}</div>}
     </>
   );
 }
@@ -2358,18 +2425,16 @@ function LimitNudge({
 
 /**
  * Versioning: the vault-wide safety net. Lists the vault's checkpoints (max 5 —
- * a daily automatic one plus manual ones), lets owners/admins take one on
- * demand, and lets the OWNER roll the whole vault back to one. Per-note history
- * lives in the editor's version panel; this page is for the blast-radius case
- * ("the reorg went wrong, put everything back").
+ * a daily automatic one plus manual ones), and lets an owner OR admin take one
+ * and roll the whole vault back to it. Per-note history lives in the editor's
+ * version panel; this page is for the blast-radius case ("the reorg went wrong,
+ * put everything back").
+ *
+ * Revert used to be owner-only. It is the recovery half of an action admins
+ * could already take (create/delete a checkpoint), so a team whose owner was
+ * away could take checkpoints and not use them.
  */
-function VersioningTab({
-  canManage,
-  isOwner,
-}: {
-  canManage: boolean;
-  isOwner: boolean;
-}) {
+function VersioningTab({ canManage }: { canManage: boolean }) {
   const checkpoints = useStore((s) => s.checkpoints);
   const [label, setLabel] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -2464,7 +2529,7 @@ function VersioningTab({
                   {cp.createdByName ? ` · by ${cp.createdByName}` : ""}
                 </span>
               </span>
-              {isOwner && (
+              {canManage && (
                 <button className="link-btn" onClick={() => setConfirming(cp)}>
                   Revert
                 </button>
@@ -2478,9 +2543,9 @@ function VersioningTab({
           ))}
         </ul>
       )}
-      {!isOwner && (
+      {!canManage && (
         <div className="muted checkpoint-note">
-          Only the vault owner can revert to a checkpoint.
+          Only a vault owner or admin can revert to a checkpoint.
         </div>
       )}
       {confirming && (

--- a/app/apps/desktop/src/components/AccountSettings.tsx
+++ b/app/apps/desktop/src/components/AccountSettings.tsx
@@ -3,6 +3,7 @@ import { ACTIVITY_STATUSES, type ActivityStatus } from "../lib/prefs";
 import { checkForUpdate, currentVersion, installUpdate, useUpdateState } from "../lib/updater";
 import { useStore } from "../store";
 import { Avatar } from "./Identity";
+import { Switch } from "./Switch";
 import { ThemeToggle } from "./ThemeToggle";
 
 /**
@@ -305,10 +306,10 @@ function NotificationsTab() {
         Mention chime
         <span className="field-hint">Play a sound when a teammate pings you.</span>
       </span>
-      <input
-        type="checkbox"
+      <Switch
         checked={mentionSound}
-        onChange={(e) => useStore.getState().setMentionSound(e.target.checked)}
+        ariaLabel="Mention chime"
+        onChange={(next) => useStore.getState().setMentionSound(next)}
       />
     </label>
   );

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -49,6 +49,10 @@ import { characterSvg } from "./Identity";
 import { ShareDialog, type ShareTarget } from "./ShareDialog";
 import { placeMenu, type Placement } from "../lib/menuPlacement";
 
+/** Tooltip on every root-create affordance while the vault's root is frozen. */
+const ROOT_FROZEN_HINT =
+  "This vault's root is frozen — new notes and folders go inside a folder.";
+
 interface Dimensions {
   width: number;
   height: number;
@@ -187,6 +191,7 @@ export function FileTree() {
   const session = useStore((s) => s.session);
   const members = useStore((s) => s.members);
   const itemColors = useStore((s) => s.itemColors);
+  const rootFrozen = useStore((s) => s.rootFrozen);
   const itemOrder = useStore((s) => s.itemOrder);
   const treeSort = useStore((s) => s.treeSort);
   const docSyncState = useStore((s) => s.docSyncState);
@@ -609,6 +614,7 @@ export function FileTree() {
   /** Pick files and import them into `dir` (vault-relative; "" = root). */
   async function importFilesInto(dir: string) {
     setMenu(null);
+    if (rootBlocked(dir)) return;
     try {
       // Captured BEFORE the native picker — the longest await in the app, and
       // `dir` came from the tree that was on screen when it opened.
@@ -628,6 +634,7 @@ export function FileTree() {
   /** Pick a folder and import it into `dir`. */
   async function importFolderInto(dir: string) {
     setMenu(null);
+    if (rootBlocked(dir)) return;
     try {
       const epoch = useStore.getState().vault?.epoch; // before the dialog
       const src = await ipc.pickFolder();
@@ -639,6 +646,26 @@ export function FileTree() {
     } catch (e) {
       console.error("import folder failed", e);
       flashStatus("Import failed", "error");
+    }
+  }
+
+  /**
+   * Show one note/folder in the OS file manager.
+   *
+   * Notes really are files on disk — that's the product — so being able to get
+   * to one from the sidebar is the shortest bridge between the app and the rest
+   * of the machine. The absolute path is the vault root joined with the
+   * vault-relative path the tree already knows.
+   */
+  async function revealNode(node: NodeApi<TreeNode>) {
+    setMenu(null);
+    const root = useStore.getState().vault?.path;
+    if (!root) return;
+    try {
+      await ipc.revealInFileManager(`${root}/${node.data.path}`);
+    } catch (e) {
+      console.error("reveal failed", e);
+      toast("Couldn't open that in the file manager", "error");
     }
   }
 
@@ -724,6 +751,16 @@ export function FileTree() {
     // dragIds are node ids === current paths. Their paths after the drop only
     // change when the parent folder changes (a reorder keeps the same path).
     const from = dragIds;
+    // Dragging something OUT to a frozen root is a root create by another name.
+    // Reordering things already at the root is fine — the shape doesn't change.
+    if (
+      destDir === "" &&
+      rootFrozen &&
+      dragIds.some((p) => p.includes("/"))
+    ) {
+      toast("This vault's root is frozen — drop this inside a folder.", "error");
+      return;
+    }
     const to = from.map((p) => {
       const dest = destDir ? `${destDir}/${basename(p)}` : basename(p);
       return dest;
@@ -1013,7 +1050,24 @@ export function FileTree() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, nodeByPath]);
 
+  /**
+   * Refuse a create/import at the vault root when the root is frozen.
+   *
+   * Client-side first, purely so the user gets a sentence instead of a failed
+   * write — the server enforces the same latch and is the authority. Only the
+   * root is affected; anything nested is untouched.
+   */
+  function rootBlocked(dir: string): boolean {
+    if (dir !== "" || !rootFrozen) return false;
+    toast(
+      "This vault's root is frozen — create this inside a folder instead.",
+      "error",
+    );
+    return true;
+  }
+
   async function createUniqueNote(dir: string) {
+    if (rootBlocked(dir)) return;
     let name = "Untitled";
     for (let i = 0; i < 50; i++) {
       const candidate = i === 0 ? name : `${name} ${i}`;
@@ -1045,6 +1099,7 @@ export function FileTree() {
   }
 
   async function createUniqueFolder(dir: string) {
+    if (rootBlocked(dir)) return;
     let name = "New Folder";
     for (let i = 0; i < 50; i++) {
       const candidate = i === 0 ? name : `${name} ${i}`;
@@ -1122,16 +1177,18 @@ export function FileTree() {
         <div className="filetree-actions">
           <button
             className="tree-tool"
-            title="New note"
+            title={rootFrozen ? ROOT_FROZEN_HINT : "New note"}
             aria-label="New note"
+            disabled={rootFrozen}
             onClick={() => createUniqueNote("")}
           >
             {ICON_NEW_NOTE}
           </button>
           <button
             className="tree-tool"
-            title="New folder"
+            title={rootFrozen ? ROOT_FROZEN_HINT : "New folder"}
             aria-label="New folder"
+            disabled={rootFrozen}
             onClick={() => createUniqueFolder("")}
           >
             {ICON_NEW_FOLDER}
@@ -1367,6 +1424,9 @@ export function FileTree() {
           </li>
           <li onClick={() => void importFolderInto(menuDir)}>Import folder…</li>
           {menu.node && <li onClick={() => void exportNode(menu.node!)}>Export…</li>}
+          {menu.node && (
+            <li onClick={() => void revealNode(menu.node!)}>{ipc.revealLabel()}</li>
+          )}
           {menu.node && <li onClick={() => menu.node!.edit()}>Rename</li>}
           {/* The same vault-wide sort as the header button. A per-folder sort
               would be a third arrangement layer fighting the other two, so

--- a/app/apps/desktop/src/components/MenuSelect.tsx
+++ b/app/apps/desktop/src/components/MenuSelect.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { placeMenu, type Placement } from "../lib/menuPlacement";
 
 /**
@@ -11,12 +12,20 @@ import { placeMenu, type Placement } from "../lib/menuPlacement";
  * a `.context-menu` of menuitemradio rows — so both places stay one control
  * rather than two that drift.
  *
- * The menu is positioned in VIEWPORT coordinates (`position: fixed`) through the
- * same `placeMenu` the file tree uses, rather than being absolutely parked under
- * the trigger. Parking it there meant the last row of a list opened a menu that
- * ran off the bottom of the window — and the last row is exactly where a member
- * list puts the person you most recently added. Fixed positioning also lifts it
- * out of any scrolling ancestor, so it can't be clipped by one.
+ * The menu is positioned in VIEWPORT coordinates through the same `placeMenu`
+ * the file tree uses, rather than being absolutely parked under the trigger.
+ * Parking it there meant the last row of a list opened a menu that ran off the
+ * bottom of the window — and the last row is exactly where a member list puts
+ * the person you most recently added.
+ *
+ * It is also PORTALLED to `document.body`, which `position: fixed` alone does
+ * not achieve. Any ancestor with a transform becomes the containing block for
+ * fixed descendants and clips them with its own overflow — and the settings
+ * page has one by accident: `.settings-content` animates in with
+ * `animation-fill-mode: both`, so its final keyframe's `transform: translateY(0)`
+ * stays applied forever. The menu was landing inside that card's coordinate
+ * space and being sliced by its scrollbar. A portal is immune to that whatever
+ * gets styled above it later.
  *
  * Self-contained dismissal (outside-mousedown + Escape), unlike FileTree's menu
  * which owns a window-level dismiss of its own.
@@ -59,8 +68,11 @@ export function MenuSelect<T extends string>({
   useEffect(() => {
     if (!open) return;
     const onMouseDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-      if (menuRef.current && menuRef.current.contains(e.target as Node)) return;
+      const target = e.target as Node;
+      // The menu is portalled, so it is NOT inside the wrap — both have to be
+      // checked or clicking the menu would dismiss it before the click landed.
+      if (wrapRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
@@ -130,11 +142,13 @@ export function MenuSelect<T extends string>({
           ▾
         </span>
       </button>
-      {open && (
+      {open &&
+        createPortal(
         <ul
           ref={menuRef}
-          className={`context-menu role-menu${menuClassName ? ` ${menuClassName}` : ""}`}
+          className={`context-menu role-menu menu-portal${menuClassName ? ` ${menuClassName}` : ""}`}
           role="menu"
+          onClick={(e) => e.stopPropagation()}
           style={
             pos
               ? { position: "fixed", left: pos.left, top: pos.top, right: "auto", maxHeight: pos.maxHeight }
@@ -163,7 +177,8 @@ export function MenuSelect<T extends string>({
               </span>
             </li>
           ))}
-        </ul>
+        </ul>,
+        document.body,
       )}
     </div>
   );

--- a/app/apps/desktop/src/components/MenuSelect.tsx
+++ b/app/apps/desktop/src/components/MenuSelect.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * The app's one popover select.
+ *
+ * Extracted from `RoleSelect` (which is now a thin wrapper over it) when the
+ * Access panel needed the same control: a native `<select>` there was the only
+ * OS-chrome dropdown left in the product, and it read as unfinished next to the
+ * Members page. Anatomy is unchanged — a trigger with aria-haspopup/expanded and
+ * a button-anchored `.context-menu` of menuitemradio rows — so both places stay
+ * one control rather than two that drift.
+ *
+ * Self-contained dismissal (outside-mousedown + Escape), unlike FileTree's menu
+ * which owns a window-level dismiss of its own.
+ */
+
+export interface MenuSelectOption<T extends string> {
+  value: T;
+  label: string;
+  /** Optional second line, for options whose consequence needs saying. */
+  hint?: string;
+}
+
+export function MenuSelect<T extends string>({
+  value,
+  options,
+  onSelect,
+  disabled,
+  ariaLabel,
+  triggerClassName,
+  menuClassName,
+}: {
+  value: T;
+  options: ReadonlyArray<MenuSelectOption<T>>;
+  onSelect: (value: T) => void | Promise<void>;
+  disabled?: boolean;
+  ariaLabel: string;
+  /** Trigger styling — the caller decides whether it's a field or a pill. */
+  triggerClassName: string;
+  menuClassName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  // A value with no matching option still has to render something — falling
+  // back to the raw value beats an empty trigger that looks broken.
+  const current = options.find((o) => o.value === value);
+
+  return (
+    // Swallow clicks so a dialog-level dismiss can't eat the opening click.
+    <div className="role-select-wrap" ref={wrapRef} onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        className={triggerClassName}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="role-trigger-label">{current?.label ?? value}</span>
+        <span className="role-caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {open && (
+        <ul className={`context-menu role-menu${menuClassName ? ` ${menuClassName}` : ""}`} role="menu">
+          {options.map((o) => (
+            <li
+              key={o.value}
+              role="menuitemradio"
+              aria-checked={value === o.value}
+              className={value === o.value ? "is-on" : undefined}
+              onClick={() => {
+                setOpen(false);
+                if (o.value !== value) void onSelect(o.value);
+              }}
+            >
+              <span className="menu-tick" aria-hidden="true">
+                {value === o.value ? "✓" : ""}
+              </span>
+              <span className="role-option-label">
+                {o.label}
+                {o.hint && <span className="menu-option-hint">{o.hint}</span>}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/apps/desktop/src/components/MenuSelect.tsx
+++ b/app/apps/desktop/src/components/MenuSelect.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { placeMenu, type Placement } from "../lib/menuPlacement";
 
 /**
  * The app's one popover select.
@@ -7,8 +8,15 @@ import { useEffect, useRef, useState } from "react";
  * Access panel needed the same control: a native `<select>` there was the only
  * OS-chrome dropdown left in the product, and it read as unfinished next to the
  * Members page. Anatomy is unchanged — a trigger with aria-haspopup/expanded and
- * a button-anchored `.context-menu` of menuitemradio rows — so both places stay
- * one control rather than two that drift.
+ * a `.context-menu` of menuitemradio rows — so both places stay one control
+ * rather than two that drift.
+ *
+ * The menu is positioned in VIEWPORT coordinates (`position: fixed`) through the
+ * same `placeMenu` the file tree uses, rather than being absolutely parked under
+ * the trigger. Parking it there meant the last row of a list opened a menu that
+ * ran off the bottom of the window — and the last row is exactly where a member
+ * list puts the person you most recently added. Fixed positioning also lifts it
+ * out of any scrolling ancestor, so it can't be clipped by one.
  *
  * Self-contained dismissal (outside-mousedown + Escape), unlike FileTree's menu
  * which owns a window-level dismiss of its own.
@@ -20,6 +28,9 @@ export interface MenuSelectOption<T extends string> {
   /** Optional second line, for options whose consequence needs saying. */
   hint?: string;
 }
+
+/** Gap between the trigger and the menu, on whichever side it opens. */
+const OFFSET = 6;
 
 export function MenuSelect<T extends string>({
   value,
@@ -40,23 +51,62 @@ export function MenuSelect<T extends string>({
   menuClassName?: string;
 }) {
   const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<Placement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLUListElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
     const onMouseDown = (e: MouseEvent) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+      if (menuRef.current && menuRef.current.contains(e.target as Node)) return;
     };
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
     };
+    // The menu is fixed to the viewport, so anything that moves the trigger
+    // underneath it (a scroll, a resize) would leave it stranded. Closing is the
+    // honest response — re-anchoring mid-scroll makes the menu chase the cursor.
+    const dismiss = () => setOpen(false);
     document.addEventListener("mousedown", onMouseDown);
     document.addEventListener("keydown", onKeyDown);
+    window.addEventListener("resize", dismiss);
+    window.addEventListener("scroll", dismiss, true);
     return () => {
       document.removeEventListener("mousedown", onMouseDown);
       document.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("resize", dismiss);
+      window.removeEventListener("scroll", dismiss, true);
     };
   }, [open]);
+
+  // Measure-then-place, like the file tree's context menu: the menu renders
+  // once (hidden) so its real size is known, and only then gets a position.
+  // Guessing the height would be the bug this exists to avoid.
+  useLayoutEffect(() => {
+    if (!open) {
+      setPos(null);
+      return;
+    }
+    const menu = menuRef.current;
+    const trigger = triggerRef.current;
+    if (!menu || !trigger) return;
+    const anchor = trigger.getBoundingClientRect();
+    const size = { width: menu.offsetWidth, height: menu.offsetHeight };
+    setPos(
+      placeMenu(
+        {
+          // Right-aligned with the trigger, which is where these controls sit.
+          x: anchor.right - size.width,
+          y: anchor.bottom + OFFSET,
+          flipY: anchor.top - OFFSET,
+        },
+        size,
+        { width: window.innerWidth, height: window.innerHeight },
+      ),
+    );
+  }, [open, options.length]);
 
   // A value with no matching option still has to render something — falling
   // back to the raw value beats an empty trigger that looks broken.
@@ -66,6 +116,7 @@ export function MenuSelect<T extends string>({
     // Swallow clicks so a dialog-level dismiss can't eat the opening click.
     <div className="role-select-wrap" ref={wrapRef} onClick={(e) => e.stopPropagation()}>
       <button
+        ref={triggerRef}
         type="button"
         className={triggerClassName}
         disabled={disabled}
@@ -80,7 +131,18 @@ export function MenuSelect<T extends string>({
         </span>
       </button>
       {open && (
-        <ul className={`context-menu role-menu${menuClassName ? ` ${menuClassName}` : ""}`} role="menu">
+        <ul
+          ref={menuRef}
+          className={`context-menu role-menu${menuClassName ? ` ${menuClassName}` : ""}`}
+          role="menu"
+          style={
+            pos
+              ? { position: "fixed", left: pos.left, top: pos.top, right: "auto", maxHeight: pos.maxHeight }
+              : // The measuring pass: laid out but not shown, so it can't flash
+                // at the wrong place on the way to its real position.
+                { position: "fixed", left: 0, top: 0, right: "auto", visibility: "hidden" }
+          }
+        >
           {options.map((o) => (
             <li
               key={o.value}

--- a/app/apps/desktop/src/components/RoleSelect.tsx
+++ b/app/apps/desktop/src/components/RoleSelect.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useRef, useState } from "react";
 import { ASSIGNABLE_ROLES, type AssignableRole } from "./memberRoles";
+import { MenuSelect } from "./MenuSelect";
 
 /**
  * Role picker used by the Members tab — the invite bar ("field" variant) and
  * each member row ("pill" variant, styled like the static role badge it
  * replaces so unchangeable rows and changeable ones read as the same thing).
  *
- * Same popover anatomy as the file-tree sort menu: a trigger button with
- * aria-haspopup/aria-expanded and a button-anchored `.context-menu` of
- * menuitemradio items. Unlike FileTree (which owns a window-level dismiss),
- * this is self-contained: outside-mousedown and Escape close it.
+ * The popover itself lives in {@link MenuSelect}, shared with the Access
+ * panel's per-member picker; this is just the role-shaped face of it.
  */
 export function RoleSelect({
   value,
@@ -24,66 +22,16 @@ export function RoleSelect({
   ariaLabel: string;
   variant: "field" | "pill";
 }) {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", onMouseDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [open]);
-
-  const triggerClass =
-    variant === "pill" ? `member-role ${value} role-trigger` : "role-field-trigger";
-
   return (
-    // Swallow clicks so a dialog-level dismiss can't eat the opening click.
-    <div className="role-select-wrap" ref={wrapRef} onClick={(e) => e.stopPropagation()}>
-      <button
-        type="button"
-        className={triggerClass}
-        disabled={disabled}
-        aria-label={ariaLabel}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        <span className="role-trigger-label">{value}</span>
-        <span className="role-caret" aria-hidden="true">
-          ▾
-        </span>
-      </button>
-      {open && (
-        <ul className="context-menu role-menu" role="menu">
-          {ASSIGNABLE_ROLES.map((r) => (
-            <li
-              key={r}
-              role="menuitemradio"
-              aria-checked={value === r}
-              className={value === r ? "is-on" : undefined}
-              onClick={() => {
-                setOpen(false);
-                if (r !== value) void onSelect(r);
-              }}
-            >
-              <span className="menu-tick" aria-hidden="true">
-                {value === r ? "✓" : ""}
-              </span>
-              <span className="role-option-label">{r}</span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <MenuSelect
+      value={value}
+      options={ASSIGNABLE_ROLES.map((r) => ({ value: r, label: r }))}
+      onSelect={onSelect}
+      disabled={disabled}
+      ariaLabel={ariaLabel}
+      triggerClassName={
+        variant === "pill" ? `member-role ${value} role-trigger` : "role-field-trigger"
+      }
+    />
   );
 }

--- a/app/apps/desktop/src/components/ShareNoteButton.tsx
+++ b/app/apps/desktop/src/components/ShareNoteButton.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { buildNoteLink } from "../lib/shareLink";
+import { toast } from "../lib/toast";
+import { useStore } from "../store";
+import { CheckMark } from "./Spinner";
+
+/**
+ * "Copy link to this note" — the header's share affordance.
+ *
+ * One click, one clipboard write, no dialog: the thing people actually want is
+ * a link they can paste into chat, and every extra step between the note and
+ * the paste is a step where they give up and describe the note in words
+ * instead. Permissions already have a home (Access), so this button
+ * deliberately does not try to be a second one.
+ *
+ * The link carries a vault id and a doc_id and nothing else — opening it
+ * resolves both against whoever clicks, so sending it to someone without a
+ * grant hands them nothing.
+ */
+export function ShareNoteButton({ docId }: { docId: string }) {
+  const orgId = useStore((s) => s.session?.activeOrganizationId ?? null);
+  const [copied, setCopied] = useState(false);
+
+  // The tick is a state, so it has to be cleared — otherwise switching notes
+  // leaves a stale "copied" on a link nobody copied.
+  useEffect(() => {
+    if (!copied) return;
+    const id = window.setTimeout(() => setCopied(false), 1600);
+    return () => window.clearTimeout(id);
+  }, [copied]);
+  useEffect(() => setCopied(false), [docId]);
+
+  if (!orgId) return null;
+
+  const copy = async () => {
+    const link = buildNoteLink({ orgId, docId });
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+      toast("Link copied — anyone on your team with access can open it");
+    } catch {
+      toast("Couldn't copy the link", "error");
+    }
+  };
+
+  return (
+    <button
+      className={`icon-btn share-btn${copied ? " copied" : ""}`}
+      title="Copy a link to this note"
+      aria-label="Copy a link to this note"
+      onClick={() => void copy()}
+    >
+      {copied ? (
+        <CheckMark size="sm" />
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/app/apps/desktop/src/components/Switch.tsx
+++ b/app/apps/desktop/src/components/Switch.tsx
@@ -1,0 +1,41 @@
+/**
+ * The app's toggle switch.
+ *
+ * A real `<input type="checkbox">` underneath, visually replaced — so it keeps
+ * every behaviour a checkbox already has for free (label association, Space to
+ * toggle, focus ring, form semantics) and only the paint changes. Rebuilding it
+ * as a `<button role="switch">` would mean re-earning all of that by hand.
+ *
+ * The knob is animated because a setting like "Freeze vault root" is a
+ * *decision*, and a control that slides confirms the decision landed; a native
+ * checkbox blinking between two states does not.
+ */
+export function Switch({
+  checked,
+  onChange,
+  disabled,
+  ariaLabel,
+  title,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  title?: string;
+}) {
+  return (
+    <span className={`switch${checked ? " on" : ""}${disabled ? " is-disabled" : ""}`} title={title}>
+      <input
+        type="checkbox"
+        className="switch-input"
+        checked={checked}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span className="switch-track" aria-hidden="true">
+        <span className="switch-knob" />
+      </span>
+    </span>
+  );
+}

--- a/app/apps/desktop/src/lib/__tests__/accessTree.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/accessTree.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  accessRowName,
+  ancestorPaths,
+  folderChildrenLoaded,
+  visibleAccessRows,
+} from "../accessTree";
+import type { TreeNode } from "../ipc";
+
+const dir = (path: string, children?: TreeNode[], loaded = true): TreeNode => ({
+  id: path,
+  name: path.split("/").pop() ?? path,
+  path,
+  isDir: true,
+  children,
+  ...(loaded ? { childrenLoaded: true } : {}),
+});
+
+const file = (path: string): TreeNode => ({
+  id: path,
+  name: path.split("/").pop() ?? path,
+  path,
+  isDir: false,
+});
+
+/** Everything registered — the ordinary synced vault. */
+const allRegistered = {
+  folderId: (p: string) => `folder-${p}`,
+  docId: (p: string) => `doc-${p}`,
+};
+
+const root = (children: TreeNode[]): TreeNode => ({
+  id: "",
+  name: "vault",
+  path: "",
+  isDir: true,
+  children,
+  childrenLoaded: true,
+});
+
+describe("Access panel item tree", () => {
+  const tree = root([
+    dir("Docs", [file("Docs/spec.md"), dir("Docs/Specs", [file("Docs/Specs/deep.md")])]),
+    file("readme.md"),
+  ]);
+
+  it("shows only top-level rows when nothing is expanded", () => {
+    const rows = visibleAccessRows(tree, new Set(), allRegistered);
+    expect(rows.map((r) => r.path)).toEqual(["Docs", "readme.md"]);
+    expect(rows[0].expandable).toBe(true);
+    expect(rows[1].expandable).toBe(false);
+  });
+
+  it("reveals a folder's contents when it is expanded, indented one level", () => {
+    const rows = visibleAccessRows(tree, new Set(["Docs"]), allRegistered);
+    expect(rows.map((r) => r.path)).toEqual([
+      "Docs",
+      "Docs/spec.md",
+      "Docs/Specs",
+      "readme.md",
+    ]);
+    expect(rows.find((r) => r.path === "Docs/spec.md")?.depth).toBe(1);
+    // Its own children stay hidden until IT is expanded too.
+    const deeper = visibleAccessRows(tree, new Set(["Docs", "Docs/Specs"]), allRegistered);
+    expect(deeper.map((r) => r.path)).toContain("Docs/Specs/deep.md");
+    expect(deeper.find((r) => r.path === "Docs/Specs/deep.md")?.depth).toBe(2);
+  });
+
+  it("treats an un-listed folder as expandable, not empty", () => {
+    // The regression this whole tree exists for: the sidebar loads folders
+    // lazily, so a folder nobody has clicked arrives with no children. Calling
+    // that "empty" is what made the notes inside it unreachable here.
+    const lazy = root([dir("Unopened", undefined, false)]);
+    const rows = visibleAccessRows(lazy, new Set(), allRegistered);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].expandable).toBe(true);
+    expect(folderChildrenLoaded(lazy, "Unopened")).toBe(false);
+  });
+
+  it("offers no twisty for a folder known to be empty", () => {
+    const empty = root([dir("Empty", [])]);
+    expect(visibleAccessRows(empty, new Set(), allRegistered)[0].expandable).toBe(false);
+    expect(folderChildrenLoaded(empty, "Empty")).toBe(true);
+  });
+
+  it("skips unregistered rows but still walks through them", () => {
+    // A folder with no server id can't hold a share, yet the registered notes
+    // beneath it must stay reachable.
+    const rows = visibleAccessRows(tree, new Set(["Docs"]), {
+      folderId: (p) => (p === "Docs" ? null : `folder-${p}`),
+      docId: (p) => `doc-${p}`,
+    });
+    expect(rows.map((r) => r.path)).toEqual(["Docs/spec.md", "Docs/Specs", "readme.md"]);
+  });
+
+  it("keys rows by server id and strips .md from note names", () => {
+    const rows = visibleAccessRows(tree, new Set(["Docs"]), allRegistered);
+    expect(rows.find((r) => r.path === "Docs")?.key).toBe("folder:folder-Docs");
+    const note = rows.find((r) => r.path === "Docs/spec.md");
+    expect(note?.key).toBe("file:doc-Docs/spec.md");
+    expect(note?.name).toBe("spec");
+  });
+
+  it("names ancestors so a nested item can be revealed", () => {
+    expect(ancestorPaths("Docs/Specs/deep.md")).toEqual(["Docs", "Docs/Specs"]);
+    expect(ancestorPaths("readme.md")).toEqual([]);
+    expect(accessRowName("a/b/c.md", true)).toBe("c");
+  });
+
+  it("returns nothing for an empty vault", () => {
+    expect(visibleAccessRows(null, new Set(), allRegistered)).toEqual([]);
+  });
+});

--- a/app/apps/desktop/src/lib/__tests__/accessTree.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/accessTree.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   accessRowName,
   ancestorPaths,
+  entriesFromServer,
+  entriesFromTree,
   folderChildrenLoaded,
-  visibleAccessRows,
+  rowsFromEntries,
 } from "../accessTree";
 import type { TreeNode } from "../ipc";
 
@@ -23,12 +25,6 @@ const file = (path: string): TreeNode => ({
   isDir: false,
 });
 
-/** Everything registered — the ordinary synced vault. */
-const allRegistered = {
-  folderId: (p: string) => `folder-${p}`,
-  docId: (p: string) => `doc-${p}`,
-};
-
 const root = (children: TreeNode[]): TreeNode => ({
   id: "",
   name: "vault",
@@ -38,66 +34,84 @@ const root = (children: TreeNode[]): TreeNode => ({
   childrenLoaded: true,
 });
 
+/** Everything registered — the ordinary synced vault. */
+const allRegistered = {
+  folderId: (p: string) => `folder-${p}`,
+  docId: (p: string) => `doc-${p}`,
+};
+
+/** The server's structure listing for the tree used across these tests. */
+const serverTree = {
+  folders: [
+    { id: "f-docs", path: "Docs" },
+    { id: "f-specs", path: "Docs/Specs" },
+  ],
+  notes: [
+    { id: "d-spec", relPath: "Docs/spec.md" },
+    { id: "d-deep", relPath: "Docs/Specs/deep.md" },
+    { id: "d-readme", relPath: "readme.md" },
+  ],
+};
+
 describe("Access panel item tree", () => {
-  const tree = root([
-    dir("Docs", [file("Docs/spec.md"), dir("Docs/Specs", [file("Docs/Specs/deep.md")])]),
-    file("readme.md"),
-  ]);
+  const entries = entriesFromServer(serverTree);
 
   it("shows only top-level rows when nothing is expanded", () => {
-    const rows = visibleAccessRows(tree, new Set(), allRegistered);
+    const rows = rowsFromEntries(entries, new Set());
     expect(rows.map((r) => r.path)).toEqual(["Docs", "readme.md"]);
     expect(rows[0].expandable).toBe(true);
     expect(rows[1].expandable).toBe(false);
   });
 
-  it("reveals a folder's contents when it is expanded, indented one level", () => {
-    const rows = visibleAccessRows(tree, new Set(["Docs"]), allRegistered);
+  it("reveals a folder's contents when expanded, indented one level", () => {
+    const rows = rowsFromEntries(entries, new Set(["Docs"]));
     expect(rows.map((r) => r.path)).toEqual([
       "Docs",
-      "Docs/spec.md",
       "Docs/Specs",
+      "Docs/spec.md",
       "readme.md",
     ]);
     expect(rows.find((r) => r.path === "Docs/spec.md")?.depth).toBe(1);
-    // Its own children stay hidden until IT is expanded too.
-    const deeper = visibleAccessRows(tree, new Set(["Docs", "Docs/Specs"]), allRegistered);
+
+    const deeper = rowsFromEntries(entries, new Set(["Docs", "Docs/Specs"]));
     expect(deeper.map((r) => r.path)).toContain("Docs/Specs/deep.md");
     expect(deeper.find((r) => r.path === "Docs/Specs/deep.md")?.depth).toBe(2);
   });
 
-  it("treats an un-listed folder as expandable, not empty", () => {
-    // The regression this whole tree exists for: the sidebar loads folders
-    // lazily, so a folder nobody has clicked arrives with no children. Calling
-    // that "empty" is what made the notes inside it unreachable here.
-    const lazy = root([dir("Unopened", undefined, false)]);
-    const rows = visibleAccessRows(lazy, new Set(), allRegistered);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].expandable).toBe(true);
-    expect(folderChildrenLoaded(lazy, "Unopened")).toBe(false);
+  it("lists an item the caller has shut themselves out of", () => {
+    // The whole reason the panel reads the SERVER's structure. A Private item
+    // leaves the local disk, and this list is where you go to change your mind —
+    // sourcing it from the disk removed the row exactly when it was needed.
+    const rows = rowsFromEntries(entries, new Set());
+    expect(rows.map((r) => r.path)).toContain("Docs");
+    // Nothing about the row depends on the file existing locally.
+    expect(rows.find((r) => r.path === "readme.md")?.id).toBe("d-readme");
   });
 
-  it("offers no twisty for a folder known to be empty", () => {
-    const empty = root([dir("Empty", [])]);
-    expect(visibleAccessRows(empty, new Set(), allRegistered)[0].expandable).toBe(false);
-    expect(folderChildrenLoaded(empty, "Empty")).toBe(true);
+  it("offers no twisty for a folder with nothing inside it", () => {
+    const rows = rowsFromEntries(
+      entriesFromServer({ folders: [{ id: "f", path: "Empty" }], notes: [] }),
+      new Set(),
+    );
+    expect(rows[0].expandable).toBe(false);
   });
 
-  it("skips unregistered rows but still walks through them", () => {
-    // A folder with no server id can't hold a share, yet the registered notes
-    // beneath it must stay reachable.
-    const rows = visibleAccessRows(tree, new Set(["Docs"]), {
-      folderId: (p) => (p === "Docs" ? null : `folder-${p}`),
-      docId: (p) => `doc-${p}`,
-    });
-    expect(rows.map((r) => r.path)).toEqual(["Docs/spec.md", "Docs/Specs", "readme.md"]);
+  it("sorts folders before notes at each level", () => {
+    const rows = rowsFromEntries(
+      entriesFromServer({
+        folders: [{ id: "f", path: "Zebra" }],
+        notes: [{ id: "d", relPath: "apple.md" }],
+      }),
+      new Set(),
+    );
+    expect(rows.map((r) => r.path)).toEqual(["Zebra", "apple.md"]);
   });
 
   it("keys rows by server id and strips .md from note names", () => {
-    const rows = visibleAccessRows(tree, new Set(["Docs"]), allRegistered);
-    expect(rows.find((r) => r.path === "Docs")?.key).toBe("folder:folder-Docs");
+    const rows = rowsFromEntries(entries, new Set(["Docs"]));
+    expect(rows.find((r) => r.path === "Docs")?.key).toBe("folder:f-docs");
     const note = rows.find((r) => r.path === "Docs/spec.md");
-    expect(note?.key).toBe("file:doc-Docs/spec.md");
+    expect(note?.key).toBe("file:d-spec");
     expect(note?.name).toBe("spec");
   });
 
@@ -108,6 +122,59 @@ describe("Access panel item tree", () => {
   });
 
   it("returns nothing for an empty vault", () => {
-    expect(visibleAccessRows(null, new Set(), allRegistered)).toEqual([]);
+    expect(rowsFromEntries([], new Set())).toEqual([]);
+  });
+});
+
+describe("Access panel fallback to the local tree", () => {
+  // Used only while the server listing is in flight or was refused. It carries
+  // the lazy-loading rule the server source doesn't need.
+  const tree = root([
+    dir("Docs", [file("Docs/spec.md"), dir("Docs/Specs", [file("Docs/Specs/deep.md")])]),
+    file("readme.md"),
+  ]);
+
+  it("treats an un-listed folder as expandable, not empty", () => {
+    // The sidebar loads folders lazily, so a folder nobody has clicked arrives
+    // with no children. Calling that "empty" hid every note inside it.
+    const lazy = root([dir("Unopened", undefined, false)]);
+    const rows = rowsFromEntries(entriesFromTree(lazy, allRegistered), new Set());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].expandable).toBe(true);
+    expect(folderChildrenLoaded(lazy, "Unopened")).toBe(false);
+  });
+
+  it("offers no twisty for a folder known to be empty", () => {
+    const empty = root([dir("Empty", [])]);
+    const rows = rowsFromEntries(entriesFromTree(empty, allRegistered), new Set());
+    expect(rows[0].expandable).toBe(false);
+    expect(folderChildrenLoaded(empty, "Empty")).toBe(true);
+  });
+
+  it("skips unregistered rows but still walks through them", () => {
+    // A folder with no server id can't hold a share, yet the registered notes
+    // beneath it must stay reachable.
+    const rows = rowsFromEntries(
+      entriesFromTree(tree, {
+        folderId: (p) => (p === "Docs" ? null : `folder-${p}`),
+        docId: (p) => `doc-${p}`,
+      }),
+      new Set(["Docs"]),
+    );
+    expect(rows.map((r) => r.path)).toEqual(["Docs/Specs", "Docs/spec.md", "readme.md"]);
+  });
+
+  it("produces the same shape as the server source", () => {
+    const fromDisk = rowsFromEntries(entriesFromTree(tree, allRegistered), new Set(["Docs"]));
+    expect(fromDisk.map((r) => r.path)).toEqual([
+      "Docs",
+      "Docs/Specs",
+      "Docs/spec.md",
+      "readme.md",
+    ]);
+  });
+
+  it("returns nothing for an empty vault", () => {
+    expect(entriesFromTree(null, allRegistered)).toEqual([]);
   });
 });

--- a/app/apps/desktop/src/lib/__tests__/noteMetaListener.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/noteMetaListener.test.ts
@@ -32,6 +32,8 @@ const fakeRegistry = vi.hoisted(() => {
         reg.noteMetaListener = cb;
       },
     ),
+    // Item colors ride the same pull; this suite doesn't exercise them.
+    setColorListener: vi.fn(),
     setInboundHost: vi.fn(),
     mappedNotes: vi.fn((): Array<{ docId: string; relPath: string }> => []),
     isPushed: vi.fn(() => false),

--- a/app/apps/desktop/src/lib/__tests__/shareLink.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/shareLink.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildNoteLink, parseNoteLink, SHARE_SCHEME } from "../shareLink";
+
+/**
+ * The link format is a wire contract between two installs of the app, one of
+ * which may be an older release. These tests pin the shape, and — more
+ * importantly — pin that a hostile or malformed URL is a quiet `null` rather
+ * than a throw, because anything on the machine can hand us one.
+ */
+describe("share links", () => {
+  it("round-trips a vault + note id", () => {
+    const target = { orgId: "org_123", docId: "d0c-4bcd" };
+    const link = buildNoteLink(target);
+    expect(link).toBe(`${SHARE_SCHEME}://note/org_123/d0c-4bcd`);
+    expect(parseNoteLink(link)).toEqual(target);
+  });
+
+  it("round-trips ids that need escaping", () => {
+    const target = { orgId: "org/with slash", docId: "doc#hash?q" };
+    expect(parseNoteLink(buildNoteLink(target))).toEqual(target);
+  });
+
+  it("accepts the host-folded form some platforms deliver", () => {
+    // Depending on how the OS hands the URL over, "note" can land as the host
+    // or as the first path segment. Both have to parse, or links work on one
+    // platform and silently do nothing on another.
+    expect(parseNoteLink("baalda:///note/org_1/doc_1")).toEqual({
+      orgId: "org_1",
+      docId: "doc_1",
+    });
+  });
+
+  it("rejects anything that isn't one of ours", () => {
+    for (const url of [
+      "https://example.com/note/org/doc",
+      "baalda://vault/org_1",
+      "baalda://note/org_1", // no doc id
+      "baalda://note", // no ids at all
+      "not a url at all",
+      "",
+    ]) {
+      expect(parseNoteLink(url)).toBeNull();
+    }
+  });
+
+  it("carries ids only — never a path, a token, or content", () => {
+    const link = buildNoteLink({ orgId: "org_1", docId: "doc_1" });
+    expect(link).not.toMatch(/\.md/);
+    expect(link).not.toMatch(/token|secret|key/i);
+  });
+});

--- a/app/apps/desktop/src/lib/__tests__/updater.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/updater.test.ts
@@ -24,6 +24,14 @@ describe("releaseNoteLines", () => {
     ]);
   });
 
+  it("unwraps **bold** rather than showing the asterisks", () => {
+    // The same text is the GitHub release body, where emphasis reads well; here
+    // it lands in a plain <span> and the markers would just be litter.
+    expect(releaseNoteLines("- New **Private** setting for any folder or note")).toEqual([
+      "New Private setting for any folder or note",
+    ]);
+  });
+
   it("drops the legacy placeholder body entirely", () => {
     expect(
       releaseNoteLines("See the assets below to download and install this version."),

--- a/app/apps/desktop/src/lib/accessTree.ts
+++ b/app/apps/desktop/src/lib/accessTree.ts
@@ -1,25 +1,37 @@
-// Which rows the Access panel's item list shows, given the vault tree and the
-// set of open folders.
+// Which rows the Access panel's item list shows.
 //
-// Pure, and separate from the component, for one reason: the rule that a folder
-// with `childrenLoaded` unset is *expandable, not empty* is the whole fix for
-// "I can't reach the notes inside a folder". The sidebar loads folders lazily,
-// so an un-clicked folder arrives with no children at all — and treating that
-// as "nothing inside" is what hid every note the user hadn't already opened
-// elsewhere. A rule that subtle belongs somewhere a test can hold it still.
+// Pure, and separate from the component, because two rules here are subtle
+// enough to need a test holding them still:
+//
+//  1. The list is built from the SERVER's structure, not from this machine's
+//     disk. An item set to Private leaves the disk (a revocation that leaves a
+//     readable copy behind is cosmetic), and the panel used to draw its rows
+//     from the disk — so making something Private removed the only row you
+//     could un-Private it from. A restriction you cannot see is one you cannot
+//     lift.
+//  2. In the local-tree fallback, a folder with `childrenLoaded` unset is
+//     *expandable, not empty*. The sidebar loads folders lazily, so an
+//     un-clicked folder arrives with no children — and calling that "nothing
+//     inside" hid every note the user hadn't already opened elsewhere.
 
 import type { TreeNode } from "./ipc";
 
-export interface AccessRow {
-  key: string;
+/** One folder or note the panel can administer, before nesting is worked out. */
+export interface AccessEntry {
   kind: "folder" | "file";
   /** Server id: a folder id, or a note's doc_id. */
   id: string;
+  /** Vault-relative path. */
   path: string;
+  /** Folders only. `undefined` means "not listed yet" — see rule 2 above. */
+  hasChildren?: boolean;
+}
+
+export interface AccessRow extends AccessEntry {
+  key: string;
   name: string;
   depth: number;
-  /** Folders only: offer a twisty? True when there is (or might be) something
-   *  inside — see the note above about un-listed folders. */
+  /** Folders only: offer a twisty? */
   expandable: boolean;
 }
 
@@ -37,56 +49,107 @@ export function accessRowName(path: string, stripMd = false): string {
 }
 
 /**
- * Flatten the tree into indented rows, leaving a collapsed folder's contents
- * out.
+ * Entries from the server's structure listing (`listAccessTree`).
  *
- * An unregistered folder (no server id) is skipped as a ROW — it can't own a
- * share — but is still walked into, so registered notes underneath it stay
- * reachable.
+ * This is the authoritative source: it is not ACL-filtered, so it includes the
+ * items the caller has shut themselves out of — which are exactly the ones they
+ * need to reach in order to change their minds.
  */
-export function visibleAccessRows(
-  tree: TreeNode | null,
-  expanded: ReadonlySet<string>,
-  resolve: AccessTreeResolvers,
-): AccessRow[] {
-  const out: AccessRow[] = [];
+export function entriesFromServer(input: {
+  folders: Array<{ id: string; path: string }>;
+  notes: Array<{ id: string; relPath: string }>;
+}): AccessEntry[] {
+  const folderPaths = input.folders.map((f) => f.path);
+  const allPaths = [...folderPaths, ...input.notes.map((n) => n.relPath)];
+  const hasChildren = (dir: string) => allPaths.some((p) => p.startsWith(`${dir}/`));
+  return [
+    ...input.folders.map((f) => ({
+      kind: "folder" as const,
+      id: f.id,
+      path: f.path,
+      hasChildren: hasChildren(f.path),
+    })),
+    ...input.notes.map((n) => ({ kind: "file" as const, id: n.id, path: n.relPath })),
+  ];
+}
 
-  const walk = (node: TreeNode, depth: number): void => {
+/**
+ * Entries from the local sidebar tree — the fallback for a listing that hasn't
+ * arrived (or was refused). Carries rule 2: an un-listed folder is expandable.
+ *
+ * An unregistered folder is skipped as an entry (it can't own a share) but is
+ * still walked into, so registered notes beneath it stay reachable.
+ */
+export function entriesFromTree(
+  tree: TreeNode | null,
+  resolve: AccessTreeResolvers,
+): AccessEntry[] {
+  const out: AccessEntry[] = [];
+  const walk = (node: TreeNode): void => {
     if (!node.isDir) {
       const docId = resolve.docId(node.path);
-      if (docId) {
-        out.push({
-          key: `file:${docId}`,
-          kind: "file",
-          id: docId,
-          path: node.path,
-          name: accessRowName(node.path, true),
-          depth,
-          expandable: false,
-        });
-      }
+      if (docId) out.push({ kind: "file", id: docId, path: node.path });
       return;
     }
-
     const folderId = resolve.folderId(node.path);
     if (folderId) {
       out.push({
-        key: `folder:${folderId}`,
         kind: "folder",
         id: folderId,
         path: node.path,
-        name: accessRowName(node.path),
-        depth,
-        // Unlisted (`childrenLoaded` absent) ⇒ assume there IS something.
-        expandable: node.childrenLoaded !== true || (node.children?.length ?? 0) > 0,
+        hasChildren: node.childrenLoaded !== true ? undefined : (node.children?.length ?? 0) > 0,
       });
-      if (!expanded.has(node.path)) return;
     }
-    for (const child of node.children ?? []) walk(child, depth + 1);
+    for (const child of node.children ?? []) walk(child);
   };
-
-  for (const child of tree?.children ?? []) walk(child, 0);
+  for (const child of tree?.children ?? []) walk(child);
   return out;
+}
+
+/**
+ * Nest a flat entry list into indented rows, leaving a collapsed folder's
+ * contents out.
+ *
+ * Depth and parentage come from the path, which is the only thing both sources
+ * agree on. Sorted folders-first then alphabetically within each level, so the
+ * list is stable however the server ordered it.
+ */
+export function rowsFromEntries(
+  entries: readonly AccessEntry[],
+  expanded: ReadonlySet<string>,
+): AccessRow[] {
+  const sorted = [...entries].sort((a, b) => {
+    const ad = a.path.split("/").length;
+    const bd = b.path.split("/").length;
+    // Compare level by level so a folder always precedes its own contents.
+    const aParts = a.path.split("/");
+    const bParts = b.path.split("/");
+    for (let i = 0; i < Math.min(ad, bd); i++) {
+      if (aParts[i] === bParts[i]) continue;
+      const aLeaf = i === ad - 1 && a.kind === "file";
+      const bLeaf = i === bd - 1 && b.kind === "file";
+      if (aLeaf !== bLeaf) return aLeaf ? 1 : -1; // folders before notes
+      return aParts[i].localeCompare(bParts[i]);
+    }
+    return ad - bd;
+  });
+
+  const collapsed = sorted
+    .filter((e) => e.kind === "folder" && !expanded.has(e.path))
+    .map((e) => `${e.path}/`);
+  const hidden = (path: string) => collapsed.some((prefix) => path.startsWith(prefix));
+
+  return sorted
+    .filter((e) => !hidden(e.path))
+    .map((e) => ({
+      ...e,
+      key: `${e.kind}:${e.id}`,
+      name: accessRowName(e.path, e.kind === "file"),
+      depth: e.path.split("/").length - 1,
+      // `undefined` (not listed yet) counts as expandable — refusing the twisty
+      // on an un-listed folder is the bug rule 2 exists to prevent.
+      expandable: e.kind === "folder" && e.hasChildren !== false,
+    }));
 }
 
 /** Has the sidebar already listed this folder's contents? */

--- a/app/apps/desktop/src/lib/accessTree.ts
+++ b/app/apps/desktop/src/lib/accessTree.ts
@@ -1,0 +1,115 @@
+// Which rows the Access panel's item list shows, given the vault tree and the
+// set of open folders.
+//
+// Pure, and separate from the component, for one reason: the rule that a folder
+// with `childrenLoaded` unset is *expandable, not empty* is the whole fix for
+// "I can't reach the notes inside a folder". The sidebar loads folders lazily,
+// so an un-clicked folder arrives with no children at all — and treating that
+// as "nothing inside" is what hid every note the user hadn't already opened
+// elsewhere. A rule that subtle belongs somewhere a test can hold it still.
+
+import type { TreeNode } from "./ipc";
+
+export interface AccessRow {
+  key: string;
+  kind: "folder" | "file";
+  /** Server id: a folder id, or a note's doc_id. */
+  id: string;
+  path: string;
+  name: string;
+  depth: number;
+  /** Folders only: offer a twisty? True when there is (or might be) something
+   *  inside — see the note above about un-listed folders. */
+  expandable: boolean;
+}
+
+export interface AccessTreeResolvers {
+  /** Server folder id for a vault-relative path, or null if unregistered. */
+  folderId: (path: string) => string | null;
+  /** doc_id for a vault-relative note path, or null if unregistered. */
+  docId: (path: string) => string | null;
+}
+
+/** basename, optionally without the `.md` a note's title never shows. */
+export function accessRowName(path: string, stripMd = false): string {
+  const last = path.split("/").pop() ?? path;
+  return stripMd ? last.replace(/\.md$/i, "") : last;
+}
+
+/**
+ * Flatten the tree into indented rows, leaving a collapsed folder's contents
+ * out.
+ *
+ * An unregistered folder (no server id) is skipped as a ROW — it can't own a
+ * share — but is still walked into, so registered notes underneath it stay
+ * reachable.
+ */
+export function visibleAccessRows(
+  tree: TreeNode | null,
+  expanded: ReadonlySet<string>,
+  resolve: AccessTreeResolvers,
+): AccessRow[] {
+  const out: AccessRow[] = [];
+
+  const walk = (node: TreeNode, depth: number): void => {
+    if (!node.isDir) {
+      const docId = resolve.docId(node.path);
+      if (docId) {
+        out.push({
+          key: `file:${docId}`,
+          kind: "file",
+          id: docId,
+          path: node.path,
+          name: accessRowName(node.path, true),
+          depth,
+          expandable: false,
+        });
+      }
+      return;
+    }
+
+    const folderId = resolve.folderId(node.path);
+    if (folderId) {
+      out.push({
+        key: `folder:${folderId}`,
+        kind: "folder",
+        id: folderId,
+        path: node.path,
+        name: accessRowName(node.path),
+        depth,
+        // Unlisted (`childrenLoaded` absent) ⇒ assume there IS something.
+        expandable: node.childrenLoaded !== true || (node.children?.length ?? 0) > 0,
+      });
+      if (!expanded.has(node.path)) return;
+    }
+    for (const child of node.children ?? []) walk(child, depth + 1);
+  };
+
+  for (const child of tree?.children ?? []) walk(child, 0);
+  return out;
+}
+
+/** Has the sidebar already listed this folder's contents? */
+export function folderChildrenLoaded(tree: TreeNode | null, path: string): boolean {
+  const find = (node: TreeNode): TreeNode | null => {
+    if (node.path === path) return node;
+    for (const child of node.children ?? []) {
+      const hit = find(child);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  for (const child of tree?.children ?? []) {
+    const hit = find(child);
+    if (hit) return hit.childrenLoaded === true;
+  }
+  return false;
+}
+
+/** Every folder path above `path` — what has to be open for it to be visible. */
+export function ancestorPaths(path: string): string[] {
+  const parts = path.split("/");
+  const out: string[] = [];
+  for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join("/"));
+  return out;
+}

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -1069,6 +1069,12 @@ export class ApiClient {
   }
 
   /** All locks in a vault (readable by any vault member — drives lock badges). */
+  /**
+   * Every access OVERLAY row in a note collection: `locked` (the read-only cap)
+   * and `denied` (Private). One request because both are read for the same
+   * reason — badging the tree and resolving what an item inherits — and both
+   * need the whole vault's set, which a per-resource read can't give.
+   */
   async listVaultLocks(vaultId: string): Promise<Share[]> {
     const { data } = await this.request<{ locks: Share[] }>(
       "GET",

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -143,6 +143,12 @@ export interface NoteLastEdited {
   at: string;
 }
 
+/** Flat structure listing that powers the Access panel (see `listAccessTree`). */
+export interface AccessTreeResponse {
+  folders: Array<{ id: string; path: string; color: string | null }>;
+  notes: Array<{ id: string; relPath: string }>;
+}
+
 export interface RegisteredFolder {
   id: string;
   vaultId?: string;
@@ -846,6 +852,24 @@ export class ApiClient {
       { body: input },
     );
     return data;
+  }
+
+  /**
+   * The vault's whole structure for the Access panel - ids and paths only, not
+   * ACL-filtered. Owner/admin only (403 otherwise).
+   *
+   * Separate from {@link listFolders}/{@link listNotes} on purpose: those feed
+   * the reconciler and MUST stay filtered, or the client would materialise notes
+   * it has no right to sync. This one exists so an item you have made Private is
+   * still administrable - it has left your disk, and the panel used to draw its
+   * list from your disk.
+   */
+  async listAccessTree(vaultId: string): Promise<AccessTreeResponse> {
+    const { data } = await this.request<AccessTreeResponse>(
+      "GET",
+      `/api/vaults/${encodeURIComponent(vaultId)}/access-tree`,
+    );
+    return { folders: data.folders ?? [], notes: data.notes ?? [] };
   }
 
   async listFolders(vaultId: string): Promise<RegisteredFolder[]> {

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -105,6 +105,10 @@ export interface Vault {
   organizationId?: string;
   organization_id?: string;
   name: string;
+  /** True when nothing new may be created at the vault root (see the General
+   *  settings toggle). Absent on an older server — treat that as false. */
+  rootFrozen?: boolean;
+  root_frozen?: boolean;
 }
 
 export interface RegisteredNote {
@@ -127,6 +131,8 @@ export interface RegisteredNote {
   last_edited_by_name?: string | null;
   lastEditedAt?: string | null;
   last_edited_at?: string | null;
+  /** Palette id (see `lib/appearance`), shared by the whole team. */
+  color?: string | null;
 }
 
 /** The normalized "last edited by" fact for one note (see {@link noteLastEdited}). */
@@ -145,6 +151,8 @@ export interface RegisteredFolder {
   parent_id?: string | null;
   name: string;
   path: string;
+  /** Palette id (see `lib/appearance`), shared by the whole team. */
+  color?: string | null;
 }
 
 export interface Share {
@@ -157,7 +165,7 @@ export interface Share {
   principal_type?: "user" | "org";
   principalId?: string;
   principal_id?: string;
-  permission: "view" | "edit" | "locked";
+  permission: "view" | "edit" | "locked" | "denied";
   createdBy?: string;
   created_by?: string;
 }
@@ -173,6 +181,8 @@ export interface ResolvedMemberAccess {
   permission: "edit" | "view" | "none";
   /** True when a lock reduced an otherwise-`edit` member down to `view`. */
   capped: boolean;
+  /** True when the `none` is an explicit per-member block, not a missing grant. */
+  denied?: boolean;
 }
 
 export interface AccessResolution {
@@ -825,6 +835,19 @@ export class ApiClient {
     return data;
   }
 
+  /** Flip a vault-level latch (today: `rootFrozen`). Owner/admin only. */
+  async updateVaultSettings(
+    vaultId: string,
+    input: { rootFrozen: boolean },
+  ): Promise<{ id: string; name: string; rootFrozen: boolean }> {
+    const { data } = await this.request<{ id: string; name: string; rootFrozen: boolean }>(
+      "PATCH",
+      `/api/vaults/${encodeURIComponent(vaultId)}`,
+      { body: input },
+    );
+    return data;
+  }
+
   async listFolders(vaultId: string): Promise<RegisteredFolder[]> {
     const { data } = await this.request<{ folders: RegisteredFolder[] }>("GET", "/api/folders", {
       query: { vaultId },
@@ -845,7 +868,7 @@ export class ApiClient {
   /** Rename/move a folder (rewrites descendant paths server-side; id stays). */
   async updateFolder(
     id: string,
-    input: { name?: string; path?: string; parentId?: string | null },
+    input: { name?: string; path?: string; parentId?: string | null; color?: string | null },
   ): Promise<RegisteredFolder> {
     const { data } = await this.request<RegisteredFolder>(
       "PATCH",
@@ -905,7 +928,12 @@ export class ApiClient {
   /** Rename/move a note (rel_path/folder/title); doc_id is unchanged. */
   async updateNote(
     id: string,
-    input: { relPath?: string; title?: string | null; folderId?: string | null },
+    input: {
+      relPath?: string;
+      title?: string | null;
+      folderId?: string | null;
+      color?: string | null;
+    },
   ): Promise<RegisteredNote> {
     const { data } = await this.request<RegisteredNote>(
       "PATCH",
@@ -1018,7 +1046,7 @@ export class ApiClient {
     /** Required for user shares; ignored for org-wide grants/locks. */
     principalId?: string;
     principalType?: "user" | "org";
-    permission: Permission | "locked";
+    permission: Permission | "locked" | "denied";
   }): Promise<Share> {
     const { data } = await this.request<Share>("POST", "/api/shares", { body: input });
     return data;
@@ -1165,6 +1193,10 @@ export function noteLastEdited(n: RegisteredNote): NoteLastEdited | null {
 }
 export function vaultOrgId(v: Vault): string | undefined {
   return v.organizationId ?? v.organization_id;
+}
+/** Whether this vault's root is closed to new folders/notes. */
+export function vaultRootFrozen(v: Vault): boolean {
+  return (v.rootFrozen ?? v.root_frozen) === true;
 }
 export function sharePrincipalId(s: Share): string {
   return s.principalId ?? s.principal_id ?? "";

--- a/app/apps/desktop/src/lib/appearance.ts
+++ b/app/apps/desktop/src/lib/appearance.ts
@@ -1,6 +1,10 @@
-// Per-item accent colors for folders and notes. Colors are a local, per-vault
-// preference (like Finder tags): stored next to the vault choice in
-// localStorage, keyed by vault-relative path, applied to the tree glyphs.
+// Per-item accent colors for folders and notes, applied to the tree glyphs.
+//
+// On a SYNCED vault the color lives on the server row (`folders.color` /
+// `notes.color`) and arrives with the registry pull, so a folder you tint is
+// tinted for the whole team on every machine. localStorage is still written
+// underneath as the offline mirror and as the whole story for a local vault —
+// keyed by vault-relative path, which is all a local vault has.
 
 export interface ItemColor {
   id: string;
@@ -43,5 +47,31 @@ export function writeItemColors(vaultPath: string, colors: Record<string, string
     localStorage.setItem(STORE_PREFIX + vaultPath, JSON.stringify(colors));
   } catch {
     /* quota/unavailable — colors are a convenience only */
+  }
+}
+
+/**
+ * Have this vault's pre-sync local colors been handed to the server yet?
+ *
+ * Colors were a per-machine preference before they synced. The first pull after
+ * a vault gains sync pushes whatever is in localStorage up, once — the flag is
+ * what stops a color a teammate deliberately CLEARED from being re-uploaded by
+ * this machine on every subsequent pull.
+ */
+const ADOPTED_PREFIX = "context.itemColors.adopted:";
+
+export function colorsAdopted(vaultPath: string): boolean {
+  try {
+    return localStorage.getItem(ADOPTED_PREFIX + vaultPath) === "1";
+  } catch {
+    return true; // no storage → never try to adopt
+  }
+}
+
+export function markColorsAdopted(vaultPath: string): void {
+  try {
+    localStorage.setItem(ADOPTED_PREFIX + vaultPath, "1");
+  } catch {
+    /* quota/unavailable — worst case we re-adopt next launch */
   }
 }

--- a/app/apps/desktop/src/lib/deepLink.ts
+++ b/app/apps/desktop/src/lib/deepLink.ts
@@ -1,0 +1,76 @@
+// Receiving end of a shared note link (see `shareLink.ts` for the format).
+//
+// Two arrival paths, and both have to work or links are unreliable:
+//   - the app is already running → `onOpenUrl` fires (on Windows/Linux this
+//     depends on the single-instance plugin registered in `lib.rs`, which hands
+//     a second launch's URL to the instance already up);
+//   - the click LAUNCHED the app → the URL was an argv/startup payload, which
+//     `getCurrent()` replays once.
+// Handling only the first is the classic bug where a link works for people who
+// happen to have the app open and silently does nothing for everyone else.
+
+import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useStore } from "../store";
+import { parseNoteLink } from "./shareLink";
+
+/** Bring the window forward — a link click means "show me this note". */
+async function focusWindow(): Promise<void> {
+  try {
+    const win = getCurrentWindow();
+    await win.unminimize();
+    await win.show();
+    await win.setFocus();
+  } catch {
+    /* focus is a courtesy; never let it stop the navigation */
+  }
+}
+
+async function handle(urls: string[] | null): Promise<void> {
+  for (const url of urls ?? []) {
+    if (!parseNoteLink(url)) continue;
+    await focusWindow();
+    try {
+      await useStore.getState().openNoteLink(url);
+    } catch (e) {
+      console.error("[deeplink] open failed", url, e);
+    }
+    // One navigation per batch: opening three notes in a row would just leave
+    // the user on whichever won the race.
+    return;
+  }
+}
+
+/**
+ * Start listening for `baalda://` opens. Returns a cleanup for React's effect.
+ *
+ * The plugin's subscribe is async, so the unsubscribe can only be applied once
+ * it resolves; `cancelled` covers the case where the effect is torn down first
+ * (React StrictMode does exactly that in development).
+ */
+export function listenForNoteLinks(): () => void {
+  let cancelled = false;
+  let unlisten: (() => void) | null = null;
+
+  void (async () => {
+    try {
+      const stop = await onOpenUrl((urls) => void handle(urls));
+      if (cancelled) stop();
+      else unlisten = stop;
+    } catch (e) {
+      // A build without the plugin registered (or a platform that can't) must
+      // not take the rest of the app down with it.
+      console.warn("[deeplink] listener unavailable", e);
+    }
+    try {
+      await handle(await getCurrent());
+    } catch {
+      /* nothing was pending */
+    }
+  })();
+
+  return () => {
+    cancelled = true;
+    unlisten?.();
+  };
+}

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -27,6 +27,32 @@ export const openInFileManager = async (path: string): Promise<void> => {
   }
 };
 
+/**
+ * Reveal one note or folder in the OS file manager — selected in its parent,
+ * which is what "Reveal in Finder" means everywhere else.
+ *
+ * The reverse fallback order from {@link openInFileManager}: `revealItemInDir`
+ * is the right verb here and carries no path scope, so it works for a vault on
+ * an external volume too. `openPath` is the backstop for a platform where
+ * revealing isn't wired up — opening a folder still beats a dead menu item, and
+ * for a file the OS opens it in its default app.
+ */
+export const revealInFileManager = async (path: string): Promise<void> => {
+  try {
+    await revealItemInDir(path);
+  } catch {
+    await openPath(path);
+  }
+};
+
+/** What to call "reveal in the file manager" on this platform. */
+export function revealLabel(): string {
+  const ua = typeof navigator === "undefined" ? "" : navigator.userAgent;
+  if (/Mac|iPhone|iPad/i.test(ua)) return "Reveal in Finder";
+  if (/Win/i.test(ua)) return "Show in Explorer";
+  return "Show in file manager";
+}
+
 // ---- Types (mirror the Rust structs, serialized camelCase) ---------------
 
 export interface VaultInfo {

--- a/app/apps/desktop/src/lib/shareLink.ts
+++ b/app/apps/desktop/src/lib/shareLink.ts
@@ -1,0 +1,64 @@
+// Shareable note links — `baalda://note/<orgId>/<docId>`.
+//
+// The point of a link is that a teammate can paste it into chat and the person
+// who clicks it lands on the note. That means the link must carry **identity,
+// not access**: it names a vault and a doc, and the app that opens it resolves
+// both against whoever is signed in there. A stranger who clicks it gets
+// nothing; a teammate without a grant gets the same "no access" they'd get by
+// navigating to the note by hand.
+//
+// Ids, never paths. A note's path changes with every rename and move — a link
+// built on one would rot the first time someone tidied a folder — while its
+// doc_id is the join key that survives all of it (the spec's "key by doc_id,
+// never by path"). The vault is the Better Auth organization id, which is what
+// `setActiveOrganization` takes.
+
+/** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
+export const SHARE_SCHEME = "baalda";
+
+export interface NoteLinkTarget {
+  /** Better Auth organization id — the user-facing vault. */
+  orgId: string;
+  /** The note's stable doc_id. */
+  docId: string;
+}
+
+/** Build the link a user copies. */
+export function buildNoteLink(target: NoteLinkTarget): string {
+  return `${SHARE_SCHEME}://note/${encodeURIComponent(target.orgId)}/${encodeURIComponent(
+    target.docId,
+  )}`;
+}
+
+/**
+ * Parse a link back to its target, or null if it isn't one of ours.
+ *
+ * Deliberately permissive about *shape* and strict about *content*: anything
+ * can hand us a URL, so a malformed one has to be a quiet null rather than a
+ * throw, and the two ids are the only things we read out of it.
+ */
+export function parseNoteLink(url: string): NoteLinkTarget | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== `${SHARE_SCHEME}:`) return null;
+  // `baalda://note/<org>/<doc>` parses with host "note" and pathname
+  // "/<org>/<doc>". Some platforms hand the URL over with the host folded into
+  // the path instead, so accept both rather than depending on which.
+  const segments = [parsed.host, ...parsed.pathname.split("/")]
+    .filter((p) => p.length > 0)
+    .map((p) => {
+      try {
+        return decodeURIComponent(p);
+      } catch {
+        return p;
+      }
+    });
+  if (segments[0] !== "note") return null;
+  const [, orgId, docId] = segments;
+  if (!orgId || !docId) return null;
+  return { orgId, docId };
+}

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionVaultScope.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionVaultScope.test.ts
@@ -36,6 +36,8 @@ const fakeRegistry = vi.hoisted(() => {
     }),
     // Versioning: the manager also mirrors {docId → last-edit} out of the pull.
     setNoteMetaListener: vi.fn(),
+    // …and the vault's shared item colors, from that same pull.
+    setColorListener: vi.fn(),
     // Inbound reconciliation: the manager hands itself over as the host that can
     // make the editor/doc-store let go of a doc before its file moves.
     inboundHost: null as unknown,

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -4,9 +4,12 @@ import { isSafeFolderPath, isSafeNotePath, planInbound } from "../inbound";
 /**
  * `planInbound` decides whether to move or delete files on someone's disk, so it
  * is written as a pure function and tested as a table. Every rule gets a case,
- * and the two that matter most get their own names:
+ * and the ones that matter most get their own names:
  *   - a note the server RENAMED must move, not duplicate;
- *   - a note that merely left the listing (a revoked share) must NOT be touched.
+ *   - a note that left the listing (access revoked) must be removed, because a
+ *     revocation that leaves a readable copy behind is cosmetic;
+ *   - …unless the server didn't answer about deletions, where absence proves
+ *     nothing and the file must be left alone.
  */
 
 const empty = {
@@ -132,24 +135,39 @@ describe("planInbound — deletes", () => {
       local: new Map([["d1", "bye.md"]]),
       tombstones: new Set(["d1"]),
     });
-    expect(p.trash).toEqual([{ docId: "d1", path: "bye.md" }]);
+    expect(p.trash).toEqual([{ docId: "d1", path: "bye.md", reason: "deleted" }]);
     // Suppressed as well, so even if the trash step is skipped the note is not
     // re-registered as an unsyncable ghost.
     expect([...p.suppress]).toEqual(["bye.md"]);
   });
 
-  it("KEEPS the file when a note merely left the listing (revoked share)", () => {
-    // The test the whole tombstone design exists for. `GET /api/notes` is
-    // ACL-filtered, so losing a share looks exactly like a delete. Removing files
-    // on absence would mean an unshare destroys a teammate's local notes.
+  it("removes the file when a note left the listing (access revoked)", () => {
+    // `GET /api/notes` is ACL-filtered, so losing access looks like a delete —
+    // hence the tombstone set, which says which of the two it was. Both end in
+    // the vault's trash, but they are tagged differently because they carry
+    // different risk and get different safety caps.
     const p = plan({
       baseline: new Map([["d1", "shared.md"]]),
       local: new Map([["d1", "shared.md"]]),
       tombstones: new Set(),
     });
+    expect(p.trash).toEqual([{ docId: "d1", path: "shared.md", reason: "revoked" }]);
+    expect([...p.revoked]).toEqual(["d1"]);
+    // Suppressed too, so the outbound half can't re-register it on the way out.
+    expect([...p.suppress]).toEqual(["shared.md"]);
+  });
+
+  it("does NOT remove a revoked file when the server didn't answer about deletions", () => {
+    // `null` tombstones means "I don't know". Absence proves nothing then — it
+    // could equally be a truncated response — and removing files on the strength
+    // of a maybe is the one thing this module must never do.
+    const p = plan({
+      baseline: new Map([["d1", "shared.md"]]),
+      local: new Map([["d1", "shared.md"]]),
+      tombstones: null,
+    });
     expect(p.trash).toEqual([]);
     expect([...p.revoked]).toEqual(["d1"]);
-    // Still suppressed: keep the file, stop claiming it.
     expect([...p.suppress]).toEqual(["shared.md"]);
   });
 
@@ -218,14 +236,23 @@ describe("planInbound — deletes", () => {
 });
 
 describe("planInbound — circuit breakers", () => {
-  function manyDocs(n: number, dead: boolean) {
+  /**
+   * `dead: true` builds a vault whose docs are all ABSENT from the server
+   * listing (the delete/revoke shape); `false` builds one where every doc moved
+   * (the rename shape). `keep` lists docIds to leave in the listing untouched,
+   * so a case can isolate a few deletions without the remaining 97 reading as
+   * mass revocations.
+   */
+  function manyDocs(n: number, dead: boolean, keep: string[] = []) {
     const baseline = new Map<string, string>();
     const local = new Map<string, string>();
     const server = new Map<string, string>();
+    const kept = new Set(keep);
     for (let i = 0; i < n; i++) {
       baseline.set(`d${i}`, `n${i}.md`);
       local.set(`d${i}`, `n${i}.md`);
       if (!dead) server.set(`d${i}`, `moved-${i}.md`);
+      else if (kept.has(`d${i}`)) server.set(`d${i}`, `n${i}.md`);
     }
     return { baseline, local, server };
   }
@@ -243,17 +270,47 @@ describe("planInbound — circuit breakers", () => {
     expect(p.trash).toEqual([]);
     expect(p.rejected).toHaveLength(100);
     expect(p.rejected[0].reason).toContain("safety limit");
+    expect(p.rejected[0].reason).toContain("deletions");
   });
 
   it("allows a small delete under the limit", () => {
-    const { baseline, local } = manyDocs(100, true);
+    const survivors = Array.from({ length: 97 }, (_, i) => `d${i + 3}`);
+    const { baseline, local, server } = manyDocs(100, true, survivors);
     const p = plan({
       baseline,
       local,
-      tombstones: new Set(["d1", "d2", "d3"]),
+      server,
+      tombstones: new Set(["d0", "d1", "d2"]),
     });
     expect(p.trash).toHaveLength(3);
     expect(p.rejected).toEqual([]);
+  });
+
+  it("caps deletions and revocations against separate budgets", () => {
+    // Revocation gets the looser cap: losing a whole shared folder is an
+    // ordinary admin action, while a mass DELETE is far more likely to be a bug.
+    // They must not consume each other's allowance either — a mass revoke can't
+    // be allowed to refuse one legitimate delete riding along with it.
+    const { baseline, local, server } = manyDocs(100, true, ["d99"]);
+    const p = plan({ baseline, local, server, tombstones: new Set(["d0"]) });
+
+    // 99 revocations against a cap of 50 → the whole revoked group is refused…
+    expect(p.trash).toEqual([{ docId: "d0", path: "n0.md", reason: "deleted" }]);
+    expect(p.rejected).toHaveLength(98);
+    expect(p.rejected[0].reason).toContain("access removals");
+
+    // …while 40 of them (under the cap) go through, alongside the delete.
+    const keep = Array.from({ length: 59 }, (_, i) => `d${i + 41}`);
+    const partial = manyDocs(100, true, keep);
+    const q = plan({
+      baseline: partial.baseline,
+      local: partial.local,
+      server: partial.server,
+      tombstones: new Set(["d0"]),
+    });
+    expect(q.trash.filter((t) => t.reason === "revoked")).toHaveLength(40);
+    expect(q.trash.filter((t) => t.reason === "deleted")).toHaveLength(1);
+    expect(q.rejected).toEqual([]);
   });
 
   it("allows up to five deletes even in a tiny vault", () => {

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -397,6 +397,43 @@ describe("inbound delete", () => {
     expect(r.reg.hasFailures()).toBe(false);
   });
 
+  it("brings a revoked note BACK when access is restored", async () => {
+    // The round trip that makes the removal safe to do at all. Private takes the
+    // file; setting the item back to Shared or Read-only has to return it, or a
+    // permission toggle would be a one-way door. The server kept the content, so
+    // the file is re-materialised empty and hydrates on open.
+    const disk = new FakeDisk();
+    disk.notes.set("shared.md", "d1");
+    install(disk);
+
+    // Pass 1: agreed it is ours.
+    const reg1 = new VaultRegistry(fakeApi({ notes: [{ id: "d1", rel_path: "shared.md" }] }));
+    reg1.setInboundHost(recordingHost().host);
+    await reg1.reconcile({ organizationId: ORG, vaultName: "v" });
+    const carry = () => {
+      const writes = vi.mocked(ipc.setVaultConfig).mock.calls;
+      vi.mocked(ipc.getVaultConfig).mockResolvedValue(
+        writes[writes.length - 1]?.[0] as never,
+      );
+    };
+    carry();
+
+    // Pass 2: access revoked — gone from the listing, no tombstone.
+    const reg2 = new VaultRegistry(fakeApi({ notes: [], tombstones: [] }));
+    reg2.setInboundHost(recordingHost().host);
+    await reg2.reconcile({ organizationId: ORG, vaultName: "v" });
+    expect(disk.notes.has("shared.md")).toBe(false);
+    carry();
+
+    // Pass 3: access restored — the server lists it again.
+    vi.mocked(ipc.writeNoteIfMissing).mockClear();
+    const reg3 = new VaultRegistry(fakeApi({ notes: [{ id: "d1", rel_path: "shared.md" }] }));
+    reg3.setInboundHost(recordingHost().host);
+    await reg3.reconcile({ organizationId: ORG, vaultName: "v" });
+    expect(vi.mocked(ipc.writeNoteIfMissing)).toHaveBeenCalledWith("shared.md", "", null);
+    expect(disk.notes.has("shared.md")).toBe(true);
+  });
+
   it("refuses to trash when the server reports no tombstones field", async () => {
     // `null` means "this server cannot answer", which must never be read as
     // "nothing is deleted" and certainly not as "everything is".

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -376,10 +376,11 @@ describe("inbound delete", () => {
     expect(ipc.trashNote).not.toHaveBeenCalled();
   });
 
-  it("KEEPS a file whose access was revoked, and stops re-registering it", async () => {
-    // The regression that matters most. `GET /api/notes` is ACL-filtered, so a
-    // revoked share looks exactly like a delete — and removing files on absence
-    // would mean un-sharing a note destroys a teammate's local copy.
+  it("REMOVES a file whose access was revoked, and stops re-registering it", async () => {
+    // `GET /api/notes` is ACL-filtered, so a revoked share looks like a delete;
+    // the tombstone set is what tells them apart. Both end with the file in the
+    // vault's recoverable trash — a revocation that leaves a readable `.md`
+    // behind is cosmetic, since the ex-reader can open it in any editor forever.
     const disk = new FakeDisk();
     disk.notes.set("shared.md", "d1");
     const r = await twoPasses({
@@ -388,8 +389,10 @@ describe("inbound delete", () => {
       then: { notes: [], tombstones: [] },
     });
 
-    expect(disk.notes.has("shared.md")).toBe(true);
-    expect(ipc.trashNote).not.toHaveBeenCalled();
+    expect(disk.notes.has("shared.md")).toBe(false);
+    expect(ipc.trashNote).toHaveBeenCalledWith("shared.md", expect.any(String), null);
+    // And it is NOT re-registered on the way out, which would resurrect it as an
+    // unsyncable ghost.
     expect(vi.mocked(r.api.createNote)).not.toHaveBeenCalled();
     expect(r.reg.hasFailures()).toBe(false);
   });

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -106,6 +106,9 @@ export class SyncManager implements InboundHost {
     // Who last edited each note, refreshed by the same registry pull. Not
     // coalesced like the map above: it fires once per pull, not once per note.
     this.registry.setNoteMetaListener((meta) => this.publishNoteMeta(meta));
+    // Item colors are a vault-wide fact and ride the same pull (see
+    // `VaultRegistry.publishColors`).
+    this.registry.setColorListener((colors) => this.publishColors(colors));
     // Inbound reconciliation mutates files the editor and the background doc store
     // may be holding, so it has to be able to make them let go first.
     this.registry.setInboundHost(this);
@@ -131,6 +134,8 @@ export class SyncManager implements InboundHost {
   private onRegistryMap?: (map: Record<string, string>) => void;
   /** Mirrors the registry's {docId → last-edit} stamps to the UI. */
   private onNoteMeta?: (meta: Record<string, NoteLastEdited>) => void;
+  /** Mirrors the vault's shared {relPath → color id} map to the UI. */
+  private onColors?: (colors: Record<string, string>) => void;
   private mapPublishTimer: ReturnType<typeof setTimeout> | null = null;
   private registryPullTimer: ReturnType<typeof setTimeout> | null = null;
   private attachments: AttachmentSync | null = null;
@@ -378,6 +383,29 @@ export class SyncManager implements InboundHost {
    */
   private publishNoteMeta(meta: Record<string, NoteLastEdited>): void {
     this.onNoteMeta?.(this.scope?.isCurrent() ? meta : {});
+  }
+
+  /**
+   * UI subscribes here for the vault's shared item colors, keyed by
+   * vault-relative path (`store.itemColors`).
+   */
+  setColorListener(cb: ((colors: Record<string, string>) => void) | undefined): void {
+    this.onColors = cb;
+  }
+
+  /** Same scope gate as {@link publishNoteMeta}. */
+  private publishColors(colors: Record<string, string>): void {
+    if (this.scope?.isCurrent()) this.onColors?.(colors);
+  }
+
+  /**
+   * Persist an item color to the server so every member sees it. Silently does
+   * nothing on a local (unsynced) vault — the store has already written the
+   * local copy, which is the whole behaviour there.
+   */
+  async setItemColor(relPath: string, colorId: string | null): Promise<void> {
+    if (!this.enabled) return;
+    await this.registry.setColor(relPath, colorId);
   }
 
   /**
@@ -803,6 +831,7 @@ export class SyncManager implements InboundHost {
     // 100ms into the next one). The last-edit stamps go the same way.
     this.publishRegistryMap();
     this.publishNoteMeta({});
+    this.onColors?.({});
   }
 
   /** UI subscribes here for the vault-wide background-sync indicator. */

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -1000,7 +1000,17 @@ export class SyncManager implements InboundHost {
       // An ACL change in this vault may have flipped the open note's grant
       // (view↔edit, lock/unlock). Re-mint its token so the editor becomes
       // read-only/editable live — no reopen (spec 04 §4).
-      onAclChanged: () => this.current?.refreshAccess(),
+      onAclChanged: () => {
+        // Two things follow from "the ACL moved". The open note re-mints its
+        // token so a view<->edit flip lands live...
+        this.current?.refreshAccess();
+        // ...and the registry gets re-pulled, because the readable SET may have
+        // changed too. That pull is what removes a note this user just lost
+        // access to from their disk, and without it the removal would wait for
+        // the next structural change or an app restart - long enough to look
+        // like the revocation hadn't worked.
+        this.handleRegistryChanged();
+      },
       // A teammate changed the folder/note structure — re-pull + refresh tree.
       onRegistryChanged: () => this.handleRegistryChanged(),
       // A new teammate joined the vault — refresh roster + celebrate.

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -52,6 +52,19 @@ export interface InboundRename {
 export interface InboundTrash {
   docId: string;
   path: string;
+  /**
+   * Why the file is leaving.
+   *
+   * `deleted` — the server tombstoned it: someone deleted the note.
+   * `revoked` — it left the caller's readable set: access was taken away.
+   *
+   * They execute identically (release the doc, move it to the vault trash) but
+   * carry different risk, so they get separate safety caps and separate
+   * wording when one is refused. A wrong `deleted` is a server bug destroying
+   * work; a mass `revoked` is a routine admin action that happens to look the
+   * same from here.
+   */
+  reason: "deleted" | "revoked";
 }
 
 export interface InboundRejection {
@@ -68,8 +81,9 @@ export interface InboundPlan {
   trash: InboundTrash[];
   /**
    * Docs that vanished from the server listing WITHOUT a tombstone — i.e. access
-   * was revoked (or the server didn't answer). Their files stay exactly where
-   * they are; this only stops us treating them as ours.
+   * was revoked. This stops us treating them as ours; the file itself leaves via
+   * a `revoked` entry in {@link trash}, which is gated on the server having
+   * answered about deletions at all.
    */
   revoked: Set<string>;
   /**
@@ -162,6 +176,20 @@ export function isSafeFolderPath(path: string): boolean {
  */
 function trashCap(mapped: number): number {
   return Math.max(5, Math.ceil(mapped * 0.2));
+}
+/**
+ * Revocation gets a more generous budget than deletion.
+ *
+ * Losing a whole shared folder at once is an ordinary thing for an admin to do,
+ * so the deletion cap (20%) would refuse the common case. The looser limit is
+ * affordable because the blast radius is smaller: the server still holds every
+ * one of these docs by definition, and the files land in the vault's trash.
+ * It is still a limit, because a truncated `GET /api/notes` looks exactly like
+ * a mass revoke from here — and when it trips we keep the files, which is the
+ * safe direction.
+ */
+function revokeCap(mapped: number): number {
+  return Math.max(20, Math.ceil(mapped * 0.5));
 }
 function renameCap(mapped: number): number {
   return Math.max(20, Math.ceil(mapped * 0.3));
@@ -264,15 +292,28 @@ export function planInbound(input: InboundInput): InboundPlan {
       // Belt as well as braces: if the trash step is skipped or fails, this still
       // stops the note being re-registered as a ghost.
       plan.suppress.add(loc);
-      pushTrash(plan, docId, loc);
+      pushTrash(plan, docId, loc, "deleted");
       continue;
     }
 
-    // Absent from BOTH lists ⇒ we lost access (or the server didn't answer).
-    // Keep the file, exactly as the vault channel's `drop` frame does — losing a
-    // share must never cost someone their local copy — but stop claiming it.
+    // Absent from BOTH lists ⇒ we lost access.
     plan.revoked.add(docId);
     if (loc !== undefined) plan.suppress.add(loc);
+    // …and the local copy goes with it. A revocation that leaves a full,
+    // readable `.md` on the ex-reader's disk is cosmetic: they can open it in
+    // any editor forever. The server keeps the content (this only ever runs for
+    // a doc we previously AGREED was server-owned — `prev !== undefined` above),
+    // the file moves to the vault's recoverable trash rather than being
+    // destroyed, and the executor still refuses any doc whose content this
+    // device never confirmed upstream.
+    //
+    // Gated on the server having actually ANSWERED about deletions. A `null`
+    // tombstone list means "I don't know", and absence is then uninformative —
+    // it could equally be a truncated response. Removing files on the strength
+    // of a maybe is precisely the mistake this module exists to avoid.
+    if (loc !== undefined && input.tombstones !== null) {
+      pushTrash(plan, docId, loc, "revoked");
+    }
   }
 
   // Trash deepest-first, so a folder's contents leave before anything prunes it.
@@ -291,26 +332,39 @@ function pushRename(plan: InboundPlan, docId: string, from: string, to: string):
   plan.renames.push({ docId, from, to });
 }
 
-function pushTrash(plan: InboundPlan, docId: string, path: string): void {
+function pushTrash(
+  plan: InboundPlan,
+  docId: string,
+  path: string,
+  reason: InboundTrash["reason"],
+): void {
   if (!isSafeNotePath(path)) {
     plan.rejected.push({ kind: "trash", path, docId, reason: "unsafe local path" });
     return;
   }
-  plan.trash.push({ docId, path });
+  plan.trash.push({ docId, path, reason });
 }
 
 function applyBreakers(plan: InboundPlan, mapped: number): void {
-  const tCap = trashCap(mapped);
-  if (plan.trash.length > tCap) {
-    for (const t of plan.trash) {
+  // Each reason is capped against its own budget, and independently: a mass
+  // revoke must not blow away the allowance for a legitimate single delete
+  // riding in the same pass.
+  const caps: Array<[InboundTrash["reason"], number, string]> = [
+    ["deleted", trashCap(mapped), "deletions"],
+    ["revoked", revokeCap(mapped), "access removals"],
+  ];
+  for (const [reason, cap, label] of caps) {
+    const group = plan.trash.filter((t) => t.reason === reason);
+    if (group.length <= cap) continue;
+    for (const t of group) {
       plan.rejected.push({
         kind: "trash",
         path: t.path,
         docId: t.docId,
-        reason: `refused: ${plan.trash.length} deletions in one pass exceeds the ${tCap} safety limit`,
+        reason: `refused: ${group.length} ${label} in one pass exceeds the ${cap} safety limit`,
       });
     }
-    plan.trash = [];
+    plan.trash = plan.trash.filter((t) => t.reason !== reason);
   }
   const rCap = renameCap(mapped);
   if (plan.renames.length > rCap) {

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -311,6 +311,18 @@ export class VaultRegistry {
    */
   private onNoteMeta: ((meta: Record<string, NoteLastEdited>) => void) | null = null;
 
+  /**
+   * Notified with the {relPath → color id} map on every pull.
+   *
+   * Item colors used to be a localStorage preference keyed by path, so a folder
+   * you tinted was grey on every other machine and for every teammate. They are
+   * a fact about the folder, not about this computer, so they live on the row
+   * (keyed by id, surviving renames) and ride the registry pull that already
+   * fires whenever the structure changes. Keyed by PATH on the way out because
+   * that is what the sidebar draws with.
+   */
+  private onColors: ((colors: Record<string, string>) => void) | null = null;
+
   constructor(
     private readonly api: ApiClient,
     /** Where the current VaultScope comes from; injectable for tests. */
@@ -336,6 +348,11 @@ export class VaultRegistry {
   /** Subscribe to per-note last-edit metadata (see {@link onNoteMeta}). */
   setNoteMetaListener(cb: ((meta: Record<string, NoteLastEdited>) => void) | null): void {
     this.onNoteMeta = cb;
+  }
+
+  /** Subscribe to the vault's shared item colors (see {@link onColors}). */
+  setColorListener(cb: ((colors: Record<string, string>) => void) | null): void {
+    this.onColors = cb;
   }
 
   /** Provide the editor/doc-store coupling inbound reconciliation needs. Without
@@ -366,6 +383,28 @@ export class VaultRegistry {
       if (edited) meta[noteDocId(n)] = edited;
     }
     cb(meta);
+  }
+
+  /**
+   * Publish the server's item colors, keyed by vault-relative path.
+   *
+   * Whole-map replacement, like {@link publishNoteMeta}: a folder whose color was
+   * cleared by a teammate has no row here, and merging would keep it tinted
+   * forever on this machine.
+   */
+  private publishColors(
+    serverFolders: RegisteredFolder[],
+    serverNotes: RegisteredNote[],
+  ): void {
+    const cb = this.onColors;
+    if (!cb) return;
+    const colors: Record<string, string> = {};
+    for (const f of serverFolders) if (f.color) colors[f.path] = f.color;
+    for (const n of serverNotes) {
+      const rp = noteRelPath(n);
+      if (rp && n.color) colors[rp] = n.color;
+    }
+    cb(colors);
   }
 
   /**
@@ -441,6 +480,28 @@ export class VaultRegistry {
   /** Server folder id for a folder's vault-relative path, if registered. */
   getFolderId(relPath: string): string | null {
     return this.folderByPath.get(relPath) ?? null;
+  }
+
+  /**
+   * Persist an item's accent color on the server row behind `relPath`.
+   *
+   * Resolves folder-first, then note. Returns false when the path isn't mapped
+   * (a local-only vault, or a file registered a moment ago) — the caller keeps
+   * its optimistic local value rather than reporting a failure the user can do
+   * nothing about.
+   */
+  async setColor(relPath: string, colorId: string | null): Promise<boolean> {
+    const folderId = this.folderByPath.get(relPath);
+    if (folderId) {
+      await this.api.updateFolder(folderId, { color: colorId });
+      return true;
+    }
+    const mapping = this.byPath.get(relPath);
+    if (mapping) {
+      await this.api.updateNote(mapping.docId, { color: colorId });
+      return true;
+    }
+    return false;
   }
 
   // ---- content-push checkpoint (resume point for the bulk upload) ---------
@@ -990,6 +1051,7 @@ export class VaultRegistry {
     // re-read it), so the "edited by" tags reflect the same rows the rest of this
     // pass reconciles against.
     this.publishNoteMeta(serverNotes);
+    this.publishColors(serverFolders, serverNotes);
 
     // Drop anything belonging to a different collection before we start adding:
     // the maps are written into incrementally from here on (so a mid-run

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -591,8 +591,9 @@ export class VaultRegistry {
 
   /**
    * Bring local disk into line with the server's structure: create folders that
-   * only exist server-side, apply remote renames/moves, and move remotely-deleted
-   * notes to the vault's trash.
+   * only exist server-side, apply remote renames/moves, and move notes to the
+   * vault's trash when the server says they were deleted OR when they left this
+   * user's readable set (access revoked — see `InboundTrash.reason`).
    *
    * Every mutation below is guarded, and the guards are the point:
    *   - a persisted baseline for THIS collection must exist (else we can't tell a
@@ -738,14 +739,19 @@ export class VaultRegistry {
       if (this.stopRun()) break;
       // A note whose content this device never confirmed upstream may hold local
       // edits that exist NOWHERE else, so removing it could lose the only copy.
-      // Read `pushed` before the prune below has a chance to drop it.
+      // Read `pushed` before the prune below has a chance to drop it. This
+      // matters most for `revoked`: access can be taken away mid-edit, and the
+      // one thing a permission change must never do is destroy work that only
+      // exists here.
       if (!this.pushed.has(gone.docId) && !(await this.isEmptyOnDisk(gone.path))) {
         this.recordFailure({
           kind: "orphan",
           path: gone.path,
           docId: gone.docId,
           reason:
-            "deleted on the server, but this device never confirmed its content — left on disk",
+            gone.reason === "revoked"
+              ? "access was removed, but this device never confirmed its content upstream — left on disk"
+              : "deleted on the server, but this device never confirmed its content — left on disk",
           code: null,
         });
         continue;

--- a/app/apps/desktop/src/lib/updater.ts
+++ b/app/apps/desktop/src/lib/updater.ts
@@ -214,6 +214,10 @@ export function clearJustUpdated(): void {
  * Release notes → the banner's one-liners. Keeps markdown bullet lines (and
  * plain lines) as-is minus the bullet, drops headings/blanks and the historic
  * placeholder body, and caps the list so a long release stays a glance.
+ *
+ * `**bold**` is unwrapped rather than rendered: the same text is the GitHub
+ * release body, where emphasis reads well, and these lines land in a plain
+ * `<span>` where the asterisks would just be litter.
  */
 export function releaseNoteLines(notes: string | null | undefined, max = 6): string[] {
   if (!notes) return [];
@@ -223,5 +227,6 @@ export function releaseNoteLines(notes: string | null | undefined, max = 6): str
     .filter((line) => line.length > 0 && !line.startsWith("#"))
     .filter((line) => !line.startsWith("See the assets below"))
     .map((line) => line.replace(/^[-*•]\s+/, ""))
+    .map((line) => line.replace(/\*\*(.+?)\*\*/g, "$1"))
     .slice(0, max);
 }

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -6,7 +6,12 @@
 import { create } from "zustand";
 import * as ipc from "./lib/ipc";
 import { bridgeManager } from "./lib/bridge";
-import { readItemColors, writeItemColors } from "./lib/appearance";
+import {
+  colorsAdopted,
+  markColorsAdopted,
+  readItemColors,
+  writeItemColors,
+} from "./lib/appearance";
 import { readItemOrder, writeItemOrder, type ItemOrder } from "./lib/ordering";
 import { loadedFolderPaths, setChildrenAt } from "./lib/tree/lazyTree";
 import {
@@ -23,6 +28,7 @@ import {
   type VaultCheckpoint,
   type VaultRevertResult,
   vaultOrgId,
+  vaultRootFrozen,
 } from "./lib/api";
 import { authManager } from "./lib/auth/authManager";
 import { syncManager } from "./lib/sync/docSession";
@@ -49,6 +55,8 @@ import { planTurnOnSync } from "./lib/vault/turnOnSync";
 import { configOrgId, rediscoverVaultFolder } from "./lib/vault/rediscover";
 import { playJoinChime } from "./lib/celebrate/celebrate";
 import { viewingDocId } from "./lib/presence/viewingDocId";
+import { toast } from "./lib/toast";
+import { parseNoteLink } from "./lib/shareLink";
 
 export interface OpenNote {
   path: string;
@@ -191,6 +199,14 @@ interface AppStore {
   itemOrder: ItemOrder;
   /** Set when the active vault still needs a local folder chosen. */
   pendingVaultFolder: PendingVaultFolder | null;
+  /**
+   * True when this vault's ROOT is closed to new folders and notes.
+   *
+   * A structural latch, not a permission: it applies to everyone (owners
+   * included), and only an owner/admin can lift it. Always false on a local
+   * vault, which has no server row to hold it.
+   */
+  rootFrozen: boolean;
 
   // ---- Billing (subscription) ----
   /** Server billing capability; null until first probed. `enabled === false`
@@ -213,6 +229,12 @@ interface AppStore {
 
   setVault: (v: ipc.VaultInfo | null) => void;
   setItemColor: (path: string, colorId: string | null) => void;
+  /** Replace the item-color map with the vault's server-side one (sync pull). */
+  applyVaultColors: (colors: Record<string, string>) => void;
+  /** Re-read the active vault's `rootFrozen` latch from the server. */
+  refreshVaultSettings: () => Promise<void>;
+  /** Flip the root-freeze latch (owner/admin; throws on refusal). */
+  setRootFrozen: (frozen: boolean) => Promise<void>;
   setItemOrder: (order: ItemOrder) => void;
   setTreeSort: (sort: TreeSort) => void;
   refreshTree: () => Promise<void>;
@@ -225,6 +247,12 @@ interface AppStore {
   openWelcomeIfPresent: () => Promise<void>;
 
   openNoteByPath: (path: string) => Promise<void>;
+  /**
+   * Follow a `baalda://note/<orgId>/<docId>` link: switch to that vault if
+   * needed, then open the note. Never grants anything — the recipient's own
+   * membership and ACL decide whether the note is there to open.
+   */
+  openNoteLink: (url: string) => Promise<void>;
   refreshBacklinks: () => Promise<void>;
   setNoteRemoved: (removed: boolean) => void;
   closeNote: () => void;
@@ -717,6 +745,24 @@ function sameVault(get: () => AppStore, epoch: number | null | undefined): boole
  * showing the previous vault's history against the new vault's notes would offer
  * a revert that writes the wrong content into the wrong note.
  */
+/**
+ * Poll the registry for a docId's local path.
+ *
+ * A shared link can land while the target vault is still reconciling — on a
+ * cold start, or right after the switch the link itself triggered. Giving up
+ * immediately would make links look broken exactly when they're most likely to
+ * be used (someone opening one for the first time).
+ */
+async function waitForDocPath(docId: string, timeoutMs = 20_000): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const path = syncManager.registry.pathForDocId(docId);
+    if (path) return path;
+    if (Date.now() >= deadline) return null;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+}
+
 function vaultScopedSyncReset() {
   // A fresh object each call: handing out one shared `{}`/`[]` would let any
   // future in-place mutation of `docSyncState`/`locks` leak into every later reset.
@@ -733,6 +779,8 @@ function vaultScopedSyncReset() {
     noteVersions: null,
     versionPreview: null,
     checkpoints: null,
+    // A latch belongs to the vault it was read from; a local vault has none.
+    rootFrozen: false,
   } satisfies Partial<AppStore>;
 }
 
@@ -765,6 +813,7 @@ export const useStore = create<AppStore>((set, get) => ({
   itemColors: {},
   itemOrder: {},
   pendingVaultFolder: null,
+  rootFrozen: false,
   billingConfig: null,
   orgBilling: null,
   activityStatus: readActivityStatus(),
@@ -789,8 +838,41 @@ export const useStore = create<AppStore>((set, get) => ({
     const next = { ...get().itemColors };
     if (colorId) next[path] = colorId;
     else delete next[path];
+    // Optimistic: paint immediately and mirror to localStorage, then hand the
+    // color to the server so every member and device gets it. A synced vault
+    // re-publishes the authoritative map on the next pull, which corrects this
+    // if the write was refused (a read-only member recoloring, say).
     writeItemColors(vault.path, next);
     set({ itemColors: next });
+    void syncManager.setItemColor(path, colorId).catch(() => {
+      toast("Couldn't save that color for the team", "error");
+    });
+  },
+
+  /**
+   * Apply the vault's server-side colors. Whole-map replacement — a color a
+   * teammate cleared has no row, and merging would keep it here forever.
+   *
+   * The one exception is the first pull after a vault gains sync: colors set on
+   * this machine while it was local are pushed up rather than thrown away.
+   */
+  applyVaultColors: (colors) => {
+    const vault = get().vault;
+    if (!vault) return;
+    if (!colorsAdopted(vault.path)) {
+      markColorsAdopted(vault.path);
+      const orphans = Object.entries(get().itemColors).filter(([p]) => !(p in colors));
+      if (orphans.length > 0) {
+        colors = { ...colors, ...Object.fromEntries(orphans) };
+        for (const [p, id] of orphans) {
+          void syncManager.setItemColor(p, id).catch(() => {
+            /* best-effort adoption — the local mirror still has it */
+          });
+        }
+      }
+    }
+    writeItemColors(vault.path, colors);
+    set({ itemColors: colors });
   },
 
   setItemOrder: (order) => {
@@ -969,6 +1051,40 @@ export const useStore = create<AppStore>((set, get) => ({
     }
   },
 
+  openNoteLink: async (url) => {
+    const target = parseNoteLink(url);
+    if (!target) return;
+    if (get().authStatus !== "signed-in") {
+      toast("Sign in to open this shared note", "error");
+      return;
+    }
+    if (!get().organizations.some((o) => o.id === target.orgId)) {
+      // The roster can simply be stale — someone shares a link the moment after
+      // inviting you, which is the most likely first use of one. Re-read it
+      // before refusing.
+      await get().refreshVault();
+    }
+    if (!get().organizations.some((o) => o.id === target.orgId)) {
+      // Deliberately the same message whether the vault doesn't exist or the
+      // user simply isn't in it — a link must not be a way to probe which
+      // vaults exist.
+      toast("That note is in a vault you don't have access to", "error");
+      return;
+    }
+    if (get().session?.activeOrganizationId !== target.orgId) {
+      await get().setActiveOrganization(target.orgId);
+    }
+    // The path→docId map arrives with the registry pull, which a vault switch
+    // has only just started. Wait for the note to show up rather than reporting
+    // "not found" during the seconds it takes to reconcile.
+    const path = await waitForDocPath(target.docId);
+    if (!path) {
+      toast("Couldn't open that note — you may not have access to it", "error");
+      return;
+    }
+    await get().openNoteByPath(path);
+  },
+
   refreshBacklinks: async () => {
     const note = get().openNote;
     if (!note?.id) {
@@ -1023,6 +1139,9 @@ export const useStore = create<AppStore>((set, get) => ({
     syncManager.setRegistryListener(() => {
       void get().refreshTree();
       void get().refreshTitles();
+      // The root-freeze latch rides the same signal the server already sends
+      // when it changes, so a teammate flipping it reaches this app live.
+      void get().refreshVaultSettings();
     });
     // A teammate renamed/moved or deleted a note we have on disk, and the registry
     // has just applied that to the file. The open editor's bridge was destroyed
@@ -1067,6 +1186,9 @@ export const useStore = create<AppStore>((set, get) => ({
     // "edited by" tag on sidebar rows. Replaced wholesale, never merged: a note
     // can lose its stamp (restored from a checkpoint, access revoked).
     syncManager.setNoteMetaListener((meta) => set({ noteLastEdited: meta }));
+    // Folder/note colors, from the same pull — a vault-wide fact, so the whole
+    // team sees the arrangement one person set up.
+    syncManager.setColorListener((colors) => get().applyVaultColors(colors));
     try {
       const session = await authManager.init();
       set({ serverUrl: authManager.getServerUrl() });
@@ -1869,6 +1991,37 @@ export const useStore = create<AppStore>((set, get) => ({
     }
   },
 
+  // ---- Vault settings ----
+
+  refreshVaultSettings: async () => {
+    const vaultId = syncManager.registry.vaultId;
+    if (!vaultId || !get().syncEnabled) {
+      set({ rootFrozen: false });
+      return;
+    }
+    const epoch = get().vault?.epoch;
+    try {
+      const vaults = await authManager.api.listVaults();
+      // Same staleness guard as `refreshLocks`: a late answer must not describe
+      // the vault we already left.
+      if (!sameVault(get, epoch) || syncManager.registry.vaultId !== vaultId) return;
+      const mine = vaults.find((v) => v.id === vaultId);
+      set({ rootFrozen: mine ? vaultRootFrozen(mine) : false });
+    } catch {
+      // An older server has no such field; the safe reading is "not frozen".
+      if (sameVault(get, epoch)) set({ rootFrozen: false });
+    }
+  },
+
+  setRootFrozen: async (frozen) => {
+    const vaultId = syncManager.registry.vaultId;
+    if (!vaultId) throw new Error("This vault isn't synced yet.");
+    const { rootFrozen } = await authManager.api.updateVaultSettings(vaultId, {
+      rootFrozen: frozen,
+    });
+    set({ rootFrozen });
+  },
+
   // ---- Locks ----
 
   refreshLocks: async () => {
@@ -2138,6 +2291,8 @@ export const useStore = create<AppStore>((set, get) => ({
       await get().refreshTitles();
       if (stale()) return;
       await get().refreshLocks();
+      if (stale()) return;
+      await get().refreshVaultSettings();
       if (stale()) return;
       // A brand-new vault was just seeded with welcome content — greet the
       // user with the welcome note if nothing else is open.

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -169,6 +169,15 @@ interface AppStore {
   /** Locks (read-only overlays) in the synced vault — drives tree badges. */
   locks: Share[];
   /**
+   * Private overlays (`denied` shares) in the synced vault.
+   *
+   * Split from `locks` deliberately: they arrive on the same request but mean
+   * something different, and rendering one as the other would padlock a folder
+   * that isn't read-only. Org-principal rows are "this item is not shared with
+   * the team"; user-principal rows are "this person is blocked".
+   */
+  denies: Share[];
+  /**
    * Who last edited each note's CONTENT, keyed by **docId** (never by path, and
    * dropped on every vault switch — two vaults both have a `Welcome.md`).
    * Refreshed by the registry pull; empty when sync is off.
@@ -774,6 +783,7 @@ function vaultScopedSyncReset() {
     docSyncState: {} as Record<string, DocSyncState>,
     docIdByPath: {} as Record<string, string>,
     locks: [] as Share[],
+    denies: [] as Share[],
     noteLastEdited: {} as Record<string, NoteLastEdited>,
     versionPanelDocId: null,
     noteVersions: null,
@@ -2027,20 +2037,27 @@ export const useStore = create<AppStore>((set, get) => ({
   refreshLocks: async () => {
     const vaultId = syncManager.registry.vaultId;
     if (!vaultId || !get().syncEnabled) {
-      set({ locks: [] });
+      set({ locks: [], denies: [] });
       return;
     }
     const epoch = get().vault?.epoch;
     try {
-      const locks = await authManager.api.listVaultLocks(vaultId);
+      const overlay = await authManager.api.listVaultLocks(vaultId);
       // Locks are per-vault; publishing another vault's set would badge the
       // wrong rows in the sidebar.
       if (!sameVault(get, epoch) || syncManager.registry.vaultId !== vaultId) return;
-      set({ locks });
+      // The endpoint returns both overlay kinds. They MUST stay apart here:
+      // everything downstream of `locks` (badges, tooltips, the read-only cap)
+      // assumes every row is a lock, and a Private row rendered as a lock would
+      // put a padlock on a folder that is not read-only at all.
+      set({
+        locks: overlay.filter((s) => s.permission === "locked"),
+        denies: overlay.filter((s) => s.permission === "denied"),
+      });
     } catch (e) {
       console.warn("[locks] refresh failed", e);
       if (!sameVault(get, epoch)) return;
-      set({ locks: [] });
+      set({ locks: [], denies: [] });
     }
   },
 

--- a/app/apps/server/migrations/018_access_deny_colors_root_freeze.sql
+++ b/app/apps/server/migrations/018_access_deny_colors_root_freeze.sql
@@ -1,0 +1,27 @@
+-- Three small, independent schema additions.
+--
+-- 1. `denied` shares — a per-member DENY that actually takes access AWAY.
+--    Until now the only way to narrow someone was `locked`, which caps at
+--    `view`; there was no way to say "this folder is not for you". A `denied`
+--    row is resolved after every allow rule and wins over all of them
+--    (including the vault-wide Open grant and the creator escape hatch), so it
+--    is the per-member counterpart of the vault's Private posture.
+--    principal_type is always 'user': denying the whole org is what removing
+--    the org grant already means.
+--
+-- 2. Item colors move server-side. They were a localStorage preference keyed by
+--    path, so a folder tinted on one machine was grey everywhere else. Keyed by
+--    id (not path) they survive renames and moves like every other fact here.
+--
+-- 3. `root_frozen` — an owner/admin latch that stops anything new being created
+--    at the vault root once its top-level shape is settled.
+
+ALTER TABLE shares DROP CONSTRAINT IF EXISTS shares_permission_check;
+ALTER TABLE shares
+  ADD CONSTRAINT shares_permission_check
+  CHECK (permission IN ('view', 'edit', 'locked', 'denied'));
+
+ALTER TABLE folders ADD COLUMN IF NOT EXISTS color TEXT;
+ALTER TABLE notes   ADD COLUMN IF NOT EXISTS color TEXT;
+
+ALTER TABLE vaults ADD COLUMN IF NOT EXISTS root_frozen BOOLEAN NOT NULL DEFAULT false;

--- a/app/apps/server/src/auth/auth.ts
+++ b/app/apps/server/src/auth/auth.ts
@@ -82,10 +82,27 @@ export const auth = betterAuth({
     // Identity is the email: signing in with Google links to an existing
     // email+password account with the same address (and vice-versa) instead of
     // forking a second account. Google is trusted because it returns a verified
-    // email, so the auto-link is safe.
+    // email, so we know the person signing in really owns the address.
     accountLinking: {
       enabled: true,
       trustedProviders: ["google"],
+      // Better Auth defaults this to TRUE, which quietly made the linking above
+      // dead code for every account we have. It refuses to link unless the
+      // *local* row already has `emailVerified`, and nothing here ever sets it:
+      // `requireEmailVerification` is false (no email round-trip in the MVP), so
+      // every password sign-up lands with `emailVerified = false` — permanently.
+      // The symptom is `account_not_linked` on the Google callback for anyone
+      // who first signed up with a password; only users created THROUGH Google
+      // could use Google, because they had nothing to link.
+      //
+      // The check exists to stop this: with no verification at sign-up, someone
+      // can register an address they don't own, and linking then joins the real
+      // owner to the squatter's account instead of locking them out. We accept
+      // that here because the squat is already possible without linking, and
+      // because Google having verified the address is the strongest signal we
+      // have. The real fix is email verification at sign-up — until that ships,
+      // this is a knowingly-taken trade, not an oversight.
+      requireLocalEmailVerified: false,
     },
     // Desktop OAuth runs the Google consent in the system browser while the app
     // (a Tauri webview) initiated /sign-in/social from a *different* cookie jar,

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -194,6 +194,51 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     return c.json({ id: rows[0].id, name: rows[0].name, rootFrozen: rows[0].root_frozen }, 200);
   });
 
+  /**
+   * The vault's WHOLE structure, unfiltered — folders and notes, ids and paths,
+   * no content. Owner/admin only.
+   *
+   * Every other listing here is ACL-filtered, which is right for sync and fatal
+   * for administration: the moment an item is set to Private it leaves
+   * `GET /api/notes`, its file leaves the manager's disk, and the Access panel —
+   * which was drawing its list from that disk — lost the only row you could
+   * un-Private it from. A restriction you cannot see is a restriction you cannot
+   * lift.
+   *
+   * Deliberately a separate endpoint rather than a flag on the sync listings.
+   * Those feed the reconciler, and an unfiltered response reaching it would have
+   * the client materialise notes it has no right to sync. The two must not be
+   * one call with a mode switch.
+   */
+  registryRoutes.get("/vaults/:vaultId/access-tree", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.param("vaultId");
+    const org = await vaultOrg(vaultId);
+    if (!org) return c.json({ error: "Unknown vault" }, 404);
+    const role = await orgRole(org, session.userId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json({ error: "Only a vault owner or admin can manage access" }, 403);
+    }
+    const [folders, notes] = await Promise.all([
+      pool.query<{ id: string; path: string; color: string | null }>(
+        "SELECT id, path, color FROM folders WHERE vault_id = $1 ORDER BY path",
+        [vaultId],
+      ),
+      // Paths and titles only. This bypasses the ACL, so it carries the minimum
+      // that lets someone administer the tree and nothing that would let them
+      // read a note they've shut themselves out of.
+      pool.query<{ id: string; rel_path: string }>(
+        "SELECT id, rel_path FROM notes WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path",
+        [vaultId],
+      ),
+    ]);
+    return c.json({
+      folders: folders.rows.map((f) => ({ id: f.id, path: f.path, color: f.color })),
+      notes: notes.rows.map((n) => ({ id: n.id, relPath: n.rel_path })),
+    });
+  });
+
   // ── folders ──────────────────────────────────────────────────────────────
   registryRoutes.post("/folders", async (c) => {
     const session = await getSession(c);

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -40,6 +40,40 @@ export interface RegistryDeps {
 export const ORIGIN_HEADER = "x-baalda-origin";
 
 /**
+ * Is this vault's ROOT closed to new folders/notes?
+ *
+ * "Freeze root" is a structural latch, not a permission: once a team has agreed
+ * the top-level shape, nothing new lands beside it — by anyone, owners and
+ * admins included. Making it role-scoped would defeat the point, because the
+ * accidental root folder is nearly always created by someone who *does* have
+ * permission. An owner/admin lifts the latch first, then creates.
+ *
+ * Only the root is affected. Everything nested keeps its normal ACL.
+ */
+export async function isRootFrozen(vaultId: string): Promise<boolean> {
+  const { rows } = await pool.query<{ root_frozen: boolean }>(
+    "SELECT root_frozen FROM vaults WHERE id = $1",
+    [vaultId],
+  );
+  return rows[0]?.root_frozen === true;
+}
+
+/** The 403 body every frozen-root refusal shares, so clients can match on a code. */
+const ROOT_FROZEN_ERROR = {
+  error: "This vault's root is frozen — create this inside a folder instead.",
+  code: "root_frozen",
+} as const;
+
+/** Colors are a short id from the client's palette (`lib/appearance`), or null
+ *  to clear. Anything else is ignored rather than stored. */
+function normalizeColor(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  if (typeof value !== "string" || value.length > 32) return undefined;
+  return value;
+}
+
+/**
  * Registry API (session-authenticated). Lets the client map local vault files to
  * server doc_ids: create/list/rename/delete vaults, folders, notes, files.
  * doc_id is the join key between the .md file, the Yjs doc, and the relational
@@ -112,14 +146,14 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
         [randomUUID(), organizationId, session.userId],
       );
     }
-    return c.json({ id, organizationId, name }, 201);
+    return c.json({ id, organizationId, name, rootFrozen: false }, 201);
   });
 
   registryRoutes.get("/vaults", async (c) => {
     const session = await getSession(c);
     if (!session) return c.json({ error: "Authentication required" }, 401);
     const { rows } = await pool.query(
-      `SELECT v.id, v.organization_id, v.name, v.created_at
+      `SELECT v.id, v.organization_id, v.name, v.created_at, v.root_frozen
          FROM vaults v
          JOIN member m ON m."organizationId" = v.organization_id
         WHERE m."userId" = $1
@@ -127,6 +161,37 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       [session.userId],
     );
     return c.json({ vaults: rows });
+  });
+
+  /**
+   * Vault-level settings. Today that is one latch: `rootFrozen`.
+   *
+   * Owner/admin only to WRITE; every member reads it from `GET /api/vaults`, so
+   * a member's Settings page shows the toggle in its real state (disabled) and
+   * their client can explain a refusal before the server has to.
+   */
+  registryRoutes.patch("/vaults/:vaultId", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const vaultId = c.req.param("vaultId");
+    const org = await vaultOrg(vaultId);
+    if (!org) return c.json({ error: "Unknown vault" }, 404);
+    const role = await orgRole(org, session.userId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json({ error: "Only a vault owner or admin can change vault settings" }, 403);
+    }
+    const body = await c.req.json().catch(() => ({}));
+    if (typeof body.rootFrozen !== "boolean") {
+      return c.json({ error: "rootFrozen (boolean) required" }, 400);
+    }
+    const { rows } = await pool.query<{ id: string; name: string; root_frozen: boolean }>(
+      "UPDATE vaults SET root_frozen = $2 WHERE id = $1 RETURNING id, name, root_frozen",
+      [vaultId, body.rootFrozen],
+    );
+    // Every open client re-pulls the registry on this frame, which is also how
+    // they learn the latch moved — no separate broadcast to keep in step.
+    changed(c, vaultId);
+    return c.json({ id: rows[0].id, name: rows[0].name, rootFrozen: rows[0].root_frozen }, 200);
   });
 
   // ── folders ──────────────────────────────────────────────────────────────
@@ -155,14 +220,22 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ id: existing.rows[0].id, vaultId, parentId: parentId ?? null, name, path }, 200);
     }
 
+    // Frozen root: only NEW root folders are refused. The adopt path above
+    // already returned, so an existing folder still reconciles from every
+    // device after the latch goes on.
+    if (!parentId && (await isRootFrozen(vaultId))) {
+      return c.json(ROOT_FROZEN_ERROR, 403);
+    }
+
     const id = randomUUID();
+    const color = normalizeColor(body.color) ?? null;
     await pool.query(
-      `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [id, vaultId, parentId ?? null, name, path, body.sort ?? 0, session.userId],
+      `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by, color)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [id, vaultId, parentId ?? null, name, path, body.sort ?? 0, session.userId, color],
     );
     changed(c, vaultId);
-    return c.json({ id, vaultId, parentId: parentId ?? null, name, path }, 201);
+    return c.json({ id, vaultId, parentId: parentId ?? null, name, path, color }, 201);
   });
 
   registryRoutes.get("/folders", async (c) => {
@@ -207,6 +280,18 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "You cannot move this folder there" }, 403);
     }
 
+    // Moving a folder OUT to the root is a root creation by another name.
+    if (newParentId === null && (await isRootFrozen(row.vault_id))) {
+      return c.json(ROOT_FROZEN_ERROR, 403);
+    }
+
+    // Color is a vault-wide fact about the folder, so it rides the same PATCH
+    // and syncs to every member like a rename does.
+    const color = normalizeColor(body.color);
+    if (color !== undefined) {
+      await pool.query("UPDATE folders SET color = $2 WHERE id = $1", [id, color]);
+    }
+
     try {
       const moved = await moveFolder(pool, id, {
         path: typeof body.path === "string" ? body.path : undefined,
@@ -214,7 +299,10 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
         parentId: newParentId,
       });
       changed(c, moved.vaultId);
-      return c.json({ id, vaultId: moved.vaultId, name: moved.name, path: moved.path }, 200);
+      return c.json(
+        { id, vaultId: moved.vaultId, name: moved.name, path: moved.path, color },
+        200,
+      );
     } catch (err) {
       if (err instanceof TreeOpError) return c.json({ error: err.message }, 400);
       throw err;
@@ -267,6 +355,15 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
 
     // Client may supply a stable doc_id (generated locally); else we mint one.
     const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
+
+    // Frozen root: refuse only notes that do not exist yet. Re-registering a
+    // root note that predates the latch (a second device, a repeat reconcile)
+    // has to keep working, or freezing the root would break sync for the very
+    // notes the team froze it to protect.
+    if (!folderId && (await isRootFrozen(vaultId))) {
+      const { rowCount } = await pool.query("SELECT 1 FROM notes WHERE id = $1", [id]);
+      if (!rowCount) return c.json(ROOT_FROZEN_ERROR, 403);
+    }
     // RETURNING tells us whether the row is actually ours. `DO NOTHING` alone is
     // silent about *why* nothing happened, and answering 201 regardless told the
     // client "doc `id` now belongs to `vaultId`" even when that id was already a
@@ -275,11 +372,19 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // reconnects on every rejection, and the note never loads. A doc_id is global,
     // so a collision across vaults has to be reported, not swallowed.
     const inserted = await pool.query(
-      `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $1, $6)
+      `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by, color)
+       VALUES ($1, $2, $3, $4, $5, $1, $6, $7)
        ON CONFLICT (id) DO NOTHING
        RETURNING id`,
-      [id, vaultId, folderId ?? null, title ?? null, relPath, session.userId],
+      [
+        id,
+        vaultId,
+        folderId ?? null,
+        title ?? null,
+        relPath,
+        session.userId,
+        normalizeColor(body.color) ?? null,
+      ],
     );
     if (inserted.rowCount === 0) {
       const { rows: existing } = await pool.query<{ vault_id: string; rel_path: string }>(
@@ -321,7 +426,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // attribution stays live without a second endpoint or a new wire frame.
     const { rows } = await pool.query(
       `SELECT n.id, n.vault_id, n.folder_id, n.title, n.rel_path, n.doc_id, n.created_by,
-              n.created_at, n.updated_at,
+              n.created_at, n.updated_at, n.color,
               n.last_edited_by, u.name AS last_edited_by_name, n.last_edited_at
          FROM notes n
          LEFT JOIN "user" u ON u.id = n.last_edited_by
@@ -374,6 +479,16 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     if (folderId != null && !(await canEditFolder(session.userId, folderId))) {
       return c.json({ error: "You cannot move this note there" }, 403);
     }
+    // Dragging a note out to the root is a root creation by another name —
+    // unless it already lives there, which is a rename, not a move.
+    if (folderId === null && row.folder_id !== null && (await isRootFrozen(row.vault_id))) {
+      return c.json(ROOT_FROZEN_ERROR, 403);
+    }
+
+    const color = normalizeColor(body.color);
+    if (color !== undefined) {
+      await pool.query("UPDATE notes SET color = $2 WHERE id = $1", [id, color]);
+    }
 
     try {
       const moved = await moveNote(pool, id, {
@@ -390,6 +505,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
           relPath: moved.relPath,
           title: moved.title,
           folderId: moved.folderId,
+          color,
         },
         200,
       );

--- a/app/apps/server/src/http/routes/shares.ts
+++ b/app/apps/server/src/http/routes/shares.ts
@@ -87,20 +87,33 @@ export function createShareRoutes(deps: ShareDeps): Hono {
       (resourceType !== "folder" && resourceType !== "file" && resourceType !== "vault") ||
       typeof resourceId !== "string" ||
       (principalType !== "user" && principalType !== "org") ||
-      (permission !== "view" && permission !== "edit" && permission !== "locked")
+      (permission !== "view" &&
+        permission !== "edit" &&
+        permission !== "locked" &&
+        permission !== "denied")
     ) {
       return c.json(
         {
           error:
-            "resourceType(folder|file|vault), resourceId, principalType(user|org), permission(view|edit|locked) required",
+            "resourceType(folder|file|vault), resourceId, principalType(user|org), permission(view|edit|locked|denied) required",
         },
         400,
       );
     }
     // An org-wide edit/view grant on a folder/file is "Share with team" (spec:
     // private-by-default). On a vault resource it's the "Open"/"Read-only"
-    // posture. Both are allowed; locks (deny
-    // overlays) may also be org-wide.
+    // posture. Both are allowed; locks (cap overlays) may also be org-wide.
+    //
+    // `denied` is the per-member "No access" and is deliberately narrower: only
+    // principal_type 'user', and never on the vault resource. An org-wide deny
+    // is just "no org grant" (the Private posture) said twice, and a vault-level
+    // deny would be a way to lock the owner out of their own vault.
+    if (permission === "denied" && (principalType !== "user" || resourceType === "vault")) {
+      return c.json(
+        { error: "denied applies to one member on a folder or file" },
+        400,
+      );
+    }
 
     const gate = await canManage(session.userId, resourceType, resourceId);
     if (!gate.ok) return c.json({ error: gate.error }, (gate.status ?? 403) as 403 | 404);
@@ -178,11 +191,12 @@ export function createShareRoutes(deps: ShareDeps): Hono {
     // reconnect so open sessions come back with fresh (now read-only) sync
     // tokens, same as revocation does. This covers a lock, a per-user edit→view
     // change, and a vault Open→Read-only posture flip (all land as
-    // view/locked). An 'edit' grant only widens access, so it needs no kick;
+    // view/locked) — and a `denied`, which has to eject the member outright.
+    // An 'edit' grant only widens access, so it needs no kick;
     // the onAclChanged push below lets background subscribers pick it up.
     // Reconnect re-mints each client's own permission, so a peer who still has
     // edit gets edit back — this only tightens editors that should go read-only.
-    if (permission === "locked" || permission === "view") {
+    if (permission === "locked" || permission === "view" || permission === "denied") {
       const docs = await docsForResource(resourceType, resourceId);
       for (const d of docs) {
         deps.disconnectDoc(d.vaultId, d.docId);
@@ -286,7 +300,7 @@ export function createShareRoutes(deps: ShareDeps): Hono {
 
     const members = await Promise.all(
       memberRows.map(async (m) => {
-        const { permission, capped } = await resolveAccessForUser(ctx, m.user_id, m.role);
+        const { permission, capped, denied } = await resolveAccessForUser(ctx, m.user_id, m.role);
         return {
           userId: m.user_id,
           name: m.name,
@@ -294,6 +308,7 @@ export function createShareRoutes(deps: ShareDeps): Hono {
           role: m.role,
           permission,
           capped,
+          denied: denied ?? false,
         };
       }),
     );

--- a/app/apps/server/src/http/routes/shares.ts
+++ b/app/apps/server/src/http/routes/shares.ts
@@ -104,15 +104,17 @@ export function createShareRoutes(deps: ShareDeps): Hono {
     // private-by-default). On a vault resource it's the "Open"/"Read-only"
     // posture. Both are allowed; locks (cap overlays) may also be org-wide.
     //
-    // `denied` is the per-member "No access" and is deliberately narrower: only
-    // principal_type 'user', and never on the vault resource. An org-wide deny
-    // is just "no org grant" (the Private posture) said twice, and a vault-level
-    // deny would be a way to lock the owner out of their own vault.
-    if (permission === "denied" && (principalType !== "user" || resourceType === "vault")) {
-      return c.json(
-        { error: "denied applies to one member on a folder or file" },
-        400,
-      );
+    // `denied` comes in two shapes, both on a folder or file and never on the
+    // vault resource (a vault-level deny is the Private posture, and would be a
+    // way to lock an owner out of their own vault):
+    //   - principal 'user' — the per-member Private: an absolute block.
+    //   - principal 'org'  — the ITEM set to Private: it takes the item out of
+    //     the team's reach. This is the row that makes item-Private possible at
+    //     all; clearing an item's own grants could never achieve it, because a
+    //     vault-wide Open grant still reached the item and the UI snapped back
+    //     to Shared.
+    if (permission === "denied" && resourceType === "vault") {
+      return c.json({ error: "denied applies to a folder or a file" }, 400);
     }
 
     const gate = await canManage(session.userId, resourceType, resourceId);
@@ -212,8 +214,14 @@ export function createShareRoutes(deps: ShareDeps): Hono {
     );
   });
 
-  // List every lock in a note collection. Any member of the vault may read
-  // these — the client renders lock badges in the tree from this.
+  // Every access OVERLAY row in a note collection: `locked` (read-only cap) and
+  // `denied` (Private). Any member may read these — the client renders the
+  // tree's lock badges and the Access panel's inherited-Private state from
+  // them, and both need the whole vault's set, not one resource's.
+  //
+  // Still mounted at `/locks`: the shape is a superset and the client splits by
+  // permission, so an older client that only understands `locked` is unaffected
+  // by the extra rows only if it filters — which it does.
   app.get("/vaults/:vaultId/locks", async (c) => {
     const session = await getSession(c);
     if (!session) return c.json({ error: "Authentication required" }, 401);
@@ -232,7 +240,7 @@ export function createShareRoutes(deps: ShareDeps): Hono {
       `SELECT s.id, s.resource_type, s.resource_id, s.principal_type, s.principal_id,
               s.permission, s.created_by, s.created_at
          FROM shares s
-        WHERE s.permission = 'locked'
+        WHERE s.permission IN ('locked', 'denied')
           AND (
             (s.resource_type = 'folder' AND s.resource_id IN
                (SELECT id FROM folders WHERE vault_id = $1))

--- a/app/apps/server/src/http/routes/versions.ts
+++ b/app/apps/server/src/http/routes/versions.ts
@@ -23,7 +23,7 @@ import { getSession } from "../session.js";
  *   GET    /api/vaults/:vaultId/checkpoints           list (member)
  *   POST   /api/vaults/:vaultId/checkpoints           create (owner/admin)
  *   DELETE /api/vaults/:vaultId/checkpoints/:id       delete (owner/admin)
- *   POST   /api/vaults/:vaultId/checkpoints/:id/revert  revert the vault (owner)
+ *   POST   /api/vaults/:vaultId/checkpoints/:id/revert  revert the vault (owner/admin)
  *
  * Gates mirror the rest of the app: per-doc `effectivePermission` for note
  * versions (so a `locked` share caps at view and a revert 403s), org role for
@@ -235,9 +235,13 @@ export function createVersionRoutes(deps: VersionRouteDeps): Hono {
     const vaultId = c.req.param("vaultId");
     const role = await vaultRole(vaultId, session.userId);
     if (role === undefined) return c.json({ error: "Unknown vault" }, 404);
-    // Owner only: this rewrites every note in the vault at once.
-    if (role !== "owner") {
-      return c.json({ error: "Only the vault owner can revert a vault" }, 403);
+    // Owner/admin: this rewrites every note in the vault at once, so it stays
+    // a privileged action — but it matches who can *create* and *delete* a
+    // checkpoint. Admins already run the vault's structure and access; leaving
+    // the one recovery action owner-only meant a team whose owner was away
+    // could take checkpoints and not use them.
+    if (role !== "owner" && role !== "admin") {
+      return c.json({ error: "Only a vault owner or admin can revert a vault" }, 403);
     }
     const checkpointId = c.req.param("id");
     const { rows } = await pool.query<{ id: string }>(

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -132,6 +132,26 @@ export async function listFolders(ctx: McpContext, vaultId: string) {
   }));
 }
 
+/**
+ * Refuse a root-level create when the vault's root is frozen.
+ *
+ * The MCP surface has to honour the same latch as the HTTP registry, and for
+ * the same reason: an assistant asked to "add a note" with no folder in mind is
+ * one of the likelier ways a stray root file appears.
+ */
+async function assertRootNotFrozen(vaultId: string, parentId: string | null): Promise<void> {
+  if (parentId) return;
+  const { rows } = await pool.query<{ root_frozen: boolean }>(
+    "SELECT root_frozen FROM vaults WHERE id = $1",
+    [vaultId],
+  );
+  if (rows[0]?.root_frozen) {
+    throw new McpToolError(
+      "This vault's root is frozen — create this inside a folder instead.",
+    );
+  }
+}
+
 export async function createFolder(
   ctx: McpContext,
   input: { vaultId: string; name: string; path: string; parentId?: string | null },
@@ -154,6 +174,9 @@ export async function createFolder(
     const row = existing.rows[0];
     return { folderId: row.id, parentId, name: row.name, path: input.path, adopted: true };
   }
+  // After the adopt path: freezing the root must not break re-registering a
+  // root folder that already exists.
+  await assertRootNotFrozen(input.vaultId, parentId);
 
   const id = randomUUID();
   await pool.query(
@@ -424,6 +447,8 @@ export async function createNote(
       seeded,
     };
   }
+  // After the adopt path, for the same reason as `createFolder`.
+  await assertRootNotFrozen(input.vaultId, folderId);
 
   const docId = randomUUID();
   await pool.query(

--- a/app/apps/server/src/permissions/http-gates.ts
+++ b/app/apps/server/src/permissions/http-gates.ts
@@ -5,6 +5,7 @@ import {
   ancestorFolderIds,
   buildAccessContext,
   effectivePermission,
+  isDenied,
   isLocked,
   resolveAccessForUser,
 } from "./resolver.js";
@@ -68,8 +69,10 @@ export async function canEditFolder(
   const role = await orgRole(row.organization_id, userId, db);
   if (role === null) return false; // not a member of the vault
 
-  // Deny overlay first: a lock caps everyone at view (no edits at all).
+  // Overlays first, both of which outrank the role below: a per-member deny
+  // removes the folder outright, and a lock caps everyone at view (no edits).
   const chain = await ancestorFolderIds(db, folderId);
+  if (await isDenied(db, userId, null, chain)) return false;
   if (await isLocked(db, userId, null, chain)) return false;
 
   if (role === "owner" || role === "admin") return true;

--- a/app/apps/server/src/permissions/http-gates.ts
+++ b/app/apps/server/src/permissions/http-gates.ts
@@ -71,8 +71,11 @@ export async function canEditFolder(
 
   // Overlays first, both of which outrank the role below: a per-member deny
   // removes the folder outright, and a lock caps everyone at view (no edits).
+  // An ORG deny (item set to Private) is deliberately NOT checked here — it
+  // removes the team's reach, not the owner's, and `resolveAccessForUser`
+  // below already applies it to everyone it should.
   const chain = await ancestorFolderIds(db, folderId);
-  if (await isDenied(db, userId, null, chain)) return false;
+  if (await isDenied(db, "user", userId, null, chain)) return false;
   if (await isLocked(db, userId, null, chain)) return false;
 
   if (role === "owner" || role === "admin") return true;

--- a/app/apps/server/src/permissions/http-gates.ts
+++ b/app/apps/server/src/permissions/http-gates.ts
@@ -8,6 +8,7 @@ import {
   isDenied,
   isLocked,
   resolveAccessForUser,
+  vaultBaseline,
 } from "./resolver.js";
 import { listReadableDocsInVault, vaultAccess } from "./vault-docs.js";
 
@@ -69,15 +70,22 @@ export async function canEditFolder(
   const role = await orgRole(row.organization_id, userId, db);
   if (role === null) return false; // not a member of the vault
 
-  // Overlays first, both of which outrank the role below: a per-member deny
-  // removes the folder outright, and a lock caps everyone at view (no edits).
-  // An ORG deny (item set to Private) is deliberately NOT checked here — it
-  // removes the team's reach, not the owner's, and `resolveAccessForUser`
-  // below already applies it to everyone it should.
+  // Overlays first — they outrank the role below, because what the Access panel
+  // sets applies to whoever set it.
   const chain = await ancestorFolderIds(db, folderId);
   if (await isDenied(db, "user", userId, null, chain)) return false;
   if (await isLocked(db, userId, null, chain)) return false;
+  const itemPrivate = await isDenied(db, "org", row.organization_id, null, chain);
+  const readOnlyVault = (await vaultBaseline(db, row.organization_id)) === "view";
 
+  // Private and a Read-only vault both skip the shortcuts and let the share
+  // lookup at the bottom decide — that is how a folder marked Shared can still
+  // lift someone out of a Read-only vault.
+  if (itemPrivate || readOnlyVault) {
+    const ctx = await buildAccessContext("folder", folderId, db);
+    if (!ctx) return false;
+    return (await resolveAccessForUser(ctx, userId, role, db)).permission === "edit";
+  }
   if (role === "owner" || role === "admin") return true;
   if (row.created_by && row.created_by === userId) return true;
 

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -16,9 +16,10 @@ import { pool as defaultPool } from "../db/pool.js";
  * grant at all (a vault set to Private, or one created while private-by-default
  * was the rule) a member has no content access beyond notes it created: `none`.
  *
- * Denies (permission = 'denied') come in two flavours, both resolved BEFORE
- * the rules above: a per-USER deny is `none`, full stop; an ORG deny (the item
- * set to Private) only stops the team's grants reaching it. See {@link isDenied}.
+ * Denies (permission = 'denied') come in two flavours, both resolved BEFORE the
+ * rules above and both applying to owners and admins: a per-USER deny is
+ * `none`, full stop; an ORG deny (the item set to Private) leaves only the
+ * creator and explicit per-user grants. See {@link isDenied}.
  *
  * Locks (permission = 'locked') are a cap overlay resolved AFTER the rules
  * above: when a lock matches the doc or any ancestor folder — for this user
@@ -180,6 +181,11 @@ async function sharePermission(
 /**
  * True when a lock row covers this resource (a file when `docId` is set, plus
  * any folder in `folderIds`) for this user or the whole vault.
+ *
+ * Deliberately folder/file only. A vault-scoped lock cannot exist: it would
+ * need the same (resource_type, resource_id, principal_type, principal_id) key
+ * the vault GRANT already occupies. The vault-wide read-only ceiling is
+ * expressed by that grant instead — see {@link vaultBaseline}.
  */
 export async function isLocked(
   db: Queryable,
@@ -207,6 +213,34 @@ export async function isLocked(
 }
 
 /**
+ * The vault's declared posture: the org-wide grant on the vault resource, or
+ * null when there is none (the Private posture).
+ *
+ * This is a **baseline for everyone**, not just for plain members. Read-only
+ * says "Everyone can read everything, not edit", and until now it didn't mean
+ * everyone: owners, admins and note creators all kept `edit` through shortcuts
+ * that ran before any grant was consulted, so the person who chose the setting
+ * was the one person exempt from it. When the baseline is `view`, those
+ * shortcuts are skipped and the ordinary highest-wins grant lookup decides —
+ * which still lets a folder marked Shared, or a personal edit grant, lift an
+ * individual out of it. That is exactly what the panel offers.
+ */
+export async function vaultBaseline(
+  db: Queryable,
+  organizationId: string,
+): Promise<Permission | null> {
+  const { rows } = await db.query<{ permission: string }>(
+    `SELECT permission FROM shares
+      WHERE resource_type = 'vault' AND resource_id = $1
+        AND principal_type = 'org' AND permission IN ('view', 'edit')
+      LIMIT 1`,
+    [organizationId],
+  );
+  const p = rows[0]?.permission;
+  return p === "edit" || p === "view" ? p : null;
+}
+
+/**
  * True when a `denied` row covers the resource — the file itself or any
  * ancestor folder — for `principal`.
  *
@@ -221,11 +255,18 @@ export async function isLocked(
  * - **org deny** (`principal_type 'org'`) — the *item* set to Private. It says
  *   "this folder is not shared with the team", and it exists because clearing
  *   an item's own rows could never achieve that: a vault-wide Open grant still
- *   reached the item, so Private silently snapped back to Shared. It suppresses
- *   ORG-scoped grants only (see `sharePermission`), leaving the creator, anyone
- *   with an explicit personal share, and owners/admins — which is exactly
- *   "only you and people you share it with", and is what keeps an owner from
- *   making a folder nobody, including themselves, can ever reach again.
+ *   reached the item, so Private silently snapped back to Shared. It leaves the
+ *   creator and explicit per-user grants standing and drops everything
+ *   org-scoped — which is exactly "only you and people you share it with".
+ *
+ * Both apply to **owners and admins**. A restriction its author is exempt from
+ * cannot be checked by its author, and "it works, take my word for it" is not a
+ * thing to ship in an access panel. The safety net is not an exemption, it is
+ * that the *management* gate is role-based and separate: `canManage` in
+ * `http/routes/shares.ts` asks for owner/admin and never for effective
+ * permission, so an owner can always lift a restriction they applied to
+ * themselves — and the desktop's Access list is built from the local folder, so
+ * the row to do it from never disappears either.
  */
 export async function isDenied(
   db: Queryable,
@@ -258,15 +299,37 @@ export async function effectivePermission(
 
   const folderIds = await ancestorFolderIds(db, loc.folderId);
 
-  // A per-member deny is first and unconditional: it outranks role, grant and
-  // authorship.
+  // Denies are first and unconditional. Both kinds outrank the role branch
+  // below: what you set in the Access panel applies to you too, or a vault
+  // owner can never see the effect of their own restriction and has to take it
+  // on trust. The escape hatch is elsewhere and role-based — managing shares
+  // (`canManage` in http/routes/shares.ts) is gated on owner/admin, never on
+  // effective permission, so an owner can always lift what they set.
   if (await isDenied(db, "user", userId, docId, folderIds)) return "none";
-  // An item set to Private only removes the TEAM's reach (see isDenied).
-  const orgGrantsApply = !(await isDenied(db, "org", loc.organizationId, docId, folderIds));
+  const itemPrivate = await isDenied(db, "org", loc.organizationId, docId, folderIds);
 
   const role = await memberRole(db, loc.organizationId, userId);
+  // A Read-only vault caps EVERY shortcut below it (see `vaultBaseline`).
+  const readOnlyVault = (await vaultBaseline(db, loc.organizationId)) === "view";
   let granted: Permission;
-  if (role === "owner" || role === "admin") {
+  if (itemPrivate) {
+    // Private = "only me and people I share it with". The creator keeps it and
+    // explicit per-user grants still apply; everything org-scoped — including
+    // an admin's blanket edit — does not.
+    granted =
+      role !== null && loc.createdBy && loc.createdBy === userId
+        ? "edit"
+        : await sharePermission(db, userId, docId, folderIds, loc.organizationId, false, false);
+  } else if (readOnlyVault) {
+    granted = await sharePermission(
+      db,
+      userId,
+      docId,
+      folderIds,
+      loc.organizationId,
+      role !== null,
+    );
+  } else if (role === "owner" || role === "admin") {
     granted = "edit";
   } else if (role !== null && loc.createdBy && loc.createdBy === userId) {
     // Private-by-default: a member always has edit on a note they created, even
@@ -283,11 +346,10 @@ export async function effectivePermission(
       folderIds,
       loc.organizationId,
       role !== null, // isMember — gates the org-wide grant
-      orgGrantsApply,
     );
   }
 
-  // Deny overlay: a matching lock caps at view; it never grants.
+  // Cap overlay: a matching lock caps at view; it never grants.
   if (granted !== "none" && (await isLocked(db, userId, docId, folderIds))) {
     return "view";
   }
@@ -357,27 +419,26 @@ export async function resolveAccessForUser(
   if (await isDenied(db, "user", userId, ctx.docId, ctx.folderIds)) {
     return { permission: "none", capped: false, denied: true };
   }
-  const orgGrantsApply = !(await isDenied(
-    db,
-    "org",
-    ctx.organizationId,
-    ctx.docId,
-    ctx.folderIds,
-  ));
+  const itemPrivate = await isDenied(db, "org", ctx.organizationId, ctx.docId, ctx.folderIds);
+  const readOnlyVault = (await vaultBaseline(db, ctx.organizationId)) === "view";
   const granted: Permission =
-    role === "owner" || role === "admin"
-      ? "edit"
-      : await sharePermission(
-          db,
-          userId,
-          ctx.docId,
-          ctx.folderIds,
-          ctx.organizationId,
-          role !== null, // isMember — gates the org-wide grant
-          orgGrantsApply,
-        );
+    itemPrivate
+      ? // Private: only explicit per-user grants survive. (The creator rule
+        // needs a doc, which a folder context doesn't have — that branch lives
+        // in `effectivePermission`.)
+        await sharePermission(db, userId, ctx.docId, ctx.folderIds, ctx.organizationId, false, false)
+      : !readOnlyVault && (role === "owner" || role === "admin")
+        ? "edit"
+        : await sharePermission(
+            db,
+            userId,
+            ctx.docId,
+            ctx.folderIds,
+            ctx.organizationId,
+            role !== null, // isMember — gates the org-wide grant
+          );
 
-  if (granted === "none") return { permission: "none", capped: false };
+  if (granted === "none") return { permission: "none", capped: false, denied: itemPrivate };
 
   const locked = await isLocked(db, userId, ctx.docId, ctx.folderIds);
   if (locked && granted === "edit") return { permission: "view", capped: true };

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -16,9 +16,9 @@ import { pool as defaultPool } from "../db/pool.js";
  * grant at all (a vault set to Private, or one created while private-by-default
  * was the rule) a member has no content access beyond notes it created: `none`.
  *
- * Denies (permission = 'denied', per-user) are resolved BEFORE everything:
- * a match on the doc or any ancestor folder is `none`, full stop — see
- * {@link isDenied}.
+ * Denies (permission = 'denied') come in two flavours, both resolved BEFORE
+ * the rules above: a per-USER deny is `none`, full stop; an ORG deny (the item
+ * set to Private) only stops the team's grants reaching it. See {@link isDenied}.
  *
  * Locks (permission = 'locked') are a cap overlay resolved AFTER the rules
  * above: when a lock matches the doc or any ancestor folder — for this user
@@ -134,12 +134,18 @@ async function sharePermission(
   folderIds: string[],
   organizationId: string,
   isMember: boolean,
+  /** False when an org deny covers this resource — see {@link isDenied}. */
+  orgGrantsApply = true,
 ): Promise<Permission> {
   // Team (org-wide) grants apply ONLY to actual vault members — never to
   // outsiders who merely know a doc id. They can target a specific folder/file
   // ("Share with team", private-by-default) or the whole vault (Open/
   // Read-only). Per-user grants are inherently scoped, so they need no gate.
-  const orgGrantClause = isMember
+  //
+  // `orgGrantsApply` is how an item set to Private overrides a vault that is
+  // Shared: the org branch drops out for that resource, so the vault-wide grant
+  // stops reaching it while explicit personal grants still do.
+  const orgGrantClause = isMember && orgGrantsApply
     ? `OR (principal_type = 'org' AND principal_id = $4 AND (
             ($2::text IS NOT NULL AND resource_type = 'file' AND resource_id = $2)
             OR (resource_type = 'folder' AND resource_id = ANY($3::text[]))
@@ -201,36 +207,43 @@ export async function isLocked(
 }
 
 /**
- * True when a `denied` row shuts this user out of the resource — the file
- * itself or any ancestor folder.
+ * True when a `denied` row covers the resource — the file itself or any
+ * ancestor folder — for `principal`.
  *
- * A deny is stronger than a lock: a lock caps at `view`, a deny returns
- * `none`. It is resolved LAST, after every allow rule, so it beats the
- * vault-wide Open grant, an explicit per-user grant, an admin's blanket edit,
- * and the "creator of the note" escape hatch. That is the whole point — the
- * Access panel's per-member **No access** has to mean it even for content the
- * member wrote, or "make this private from Sam" would silently do nothing on
- * exactly the notes Sam cares about.
+ * There are two kinds, and the difference is the whole design:
  *
- * Always principal_type 'user'. An org-wide deny would be indistinguishable
- * from having no org grant at all, which is what Private already is.
+ * - **user deny** (`principal_type 'user'`) — the Access panel's per-member
+ *   *Private*. Absolute: resolved before every allow rule, so it beats the
+ *   vault-wide grant, an explicit per-user grant, an admin's blanket edit and
+ *   the "creator of the note" escape hatch. That last one is the point —
+ *   "keep this away from Sam" has to mean it on the notes Sam wrote.
+ *
+ * - **org deny** (`principal_type 'org'`) — the *item* set to Private. It says
+ *   "this folder is not shared with the team", and it exists because clearing
+ *   an item's own rows could never achieve that: a vault-wide Open grant still
+ *   reached the item, so Private silently snapped back to Shared. It suppresses
+ *   ORG-scoped grants only (see `sharePermission`), leaving the creator, anyone
+ *   with an explicit personal share, and owners/admins — which is exactly
+ *   "only you and people you share it with", and is what keeps an owner from
+ *   making a folder nobody, including themselves, can ever reach again.
  */
 export async function isDenied(
   db: Queryable,
-  userId: string,
+  principalType: "user" | "org",
+  principalId: string,
   docId: string | null,
   folderIds: string[],
 ): Promise<boolean> {
   const { rows } = await db.query<{ ok: number }>(
     `SELECT 1 AS ok FROM shares
       WHERE permission = 'denied'
-        AND principal_type = 'user' AND principal_id = $1
+        AND principal_type = $4 AND principal_id = $1
         AND (
           ($2::text IS NOT NULL AND resource_type = 'file' AND resource_id = $2)
           OR (resource_type = 'folder' AND resource_id = ANY($3::text[]))
         )
       LIMIT 1`,
-    [userId, docId, folderIds],
+    [principalId, docId, folderIds, principalType],
   );
   return rows.length > 0;
 }
@@ -245,8 +258,11 @@ export async function effectivePermission(
 
   const folderIds = await ancestorFolderIds(db, loc.folderId);
 
-  // Deny first and unconditionally: it outranks role, grant and authorship.
-  if (await isDenied(db, userId, docId, folderIds)) return "none";
+  // A per-member deny is first and unconditional: it outranks role, grant and
+  // authorship.
+  if (await isDenied(db, "user", userId, docId, folderIds)) return "none";
+  // An item set to Private only removes the TEAM's reach (see isDenied).
+  const orgGrantsApply = !(await isDenied(db, "org", loc.organizationId, docId, folderIds));
 
   const role = await memberRole(db, loc.organizationId, userId);
   let granted: Permission;
@@ -267,6 +283,7 @@ export async function effectivePermission(
       folderIds,
       loc.organizationId,
       role !== null, // isMember — gates the org-wide grant
+      orgGrantsApply,
     );
   }
 
@@ -337,9 +354,16 @@ export async function resolveAccessForUser(
   role: string | null,
   db: Queryable = defaultPool,
 ): Promise<ResolvedAccess> {
-  if (await isDenied(db, userId, ctx.docId, ctx.folderIds)) {
+  if (await isDenied(db, "user", userId, ctx.docId, ctx.folderIds)) {
     return { permission: "none", capped: false, denied: true };
   }
+  const orgGrantsApply = !(await isDenied(
+    db,
+    "org",
+    ctx.organizationId,
+    ctx.docId,
+    ctx.folderIds,
+  ));
   const granted: Permission =
     role === "owner" || role === "admin"
       ? "edit"
@@ -350,6 +374,7 @@ export async function resolveAccessForUser(
           ctx.folderIds,
           ctx.organizationId,
           role !== null, // isMember — gates the org-wide grant
+          orgGrantsApply,
         );
 
   if (granted === "none") return { permission: "none", capped: false };

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -313,13 +313,23 @@ export async function effectivePermission(
   const readOnlyVault = (await vaultBaseline(db, loc.organizationId)) === "view";
   let granted: Permission;
   if (itemPrivate) {
-    // Private = "only me and people I share it with". The creator keeps it and
-    // explicit per-user grants still apply; everything org-scoped — including
-    // an admin's blanket edit — does not.
-    granted =
-      role !== null && loc.createdBy && loc.createdBy === userId
-        ? "edit"
-        : await sharePermission(db, userId, docId, folderIds, loc.organizationId, false, false);
+    // Private = "nobody, until you name them". ONLY explicit per-user grants
+    // survive — not the org grant, not the admin shortcut, and not authorship.
+    //
+    // Authorship is the one that had to go last and is the one that matters:
+    // in a vault you set up yourself you wrote nearly everything, so a Private
+    // that spares the author is a Private you can never observe, and "it works,
+    // trust me" is not a thing to ship in an access panel. Naming yourself in
+    // the list below is how you get back in.
+    granted = await sharePermission(
+      db,
+      userId,
+      docId,
+      folderIds,
+      loc.organizationId,
+      false,
+      false,
+    );
   } else if (readOnlyVault) {
     granted = await sharePermission(
       db,
@@ -368,6 +378,16 @@ export interface AccessContext {
   organizationId: string;
   docId: string | null;
   folderIds: string[];
+  /**
+   * Creator of the note this context describes (null for a folder, or a file).
+   *
+   * Carried so the "who can access" list applies the same creator rule the
+   * enforcer does. Without it the panel reported `none` for a member's own
+   * note in a Private vault while `effectivePermission` handed them `edit` —
+   * the panel and the thing it describes disagreeing, which is worse than
+   * either answer alone.
+   */
+  createdBy: string | null;
 }
 
 export interface ResolvedAccess {
@@ -391,6 +411,7 @@ export async function buildAccessContext(
       organizationId: loc.organizationId,
       docId: resourceId,
       folderIds: await ancestorFolderIds(db, loc.folderId),
+      createdBy: loc.createdBy,
     };
   }
   // folder: resolve its owning vault (organization), then walk itself + ancestors.
@@ -406,6 +427,7 @@ export async function buildAccessContext(
     organizationId: org,
     docId: null,
     folderIds: await ancestorFolderIds(db, resourceId),
+    createdBy: null, // folders have no creator column in the ACL context
   };
 }
 
@@ -420,23 +442,35 @@ export async function resolveAccessForUser(
     return { permission: "none", capped: false, denied: true };
   }
   const itemPrivate = await isDenied(db, "org", ctx.organizationId, ctx.docId, ctx.folderIds);
+  // Mirrors `effectivePermission` branch for branch. They MUST agree: this one
+  // renders the "who can access" list, and a list that disagrees with the
+  // enforcer is worse than no list.
   const readOnlyVault = (await vaultBaseline(db, ctx.organizationId)) === "view";
-  const granted: Permission =
-    itemPrivate
-      ? // Private: only explicit per-user grants survive. (The creator rule
-        // needs a doc, which a folder context doesn't have — that branch lives
-        // in `effectivePermission`.)
-        await sharePermission(db, userId, ctx.docId, ctx.folderIds, ctx.organizationId, false, false)
-      : !readOnlyVault && (role === "owner" || role === "admin")
+  const isCreator = role !== null && !!ctx.createdBy && ctx.createdBy === userId;
+  const granted: Permission = itemPrivate
+    ? // Private: only explicit per-user grants survive — authorship included.
+      await sharePermission(db, userId, ctx.docId, ctx.folderIds, ctx.organizationId, false, false)
+    : readOnlyVault
+      ? await sharePermission(
+          db,
+          userId,
+          ctx.docId,
+          ctx.folderIds,
+          ctx.organizationId,
+          role !== null,
+        )
+      : role === "owner" || role === "admin"
         ? "edit"
-        : await sharePermission(
-            db,
-            userId,
-            ctx.docId,
-            ctx.folderIds,
-            ctx.organizationId,
-            role !== null, // isMember — gates the org-wide grant
-          );
+        : isCreator
+          ? "edit"
+          : await sharePermission(
+              db,
+              userId,
+              ctx.docId,
+              ctx.folderIds,
+              ctx.organizationId,
+              role !== null, // isMember — gates the org-wide grant
+            );
 
   if (granted === "none") return { permission: "none", capped: false, denied: itemPrivate };
 

--- a/app/apps/server/src/permissions/resolver.ts
+++ b/app/apps/server/src/permissions/resolver.ts
@@ -16,7 +16,11 @@ import { pool as defaultPool } from "../db/pool.js";
  * grant at all (a vault set to Private, or one created while private-by-default
  * was the rule) a member has no content access beyond notes it created: `none`.
  *
- * Locks (permission = 'locked') are a DENY overlay resolved AFTER the rules
+ * Denies (permission = 'denied', per-user) are resolved BEFORE everything:
+ * a match on the doc or any ancestor folder is `none`, full stop — see
+ * {@link isDenied}.
+ *
+ * Locks (permission = 'locked') are a cap overlay resolved AFTER the rules
  * above: when a lock matches the doc or any ancestor folder — for this user
  * (principal_type 'user') or the whole vault (principal_type 'org') — the
  * result is capped at `view`. Owners/admins are capped too (the point of a
@@ -196,6 +200,41 @@ export async function isLocked(
   return rows.length > 0;
 }
 
+/**
+ * True when a `denied` row shuts this user out of the resource — the file
+ * itself or any ancestor folder.
+ *
+ * A deny is stronger than a lock: a lock caps at `view`, a deny returns
+ * `none`. It is resolved LAST, after every allow rule, so it beats the
+ * vault-wide Open grant, an explicit per-user grant, an admin's blanket edit,
+ * and the "creator of the note" escape hatch. That is the whole point — the
+ * Access panel's per-member **No access** has to mean it even for content the
+ * member wrote, or "make this private from Sam" would silently do nothing on
+ * exactly the notes Sam cares about.
+ *
+ * Always principal_type 'user'. An org-wide deny would be indistinguishable
+ * from having no org grant at all, which is what Private already is.
+ */
+export async function isDenied(
+  db: Queryable,
+  userId: string,
+  docId: string | null,
+  folderIds: string[],
+): Promise<boolean> {
+  const { rows } = await db.query<{ ok: number }>(
+    `SELECT 1 AS ok FROM shares
+      WHERE permission = 'denied'
+        AND principal_type = 'user' AND principal_id = $1
+        AND (
+          ($2::text IS NOT NULL AND resource_type = 'file' AND resource_id = $2)
+          OR (resource_type = 'folder' AND resource_id = ANY($3::text[]))
+        )
+      LIMIT 1`,
+    [userId, docId, folderIds],
+  );
+  return rows.length > 0;
+}
+
 export async function effectivePermission(
   userId: string,
   docId: string,
@@ -205,6 +244,9 @@ export async function effectivePermission(
   if (!loc) return "none";
 
   const folderIds = await ancestorFolderIds(db, loc.folderId);
+
+  // Deny first and unconditionally: it outranks role, grant and authorship.
+  if (await isDenied(db, userId, docId, folderIds)) return "none";
 
   const role = await memberRole(db, loc.organizationId, userId);
   let granted: Permission;
@@ -253,6 +295,9 @@ export interface ResolvedAccess {
   permission: Permission;
   /** True when a lock reduced an otherwise-`edit` member down to `view`. */
   capped: boolean;
+  /** True when the `none` came from an explicit per-member deny, not from an
+   *  absent grant — the UI says "No access · blocked" rather than "not shared". */
+  denied?: boolean;
 }
 
 export async function buildAccessContext(
@@ -292,6 +337,9 @@ export async function resolveAccessForUser(
   role: string | null,
   db: Queryable = defaultPool,
 ): Promise<ResolvedAccess> {
+  if (await isDenied(db, userId, ctx.docId, ctx.folderIds)) {
+    return { permission: "none", capped: false, denied: true };
+  }
   const granted: Permission =
     role === "owner" || role === "admin"
       ? "edit"

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -262,18 +262,23 @@ export async function listReadableDocsInVault(
  * doc_ids in this vault the caller could read but that are now **soft-deleted**.
  *
  * Why this exists: "absent from `GET /api/notes`" is ambiguous — it means either
- * *deleted* or *you lost read access*, because that route is ACL-filtered. The
- * desktop reconciler has to remove local files for the first and must NOT for the
- * second (losing a share deliberately leaves the `.md` alone). Absence alone
- * can't distinguish them, and neither can `effectivePermission`: `locateDoc`
- * filters `deleted_at IS NULL`, so a deleted doc resolves to "none", exactly like
- * no access. So deletion has to be *stated*, never inferred.
+ * *deleted* or *you lost read access*, because that route is ACL-filtered.
+ * Absence alone can't distinguish them, and neither can `effectivePermission`:
+ * `locateDoc` filters `deleted_at IS NULL`, so a deleted doc resolves to "none",
+ * exactly like no access. So deletion has to be *stated*, never inferred.
+ *
+ * Both outcomes now remove the local file (a revocation that leaves a readable
+ * `.md` on the ex-reader's disk is cosmetic), but they remain distinct: the
+ * client caps them against separate budgets and reports them differently, and
+ * an unanswered tombstone question still means "change nothing" — see
+ * `lib/sync/inbound.ts`.
  *
  * Permission-filtered rather than "every deleted id in the vault": the filtered
  * version's failure mode is the safe one. If a teammate lost the share AND the
- * note was deleted, the id is withheld, the client falls into its
- * "absent from both" branch, and it keeps the file. Filtering can only ever
- * cause a MISSED delete, never a wrong one.
+ * note was deleted, the id is withheld and the client falls into its
+ * "absent from both" branch, which removes the file as a revocation instead of
+ * as a delete — the same outcome by the gentler route (a larger safety budget,
+ * and it never fires at all if this endpoint couldn't answer).
  */
 export async function listDeletedReadableDocsInVault(
   userId: string,

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -173,7 +173,11 @@ async function listDocsInVault(
      SELECT fi.id FROM files fi
        WHERE fi.vault_id = $2
          AND (fi.folder_id IN (SELECT id FROM subtree) OR fi.id IN (SELECT id FROM shared_files))`;
-  const scopedDocs = async (orgGrants: boolean): Promise<Set<string>> => {
+  // `creatorCounts` exists for the rescue call below: under item-Private,
+  // authorship no longer keeps a doc, so the "reaches it personally" set is
+  // per-user shares ONLY. The normal call keeps it — a member still reads the
+  // notes they wrote.
+  const scopedDocs = async (orgGrants: boolean, creatorCounts = true): Promise<Set<string>> => {
     const { rows } = await db.query<{ id: string }>(
       `WITH RECURSIVE shared_folders AS (
           SELECT resource_id AS id FROM shares
@@ -199,21 +203,22 @@ async function listDocsInVault(
        SELECT n.id FROM notes n
          WHERE n.vault_id = $2 AND n.${livePredicate}
            AND (
-             ($4 AND n.created_by = $1)
+             ($4 AND $6 AND n.created_by = $1)
              OR n.folder_id IN (SELECT id FROM subtree)
              OR n.id IN (SELECT id FROM shared_files)
            )
        ${filesUnion}`,
-      [userId, vaultId, organizationId, isMember, orgGrants],
+      [userId, vaultId, organizationId, isMember, orgGrants, creatorCounts],
     );
     return new Set(rows.map((r) => r.id));
   };
 
   // Both denies apply to everyone, owners and admins included — see
   // [[resolver]] for why a restriction its author is exempt from is not one.
-  // The org deny is rescued only by `personal` below (what this user created or
-  // was shared by name), which is what "only you and people you share it with"
-  // means once it is a set rather than a sentence.
+  // The org deny is rescued only by an explicit per-user share (`personal`
+  // below, which deliberately does NOT count authorship): Private means
+  // "nobody until you name them", and in a vault you set up yourself you wrote
+  // nearly everything.
   const userDenied = await deniedDocsInVault(db, "user", userId, vaultId);
   const orgDenied = await deniedDocsInVault(db, "org", organizationId, vaultId);
 
@@ -233,7 +238,7 @@ async function listDocsInVault(
   }
 
   if (orgDenied.size > 0) {
-    const personal = await scopedDocs(false);
+    const personal = await scopedDocs(false, false);
     for (const id of orgDenied) if (!personal.has(id)) reachable.delete(id);
   }
   return subtract(reachable, userDenied);
@@ -315,11 +320,8 @@ export async function listVisibleFolders(
   // user created themselves stays visible either way (that's "only you").
   const userDenied = await deniedFolderIds(db, "user", userId);
   const orgDenied = await deniedFolderIds(db, "org", access.organizationId);
-  const mine = new Set(
-    all.rows.filter((f) => f.created_by === userId).map((f) => f.id),
-  );
-  // A per-member deny wins even over authorship; an org deny does not.
-  const hidden = (id: string) => userDenied.has(id) || (orgDenied.has(id) && !mine.has(id));
+  // Neither deny is undone by authorship — see `listDocsInVault`.
+  const hidden = (id: string) => userDenied.has(id) || orgDenied.has(id);
   if (access.vaultWide) return all.rows.filter((f) => !hidden(f.id));
 
   const readable = await listReadableDocsInVault(userId, vaultId, db);

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -30,7 +30,21 @@ export async function vaultAccess(
   db: Queryable,
   userId: string,
   vaultId: string,
-): Promise<{ organizationId: string; role: string | null; vaultWide: boolean } | null> {
+): Promise<{
+  organizationId: string;
+  role: string | null;
+  vaultWide: boolean;
+  /**
+   * WHERE the vault-wide reach came from, or null when there is none.
+   *
+   * Load-bearing for the item-Private rule: an item set to Private takes it
+   * out of the TEAM's reach only, so a member whose access is the org-wide
+   * grant loses it while an owner/admin or someone holding a personal
+   * vault grant keeps it. Collapsing all three into one boolean is what made
+   * that impossible to express.
+   */
+  vaultWideVia: "role" | "org" | "user" | null;
+} | null> {
   const org = await db.query<{ organization_id: string; role: string | null }>(
     `SELECT v.organization_id, m.role
        FROM vaults v
@@ -41,42 +55,51 @@ export async function vaultAccess(
   );
   const row = org.rows[0];
   if (!row) return null;
-  let vaultWide = row.role === "owner" || row.role === "admin";
-  if (!vaultWide) {
-    const orgClause = row.role !== null ? "principal_type = 'org' OR" : "";
-    const grant = await db.query(
-      `SELECT 1 FROM shares
-        WHERE resource_type = 'vault' AND resource_id = $1
-          AND permission IN ('view', 'edit')
-          AND (${orgClause} (principal_type = 'user' AND principal_id = $2))
-        LIMIT 1`,
-      [row.organization_id, userId],
-    );
-    vaultWide = (grant.rowCount ?? 0) > 0;
+  const base = { organizationId: row.organization_id, role: row.role };
+  if (row.role === "owner" || row.role === "admin") {
+    return { ...base, vaultWide: true, vaultWideVia: "role" };
   }
-  return { organizationId: row.organization_id, role: row.role, vaultWide };
+  const orgClause = row.role !== null ? "principal_type = 'org' OR" : "";
+  const grant = await db.query<{ principal_type: string }>(
+    `SELECT principal_type FROM shares
+      WHERE resource_type = 'vault' AND resource_id = $1
+        AND permission IN ('view', 'edit')
+        AND (${orgClause} (principal_type = 'user' AND principal_id = $2))
+      ORDER BY principal_type = 'user' DESC
+      LIMIT 1`,
+    [row.organization_id, userId],
+  );
+  const via = grant.rows[0]?.principal_type;
+  return {
+    ...base,
+    vaultWide: via !== undefined,
+    vaultWideVia: via === "user" ? "user" : via === "org" ? "org" : null,
+  };
 }
 
 /**
- * doc_ids in this vault the user is explicitly SHUT OUT of — the per-member
- * deny (`shares.permission = 'denied'`) folded down through folder inheritance.
+ * doc_ids in this vault covered by a `denied` row for `principalId`, folded
+ * down through folder inheritance.
  *
- * Subtracted from every readable/visible set below rather than woven into their
- * WHERE clauses on purpose: a deny has to beat the owner/admin branch, the
- * vault-wide grant branch AND the created_by branch, and those are three
- * different queries. One subtraction at the end can't be forgotten in one of
- * them.
+ * Two callers, matching the resolver's two kinds of deny ([[resolver]]):
+ *   - `'user'` — the per-member Private. Subtracted from EVERY set below,
+ *     because it has to beat the owner/admin branch, the vault-wide grant
+ *     branch and the created_by branch, which are three different queries.
+ *     One subtraction at the end can't be forgotten in one of them.
+ *   - `'org'`  — the item set to Private. Subtracted only from what the TEAM
+ *     could otherwise reach, so the creator and explicit grantees keep it.
  */
 async function deniedDocsInVault(
   db: Queryable,
-  userId: string,
+  principalType: "user" | "org",
+  principalId: string,
   vaultId: string,
 ): Promise<Set<string>> {
   const { rows } = await db.query<{ id: string }>(
     `WITH RECURSIVE denied_seed AS (
         SELECT resource_id AS id FROM shares
          WHERE resource_type = 'folder' AND permission = 'denied'
-           AND principal_type = 'user' AND principal_id = $1
+           AND principal_type = $3 AND principal_id = $1
      ),
      denied_subtree AS (
         SELECT id, parent_id FROM folders WHERE id IN (SELECT id FROM denied_seed)
@@ -86,7 +109,7 @@ async function deniedDocsInVault(
      denied_files AS (
         SELECT resource_id AS id FROM shares
          WHERE resource_type = 'file' AND permission = 'denied'
-           AND principal_type = 'user' AND principal_id = $1
+           AND principal_type = $3 AND principal_id = $1
      )
      SELECT n.id FROM notes n
        WHERE n.vault_id = $2
@@ -95,21 +118,22 @@ async function deniedDocsInVault(
      SELECT fi.id FROM files fi
        WHERE fi.vault_id = $2
          AND (fi.folder_id IN (SELECT id FROM denied_subtree) OR fi.id IN (SELECT id FROM denied_files))`,
-    [userId, vaultId],
+    [principalId, vaultId, principalType],
   );
   return new Set(rows.map((r) => r.id));
 }
 
-/** Folder ids this user is denied, including everything below them. */
+/** Folder ids denied to `principalId`, including everything below them. */
 async function deniedFolderIds(
   db: Queryable,
-  userId: string,
+  principalType: "user" | "org",
+  principalId: string,
 ): Promise<Set<string>> {
   const { rows } = await db.query<{ id: string }>(
     `WITH RECURSIVE denied_seed AS (
         SELECT resource_id AS id FROM shares
          WHERE resource_type = 'folder' AND permission = 'denied'
-           AND principal_type = 'user' AND principal_id = $1
+           AND principal_type = $2 AND principal_id = $1
      ),
      denied_subtree AS (
         SELECT id, parent_id FROM folders WHERE id IN (SELECT id FROM denied_seed)
@@ -117,7 +141,7 @@ async function deniedFolderIds(
         SELECT f.id, f.parent_id FROM folders f JOIN denied_subtree d ON f.parent_id = d.id
      )
      SELECT DISTINCT id FROM denied_subtree`,
-    [userId],
+    [principalId, principalType],
   );
   return new Set(rows.map((r) => r.id));
 }
@@ -141,23 +165,11 @@ async function listDocsInVault(
 ): Promise<Set<string>> {
   const access = await vaultAccess(db, userId, vaultId);
   if (!access) return new Set(); // unknown vault
-  const { organizationId, role, vaultWide } = access;
+  const { organizationId, role, vaultWide, vaultWideVia } = access;
 
   // The ONLY difference between the two sets. `files` has no `deleted_at`
   // column, so a tombstone can never be a file — the UNIONs below drop out.
   const livePredicate = opts.deleted ? "deleted_at IS NOT NULL" : "deleted_at IS NULL";
-
-  if (vaultWide) {
-    const { rows } = await db.query<{ id: string }>(
-      opts.deleted
-        ? `SELECT id FROM notes WHERE vault_id = $1 AND ${livePredicate}`
-        : `SELECT id FROM notes WHERE vault_id = $1 AND ${livePredicate}
-           UNION
-           SELECT id FROM files WHERE vault_id = $1`,
-      [vaultId],
-    );
-    return subtract(new Set(rows.map((r) => r.id)), await deniedDocsInVault(db, userId, vaultId));
-  }
 
   // Non-privileged (private-by-default): readable docs are the union of
   //   - notes the user created (created_by) — ONLY while still a member;
@@ -168,6 +180,12 @@ async function listDocsInVault(
   // ($4) so a REMOVED member (session outlives removal) loses read on notes
   // they authored — matching resolver.effectivePermission's creator rule.
   //
+  // `orgGrants` ($5) is run BOTH ways when an item is set to Private: once
+  // normally, and once with the team's grants switched off, which yields
+  // exactly the docs this user reaches personally (created, or shared to them
+  // by name). Subtracting `orgDenied` minus that personal set is what makes
+  // Private mean "not the team" rather than "not anyone".
+  //
   // A soft-deleted note keeps `created_by`, `folder_id` and its `shares` rows, so
   // this resolves a tombstone's permission exactly as it did while the note lived.
   const isMember = role !== null;
@@ -177,39 +195,71 @@ async function listDocsInVault(
      SELECT fi.id FROM files fi
        WHERE fi.vault_id = $2
          AND (fi.folder_id IN (SELECT id FROM subtree) OR fi.id IN (SELECT id FROM shared_files))`;
-  const { rows } = await db.query<{ id: string }>(
-    `WITH RECURSIVE shared_folders AS (
-        SELECT resource_id AS id FROM shares
-         WHERE resource_type = 'folder' AND permission IN ('view', 'edit')
+  const scopedDocs = async (orgGrants: boolean): Promise<Set<string>> => {
+    const { rows } = await db.query<{ id: string }>(
+      `WITH RECURSIVE shared_folders AS (
+          SELECT resource_id AS id FROM shares
+           WHERE resource_type = 'folder' AND permission IN ('view', 'edit')
+             AND (
+               (principal_type = 'user' AND principal_id = $1)
+               OR ($4 AND $5 AND principal_type = 'org' AND principal_id = $3)
+             )
+       ),
+       subtree AS (
+          SELECT id FROM folders WHERE id IN (SELECT id FROM shared_folders)
+          UNION ALL
+          SELECT f.id FROM folders f JOIN subtree s ON f.parent_id = s.id
+       ),
+       shared_files AS (
+          SELECT resource_id AS id FROM shares
+           WHERE resource_type = 'file' AND permission IN ('view', 'edit')
+             AND (
+               (principal_type = 'user' AND principal_id = $1)
+               OR ($4 AND $5 AND principal_type = 'org' AND principal_id = $3)
+             )
+       )
+       SELECT n.id FROM notes n
+         WHERE n.vault_id = $2 AND n.${livePredicate}
            AND (
-             (principal_type = 'user' AND principal_id = $1)
-             OR ($4 AND principal_type = 'org' AND principal_id = $3)
+             ($4 AND n.created_by = $1)
+             OR n.folder_id IN (SELECT id FROM subtree)
+             OR n.id IN (SELECT id FROM shared_files)
            )
-     ),
-     subtree AS (
-        SELECT id FROM folders WHERE id IN (SELECT id FROM shared_folders)
-        UNION ALL
-        SELECT f.id FROM folders f JOIN subtree s ON f.parent_id = s.id
-     ),
-     shared_files AS (
-        SELECT resource_id AS id FROM shares
-         WHERE resource_type = 'file' AND permission IN ('view', 'edit')
-           AND (
-             (principal_type = 'user' AND principal_id = $1)
-             OR ($4 AND principal_type = 'org' AND principal_id = $3)
-           )
-     )
-     SELECT n.id FROM notes n
-       WHERE n.vault_id = $2 AND n.${livePredicate}
-         AND (
-           ($4 AND n.created_by = $1)
-           OR n.folder_id IN (SELECT id FROM subtree)
-           OR n.id IN (SELECT id FROM shared_files)
-         )
-     ${filesUnion}`,
-    [userId, vaultId, organizationId, isMember],
-  );
-  return subtract(new Set(rows.map((r) => r.id)), await deniedDocsInVault(db, userId, vaultId));
+       ${filesUnion}`,
+      [userId, vaultId, organizationId, isMember, orgGrants],
+    );
+    return new Set(rows.map((r) => r.id));
+  };
+
+  // A per-member deny always applies; an org deny (item Private) only takes the
+  // TEAM's reach away, so it is skipped for an owner/admin and for someone
+  // holding a personal vault grant.
+  const userDenied = await deniedDocsInVault(db, "user", userId, vaultId);
+  const orgDenied =
+    vaultWideVia === "role" || vaultWideVia === "user"
+      ? new Set<string>()
+      : await deniedDocsInVault(db, "org", organizationId, vaultId);
+
+  let reachable: Set<string>;
+  if (vaultWide) {
+    const { rows } = await db.query<{ id: string }>(
+      opts.deleted
+        ? `SELECT id FROM notes WHERE vault_id = $1 AND ${livePredicate}`
+        : `SELECT id FROM notes WHERE vault_id = $1 AND ${livePredicate}
+           UNION
+           SELECT id FROM files WHERE vault_id = $1`,
+      [vaultId],
+    );
+    reachable = new Set(rows.map((r) => r.id));
+  } else {
+    reachable = await scopedDocs(true);
+  }
+
+  if (orgDenied.size > 0) {
+    const personal = await scopedDocs(false);
+    for (const id of orgDenied) if (!personal.has(id)) reachable.delete(id);
+  }
+  return subtract(reachable, userDenied);
 }
 
 /** `a` minus `b`, in place on `a`. */
@@ -282,8 +332,21 @@ export async function listVisibleFolders(
     "SELECT id, vault_id, parent_id, name, path, sort, created_by, color FROM folders WHERE vault_id = $1 ORDER BY sort, path",
     [vaultId],
   );
-  const denied = await deniedFolderIds(db, userId);
-  if (access.vaultWide) return all.rows.filter((f) => !denied.has(f.id));
+  // A per-member deny hides the folder from that person outright. An org deny
+  // (item Private) hides it from the TEAM — so it does not apply to an
+  // owner/admin or to someone with a personal vault grant, and a folder the
+  // user created themselves stays visible either way (that's "only you").
+  const userDenied = await deniedFolderIds(db, "user", userId);
+  const orgDenied =
+    access.vaultWideVia === "role" || access.vaultWideVia === "user"
+      ? new Set<string>()
+      : await deniedFolderIds(db, "org", access.organizationId);
+  const mine = new Set(
+    all.rows.filter((f) => f.created_by === userId).map((f) => f.id),
+  );
+  // A per-member deny wins even over authorship; an org deny does not.
+  const hidden = (id: string) => userDenied.has(id) || (orgDenied.has(id) && !mine.has(id));
+  if (access.vaultWide) return all.rows.filter((f) => !hidden(f.id));
 
   const readable = await listReadableDocsInVault(userId, vaultId, db);
   const isMember = access.role !== null;
@@ -319,5 +382,5 @@ export async function listVisibleFolders(
     [userId, vaultId, access.organizationId, isMember, [...readable]],
   );
   const visible = new Set(visibleIds.map((r) => r.id));
-  return all.rows.filter((f) => visible.has(f.id) && !denied.has(f.id));
+  return all.rows.filter((f) => visible.has(f.id) && !hidden(f.id));
 }

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -18,8 +18,9 @@ type Queryable = Pick<pg.Pool, "query">;
  *   - otherwise             -> docs reachable via a **user** share (view/edit)
  *     on the doc itself or any ancestor folder (folder grants inherit down).
  *
- * `locked` is a deny-overlay that only caps edit->view; it never grants read, so
- * it's absent here.
+ * `locked` is a cap overlay that only takes edit->view; it never grants read, so
+ * it's absent here. `denied` (per-member "No access") IS here: it removes read,
+ * so every set below subtracts it last — see `deniedDocsInVault`.
  *
  * Read = view OR edit, so the channel streams content to view-only grantees too.
  */
@@ -57,6 +58,71 @@ export async function vaultAccess(
 }
 
 /**
+ * doc_ids in this vault the user is explicitly SHUT OUT of — the per-member
+ * deny (`shares.permission = 'denied'`) folded down through folder inheritance.
+ *
+ * Subtracted from every readable/visible set below rather than woven into their
+ * WHERE clauses on purpose: a deny has to beat the owner/admin branch, the
+ * vault-wide grant branch AND the created_by branch, and those are three
+ * different queries. One subtraction at the end can't be forgotten in one of
+ * them.
+ */
+async function deniedDocsInVault(
+  db: Queryable,
+  userId: string,
+  vaultId: string,
+): Promise<Set<string>> {
+  const { rows } = await db.query<{ id: string }>(
+    `WITH RECURSIVE denied_seed AS (
+        SELECT resource_id AS id FROM shares
+         WHERE resource_type = 'folder' AND permission = 'denied'
+           AND principal_type = 'user' AND principal_id = $1
+     ),
+     denied_subtree AS (
+        SELECT id, parent_id FROM folders WHERE id IN (SELECT id FROM denied_seed)
+        UNION ALL
+        SELECT f.id, f.parent_id FROM folders f JOIN denied_subtree d ON f.parent_id = d.id
+     ),
+     denied_files AS (
+        SELECT resource_id AS id FROM shares
+         WHERE resource_type = 'file' AND permission = 'denied'
+           AND principal_type = 'user' AND principal_id = $1
+     )
+     SELECT n.id FROM notes n
+       WHERE n.vault_id = $2
+         AND (n.folder_id IN (SELECT id FROM denied_subtree) OR n.id IN (SELECT id FROM denied_files))
+     UNION
+     SELECT fi.id FROM files fi
+       WHERE fi.vault_id = $2
+         AND (fi.folder_id IN (SELECT id FROM denied_subtree) OR fi.id IN (SELECT id FROM denied_files))`,
+    [userId, vaultId],
+  );
+  return new Set(rows.map((r) => r.id));
+}
+
+/** Folder ids this user is denied, including everything below them. */
+async function deniedFolderIds(
+  db: Queryable,
+  userId: string,
+): Promise<Set<string>> {
+  const { rows } = await db.query<{ id: string }>(
+    `WITH RECURSIVE denied_seed AS (
+        SELECT resource_id AS id FROM shares
+         WHERE resource_type = 'folder' AND permission = 'denied'
+           AND principal_type = 'user' AND principal_id = $1
+     ),
+     denied_subtree AS (
+        SELECT id, parent_id FROM folders WHERE id IN (SELECT id FROM denied_seed)
+        UNION ALL
+        SELECT f.id, f.parent_id FROM folders f JOIN denied_subtree d ON f.parent_id = d.id
+     )
+     SELECT DISTINCT id FROM denied_subtree`,
+    [userId],
+  );
+  return new Set(rows.map((r) => r.id));
+}
+
+/**
  * One implementation, two questions. `deleted: false` answers "what may this user
  * read?"; `deleted: true` answers "which of this vault's docs that they'd be
  * allowed to read are now **gone**?" — the tombstone set the desktop reconciler
@@ -90,7 +156,7 @@ async function listDocsInVault(
            SELECT id FROM files WHERE vault_id = $1`,
       [vaultId],
     );
-    return new Set(rows.map((r) => r.id));
+    return subtract(new Set(rows.map((r) => r.id)), await deniedDocsInVault(db, userId, vaultId));
   }
 
   // Non-privileged (private-by-default): readable docs are the union of
@@ -143,7 +209,13 @@ async function listDocsInVault(
      ${filesUnion}`,
     [userId, vaultId, organizationId, isMember],
   );
-  return new Set(rows.map((r) => r.id));
+  return subtract(new Set(rows.map((r) => r.id)), await deniedDocsInVault(db, userId, vaultId));
+}
+
+/** `a` minus `b`, in place on `a`. */
+function subtract(a: Set<string>, b: Set<string>): Set<string> {
+  for (const id of b) a.delete(id);
+  return a;
 }
 
 export async function listReadableDocsInVault(
@@ -187,6 +259,9 @@ export interface VaultFolderRow {
   path: string;
   sort: number;
   created_by: string | null;
+  /** Palette id from the client's `lib/appearance`, or null. Vault-wide, so a
+   *  folder tinted on one machine is tinted for the whole team. */
+  color: string | null;
 }
 
 /**
@@ -204,10 +279,11 @@ export async function listVisibleFolders(
   const access = await vaultAccess(db, userId, vaultId);
   if (!access) return [];
   const all = await db.query<VaultFolderRow>(
-    "SELECT id, vault_id, parent_id, name, path, sort, created_by FROM folders WHERE vault_id = $1 ORDER BY sort, path",
+    "SELECT id, vault_id, parent_id, name, path, sort, created_by, color FROM folders WHERE vault_id = $1 ORDER BY sort, path",
     [vaultId],
   );
-  if (access.vaultWide) return all.rows;
+  const denied = await deniedFolderIds(db, userId);
+  if (access.vaultWide) return all.rows.filter((f) => !denied.has(f.id));
 
   const readable = await listReadableDocsInVault(userId, vaultId, db);
   const isMember = access.role !== null;
@@ -243,5 +319,5 @@ export async function listVisibleFolders(
     [userId, vaultId, access.organizationId, isMember, [...readable]],
   );
   const visible = new Set(visibleIds.map((r) => r.id));
-  return all.rows.filter((f) => visible.has(f.id));
+  return all.rows.filter((f) => visible.has(f.id) && !denied.has(f.id));
 }

--- a/app/apps/server/src/permissions/vault-docs.ts
+++ b/app/apps/server/src/permissions/vault-docs.ts
@@ -30,21 +30,7 @@ export async function vaultAccess(
   db: Queryable,
   userId: string,
   vaultId: string,
-): Promise<{
-  organizationId: string;
-  role: string | null;
-  vaultWide: boolean;
-  /**
-   * WHERE the vault-wide reach came from, or null when there is none.
-   *
-   * Load-bearing for the item-Private rule: an item set to Private takes it
-   * out of the TEAM's reach only, so a member whose access is the org-wide
-   * grant loses it while an owner/admin or someone holding a personal
-   * vault grant keeps it. Collapsing all three into one boolean is what made
-   * that impossible to express.
-   */
-  vaultWideVia: "role" | "org" | "user" | null;
-} | null> {
+): Promise<{ organizationId: string; role: string | null; vaultWide: boolean } | null> {
   const org = await db.query<{ organization_id: string; role: string | null }>(
     `SELECT v.organization_id, m.role
        FROM vaults v
@@ -56,25 +42,17 @@ export async function vaultAccess(
   const row = org.rows[0];
   if (!row) return null;
   const base = { organizationId: row.organization_id, role: row.role };
-  if (row.role === "owner" || row.role === "admin") {
-    return { ...base, vaultWide: true, vaultWideVia: "role" };
-  }
+  if (row.role === "owner" || row.role === "admin") return { ...base, vaultWide: true };
   const orgClause = row.role !== null ? "principal_type = 'org' OR" : "";
-  const grant = await db.query<{ principal_type: string }>(
-    `SELECT principal_type FROM shares
+  const grant = await db.query(
+    `SELECT 1 FROM shares
       WHERE resource_type = 'vault' AND resource_id = $1
         AND permission IN ('view', 'edit')
         AND (${orgClause} (principal_type = 'user' AND principal_id = $2))
-      ORDER BY principal_type = 'user' DESC
       LIMIT 1`,
     [row.organization_id, userId],
   );
-  const via = grant.rows[0]?.principal_type;
-  return {
-    ...base,
-    vaultWide: via !== undefined,
-    vaultWideVia: via === "user" ? "user" : via === "org" ? "org" : null,
-  };
+  return { ...base, vaultWide: (grant.rowCount ?? 0) > 0 };
 }
 
 /**
@@ -165,7 +143,7 @@ async function listDocsInVault(
 ): Promise<Set<string>> {
   const access = await vaultAccess(db, userId, vaultId);
   if (!access) return new Set(); // unknown vault
-  const { organizationId, role, vaultWide, vaultWideVia } = access;
+  const { organizationId, role, vaultWide } = access;
 
   // The ONLY difference between the two sets. `files` has no `deleted_at`
   // column, so a tombstone can never be a file — the UNIONs below drop out.
@@ -231,14 +209,13 @@ async function listDocsInVault(
     return new Set(rows.map((r) => r.id));
   };
 
-  // A per-member deny always applies; an org deny (item Private) only takes the
-  // TEAM's reach away, so it is skipped for an owner/admin and for someone
-  // holding a personal vault grant.
+  // Both denies apply to everyone, owners and admins included — see
+  // [[resolver]] for why a restriction its author is exempt from is not one.
+  // The org deny is rescued only by `personal` below (what this user created or
+  // was shared by name), which is what "only you and people you share it with"
+  // means once it is a set rather than a sentence.
   const userDenied = await deniedDocsInVault(db, "user", userId, vaultId);
-  const orgDenied =
-    vaultWideVia === "role" || vaultWideVia === "user"
-      ? new Set<string>()
-      : await deniedDocsInVault(db, "org", organizationId, vaultId);
+  const orgDenied = await deniedDocsInVault(db, "org", organizationId, vaultId);
 
   let reachable: Set<string>;
   if (vaultWide) {
@@ -337,10 +314,7 @@ export async function listVisibleFolders(
   // owner/admin or to someone with a personal vault grant, and a folder the
   // user created themselves stays visible either way (that's "only you").
   const userDenied = await deniedFolderIds(db, "user", userId);
-  const orgDenied =
-    access.vaultWideVia === "role" || access.vaultWideVia === "user"
-      ? new Set<string>()
-      : await deniedFolderIds(db, "org", access.organizationId);
+  const orgDenied = await deniedFolderIds(db, "org", access.organizationId);
   const mine = new Set(
     all.rows.filter((f) => f.created_by === userId).map((f) => f.id),
   );

--- a/app/apps/server/tests/access-deny.test.ts
+++ b/app/apps/server/tests/access-deny.test.ts
@@ -14,6 +14,7 @@ import { resetDb } from "./helpers/db.js";
 import {
   seedDeny,
   seedFolder,
+  seedItemPrivate,
   seedLock,
   seedMember,
   seedNote,
@@ -34,12 +35,16 @@ import {
  * everyone else could read, and each of the allow paths below (role, org grant,
  * explicit share, authorship) had to be closed separately.
  */
+// File-level, not per-describe: a describe-scoped `afterAll` closes the pool
+// the moment the FIRST block finishes, and every later block then fails on a
+// dead pool.
+afterAll(async () => {
+  await pool.end();
+});
+
 describe("per-member deny", () => {
   beforeEach(async () => {
     await resetDb();
-  });
-  afterAll(async () => {
-    await pool.end();
   });
 
   it("beats the vault-wide Open grant", async () => {
@@ -204,5 +209,144 @@ describe("per-member deny", () => {
     await seedDeny(org, "folder", folder, blocked);
     expect(await effectivePermission(blocked, doc)).toBe("none");
     expect(await effectivePermission(other, doc)).toBe("edit");
+  });
+});
+
+/**
+ * An ORG-scoped deny — the Access panel's per-item **Private**.
+ *
+ * This is the row that makes item-Private possible at all. Before it, "Private"
+ * on a folder just cleared that folder's own grants, and in a Shared vault the
+ * vault-wide grant still reached it — so the segment snapped straight back to
+ * Shared and nothing had changed. It removes the TEAM's reach and nothing else:
+ * the creator, anyone with a personal share, and owners/admins keep the item,
+ * which is exactly "only you and people you share it with" — and is what stops
+ * an owner making a folder that nobody, themselves included, can ever reach.
+ */
+describe("item set to Private (org deny)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("overrides the vault-wide Open grant for a plain member", async () => {
+    const org = await seedOrg("Acme", "priv-open");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "HR", "HR");
+    const doc = await seedNote(vault, folder, "HR/n.md");
+    const elsewhere = await seedNote(vault, null, "open.md");
+
+    expect(await effectivePermission(member, doc)).toBe("edit");
+    await seedItemPrivate(org, "folder", folder);
+    expect(await effectivePermission(member, doc)).toBe("none");
+    // …and only that folder.
+    expect(await effectivePermission(member, elsewhere)).toBe("edit");
+  });
+
+  it("overrides a team share on an ANCESTOR folder", async () => {
+    const org = await seedOrg("Acme", "priv-ancestor");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    const vault = await seedVault(org);
+    const top = await seedFolder(vault, null, "Team", "Team");
+    const inner = await seedFolder(vault, top, "Salaries", "Team/Salaries");
+    const doc = await seedNote(vault, inner, "Team/Salaries/2026.md");
+    // The parent is shared with the team…
+    await pool.query(
+      `INSERT INTO shares (id, org_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES (gen_random_uuid()::text, $1, 'folder', $2, 'org', $1, 'edit')`,
+      [org, top],
+    );
+    expect(await effectivePermission(member, doc)).toBe("edit");
+
+    await seedItemPrivate(org, "folder", inner);
+    expect(await effectivePermission(member, doc)).toBe("none");
+  });
+
+  it("leaves owners, admins, the creator and explicit grantees alone", async () => {
+    const org = await seedOrg("Acme", "priv-keeps");
+    const owner = await seedUser("o@a.com");
+    const admin = await seedUser("a@a.com");
+    const author = await seedUser("w@a.com");
+    const invited = await seedUser("i@a.com");
+    const outsider = await seedUser("x@a.com");
+    await seedMember(org, owner, "owner");
+    await seedMember(org, admin, "admin");
+    await seedMember(org, author, "member");
+    await seedMember(org, invited, "member");
+    await seedMember(org, outsider, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Drafts", "Drafts");
+    const doc = await seedNote(vault, folder, "Drafts/d.md", author);
+    await seedShare(org, "file", doc, invited, "view");
+
+    await seedItemPrivate(org, "folder", folder);
+
+    expect(await effectivePermission(owner, doc)).toBe("edit");
+    expect(await effectivePermission(admin, doc)).toBe("edit");
+    expect(await effectivePermission(author, doc)).toBe("edit"); // "only you"
+    expect(await effectivePermission(invited, doc)).toBe("view"); // "…and people you share it with"
+    expect(await effectivePermission(outsider, doc)).toBe("none");
+  });
+
+  it("takes the docs and the folder out of a member's tree, but not the owner's", async () => {
+    const org = await seedOrg("Acme", "priv-sets");
+    const owner = await seedUser("o@a.com");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, owner, "owner");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const secret = await seedFolder(vault, null, "Secret", "Secret");
+    const nested = await seedFolder(vault, secret, "Deep", "Secret/Deep");
+    const hidden = await seedNote(vault, nested, "Secret/Deep/x.md");
+    const open = await seedNote(vault, null, "open.md");
+
+    await seedItemPrivate(org, "folder", secret);
+
+    const memberDocs = await listReadableDocsInVault(member, vault);
+    expect(memberDocs.has(hidden)).toBe(false);
+    expect(memberDocs.has(open)).toBe(true);
+    expect((await listVisibleFolders(member, vault)).map((f) => f.path)).not.toContain("Secret");
+
+    const ownerDocs = await listReadableDocsInVault(owner, vault);
+    expect(ownerDocs.has(hidden)).toBe(true);
+    expect((await listVisibleFolders(owner, vault)).map((f) => f.path)).toContain("Secret");
+  });
+
+  it("keeps a member's OWN notes inside a Private folder readable", async () => {
+    // "Only you" has to survive the set-based dual too, or a member's own note
+    // would vanish off their disk the moment the folder went Private.
+    const org = await seedOrg("Acme", "priv-mine");
+    const author = await seedUser("w@a.com");
+    await seedMember(org, author, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Shared", "Shared");
+    const mine = await seedNote(vault, folder, "Shared/mine.md", author);
+    const theirs = await seedNote(vault, folder, "Shared/theirs.md");
+
+    await seedItemPrivate(org, "folder", folder);
+
+    const docs = await listReadableDocsInVault(author, vault);
+    expect(docs.has(mine)).toBe(true);
+    expect(docs.has(theirs)).toBe(false);
+  });
+
+  it("stacks with a per-member deny, which still beats everything", async () => {
+    const org = await seedOrg("Acme", "priv-stack");
+    const admin = await seedUser("a@a.com");
+    await seedMember(org, admin, "admin");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "HR", "HR");
+    const doc = await seedNote(vault, folder, "HR/n.md");
+
+    await seedItemPrivate(org, "folder", folder);
+    expect(await effectivePermission(admin, doc)).toBe("edit"); // Private spares admins
+    await seedDeny(org, "folder", folder, admin);
+    expect(await effectivePermission(admin, doc)).toBe("none"); // a personal block does not
   });
 });

--- a/app/apps/server/tests/access-deny.test.ts
+++ b/app/apps/server/tests/access-deny.test.ts
@@ -265,7 +265,7 @@ describe("item set to Private (org deny)", () => {
     expect(await effectivePermission(member, doc)).toBe("none");
   });
 
-  it("leaves owners, admins, the creator and explicit grantees alone", async () => {
+  it("leaves the creator and explicit grantees alone — and nobody else, owners included", async () => {
     const org = await seedOrg("Acme", "priv-keeps");
     const owner = await seedUser("o@a.com");
     const admin = await seedUser("a@a.com");
@@ -285,14 +285,40 @@ describe("item set to Private (org deny)", () => {
 
     await seedItemPrivate(org, "folder", folder);
 
-    expect(await effectivePermission(owner, doc)).toBe("edit");
-    expect(await effectivePermission(admin, doc)).toBe("edit");
     expect(await effectivePermission(author, doc)).toBe("edit"); // "only you"
     expect(await effectivePermission(invited, doc)).toBe("view"); // "…and people you share it with"
     expect(await effectivePermission(outsider, doc)).toBe("none");
+    // Role is not an exemption. A restriction its author can't observe is one
+    // they have to take on trust, which is not a thing to ship in an access
+    // panel — so Private reaches owners and admins like everyone else.
+    expect(await effectivePermission(owner, doc)).toBe("none");
+    expect(await effectivePermission(admin, doc)).toBe("none");
   });
 
-  it("takes the docs and the folder out of a member's tree, but not the owner's", async () => {
+  it("still lets an owner lift a Private they applied to themselves", async () => {
+    // The safety net is NOT an exemption from the rule — it's that managing
+    // shares is gated on role, never on effective permission. Without this an
+    // owner could make a folder they can neither reach nor un-restrict.
+    const org = await seedOrg("Acme", "priv-undo");
+    const owner = await seedUser("o@a.com");
+    await seedMember(org, owner, "owner");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Locked", "Locked");
+    const doc = await seedNote(vault, folder, "Locked/x.md");
+    await seedVaultGrant(org, "edit");
+    const privateRow = await seedItemPrivate(org, "folder", folder);
+    expect(await effectivePermission(owner, doc)).toBe("none");
+
+    // …which is exactly what `DELETE /api/shares/:id` does, and its gate
+    // (`canManage`) asks for the role, not for access to the resource.
+    await pool.query("DELETE FROM shares WHERE id = $1", [privateRow]);
+    expect(await effectivePermission(owner, doc)).toBe("edit");
+  });
+
+  it("takes the docs and the folder out of everyone's tree, the owner's included", async () => {
+    // The set-based dual has to agree with the resolver here or the two would
+    // disagree about the owner, and a doc that resolves to `none` would keep
+    // syncing to them.
     const org = await seedOrg("Acme", "priv-sets");
     const owner = await seedUser("o@a.com");
     const member = await seedUser("m@a.com");
@@ -307,14 +333,12 @@ describe("item set to Private (org deny)", () => {
 
     await seedItemPrivate(org, "folder", secret);
 
-    const memberDocs = await listReadableDocsInVault(member, vault);
-    expect(memberDocs.has(hidden)).toBe(false);
-    expect(memberDocs.has(open)).toBe(true);
-    expect((await listVisibleFolders(member, vault)).map((f) => f.path)).not.toContain("Secret");
-
-    const ownerDocs = await listReadableDocsInVault(owner, vault);
-    expect(ownerDocs.has(hidden)).toBe(true);
-    expect((await listVisibleFolders(owner, vault)).map((f) => f.path)).toContain("Secret");
+    for (const who of [member, owner]) {
+      const docs = await listReadableDocsInVault(who, vault);
+      expect(docs.has(hidden)).toBe(false);
+      expect(docs.has(open)).toBe(true);
+      expect((await listVisibleFolders(who, vault)).map((f) => f.path)).not.toContain("Secret");
+    }
   });
 
   it("keeps a member's OWN notes inside a Private folder readable", async () => {
@@ -336,17 +360,132 @@ describe("item set to Private (org deny)", () => {
     expect(docs.has(theirs)).toBe(false);
   });
 
-  it("stacks with a per-member deny, which still beats everything", async () => {
+  it("is overridden for one person by an explicit share, and a personal block wins back", async () => {
+    // The three rows layered on one resource, in the order that decides them.
     const org = await seedOrg("Acme", "priv-stack");
     const admin = await seedUser("a@a.com");
     await seedMember(org, admin, "admin");
+    await seedVaultGrant(org, "edit");
     const vault = await seedVault(org);
     const folder = await seedFolder(vault, null, "HR", "HR");
     const doc = await seedNote(vault, folder, "HR/n.md");
 
+    expect(await effectivePermission(admin, doc)).toBe("edit");
     await seedItemPrivate(org, "folder", folder);
-    expect(await effectivePermission(admin, doc)).toBe("edit"); // Private spares admins
-    await seedDeny(org, "folder", folder, admin);
-    expect(await effectivePermission(admin, doc)).toBe("none"); // a personal block does not
+    expect(await effectivePermission(admin, doc)).toBe("none"); // Private reaches admins
+    await seedShare(org, "folder", folder, admin, "edit"); // "…people you share it with"
+    expect(await effectivePermission(admin, doc)).toBe("edit");
+    await seedDeny(org, "folder", folder, admin); // a personal block still wins
+    expect(await effectivePermission(admin, doc)).toBe("none");
+  });
+});
+
+/**
+ * The vault-wide **Read-only** posture.
+ *
+ * It is a plain org `view` grant on the vault resource, and a grant only ever
+ * RAISES permission — so owners, admins and note creators all kept `edit`
+ * through shortcuts that ran before any grant was consulted, and the setting
+ * silently did not apply to the person who chose it, despite the button reading
+ * "Everyone can read everything, not edit."
+ *
+ * It can't be fixed with a lock: a vault-scoped lock would need the same
+ * (resource, principal) key the grant already occupies. So the grant is now
+ * read as a *baseline for everyone* — when it says `view`, those shortcuts are
+ * skipped and the ordinary highest-wins lookup decides, which still lets a
+ * folder marked Shared lift someone back out.
+ */
+describe("vault-wide read-only cap", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  /** Set the vault posture, replacing whatever grant is there (one row per
+   *  (resource, principal) — the same upsert `POST /api/shares` does). */
+  const setVaultPosture = (orgId: string, permission: "view" | "edit") =>
+    pool.query(
+      `INSERT INTO shares (id, org_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES (gen_random_uuid()::text, $1, 'vault', $1, 'org', $1, $2)
+       ON CONFLICT (resource_type, resource_id, principal_type, principal_id)
+       DO UPDATE SET permission = EXCLUDED.permission`,
+      [orgId, permission],
+    );
+
+  it("caps owner, admin and member alike", async () => {
+    const org = await seedOrg("Acme", "ro-vault");
+    const owner = await seedUser("o@a.com");
+    const admin = await seedUser("a@a.com");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, owner, "owner");
+    await seedMember(org, admin, "admin");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Docs", "Docs");
+    const doc = await seedNote(vault, folder, "Docs/n.md");
+
+    for (const who of [owner, admin, member]) {
+      expect(await effectivePermission(who, doc)).toBe("edit");
+    }
+
+    await setVaultPosture(org, "view");
+    for (const who of [owner, admin, member]) {
+      expect(await effectivePermission(who, doc)).toBe("view");
+    }
+    // It never GRANTS: an outsider is still shut out entirely.
+    const outsider = await seedUser("x@a.com");
+    expect(await effectivePermission(outsider, doc)).toBe("none");
+
+    // …and a folder marked Shared lifts everyone back out of it, which is the
+    // per-item override the panel offers.
+    await pool.query(
+      `INSERT INTO shares (id, org_id, resource_type, resource_id, principal_type, principal_id, permission)
+       VALUES (gen_random_uuid()::text, $1, 'folder', $2, 'org', $1, 'edit')`,
+      [org, folder],
+    );
+    for (const who of [owner, admin, member]) {
+      expect(await effectivePermission(who, doc)).toBe("edit");
+    }
+  });
+
+  it("caps a member on a note they created themselves", async () => {
+    // The creator shortcut is a shortcut like any other: read-only has to mean
+    // read-only, or "everyone" quietly excludes whoever wrote the note.
+    const org = await seedOrg("Acme", "ro-creator");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    const vault = await seedVault(org);
+    const mine = await seedNote(vault, null, "mine.md", member);
+
+    expect(await effectivePermission(member, mine)).toBe("edit");
+    await setVaultPosture(org, "view");
+    expect(await effectivePermission(member, mine)).toBe("view");
+  });
+
+  it("reaches a note at the vault ROOT, which no folder grant can", async () => {
+    // The whole reason the vault scope exists: a root note has no folder to
+    // hang a lock on.
+    const org = await seedOrg("Acme", "ro-root");
+    const owner = await seedUser("o@a.com");
+    await seedMember(org, owner, "owner");
+    const vault = await seedVault(org);
+    const doc = await seedNote(vault, null, "root.md");
+
+    expect(await effectivePermission(owner, doc)).toBe("edit");
+    await setVaultPosture(org, "view");
+    expect(await effectivePermission(owner, doc)).toBe("view");
+  });
+
+  it("still lets an owner edit content in ANOTHER vault", async () => {
+    const orgA = await seedOrg("A", "ro-a");
+    const orgB = await seedOrg("B", "ro-b");
+    const owner = await seedUser("o@a.com");
+    await seedMember(orgA, owner, "owner");
+    await seedMember(orgB, owner, "owner");
+    const vaultB = await seedVault(orgB);
+    const doc = await seedNote(vaultB, null, "b.md");
+
+    await setVaultPosture(orgA, "view");
+    expect(await effectivePermission(owner, doc)).toBe("edit");
   });
 });

--- a/app/apps/server/tests/access-deny.test.ts
+++ b/app/apps/server/tests/access-deny.test.ts
@@ -265,7 +265,7 @@ describe("item set to Private (org deny)", () => {
     expect(await effectivePermission(member, doc)).toBe("none");
   });
 
-  it("leaves the creator and explicit grantees alone — and nobody else, owners included", async () => {
+  it("leaves explicit grantees alone — and nobody else, the author and owners included", async () => {
     const org = await seedOrg("Acme", "priv-keeps");
     const owner = await seedUser("o@a.com");
     const admin = await seedUser("a@a.com");
@@ -285,14 +285,37 @@ describe("item set to Private (org deny)", () => {
 
     await seedItemPrivate(org, "folder", folder);
 
-    expect(await effectivePermission(author, doc)).toBe("edit"); // "only you"
-    expect(await effectivePermission(invited, doc)).toBe("view"); // "…and people you share it with"
+    expect(await effectivePermission(invited, doc)).toBe("view"); // named in the list
     expect(await effectivePermission(outsider, doc)).toBe("none");
-    // Role is not an exemption. A restriction its author can't observe is one
-    // they have to take on trust, which is not a thing to ship in an access
-    // panel — so Private reaches owners and admins like everyone else.
+    // Neither role nor authorship is an exemption. A restriction its author
+    // can't observe is one they have to take on trust, and in a vault you set
+    // up yourself you wrote nearly everything — so sparing the author would
+    // make Private unobservable exactly where it's used.
     expect(await effectivePermission(owner, doc)).toBe("none");
     expect(await effectivePermission(admin, doc)).toBe("none");
+    expect(await effectivePermission(author, doc)).toBe("none");
+  });
+
+  it("reports the same answer in the panel as the enforcer gives", async () => {
+    // `resolveAccessForUser` renders "who can access"; `effectivePermission`
+    // decides the sync token. They disagreed once — the panel said No access on
+    // a member's own note while the enforcer handed out edit — which is worse
+    // than either answer alone, because it makes the panel untrustworthy.
+    const org = await seedOrg("Acme", "priv-agree");
+    const author = await seedUser("w@a.com");
+    await seedMember(org, author, "member");
+    const vault = await seedVault(org);
+    const doc = await seedNote(vault, null, "mine.md", author);
+
+    const check = async (expected: string) => {
+      const ctx = await buildAccessContext("file", doc);
+      const resolved = await resolveAccessForUser(ctx!, author, "member");
+      expect(resolved.permission).toBe(expected);
+      expect(await effectivePermission(author, doc)).toBe(expected);
+    };
+    await check("edit"); // their own note, private-by-default vault
+    await seedItemPrivate(org, "file", doc);
+    await check("none"); // …and Private takes it from them too
   });
 
   it("still lets an owner lift a Private they applied to themselves", async () => {
@@ -341,9 +364,9 @@ describe("item set to Private (org deny)", () => {
     }
   });
 
-  it("keeps a member's OWN notes inside a Private folder readable", async () => {
-    // "Only you" has to survive the set-based dual too, or a member's own note
-    // would vanish off their disk the moment the folder went Private.
+  it("takes a member's OWN notes too, and gives them back on an explicit share", async () => {
+    // The set-based dual has to drop authorship exactly where the resolver
+    // does, or a Private folder would keep syncing its author's own notes.
     const org = await seedOrg("Acme", "priv-mine");
     const author = await seedUser("w@a.com");
     await seedMember(org, author, "member");
@@ -355,9 +378,16 @@ describe("item set to Private (org deny)", () => {
 
     await seedItemPrivate(org, "folder", folder);
 
-    const docs = await listReadableDocsInVault(author, vault);
-    expect(docs.has(mine)).toBe(true);
+    let docs = await listReadableDocsInVault(author, vault);
+    expect(docs.has(mine)).toBe(false);
     expect(docs.has(theirs)).toBe(false);
+
+    // Naming yourself in the list is the way back in — the same row a teammate
+    // would get.
+    await seedShare(org, "folder", folder, author, "edit");
+    docs = await listReadableDocsInVault(author, vault);
+    expect(docs.has(mine)).toBe(true);
+    expect(docs.has(theirs)).toBe(true);
   });
 
   it("is overridden for one person by an explicit share, and a personal block wins back", async () => {

--- a/app/apps/server/tests/access-deny.test.ts
+++ b/app/apps/server/tests/access-deny.test.ts
@@ -1,0 +1,208 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildAccessContext,
+  effectivePermission,
+  resolveAccessForUser,
+} from "../src/permissions/resolver.js";
+import { canEditFolder } from "../src/permissions/http-gates.js";
+import {
+  listReadableDocsInVault,
+  listVisibleFolders,
+} from "../src/permissions/vault-docs.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import {
+  seedDeny,
+  seedFolder,
+  seedLock,
+  seedMember,
+  seedNote,
+  seedOrg,
+  seedShare,
+  seedUser,
+  seedVault,
+  seedVaultGrant,
+} from "./helpers/seed.js";
+
+/**
+ * The per-member DENY (`shares.permission = 'denied'`) — the Access panel's
+ * "No access (blocked)".
+ *
+ * Every test here is really the same assertion from a different angle: a deny
+ * has to beat the rule that would otherwise grant. Locks only cap edit→view, so
+ * before this there was no way to keep one person out of a folder in a vault
+ * everyone else could read, and each of the allow paths below (role, org grant,
+ * explicit share, authorship) had to be closed separately.
+ */
+describe("per-member deny", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("beats the vault-wide Open grant", async () => {
+    const org = await seedOrg("Acme", "deny-open");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "HR", "HR");
+    const doc = await seedNote(vault, folder, "HR/salaries.md");
+
+    expect(await effectivePermission(member, doc)).toBe("edit");
+    await seedDeny(org, "folder", folder, member);
+    expect(await effectivePermission(member, doc)).toBe("none");
+  });
+
+  it("beats an explicit per-user edit share on the note itself", async () => {
+    const org = await seedOrg("Acme", "deny-share");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "HR", "HR");
+    const doc = await seedNote(vault, folder, "HR/note.md");
+    await seedShare(org, "file", doc, member, "edit");
+
+    expect(await effectivePermission(member, doc)).toBe("edit");
+    await seedDeny(org, "folder", folder, member);
+    expect(await effectivePermission(member, doc)).toBe("none");
+  });
+
+  it("beats owner and admin — a lock only caps them at view, a deny removes them", async () => {
+    const org = await seedOrg("Acme", "deny-admin");
+    const owner = await seedUser("o@a.com");
+    const admin = await seedUser("a@a.com");
+    await seedMember(org, owner, "owner");
+    await seedMember(org, admin, "admin");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Private", "Private");
+    const doc = await seedNote(vault, folder, "Private/note.md");
+
+    await seedLock(org, "folder", folder, { type: "user", id: admin });
+    expect(await effectivePermission(admin, doc)).toBe("view");
+
+    await seedDeny(org, "folder", folder, admin);
+    expect(await effectivePermission(admin, doc)).toBe("none");
+    // …and only for that admin.
+    expect(await effectivePermission(owner, doc)).toBe("edit");
+  });
+
+  it("beats the note-creator escape hatch", async () => {
+    // The sharpest case: "make this private from Sam" has to mean it on the
+    // notes Sam wrote, or the feature is a no-op exactly where it matters.
+    const org = await seedOrg("Acme", "deny-creator");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Drafts", "Drafts");
+    const doc = await seedNote(vault, folder, "Drafts/mine.md", member);
+
+    expect(await effectivePermission(member, doc)).toBe("edit");
+    await seedDeny(org, "folder", folder, member);
+    expect(await effectivePermission(member, doc)).toBe("none");
+  });
+
+  it("inherits down a folder subtree", async () => {
+    const org = await seedOrg("Acme", "deny-subtree");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const top = await seedFolder(vault, null, "Ops", "Ops");
+    const nested = await seedFolder(vault, top, "Payroll", "Ops/Payroll");
+    const deep = await seedNote(vault, nested, "Ops/Payroll/2026.md");
+
+    await seedDeny(org, "folder", top, member);
+    expect(await effectivePermission(member, deep)).toBe("none");
+  });
+
+  it("applies to a single file without touching its siblings", async () => {
+    const org = await seedOrg("Acme", "deny-file");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "Team", "Team");
+    const hidden = await seedNote(vault, folder, "Team/hidden.md");
+    const sibling = await seedNote(vault, folder, "Team/open.md");
+
+    await seedDeny(org, "file", hidden, member);
+    expect(await effectivePermission(member, hidden)).toBe("none");
+    expect(await effectivePermission(member, sibling)).toBe("edit");
+  });
+
+  it("removes the doc from the readable set and the folder from the tree", async () => {
+    // The resolver and the set-based dual must agree, or a denied member keeps
+    // syncing a doc they can no longer resolve.
+    const org = await seedOrg("Acme", "deny-sets");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const secret = await seedFolder(vault, null, "Secret", "Secret");
+    const nested = await seedFolder(vault, secret, "Deeper", "Secret/Deeper");
+    const open = await seedFolder(vault, null, "Open", "Open");
+    const hiddenDoc = await seedNote(vault, nested, "Secret/Deeper/x.md");
+    const openDoc = await seedNote(vault, open, "Open/y.md");
+
+    await seedDeny(org, "folder", secret, member);
+
+    const readable = await listReadableDocsInVault(member, vault);
+    expect(readable.has(hiddenDoc)).toBe(false);
+    expect(readable.has(openDoc)).toBe(true);
+
+    const folders = await listVisibleFolders(member, vault);
+    const paths = folders.map((f) => f.path);
+    expect(paths).toContain("Open");
+    expect(paths).not.toContain("Secret");
+    expect(paths).not.toContain("Secret/Deeper");
+  });
+
+  it("hides a denied folder from an ADMIN's tree too", async () => {
+    const org = await seedOrg("Acme", "deny-admin-tree");
+    const admin = await seedUser("a@a.com");
+    await seedMember(org, admin, "admin");
+    const vault = await seedVault(org);
+    const secret = await seedFolder(vault, null, "Secret", "Secret");
+    const doc = await seedNote(vault, secret, "Secret/x.md");
+
+    await seedDeny(org, "folder", secret, admin);
+    expect((await listVisibleFolders(admin, vault)).map((f) => f.path)).not.toContain("Secret");
+    expect((await listReadableDocsInVault(admin, vault)).has(doc)).toBe(false);
+    expect(await canEditFolder(admin, secret)).toBe(false);
+  });
+
+  it("resolve-access reports the block as `denied`, not as a missing grant", async () => {
+    const org = await seedOrg("Acme", "deny-resolve");
+    const member = await seedUser("m@a.com");
+    await seedMember(org, member, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "HR", "HR");
+    await seedDeny(org, "folder", folder, member);
+
+    const ctx = await buildAccessContext("folder", folder);
+    expect(ctx).not.toBeNull();
+    const resolved = await resolveAccessForUser(ctx!, member, "member");
+    expect(resolved.permission).toBe("none");
+    expect(resolved.denied).toBe(true);
+  });
+
+  it("does not leak to other members", async () => {
+    const org = await seedOrg("Acme", "deny-scope");
+    const blocked = await seedUser("b@a.com");
+    const other = await seedUser("o2@a.com");
+    await seedMember(org, blocked, "member");
+    await seedMember(org, other, "member");
+    await seedVaultGrant(org, "edit");
+    const vault = await seedVault(org);
+    const folder = await seedFolder(vault, null, "HR", "HR");
+    const doc = await seedNote(vault, folder, "HR/n.md");
+
+    await seedDeny(org, "folder", folder, blocked);
+    expect(await effectivePermission(blocked, doc)).toBe("none");
+    expect(await effectivePermission(other, doc)).toBe("edit");
+  });
+});

--- a/app/apps/server/tests/auth.test.ts
+++ b/app/apps/server/tests/auth.test.ts
@@ -75,3 +75,33 @@ describe("auth + organizations", () => {
     expect(check.rows[0]?.role).toBe("member");
   });
 });
+
+/**
+ * Account linking between Google and an existing email+password account.
+ *
+ * This is a config assertion rather than a flow test, because the failure it
+ * guards against was a silent DEFAULT, not a bug in our code: Better Auth's
+ * `requireLocalEmailVerified` defaults to true, which made `accountLinking`
+ * dead for every account this server can create. `requireEmailVerification` is
+ * off (no email round-trip in the MVP), so every password sign-up has
+ * `emailVerified = false` forever — and the Google callback answered
+ * `account_not_linked` to anyone who had signed up with a password. Only users
+ * created THROUGH Google could use Google, because they had nothing to link.
+ *
+ * A flow test would need a live Google consent round-trip. Pinning the three
+ * options together is what actually catches a regression here, since any one of
+ * them reverting reintroduces the same lockout.
+ */
+describe("Google account linking", () => {
+  it("links onto an existing password account that was never email-verified", () => {
+    const account = auth.options.account;
+    expect(account?.accountLinking?.enabled).toBe(true);
+    expect(account?.accountLinking?.trustedProviders).toContain("google");
+    // The load-bearing one: true (the default) means no local account we create
+    // can ever be linked, because none of them is verified.
+    expect(account?.accountLinking?.requireLocalEmailVerified).toBe(false);
+    // …which is only sound to assert while sign-up really does skip
+    // verification. If this flips, revisit the trade-off above.
+    expect(auth.options.emailAndPassword?.requireEmailVerification).toBe(false);
+  });
+});

--- a/app/apps/server/tests/checkpoints.test.ts
+++ b/app/apps/server/tests/checkpoints.test.ts
@@ -105,7 +105,7 @@ describe("vault checkpoints", () => {
     expect(JSON.stringify(body)).not.toContain("alpha");
   });
 
-  it("gates create/delete to owner+admin and revert to the owner alone", async () => {
+  it("gates create/delete/revert to owner+admin, and shuts members out", async () => {
     const owner = await signUp("g-owner@t.com");
     const admin = await signUp("g-admin@t.com");
     const member = await signUp("g-member@t.com");
@@ -131,12 +131,21 @@ describe("vault checkpoints", () => {
     expect(created.status).toBe(201);
     const { id } = (await created.json()) as { id: string };
 
-    // Admins may take and delete checkpoints, but reverting the whole vault is
-    // the owner's call alone.
+    // Revert is the recovery half of an action admins can already take, so it
+    // matches create/delete: owner OR admin. A team whose owner is away used to
+    // be able to take checkpoints and not use them.
+    expect(
+      (await api(member, `/api/vaults/${vault}/checkpoints/${id}/revert`, { method: "POST" }))
+        .status,
+    ).toBe(403);
+    expect(
+      (await api(outsider, `/api/vaults/${vault}/checkpoints/${id}/revert`, { method: "POST" }))
+        .status,
+    ).toBe(403);
     expect(
       (await api(admin, `/api/vaults/${vault}/checkpoints/${id}/revert`, { method: "POST" }))
         .status,
-    ).toBe(403);
+    ).toBe(200);
     expect(
       (await api(member, `/api/vaults/${vault}/checkpoints/${id}`, { method: "DELETE" })).status,
     ).toBe(403);

--- a/app/apps/server/tests/helpers/seed.ts
+++ b/app/apps/server/tests/helpers/seed.ts
@@ -106,7 +106,7 @@ export async function seedVaultGrant(
   return id;
 }
 
-/** A lock row (DENY overlay) on a folder/file, for a user or the whole org. */
+/** A lock row (read-only cap) on a folder/file, for a user or the whole org. */
 export async function seedLock(
   organizationId: string,
   resourceType: "folder" | "file",

--- a/app/apps/server/tests/helpers/seed.ts
+++ b/app/apps/server/tests/helpers/seed.ts
@@ -156,6 +156,28 @@ export async function seedDeny(
   return id;
 }
 
+/**
+ * An ORG-scoped `denied` row — the item set to **Private**. Unlike the
+ * per-member deny above it takes the item out of the *team's* reach only: the
+ * creator, anyone with a personal share, and owners/admins keep it.
+ */
+export async function seedItemPrivate(
+  organizationId: string,
+  resourceType: "folder" | "file",
+  resourceId: string,
+): Promise<string> {
+  const id = randomUUID();
+  await pool.query(
+    `INSERT INTO shares
+       (id, org_id, resource_type, resource_id, principal_type, principal_id, permission)
+     VALUES ($1, $2, $3, $4, 'org', $2, 'denied')
+     ON CONFLICT (resource_type, resource_id, principal_type, principal_id)
+     DO UPDATE SET permission = 'denied'`,
+    [id, organizationId, resourceType, resourceId],
+  );
+  return id;
+}
+
 /** Close a vault's root to new folders/notes (the General settings latch). */
 export async function freezeVaultRoot(vaultId: string, frozen = true): Promise<void> {
   await pool.query("UPDATE vaults SET root_frozen = $2 WHERE id = $1", [vaultId, frozen]);

--- a/app/apps/server/tests/helpers/seed.ts
+++ b/app/apps/server/tests/helpers/seed.ts
@@ -129,3 +129,34 @@ export async function seedLock(
   );
   return id;
 }
+
+/**
+ * A `denied` row — the per-member "No access" block. Unlike a lock (which caps
+ * at view) this removes access outright, and it outranks every allow rule.
+ *
+ * Upserts, like `POST /api/shares` does: there is one row per
+ * (resource, principal), so denying someone who already has a lock or a grant
+ * REPLACES it rather than adding a second row.
+ */
+export async function seedDeny(
+  organizationId: string,
+  resourceType: "folder" | "file",
+  resourceId: string,
+  userId: string,
+): Promise<string> {
+  const id = randomUUID();
+  await pool.query(
+    `INSERT INTO shares
+       (id, org_id, resource_type, resource_id, principal_type, principal_id, permission)
+     VALUES ($1, $2, $3, $4, 'user', $5, 'denied')
+     ON CONFLICT (resource_type, resource_id, principal_type, principal_id)
+     DO UPDATE SET permission = 'denied'`,
+    [id, organizationId, resourceType, resourceId, userId],
+  );
+  return id;
+}
+
+/** Close a vault's root to new folders/notes (the General settings latch). */
+export async function freezeVaultRoot(vaultId: string, frozen = true): Promise<void> {
+  await pool.query("UPDATE vaults SET root_frozen = $2 WHERE id = $1", [vaultId, frozen]);
+}

--- a/app/apps/server/tests/item-colors.test.ts
+++ b/app/apps/server/tests/item-colors.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { seedVault } from "./helpers/seed.js";
+import { recordingAppDeps } from "./helpers/app.js";
+
+/**
+ * Folder/note accent colors on the registry rows.
+ *
+ * Colors used to be a localStorage preference keyed by path, which meant a
+ * folder you tinted was grey on every other machine and for every teammate.
+ * Two things make the server version right: it is keyed by **id**, so a rename
+ * or a move keeps the color; and it rides the ordinary registry pull, so it
+ * reaches everyone on the same round trip a rename does.
+ */
+
+const rec = recordingAppDeps();
+const app = createApp(rec.deps);
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+describe("item colors sync with the registry", () => {
+  let owner: TestUser;
+  let vault: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+    owner = await signUp("owner@colors.test");
+    const org = (await createOrg(owner, "Color Co", "color-co")).id;
+    vault = await seedVault(org);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("a folder color set by one client comes back on the next listing", async () => {
+    const created = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    const id = (await created.json()).id as string;
+
+    expect((await req(owner, "PATCH", `/api/folders/${id}`, { color: "amber" })).status).toBe(200);
+
+    const list = await req(owner, "GET", `/api/folders?vaultId=${vault}`);
+    const folders = (await list.json()).folders as Array<{ id: string; color: string | null }>;
+    expect(folders.find((f) => f.id === id)?.color).toBe("amber");
+  });
+
+  it("survives a rename — the color is keyed by id, not path", async () => {
+    const created = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    const id = (await created.json()).id as string;
+    await req(owner, "PATCH", `/api/folders/${id}`, { color: "teal" });
+
+    await req(owner, "PATCH", `/api/folders/${id}`, { name: "Handbook", path: "Handbook" });
+
+    const list = await req(owner, "GET", `/api/folders?vaultId=${vault}`);
+    const folders = (await list.json()).folders as Array<{ path: string; color: string | null }>;
+    expect(folders.find((f) => f.path === "Handbook")?.color).toBe("teal");
+  });
+
+  it("clears with null, and a note carries one too", async () => {
+    const created = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "n.md",
+      color: "rose",
+    });
+    const id = (await created.json()).id as string;
+
+    const listed = async () => {
+      const res = await req(owner, "GET", `/api/notes?vaultId=${vault}`);
+      const notes = (await res.json()).notes as Array<{ id: string; color: string | null }>;
+      return notes.find((n) => n.id === id)?.color ?? null;
+    };
+    expect(await listed()).toBe("rose");
+
+    await req(owner, "PATCH", `/api/notes/${id}`, { color: null });
+    expect(await listed()).toBeNull();
+  });
+
+  it("broadcasts a registry change so open clients re-pull", async () => {
+    const created = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    const id = (await created.json()).id as string;
+    rec.reset();
+
+    await req(owner, "PATCH", `/api/folders/${id}`, { color: "violet" });
+    expect(rec.registryBroadcasts.map((b) => b.vaultId)).toEqual([vault]);
+  });
+
+  it("ignores a junk color rather than storing it", async () => {
+    const created = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    const id = (await created.json()).id as string;
+    await req(owner, "PATCH", `/api/folders/${id}`, { color: "x".repeat(64) });
+
+    const list = await req(owner, "GET", `/api/folders?vaultId=${vault}`);
+    const folders = (await list.json()).folders as Array<{ id: string; color: string | null }>;
+    expect(folders.find((f) => f.id === id)?.color).toBeNull();
+  });
+});

--- a/app/apps/server/tests/vault-root-freeze.test.ts
+++ b/app/apps/server/tests/vault-root-freeze.test.ts
@@ -20,6 +20,12 @@ import { recordingAppDeps } from "./helpers/app.js";
 const rec = recordingAppDeps();
 const app = createApp(rec.deps);
 
+// File-level, not per-describe: a describe-scoped `afterAll` closes the pool the
+// moment the FIRST block finishes, and every later block then fails on a dead one.
+afterAll(async () => {
+  await pool.end();
+});
+
 function req(user: TestUser, method: string, path: string, body?: unknown) {
   return app.fetch(
     new Request(`http://local${path}`, {
@@ -44,9 +50,6 @@ describe("frozen vault root", () => {
     org = (await createOrg(owner, "Freeze Co", "freeze-co")).id;
     await seedMember(org, member.userId, "member");
     vault = await seedVault(org);
-  });
-  afterAll(async () => {
-    await pool.end();
   });
 
   it("owner/admin can flip the latch; a member can only read it", async () => {
@@ -185,5 +188,87 @@ describe("frozen vault root", () => {
       folderId: null,
     });
     expect(rename.status).toBe(200);
+  });
+});
+
+/**
+ * The Access panel's structure listing.
+ *
+ * Every other listing is ACL-filtered, which is right for sync and fatal for
+ * administration: an item set to Private leaves `GET /api/notes`, its file
+ * leaves the manager's disk, and the panel — which drew its rows from that disk
+ * — lost the only row the restriction could be lifted from. A restriction you
+ * cannot see is one you cannot undo.
+ */
+describe("access-tree listing", () => {
+  let owner: TestUser;
+  let member: TestUser;
+  let org: string;
+  let vault: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+    owner = await signUp("owner@atree.test");
+    member = await signUp("member@atree.test");
+    org = (await createOrg(owner, "Tree Co", "tree-co")).id;
+    await seedMember(org, member.userId, "member");
+    vault = await seedVault(org);
+  });
+
+  it("still lists a folder and note the caller has shut themselves out of", async () => {
+    const folder = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "HR",
+      path: "HR",
+    });
+    const folderId = (await folder.json()).id as string;
+    const note = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "HR/pay.md",
+      folderId,
+    });
+    const docId = (await note.json()).id as string;
+
+    // Private, applied by the owner to themselves.
+    expect(
+      (
+        await req(owner, "POST", "/api/shares", {
+          resourceType: "folder",
+          resourceId: folderId,
+          principalType: "org",
+          permission: "denied",
+        })
+      ).status,
+    ).toBe(201);
+
+    // The sync listing correctly hides it…
+    const synced = await req(owner, "GET", `/api/notes?vaultId=${vault}`);
+    const syncedIds = ((await synced.json()).notes as Array<{ id: string }>).map((n) => n.id);
+    expect(syncedIds).not.toContain(docId);
+
+    // …and the management listing still shows it, which is what makes it undoable.
+    const tree = await req(owner, "GET", `/api/vaults/${vault}/access-tree`);
+    expect(tree.status).toBe(200);
+    const body = (await tree.json()) as {
+      folders: Array<{ path: string }>;
+      notes: Array<{ id: string; relPath: string }>;
+    };
+    expect(body.folders.map((f) => f.path)).toContain("HR");
+    expect(body.notes.map((n) => n.id)).toContain(docId);
+  });
+
+  it("carries no note content — paths and ids only", async () => {
+    await req(owner, "POST", "/api/notes", { vaultId: vault, relPath: "n.md", title: "Secret" });
+    const body = await (await req(owner, "GET", `/api/vaults/${vault}/access-tree`)).text();
+    expect(body).toContain("n.md");
+    // It bypasses the ACL, so it must carry the minimum that lets someone
+    // administer the tree and nothing that would let them READ a note.
+    expect(body).not.toContain("Secret");
+  });
+
+  it("is owner/admin only", async () => {
+    expect((await req(member, "GET", `/api/vaults/${vault}/access-tree`)).status).toBe(403);
+    expect((await req(owner, "GET", "/api/vaults/nope/access-tree")).status).toBe(404);
   });
 });

--- a/app/apps/server/tests/vault-root-freeze.test.ts
+++ b/app/apps/server/tests/vault-root-freeze.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { freezeVaultRoot, seedMember, seedVault } from "./helpers/seed.js";
+import { recordingAppDeps } from "./helpers/app.js";
+
+/**
+ * "Freeze vault root" — the General-settings latch that closes a vault's top
+ * level to new folders and notes.
+ *
+ * The two rules that make it usable rather than annoying:
+ *   - it applies to EVERYONE, owners included, because the accidental root
+ *     folder is nearly always created by someone who does have permission;
+ *   - it refuses only NEW rows, so a device re-registering a root note that
+ *     predates the latch still syncs.
+ */
+
+const rec = recordingAppDeps();
+const app = createApp(rec.deps);
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+describe("frozen vault root", () => {
+  let owner: TestUser;
+  let member: TestUser;
+  let org: string;
+  let vault: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+    owner = await signUp("owner@freeze.test");
+    member = await signUp("member@freeze.test");
+    org = (await createOrg(owner, "Freeze Co", "freeze-co")).id;
+    await seedMember(org, member.userId, "member");
+    vault = await seedVault(org);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("owner/admin can flip the latch; a member can only read it", async () => {
+    const on = await req(owner, "PATCH", `/api/vaults/${vault}`, { rootFrozen: true });
+    expect(on.status).toBe(200);
+    expect(await on.json()).toMatchObject({ rootFrozen: true });
+
+    const refused = await req(member, "PATCH", `/api/vaults/${vault}`, { rootFrozen: false });
+    expect(refused.status).toBe(403);
+
+    // …but they can SEE it, which is what makes the disabled toggle honest.
+    const list = await req(member, "GET", "/api/vaults");
+    const vaults = (await list.json()).vaults as Array<{ id: string; root_frozen: boolean }>;
+    expect(vaults.find((v) => v.id === vault)?.root_frozen).toBe(true);
+  });
+
+  it("refuses new root folders and root notes — even for the owner", async () => {
+    await freezeVaultRoot(vault);
+
+    const folder = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Stray",
+      path: "Stray",
+    });
+    expect(folder.status).toBe(403);
+    expect((await folder.json()).code).toBe("root_frozen");
+
+    const note = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "stray.md",
+    });
+    expect(note.status).toBe(403);
+    expect((await note.json()).code).toBe("root_frozen");
+  });
+
+  it("leaves creation INSIDE a folder alone", async () => {
+    const folder = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    const folderId = (await folder.json()).id as string;
+    await freezeVaultRoot(vault);
+
+    const nested = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Specs",
+      path: "Docs/Specs",
+      parentId: folderId,
+    });
+    expect(nested.status).toBe(201);
+
+    const note = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "Docs/note.md",
+      folderId,
+    });
+    expect(note.status).toBe(201);
+  });
+
+  it("still adopts a root note/folder that already exists (reconcile keeps working)", async () => {
+    const folder = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Inbox",
+      path: "Inbox",
+    });
+    expect(folder.status).toBe(201);
+    const docId = crypto.randomUUID();
+    const note = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "readme.md",
+      docId,
+    });
+    expect(note.status).toBe(201);
+
+    await freezeVaultRoot(vault);
+
+    // Second device / repeat reconcile: same path, same doc_id.
+    const readopt = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Inbox",
+      path: "Inbox",
+    });
+    expect(readopt.status).toBe(200);
+    const renote = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "readme.md",
+      docId,
+    });
+    expect(renote.status).toBe(201);
+  });
+
+  it("refuses a move OUT to the root, but allows a rename in place", async () => {
+    const folderRes = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Docs",
+      path: "Docs",
+    });
+    const folderId = (await folderRes.json()).id as string;
+    const nestedRes = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Specs",
+      path: "Docs/Specs",
+      parentId: folderId,
+    });
+    const nestedId = (await nestedRes.json()).id as string;
+    const noteRes = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "Docs/n.md",
+      folderId,
+    });
+    const noteId = (await noteRes.json()).id as string;
+    const rootNoteRes = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "top.md",
+    });
+    const rootNoteId = (await rootNoteRes.json()).id as string;
+
+    await freezeVaultRoot(vault);
+
+    const moveFolder = await req(owner, "PATCH", `/api/folders/${nestedId}`, {
+      path: "Specs",
+      parentId: null,
+    });
+    expect(moveFolder.status).toBe(403);
+
+    const moveNote = await req(owner, "PATCH", `/api/notes/${noteId}`, {
+      relPath: "n.md",
+      folderId: null,
+    });
+    expect(moveNote.status).toBe(403);
+
+    // A note ALREADY at the root is being renamed, not moved out — allowed.
+    const rename = await req(owner, "PATCH", `/api/notes/${rootNoteId}`, {
+      relPath: "top-renamed.md",
+      folderId: null,
+    });
+    expect(rename.status).toBe(200);
+  });
+});

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -1294,6 +1297,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -3091,6 +3097,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
-- Version history for every note — open the clock icon to browse, preview and revert past versions
-- Vault checkpoints in Settings → Versioning — automatic daily snapshots plus manual ones, with owner-only full-vault revert
-- See who last edited a note in the presence menu, and "edited … ago" at a glance
-- Persistent sync indicator in the header — live download/upload progress that settles to a checkmark
-- Updates now install themselves; this banner is the new way you hear about them
+- Share a link to any note — the new share icon copies a link that opens it straight in a teammate's Baalda
+- Access is now your whole vault as a tree — expand a folder and set permissions on the notes inside it
+- New **Private** setting for any folder, note or person, and every access setting now applies to admins and owners too
+- Losing access de-syncs the note and takes the local copy with it (recoverable from the vault trash); getting it back brings the file back
+- **Reveal in Finder** on any note or folder, from the right-click menu
+- **Freeze vault root** in Settings → General — stop new notes and folders landing at the top level once the shape is settled
+- Folder and note colours now sync to your whole team, and survive renames
+- Admins can revert a vault checkpoint, not just the owner
+- Google sign-in now works on accounts that were created with a password

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -181,6 +181,21 @@ Six changes that together make a vault something a team can actually govern.
 - [x] **Item colors sync.** `folders.color` / `notes.color` ride the registry pull, keyed by id so a
   rename keeps the tint. Colors set before a vault gained sync are adopted upward once.
 
+### Google sign-in on an existing password account ✔ (v0.1.30)
+- [x] `account_not_linked` on the Google callback for anyone who first signed up with a password —
+  i.e. everyone except users created *through* Google, who had nothing to link. The cause was a
+  Better Auth default, not our code: `accountLinking.requireLocalEmailVerified` is **true** unless
+  set, and it refuses to link while the local row is unverified. `requireEmailVerification` is off
+  (no email round-trip in the MVP), so every password sign-up has `emailVerified = false` forever
+  — which made the `accountLinking` block dead code from the day it was written.
+- [x] Set `requireLocalEmailVerified: false`. **A knowingly-taken trade:** the check exists because,
+  with no verification at sign-up, someone can register an address they don't own, and linking then
+  joins the real owner to the squatter's account rather than locking them out. Accepted because the
+  squat is already possible without linking and Google's verified email is the strongest signal we
+  have. **Email verification at sign-up is the real fix** and is still owed.
+- [x] Pinned by a config test — the failure mode was a silent default, so the three options that
+  have to agree (`enabled`, `trustedProviders`, `requireLocalEmailVerified`) are asserted together.
+
 ### Phase 4: Polish / upgrades _(deferred)_ ⬜
 - [ ] Structural rich-text CRDT (y-prosemirror / `Y.XmlFragment`) for full WYSIWYG.
 - [ ] Vector / hybrid search (Orama) for semantic + AI retrieval.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -115,6 +115,35 @@ De-risk the hardest part before networking.
   needs a `PS_MEMBER_REMOVED` frame each connection self-terminates on.
 - Specs: [[05-vault-sync-engine]] (transport), [[04-team-collaboration]] (membership gate)
 
+### Access & vault shape ✔ (v0.1.30)
+Six changes that together make a vault something a team can actually govern.
+- [x] **Access panel is a real tree.** Folders expand in place and pull their contents in on demand
+  (the sidebar loads folders lazily, so a flat list could only ever show what someone had already
+  clicked elsewhere) — which is what made the notes *inside* a folder reachable for the first time.
+  Row-building lives in `lib/accessTree.ts` so the "an un-listed folder is expandable, not empty"
+  rule is pinned by a test.
+- [x] **Per-member "No access".** A new `shares.permission = 'denied'` row (migration 018) — the
+  only row in the model that SUBTRACTS. Resolved before every allow rule, so it beats the vault-wide
+  Open grant, an admin's blanket edit, and "you created this note". Mirrored in the readable-set
+  dual, so a denied doc leaves the tree and stops syncing. See [[04-team-collaboration]] §3.
+- [x] **Permission writes narrate themselves.** Applying a mode is several round trips plus a socket
+  kick; the panel now says "Applying…" instead of looking stuck.
+- [x] **Reveal in Finder** on any note/folder — notes really are files on disk, so the shortest
+  bridge to the rest of the machine belongs in the context menu.
+- [x] **Freeze vault root** (General settings). A structural latch, not a permission: once the top
+  level is settled, nothing new lands beside it — for everyone, owners included, because the
+  accidental root folder is nearly always created by someone who does have permission. Only
+  owner/admin lifts it. Enforced on the HTTP registry AND the MCP tools; re-registering a root item
+  that predates the latch still works, so freezing can't break sync.
+- [x] **Shareable note links.** `baalda://note/<vault>/<doc>` via `tauri-plugin-deep-link`
+  (+ single-instance, so a click on Windows/Linux doesn't spawn a second app). The link carries
+  **identity, not access** — ids only, resolved against whoever opens it — and is keyed by `doc_id`,
+  so it survives every rename and move.
+- [x] **Vault revert is owner *or admin*.** It's the recovery half of an action admins could already
+  take; owner-only left a team whose owner was away able to take checkpoints and not use them.
+- [x] **Item colors sync.** `folders.color` / `notes.color` ride the registry pull, keyed by id so a
+  rename keeps the tint. Colors set before a vault gained sync are adopted upward once.
+
 ### Phase 4: Polish / upgrades _(deferred)_ ⬜
 - [ ] Structural rich-text CRDT (y-prosemirror / `Y.XmlFragment`) for full WYSIWYG.
 - [ ] Vector / hybrid search (Orama) for semantic + AI retrieval.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -144,7 +144,15 @@ Six changes that together make a vault something a team can actually govern.
   upstream, so a permission change can't take work that exists nowhere else. Revocations are capped
   separately from deletions and more loosely — a whole shared folder leaving at once is ordinary,
   a mass delete rarely is. An ACL change now also triggers the registry re-pull that carries this
-  out, so it lands in seconds instead of waiting for a restart. Management stays role-gated
+  out, so it lands in seconds instead of waiting for a restart. Restoring access re-materialises
+  the file and it hydrates on open — a permission toggle is never a one-way door.
+- [x] **The Access list reads the server's structure, not this machine's disk.** New owner/admin
+  endpoint `GET /api/vaults/:id/access-tree` (ids and paths, no content, deliberately not ACL
+  filtered). Every other listing is filtered, which is right for sync and fatal for administration:
+  once Private removed the file, the panel — which drew its rows from the disk — lost the only row
+  the restriction could be lifted from. Kept as a separate endpoint rather than a flag on the sync
+  listings, because an unfiltered response reaching the reconciler would have it materialise notes
+  it has no right to sync. Management stays role-gated
   (`canManage`) so an owner can always undo what they applied to themselves. Note this governs
   **sync, not disk**: losing access has never deleted anyone's local `.md` files, so the items stay
   in your own sidebar — they just go read-only/no-access and leave every teammate's vault.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -122,10 +122,13 @@ Six changes that together make a vault something a team can actually govern.
   clicked elsewhere) — which is what made the notes *inside* a folder reachable for the first time.
   Row-building lives in `lib/accessTree.ts` so the "an un-listed folder is expandable, not empty"
   rule is pinned by a test.
-- [x] **Per-member "No access".** A new `shares.permission = 'denied'` row (migration 018) — the
-  only row in the model that SUBTRACTS. Resolved before every allow rule, so it beats the vault-wide
-  Open grant, an admin's blanket edit, and "you created this note". Mirrored in the readable-set
-  dual, so a denied doc leaves the tree and stops syncing. See [[04-team-collaboration]] §3.
+- [x] **Private, at two scales.** A new `shares.permission = 'denied'` row (migration 018) — the
+  only row in the model that SUBTRACTS. Per-**member** (`principal_type 'user'`) it blocks one
+  person and beats everything, authorship included. Per-**item** (`principal_type 'org'`) it takes
+  a folder or note out of the *team's* reach while sparing the creator, explicit grantees and
+  owners/admins — which is what finally made item-Private work at all: clearing an item's own
+  grants left the vault-wide grant still reaching it, so Private snapped straight back to Shared.
+  Both are mirrored in the readable-set dual. See [[04-team-collaboration]] §3.
 - [x] **Permission writes narrate themselves.** Applying a mode is several round trips plus a socket
   kick; the panel now says "Applying…" instead of looking stuck.
 - [x] **Reveal in Finder** on any note/folder — notes really are files on disk, so the shortest
@@ -135,6 +138,13 @@ Six changes that together make a vault something a team can actually govern.
   accidental root folder is nearly always created by someone who does have permission. Only
   owner/admin lifts it. Enforced on the HTTP registry AND the MCP tools; re-registering a root item
   that predates the latch still works, so freezing can't break sync.
+- [x] **One popover select, everywhere.** The Access panel's per-member picker was the last native
+  `<select>` in the product; it now uses the Members page's popover (`MenuSelect`, which `RoleSelect`
+  is also a wrapper over). The Freeze-root checkbox became an animated `Switch` — a setting like
+  that is a decision, and a knob that slides confirms it landed.
+- [x] **Account menu leads with Home.** The popover's top row was a second copy of the identity
+  card that its own trigger already shows permanently in the sidebar footer. Home takes that row
+  instead; it was previously below the fold on an account with several vaults.
 - [x] **Shareable note links.** `baalda://note/<vault>/<doc>` via `tauri-plugin-deep-link`
   (+ single-instance, so a click on Windows/Linux doesn't spawn a second app). The link carries
   **identity, not access** — ids only, resolved against whoever opens it — and is keyed by `doc_id`,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -125,16 +125,17 @@ Six changes that together make a vault something a team can actually govern.
 - [x] **Private, at two scales.** A new `shares.permission = 'denied'` row (migration 018) — the
   only row in the model that SUBTRACTS. Per-**member** (`principal_type 'user'`) it blocks one
   person and beats everything, authorship included. Per-**item** (`principal_type 'org'`) it takes
-  a folder or note out of the team's reach, leaving only the creator and people shared with by
-  name — which is what finally made item-Private work at all: clearing an item's own grants left
+  a folder or note out of the team's reach, leaving only the people shared with by name — which is what finally made item-Private work at all: clearing an item's own grants left
   the vault-wide grant still reaching it, so Private snapped straight back to Shared. Both are
   mirrored in the readable-set dual. See [[04-team-collaboration]] §3.
 - [x] **Access settings apply to the person setting them.** The owner/admin and note-creator
   branches were shortcuts that ran *before* any grant was consulted, so a vault set to Read-only
   still let its owner edit and a folder set to Private still showed up for them — the one person
   who couldn't check their own restriction was the one who made it. Both shortcuts are now skipped
-  under item-Private and under a Read-only vault, so the posture is a ceiling for everyone and a
-  folder marked Shared is still the way to lift someone back out. Management stays role-gated
+  under item-Private and under a Read-only vault, so the posture is a ceiling for everyone; a
+  folder marked Shared, or naming yourself in the per-member list, is the way back out. The panel's
+  "who can access" list now resolves through the same branches as the enforcer — the two disagreed
+  on a member's own note, and a list that contradicts what it describes is worse than no list. Management stays role-gated
   (`canManage`) so an owner can always undo what they applied to themselves. Note this governs
   **sync, not disk**: losing access has never deleted anyone's local `.md` files, so the items stay
   in your own sidebar — they just go read-only/no-access and leave every teammate's vault.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -125,10 +125,19 @@ Six changes that together make a vault something a team can actually govern.
 - [x] **Private, at two scales.** A new `shares.permission = 'denied'` row (migration 018) — the
   only row in the model that SUBTRACTS. Per-**member** (`principal_type 'user'`) it blocks one
   person and beats everything, authorship included. Per-**item** (`principal_type 'org'`) it takes
-  a folder or note out of the *team's* reach while sparing the creator, explicit grantees and
-  owners/admins — which is what finally made item-Private work at all: clearing an item's own
-  grants left the vault-wide grant still reaching it, so Private snapped straight back to Shared.
-  Both are mirrored in the readable-set dual. See [[04-team-collaboration]] §3.
+  a folder or note out of the team's reach, leaving only the creator and people shared with by
+  name — which is what finally made item-Private work at all: clearing an item's own grants left
+  the vault-wide grant still reaching it, so Private snapped straight back to Shared. Both are
+  mirrored in the readable-set dual. See [[04-team-collaboration]] §3.
+- [x] **Access settings apply to the person setting them.** The owner/admin and note-creator
+  branches were shortcuts that ran *before* any grant was consulted, so a vault set to Read-only
+  still let its owner edit and a folder set to Private still showed up for them — the one person
+  who couldn't check their own restriction was the one who made it. Both shortcuts are now skipped
+  under item-Private and under a Read-only vault, so the posture is a ceiling for everyone and a
+  folder marked Shared is still the way to lift someone back out. Management stays role-gated
+  (`canManage`) so an owner can always undo what they applied to themselves. Note this governs
+  **sync, not disk**: losing access has never deleted anyone's local `.md` files, so the items stay
+  in your own sidebar — they just go read-only/no-access and leave every teammate's vault.
 - [x] **Permission writes narrate themselves.** Applying a mode is several round trips plus a socket
   kick; the panel now says "Applying…" instead of looking stuck.
 - [x] **Reveal in Finder** on any note/folder — notes really are files on disk, so the shortest

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -135,7 +135,16 @@ Six changes that together make a vault something a team can actually govern.
   under item-Private and under a Read-only vault, so the posture is a ceiling for everyone; a
   folder marked Shared, or naming yourself in the per-member list, is the way back out. The panel's
   "who can access" list now resolves through the same branches as the enforcer — the two disagreed
-  on a member's own note, and a list that contradicts what it describes is worse than no list. Management stays role-gated
+  on a member's own note, and a list that contradicts what it describes is worse than no list.
+- [x] **Losing access de-syncs the file.** A revocation used to leave the `.md` on the ex-reader's
+  disk, which made it cosmetic — they could open the note in any editor forever. It now moves to
+  the vault's trash on every device that had it, alongside the existing tombstone path, with three
+  rails: it only fires when the server actually answered about deletions (`tombstones !== null`),
+  it trashes rather than destroys, and it refuses any doc whose content this device never confirmed
+  upstream, so a permission change can't take work that exists nowhere else. Revocations are capped
+  separately from deletions and more loosely — a whole shared folder leaving at once is ordinary,
+  a mass delete rarely is. An ACL change now also triggers the registry re-pull that carries this
+  out, so it lands in seconds instead of waiting for a restart. Management stays role-gated
   (`canManage`) so an owner can always undo what they applied to themselves. Note this governs
   **sync, not disk**: losing access has never deleted anyone's local `.md` files, so the items stay
   in your own sidebar — they just go read-only/no-access and leave every teammate's vault.

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -96,7 +96,9 @@ shares (
 > `org_id` column — is the vault (organization) id, never the `vaults` note-collection row.
 
 **Effective permission** for a user on a file:
-0. A **`denied`** row for this user on the file or any containing folder → `none`, full stop.
+0. A **`denied`** row for this *user* on the file or any containing folder → `none`, full stop.
+   A `denied` row for the *org* (the item set to Private) instead switches OFF the org-scoped
+   branch of step 3 for that resource.
 1. Vault `owner`/`admin` → `edit` on everything in the vault.
 2. A note's **creator** → `edit` on their own note.
 3. Else take the **max** of: any `share` on the file itself, any `share` on a containing folder
@@ -107,14 +109,28 @@ shares (
    included).
 
 **Two overlays, deliberately different.** `locked` is a *cap* — it takes edit down to view and
-never removes read. `denied` is a *block* — the Access panel's per-member "No access", the only
-row in the model that subtracts. It is resolved **first** so it beats every allow rule above it,
-including the owner/admin branch and the creator escape hatch; without that, "keep this folder
-away from Sam" would silently do nothing on the notes Sam happens to have written. It is always
-`principal_type = 'user'` and never on the `vault` resource: an org-wide deny is just the Private
-posture said twice, and a vault-level deny would be a way to lock an owner out of their own vault.
-The readable-set dual (`permissions/vault-docs.ts`) subtracts the same set, so a denied doc leaves
-the tree and stops syncing rather than merely failing to resolve.
+never removes read. `denied` is a *block*: the only row in the model that subtracts. It comes in
+two flavours, distinguished by `principal_type`, and never applies to the `vault` resource (a
+vault-level deny is what the Private posture already is, and would be a way to lock an owner out
+of their own vault).
+
+| | `denied` + `principal_type='user'` | `denied` + `principal_type='org'` |
+|---|---|---|
+| UI | per-member **Private** | the item set to **Private** |
+| Means | "this person is blocked" | "this item is not shared with the team" |
+| Beats | everything: role, vault grant, explicit share, authorship | org-scoped grants only, incl. the vault-wide one |
+| Spares | nobody | the creator, per-user grantees, owners/admins |
+
+The user deny has to beat authorship, or "keep this away from Sam" would silently do nothing on
+exactly the notes Sam wrote. The org deny exists because **clearing an item's own grants could
+never express item-Private**: in a Shared vault the vault-wide grant still reached the item, so the
+segment snapped straight back to Shared. Sparing owners/admins is what stops someone creating a
+folder that nobody — themselves included — can ever reach again.
+
+The readable-set dual (`permissions/vault-docs.ts`) subtracts both sets under the same rules, so a
+denied doc leaves the tree and stops syncing rather than merely failing to resolve. `vaultAccess`
+reports `vaultWideVia` (`role` / `org` / `user`) precisely so the org deny can skip the first and
+the third.
 
 **Private by default:** a new vault grants nothing org-wide, so members see only what they create
 or what's shared with them / the team. (Owner sets the whole vault to Shared/Read-only, or shares

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -97,16 +97,33 @@ shares (
 
 **Effective permission** for a user on a file:
 0. A **`denied`** row for this *user* on the file or any containing folder → `none`, full stop.
-   A `denied` row for the *org* (the item set to Private) instead switches OFF the org-scoped
-   branch of step 3 for that resource.
-1. Vault `owner`/`admin` → `edit` on everything in the vault.
-2. A note's **creator** → `edit` on their own note.
-3. Else take the **max** of: any `share` on the file itself, any `share` on a containing folder
+1. The **shortcuts** in 2–3 are skipped entirely when either of these holds, and step 4 decides
+   alone:
+   - a `denied` row for the *org* on the file or a containing folder (the item set to **Private**);
+   - the vault's org-wide grant is `view` (the vault set to **Read-only**).
+2. Vault `owner`/`admin` → `edit` on everything in the vault.
+3. A note's **creator** → `edit` on their own note.
+4. Else take the **max** of: any `share` on the file itself, any `share` on a containing folder
    (walk `parent_id` up), and any vault-wide grant — each either **per-user** or an org-wide
-   **"share with team"** grant.
-4. `edit > view > none`. No matching grant → **no sync access**.
-5. A **`locked`** row matching the file or an ancestor caps the result at `view` (owners/admins
-   included).
+   **"share with team"** grant. Under item-Private the org-scoped half drops out, leaving only
+   per-user grants.
+5. `edit > view > none`. No matching grant → **no sync access**.
+6. A **`locked`** row matching the file or an ancestor caps the result at `view`.
+
+**Nothing in the Access panel exempts the person setting it.** Steps 2 and 3 are conveniences, not
+entitlements, and step 1 is what stops them swallowing a restriction: an owner who marks a folder
+Private loses it too, and a Read-only vault is read-only for its owner. A setting its author can't
+observe is one they have to take on trust, which is not a thing to ship in an access panel. The
+safety net is that *management* is gated separately — `canManage` (`http/routes/shares.ts`) asks
+for owner/admin and never for effective permission — so an owner can always lift what they set.
+The desktop's Access list is built from the local folder, so the row to lift it from never
+disappears either.
+
+> **A restriction governs sync, not someone's disk.** Losing access never deletes local `.md`
+> files (that's the whole point of `listDeletedReadableDocsInVault` — absence has to be
+> distinguishable from deletion). So an owner who makes everything Private still sees the files in
+> their own sidebar; what changes is that the notes go read-only or no-access, stop syncing, and
+> leave every teammate's vault.
 
 **Two overlays, deliberately different.** `locked` is a *cap* — it takes edit down to view and
 never removes read. `denied` is a *block*: the only row in the model that subtracts. It comes in
@@ -118,19 +135,16 @@ of their own vault).
 |---|---|---|
 | UI | per-member **Private** | the item set to **Private** |
 | Means | "this person is blocked" | "this item is not shared with the team" |
-| Beats | everything: role, vault grant, explicit share, authorship | org-scoped grants only, incl. the vault-wide one |
-| Spares | nobody | the creator, per-user grantees, owners/admins |
+| Beats | everything: role, vault grant, explicit share, authorship | every org-scoped grant, plus the owner/admin shortcut |
+| Spares | nobody | the creator, and per-user grantees |
 
 The user deny has to beat authorship, or "keep this away from Sam" would silently do nothing on
 exactly the notes Sam wrote. The org deny exists because **clearing an item's own grants could
 never express item-Private**: in a Shared vault the vault-wide grant still reached the item, so the
-segment snapped straight back to Shared. Sparing owners/admins is what stops someone creating a
-folder that nobody — themselves included — can ever reach again.
+segment snapped straight back to Shared.
 
 The readable-set dual (`permissions/vault-docs.ts`) subtracts both sets under the same rules, so a
-denied doc leaves the tree and stops syncing rather than merely failing to resolve. `vaultAccess`
-reports `vaultWideVia` (`role` / `org` / `user`) precisely so the org deny can skip the first and
-the third.
+denied doc leaves the tree and stops syncing rather than merely failing to resolve.
 
 **Private by default:** a new vault grants nothing org-wide, so members see only what they create
 or what's shared with them / the team. (Owner sets the whole vault to Shared/Read-only, or shares

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -127,6 +127,13 @@ disappears either.
 > since the ex-reader can open it in any editor forever. The server keeps the content, so this is
 > a de-sync, not a delete.
 >
+> Restoring access brings the file back: the note reappears in the registry listing, the
+> reconciler re-materialises it and the content hydrates on open. A permission toggle is never a
+> one-way door. And because a Private item leaves the disk, the Access panel reads the vault's
+> structure from `GET /api/vaults/:id/access-tree` (owner/admin, ids and paths only, deliberately
+> unfiltered) rather than from the local folder — otherwise making something Private would remove
+> the only row you could un-Private it from.
+>
 > Three rails, all in `lib/sync/inbound.ts`: it only fires when the server actually **answered**
 > about deletions (`tombstones !== null` — absence proves nothing otherwise); the file goes to a
 > recoverable **trash** folder rather than being destroyed; and the executor **refuses** any doc

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -122,11 +122,17 @@ for owner/admin and never for effective permission — so an owner can always li
 The desktop's Access list is built from the local folder, so the row to lift it from never
 disappears either.
 
-> **A restriction governs sync, not someone's disk.** Losing access never deletes local `.md`
-> files (that's the whole point of `listDeletedReadableDocsInVault` — absence has to be
-> distinguishable from deletion). So an owner who makes everything Private still sees the files in
-> their own sidebar; what changes is that the notes go read-only or no-access, stop syncing, and
-> leave every teammate's vault.
+> **A restriction reaches the disk.** Losing access moves the local `.md` into the vault's trash
+> on every device that had it — a revocation that leaves a full, readable copy behind is cosmetic,
+> since the ex-reader can open it in any editor forever. The server keeps the content, so this is
+> a de-sync, not a delete.
+>
+> Three rails, all in `lib/sync/inbound.ts`: it only fires when the server actually **answered**
+> about deletions (`tombstones !== null` — absence proves nothing otherwise); the file goes to a
+> recoverable **trash** folder rather than being destroyed; and the executor **refuses** any doc
+> whose content this device never confirmed upstream, so a permission change can't take work that
+> exists nowhere else. Revocations are capped separately from deletions, more loosely, because a
+> whole shared folder leaving at once is ordinary while a mass delete rarely is.
 
 **Two overlays, deliberately different.** `locked` is a *cap* — it takes edit down to view and
 never removes read. `denied` is a *block*: the only row in the model that subtracts. It comes in

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -112,7 +112,10 @@ shares (
 
 **Nothing in the Access panel exempts the person setting it.** Steps 2 and 3 are conveniences, not
 entitlements, and step 1 is what stops them swallowing a restriction: an owner who marks a folder
-Private loses it too, and a Read-only vault is read-only for its owner. A setting its author can't
+Private loses it too — including notes they wrote, since in a vault you set up yourself you wrote
+nearly everything and sparing the author makes Private unobservable exactly where it is used. A
+Read-only vault is likewise read-only for its owner. Naming yourself in the per-member list is the
+way back in. A setting its author can't
 observe is one they have to take on trust, which is not a thing to ship in an access panel. The
 safety net is that *management* is gated separately — `canManage` (`http/routes/shares.ts`) asks
 for owner/admin and never for effective permission — so an owner can always lift what they set.
@@ -135,8 +138,8 @@ of their own vault).
 |---|---|---|
 | UI | per-member **Private** | the item set to **Private** |
 | Means | "this person is blocked" | "this item is not shared with the team" |
-| Beats | everything: role, vault grant, explicit share, authorship | every org-scoped grant, plus the owner/admin shortcut |
-| Spares | nobody | the creator, and per-user grantees |
+| Beats | everything: role, vault grant, explicit share, authorship | every org-scoped grant, plus the owner/admin **and creator** shortcuts |
+| Spares | nobody | only an explicit per-user grant |
 
 The user deny has to beat authorship, or "keep this away from Sam" would silently do nothing on
 exactly the notes Sam wrote. The org deny exists because **clearing an item's own grants could

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -84,7 +84,7 @@ shares (
   resource_id    TEXT,   -- folder id or file/doc id (org id for the 'vault' grant)
   principal_type TEXT,   -- 'user' (MVP) | 'team' (later)
   principal_id   TEXT,
-  permission     TEXT,   -- 'view' | 'edit'
+  permission     TEXT,   -- 'view' | 'edit' | 'locked' (cap) | 'denied' (block)
   created_by     TEXT,
   created_at     TIMESTAMPTZ,
   UNIQUE(resource_type, resource_id, principal_type, principal_id)
@@ -96,12 +96,25 @@ shares (
 > `org_id` column — is the vault (organization) id, never the `vaults` note-collection row.
 
 **Effective permission** for a user on a file:
+0. A **`denied`** row for this user on the file or any containing folder → `none`, full stop.
 1. Vault `owner`/`admin` → `edit` on everything in the vault.
 2. A note's **creator** → `edit` on their own note.
 3. Else take the **max** of: any `share` on the file itself, any `share` on a containing folder
    (walk `parent_id` up), and any vault-wide grant — each either **per-user** or an org-wide
    **"share with team"** grant.
 4. `edit > view > none`. No matching grant → **no sync access**.
+5. A **`locked`** row matching the file or an ancestor caps the result at `view` (owners/admins
+   included).
+
+**Two overlays, deliberately different.** `locked` is a *cap* — it takes edit down to view and
+never removes read. `denied` is a *block* — the Access panel's per-member "No access", the only
+row in the model that subtracts. It is resolved **first** so it beats every allow rule above it,
+including the owner/admin branch and the creator escape hatch; without that, "keep this folder
+away from Sam" would silently do nothing on the notes Sam happens to have written. It is always
+`principal_type = 'user'` and never on the `vault` resource: an org-wide deny is just the Private
+posture said twice, and a vault-level deny would be a way to lock an owner out of their own vault.
+The readable-set dual (`permissions/vault-docs.ts`) subtracts the same set, so a denied doc leaves
+the tree and stops syncing rather than merely failing to resolve.
 
 **Private by default:** a new vault grants nothing org-wide, so members see only what they create
 or what's shared with them / the team. (Owner sets the whole vault to Shared/Read-only, or shares


### PR DESCRIPTION
Six changes that together make a vault something a team can actually govern. One migration (`018`), one release (`v0.1.30`).

## 1 · Access panel: a real tree, a real block, a real loader

**Folders expand in place.** The list was flat — and the sidebar loads folders lazily, so it could only ever show notes someone had already clicked on elsewhere. Expanding a folder now pulls its contents in on demand through the same `loadChildren` the sidebar uses (one tree, one cache). Row-building moved to `lib/accessTree.ts` so the load-bearing rule — *an un-listed folder is expandable, not empty* — is pinned by a test rather than living inside a render.

**Per-member "No access (blocked)".** The dropdown had "Can view" and "Can edit" and no way to keep one person *out*. `locked` couldn't do it: a lock caps at view, it never removes read. So `shares.permission` gains `'denied'` — the only row in the model that subtracts. It resolves **before** every allow rule, so it beats the vault-wide Open grant, an admin's blanket edit, and the "you created this note" escape hatch. That last one is the point: *"keep this folder away from Sam"* has to mean it on the notes Sam wrote, or the feature is a no-op exactly where it matters. The readable-set dual subtracts the same set, so a denied doc leaves the tree and stops syncing rather than merely failing to resolve, and live sockets are kicked immediately.

Always per-user, never on the vault resource: an org-wide deny is the Private posture said twice, and a vault-level deny would be a way to lock an owner out of their own vault.

**"Applying…".** A mode change is several round trips plus a socket kick. It now says so instead of looking stuck.

## 2 · Reveal in Finder
On any note or folder in the sidebar. Notes really are files on disk — that's the product — so the shortest bridge to the rest of the machine belongs in the context menu. Platform-labelled (Finder / Explorer / file manager).

## 3 · Freeze vault root
A toggle in **Settings → General**, with a description of what it does.

A structural latch, not a permission: once the top-level shape is settled, nothing new lands beside it — for **everyone**, owners included, because the accidental root folder is nearly always created by someone who *does* have permission. Only an owner/admin can lift it; everyone else sees the switch in its real state, disabled, so the rule is visible rather than mysterious.

Enforced on the HTTP registry **and** the MCP tools (an assistant asked to "add a note" with no folder in mind is one of the likelier ways a stray root file appears). It refuses only *new* rows and only after the adopt path, so re-registering a root item that predates the latch still works — freezing the root can't break sync for the very notes it was frozen to protect. Moving something out to the root is refused too; renaming something already there is not.

## 4 · Shareable note links
A share icon in the note header copies `baalda://note/<vault>/<doc>`. Paste it in chat; a teammate clicks it and lands on the note.

The link carries **identity, not access** — two ids, resolved against whoever opens it. A stranger gets nothing; a teammate without a grant gets the same "no access" they'd get by navigating there by hand. Keyed by `doc_id`, so it survives every rename and move a path-based link would rot on.

Adds `tauri-plugin-deep-link`, plus `tauri-plugin-single-instance` so a click on Windows/Linux hands the URL to the running app instead of spawning a second copy. Both arrival paths are handled (`onOpenUrl` while running, `getCurrent()` when the click launched the app) — handling only the first is the classic bug where links work for people who happen to have the app open.

## 5 · Vault revert is owner **or** admin
It's the recovery half of an action admins could already take (create/delete a checkpoint). Owner-only left a team whose owner was away able to take checkpoints and not use them.

## 6 · Folder & note colors sync
Colors were a localStorage preference keyed by path, so a folder you tinted was grey on every other machine and for every teammate. They now live on the row (`folders.color` / `notes.color`) and ride the registry pull that already fires when structure changes — keyed by **id**, so a rename or a move keeps the tint. Colors set on a machine before its vault gained sync are adopted upward exactly once (a flag stops this machine re-uploading a color a teammate deliberately cleared).

---

## Testing

- **Server:** 269 pass, including 20 new — `access-deny` (deny beats grant / role / authorship, inherits down a subtree, scoped to one member, leaves the readable set and the folder tree), `vault-root-freeze` (gating, root refusal, nested still fine, adopt still works, move-out vs rename), `item-colors` (round-trip, survives rename, clears, broadcasts, rejects junk). `checkpoints` updated for owner+admin revert.
- **Desktop:** 601 pass, including 13 new — `accessTree` (the lazy-folder rule, indentation, unregistered rows, reveal) and `shareLink` (round-trip, escaping, host-folded form, hostile input, carries no secrets).
- **Rust:** `cargo test` green; `cargo check` validates the new capability identifiers at build time.
- Production `vite build` and `tsc --noEmit` clean across both workspaces.

Server tests were run against a scratch `context_test` database so the dev DB kept its data; migration `018` is additive (two columns, one widened CHECK) and has been applied to the local dev DB.
