### PR TITLE
Wrong-account vault click now prompts sign-in instead of dead-ending

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.30"
+version = "0.1.31"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -324,8 +324,9 @@ export function VaultPicker() {
   // Open a vault row. Local-only folders open in place. A synced vault —
   // whether a cached remote row or a local folder whose own config says it
   // syncs — needs a session: if we still have one, switch straight to it
-  // (opening its folder + resyncing); if we're signed out, remember it and
-  // prompt sign-in — landInLastVault opens it once the session lands. Opening
+  // (opening its folder + resyncing); if we're signed out — or signed in as an
+  // account that can't see it — remember it and prompt sign-in;
+  // landInLastVault opens it once the right session lands. Opening
   // a synced folder *without* a session would edit it silently offline under a
   // "local" label; the escape hatch for deliberate offline work is "Open
   // existing", not a click that looks like any other.
@@ -344,10 +345,17 @@ export function VaultPicker() {
           if (!organizations.some((o) => o.id === orgId)) {
             // A stamped folder whose vault this account can't see. Switching
             // would 403, and adopting it would duplicate another account's
-            // vault — say why instead.
+            // vault. Hand over to the right account instead of dead-ending:
+            // drop this session and offer sign-in with the vault stashed, so
+            // the post-auth landing opens exactly it. (The dialog needs the
+            // sign-out — it dismisses itself while a session exists.)
             setError(
               `"${e.name}" was synced under a different account. Sign in with that account to open it.`,
             );
+            await useStore.getState().signOut();
+            requestOpenVault(orgId);
+            setSignInFor("open");
+            setSignInOpen(true);
             return;
           }
           await useStore.getState().setActiveOrganization(orgId);


### PR DESCRIPTION
Clicking a synced vault on the welcome screen while signed in as an account that can't see it used to show only an error banner, with no way to sign out and switch accounts from that screen.

Now that branch signs out of the wrong session, stashes the clicked vault as the pending open target, and opens the sign-in dialog — reusing the same machinery the signed-out path already had. Signing in with the right account lands directly in that vault.

Bumps version to 0.1.31.