### PR TITLE
Cap the What's New modal height and let the notes scroll

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.31"
+version = "0.1.32"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -2207,9 +2207,16 @@ body:has(.sidebar-resizer.dragging) {
 /* Post-auto-update "What's New" modal. Rides the shared .modal/.modal-backdrop
    chrome; everything below is the celebratory dressing. */
 .whats-new {
-  width: 400px;
+  /* Wide and short rather than a tower: a long release list must never push
+     the dialog past the viewport (it used to clip top AND bottom). The card
+     caps its height, the notes list scrolls, hero + CTA stay pinned. */
+  width: 580px;
+  max-width: min(580px, 92vw);
+  max-height: min(72vh, 620px);
+  display: flex;
+  flex-direction: column;
   text-align: center;
-  padding: var(--sp-8) var(--sp-6) var(--sp-6);
+  padding: var(--sp-6) var(--sp-6) var(--sp-5);
   /* A soft accent wash from the top so the moment reads as good news, not a
      system dialog — same trick as the welcome screen's radial. */
   background:
@@ -2218,6 +2225,7 @@ body:has(.sidebar-resizer.dragging) {
 }
 .whats-new-hero {
   display: flex;
+  flex: none;
   flex-direction: column;
   align-items: center;
   gap: var(--sp-2);
@@ -2256,8 +2264,12 @@ body:has(.sidebar-resizer.dragging) {
 }
 .whats-new-notes {
   list-style: none;
-  margin: var(--sp-5) 0 0;
+  margin: var(--sp-4) 0 0;
   padding: var(--sp-4);
+  /* The one flexible region: eats the leftover height and scrolls past it. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
@@ -2283,7 +2295,8 @@ body:has(.sidebar-resizer.dragging) {
 }
 .whats-new-cta {
   width: 100%;
-  margin-top: var(--sp-5);
+  flex: none;
+  margin-top: var(--sp-4);
   padding: var(--sp-3) var(--sp-4);
 }
 @keyframes whats-new-pop {


### PR DESCRIPTION
The post-update What's New modal grew with its release notes and a long list pushed the dialog past the viewport, clipping both the top and the bottom of the card.

The card now caps its height (max-height: min(72vh, 620px)) and goes wide-and-short (580px) instead of a tower. The notes list is the single flexible region — it eats the leftover height and scrolls — while the hero and the CTA stay pinned.

Also bumps the version to 0.1.32 so the fix ships on merge.