### PR TITLE
Fix sync reliability: deletes that stick, retry from the badge, reconnect catch-up, honest folder counts

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.32"
+version = "0.1.33"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -849,6 +849,27 @@ pub async fn trash_note(
     Ok(dest)
 }
 
+/// Remove a folder the server has deleted — but only when it is empty by now
+/// (its notes leave via their own tombstones first). Returns whether it was
+/// removed; a folder still holding anything stays on disk, which is the safe
+/// direction (see `notefile::delete_folder_if_empty`).
+#[tauri::command]
+pub async fn delete_folder_if_empty(
+    state: State<'_, AppState>,
+    path: String,
+    expected_epoch: Option<u64>,
+) -> AppResult<bool> {
+    // Epoch-pinned like `trash_note`: driven by a debounced registry pull that
+    // can outlive a vault switch.
+    let (vault, index) = require_vault_at(&state, expected_epoch)?;
+    let abs = vault::resolve_in_vault(&vault, &path)?;
+    let removed = notefile::delete_folder_if_empty(&vault, &path)?;
+    if removed {
+        index.lock().unwrap().remove_note(&vault, &abs)?;
+    }
+    Ok(removed)
+}
+
 #[tauri::command]
 pub async fn delete_path(
     state: State<'_, AppState>,

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -76,6 +76,7 @@ pub fn run() {
             commands::ensure_folder,
             commands::rename_path,
             commands::delete_path,
+            commands::delete_folder_if_empty,
             commands::trash_note,
             commands::search_notes,
             commands::get_backlinks,

--- a/app/apps/desktop/src-tauri/src/notefile.rs
+++ b/app/apps/desktop/src-tauri/src/notefile.rs
@@ -185,6 +185,31 @@ fn unique_trash_dest(vault: &Path, rel: &str) -> AppResult<String> {
     Err(AppError::new("could not find a free name in the trash"))
 }
 
+/// Remove a directory ONLY if it is empty by now. Returns whether it was
+/// removed; anything still inside (an unconfirmed note, a stray image, a new
+/// local file) keeps the folder alive, which is the safe outcome.
+///
+/// This is the executor for an inbound folder delete: the server tombstones a
+/// deleted folder by id, the notes inside leave via their own tombstones, and
+/// then this unwinds the emptied directories bottom-up. Deliberately never
+/// recursive — `remove_dir`, not `remove_dir_all` — so it can only ever take
+/// away a folder that holds nothing.
+pub fn delete_folder_if_empty(vault: &Path, rel: &str) -> AppResult<bool> {
+    if crate::vault::rel_path_is_ignored(rel) {
+        return Err(AppError::new("refusing to touch an ignored dir"));
+    }
+    let abs = resolve_in_vault(vault, rel)?;
+    if !abs.exists() {
+        return Ok(true); // already gone — the goal state
+    }
+    if !abs.is_dir() {
+        return Ok(false); // a file lives at this path; not ours to remove
+    }
+    // Any failure (non-empty, permissions, races) means "leave it": a folder
+    // that lingers is cosmetic, a reconcile pass that fails over it is not.
+    Ok(std::fs::remove_dir(&abs).is_ok())
+}
+
 /// Delete a file or folder (recursively for folders).
 pub fn delete_path(vault: &Path, rel: &str) -> AppResult<()> {
     let abs = resolve_in_vault(vault, rel)?;
@@ -403,5 +428,29 @@ mod tests {
         assert!(ensure_folder(tmp.path(), ".context/evil").is_err());
         assert!(ensure_folder(tmp.path(), "node_modules/x").is_err());
         assert!(ensure_folder(tmp.path(), "../up").is_err());
+    }
+
+    #[test]
+    fn delete_folder_if_empty_is_empty_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        ensure_folder(tmp.path(), "A/B").unwrap();
+        std::fs::write(tmp.path().join("A/B/keep.md"), "content").unwrap();
+        // Non-empty: stays, reported as not removed.
+        assert!(!delete_folder_if_empty(tmp.path(), "A/B").unwrap());
+        assert!(tmp.path().join("A/B").is_dir());
+        // Emptied: removed, bottom-up.
+        std::fs::remove_file(tmp.path().join("A/B/keep.md")).unwrap();
+        assert!(delete_folder_if_empty(tmp.path(), "A/B").unwrap());
+        assert!(delete_folder_if_empty(tmp.path(), "A").unwrap());
+        assert!(!tmp.path().join("A").exists());
+        // Already gone is the goal state, not an error.
+        assert!(delete_folder_if_empty(tmp.path(), "A").unwrap());
+        // A FILE at the path is not ours to remove.
+        std::fs::write(tmp.path().join("f.md"), "x").unwrap();
+        assert!(!delete_folder_if_empty(tmp.path(), "f.md").unwrap());
+        assert!(tmp.path().join("f.md").exists());
+        // Ignored dirs and traversal are refused loudly.
+        assert!(delete_folder_if_empty(tmp.path(), ".context/trash").is_err());
+        assert!(delete_folder_if_empty(tmp.path(), "../up").is_err());
     }
 }

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -4253,6 +4253,24 @@ body:has(.sidebar-resizer.dragging) {
   background: var(--danger-soft);
   color: var(--danger);
 }
+/* A run that ended with failures renders as a button: the remedy ("Sync now")
+   lives on the message instead of asking the user to sign out and back in. */
+button.sync-badge-retry {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+}
+button.sync-badge-retry:hover {
+  filter: brightness(0.96);
+}
+.sync-retry-cta {
+  padding-left: var(--sp-2);
+  border-left: 1px solid currentColor;
+  opacity: 0.85;
+  white-space: nowrap;
+}
 @keyframes sync-pulse {
   0%,
   100% {

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -5455,6 +5455,54 @@ button.is-done:disabled {
   color: var(--text-primary);
 }
 
+/* ---- Required-update wall ----
+   Covers the whole window above everything else (modals top out at 300):
+   updates are mandatory, so nothing behind this may be reachable until the
+   install lands. The card stays calm — this is routine, not an emergency. */
+.update-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+.update-gate-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-4);
+  max-width: 420px;
+  padding: var(--sp-8) var(--sp-8);
+  text-align: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+.update-gate-card h1 {
+  margin: 0;
+  font-size: var(--fs-lg);
+  font-weight: 700;
+}
+.update-gate-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.update-gate-logo {
+  height: 22px;
+}
+.update-gate-cta {
+  min-width: 180px;
+}
+.update-gate .update-progress {
+  width: 240px;
+  flex: none;
+}
+
 /* ---- Update download progress ---- */
 .update-progress {
   position: relative;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FileTree } from "./components/FileTree";
 import { GraphView } from "./components/GraphView";
 import { SyncBadge } from "./components/Identity";
+import { Wordmark } from "./components/Logo";
 import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { SidebarResizer } from "./components/SidebarResizer";
@@ -22,8 +23,10 @@ import * as ipc from "./lib/ipc";
 import { syncManager } from "./lib/sync/docSession";
 import {
   backgroundUpdateCheck,
+  checkForUpdate,
   clearJustUpdated,
   installUpdate,
+  isUpdateBlocking,
   justUpdatedTo,
   releaseNoteLines,
   useUpdateState,
@@ -257,76 +260,102 @@ function VaultFolderPrompt() {
 }
 
 /**
- * Non-blocking bar shown when a newer version is published. The launch-time
- * check (in App) populates the shared updater state; this just renders it.
- * Errors and the "up to date" result are intentionally silent here — those
- * only surface when the user checks manually from Settings → Updates.
+ * Full-screen REQUIRED-update wall. Updates are not optional: the moment a
+ * newer version is discovered (at launch or by the background poll) this covers
+ * the whole window and the only way forward is "Install & Restart". No "Later".
+ *
+ * Why a wall and not a bar: every dismissible banner left part of the fleet on
+ * old builds, and old builds are exactly where the bugs we just fixed live —
+ * one stale client can resurrect deleted folders for a whole team. Keeping
+ * everyone on the latest version is a correctness feature here, not a nag.
+ *
+ * The version is LATCHED: once `available` has been seen, an install error
+ * keeps the wall up with a retry rather than letting a known-stale build back
+ * in. A failed background *check* (offline launch, dev build without the
+ * updater) never had an `available` to latch, so it never walls anything off.
+ * Local edits stay safe throughout — notes are on disk, and `installUpdate`
+ * flushes the open note before relaunching.
  */
-function UpdateBanner() {
-  // Dismissal is per-version: "Later" on v0.1.27 must not also swallow the
-  // v0.1.28 banner when the background poll finds it hours later.
-  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+function UpdateGate() {
   const update = useUpdateState();
+  const [required, setRequired] = useState<string | null>(null);
+  useEffect(() => {
+    if (update.phase === "available") setRequired(update.version);
+  }, [update]);
 
-  if (update.phase === "available") {
-    if (update.version === dismissedVersion) return null;
-    return (
-      <Banner show className="update-banner global-banner">
-        <span>
-          A new version of {BRAND_NAME} (<strong>v{update.version}</strong>) is
-          available.
-        </span>
-        <div className="banner-actions">
-          <AsyncButton className="primary" onClick={() => installUpdate()}>
-            Install &amp; Restart
-          </AsyncButton>
-          <button
-            className="secondary"
-            onClick={() => setDismissedVersion(update.version)}
-          >
-            Later
-          </button>
-        </div>
-      </Banner>
-    );
+  if (!isUpdateBlocking(update) && !(update.phase === "error" && required)) {
+    return null;
   }
 
-  // Once the user clicks Install & Restart the banner becomes the progress
-  // strip while the new bytes come down, and the app restarts when they're in.
-  // The post-restart story is UpdatedBanner's.
-  if (update.phase === "downloading" || update.phase === "installing") {
-    const pct =
-      update.phase === "downloading" && update.total > 0
-        ? Math.round((update.downloaded / update.total) * 100)
-        : null;
-    return (
-      <Banner show className="update-banner global-banner" role="status">
-        <span>
-          {update.phase === "installing"
-            ? "Installing update — the app will restart…"
-            : `Downloading update${pct != null ? ` — ${pct}%` : "…"}`}
-        </span>
-        {/* A determinate bar when the server sent a content length, an
-            indeterminate sweep when it didn't. The distinction is worth the
-            extra rule: a bar that fills to an unknown target and stalls is
-            worse than one that never claimed to know. */}
-        <div
-          className={`update-progress${pct == null ? " indeterminate" : ""}`}
-          role="progressbar"
-          aria-valuenow={pct ?? undefined}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          <span
-            className="update-progress-fill"
-            style={pct != null ? { width: `${pct}%` } : undefined}
-          />
-        </div>
-      </Banner>
-    );
-  }
+  const pct =
+    update.phase === "downloading" && update.total > 0
+      ? Math.round((update.downloaded / update.total) * 100)
+      : null;
 
-  return null;
+  return (
+    <div className="update-gate" role="alertdialog" aria-modal="true" aria-label="Update required">
+      <div className="update-gate-card">
+        <Wordmark className="update-gate-logo" />
+        <h1>Update required</h1>
+        {update.phase === "available" && (
+          <>
+            <p>
+              {BRAND_NAME} <strong>v{update.version}</strong> is ready. Install the update to
+              continue using the app — it takes a moment and your notes stay right where they
+              are, on your disk.
+            </p>
+            <AsyncButton className="primary update-gate-cta" onClick={() => installUpdate()}>
+              Install &amp; Restart
+            </AsyncButton>
+          </>
+        )}
+        {(update.phase === "downloading" || update.phase === "installing") && (
+          <>
+            <p role="status">
+              {update.phase === "installing"
+                ? "Installing — the app will restart itself…"
+                : `Downloading v${update.version}${pct != null ? ` — ${pct}%` : "…"}`}
+            </p>
+            {/* A determinate bar when the server sent a content length, an
+                indeterminate sweep when it didn't — a bar that fills to an
+                unknown target and stalls is worse than one that never claimed
+                to know. */}
+            <div
+              className={`update-progress${pct == null ? " indeterminate" : ""}`}
+              role="progressbar"
+              aria-valuenow={pct ?? undefined}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <span
+                className="update-progress-fill"
+                style={pct != null ? { width: `${pct}%` } : undefined}
+              />
+            </div>
+          </>
+        )}
+        {update.phase === "error" && required && (
+          <>
+            <p>
+              The update to <strong>v{required}</strong> didn&rsquo;t finish
+              {update.message ? ` — ${update.message}` : ""}. Check your connection and try
+              again.
+            </p>
+            <AsyncButton
+              className="primary update-gate-cta"
+              onClick={async () => {
+                // Re-discover then install: the failed attempt may have died at
+                // either stage, and checkForUpdate re-arms the pending update.
+                if (await checkForUpdate()) await installUpdate();
+              }}
+            >
+              Try again
+            </AsyncButton>
+          </>
+        )}
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -440,12 +469,6 @@ function WhatsNewModal() {
   );
 }
 
-function SaveIndicator() {
-  // The CRDT bridge autosaves to disk on a debounce, so the note is always
-  // being persisted; there is no "unsaved" state to surface anymore.
-  return <span className="save-indicator saved">Auto-saved</span>;
-}
-
 function SyncIndicator({ noteOpen }: { noteOpen: boolean }) {
   // Per-note sync status (offline / connecting / synced / read-only) PLUS the
   // vault's bulk-run progress, so a vault that is still uploading 380 of its 500
@@ -549,8 +572,8 @@ export default function App() {
         setBooting(false);
       }
       // Check for updates at launch AND on a background poll, but never install
-      // uninvited: a found release only raises the UpdateBanner, and the
-      // download/relaunch waits for the user's "Install & Restart" click.
+      // uninvited: a found release raises the required-update wall (UpdateGate),
+      // and the download/relaunch waits for the user's "Install & Restart" click.
       // Failures (offline, non-bundled dev build) are swallowed by the updater
       // store — surfaced only in Settings → Updates. App-lifetime interval —
       // never cleared, and the launch guard above keeps it single in dev
@@ -714,7 +737,7 @@ export default function App() {
     // the user to choose/create one before its folder opens.
     return (
       <div className="app-shell">
-        <UpdateBanner />
+        <UpdateGate />
         <VaultPicker />
         <VaultFolderPrompt />
       </div>
@@ -725,7 +748,7 @@ export default function App() {
     <div className="app-shell">
       {/* Window-global, above the sidebar+main split: a new release must be
           visible the moment the poll finds it, whatever is on screen. */}
-      <UpdateBanner />
+      <UpdateGate />
       <div
         className="app"
         style={{ "--sidebar-w": `${sidebarWidth}px` } as React.CSSProperties}
@@ -763,7 +786,6 @@ export default function App() {
               region; Tauri exempts the buttons on the right, so they still click. */}
           <header className="main-header" data-tauri-drag-region="deep">
             <span className="note-title">{openNote?.title ?? "No note open"}</span>
-            {openNote && !isPreview && <SaveIndicator />}
             <SyncIndicator noteOpen={openNote != null && !isPreview} />
             {/* Vault-wide, so it sits in the header regardless of the open note. */}
             <TalkButton />

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -468,6 +468,9 @@ function SyncIndicator({ noteOpen }: { noteOpen: boolean }) {
       pending={pending}
       progress={progress}
       noteOpen={noteOpen}
+      // "N not synced" carries its own remedy: one click re-pulls the registry
+      // and re-runs the content pass for everything still unconfirmed.
+      onRetry={syncEnabled ? () => void syncManager.retrySync() : undefined}
     />
   );
 }

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -319,7 +319,14 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
    * too, and the panel has to be able to say which folder is deciding that.
    */
   const privatePaths = useMemo(() => {
-    const idToPath = resourceIdsByPath(tree);
+    // Mapped through the same entries the rows are drawn from — the SERVER
+    // structure when available — never through the local disk tree alone: a
+    // Private item has left the disk, so a disk-keyed map could not name its
+    // path and the row it still occupies on screen badged as "Shared".
+    const idToPath = new Map(entries.map((e) => [e.id, e.path] as const));
+    for (const [id, path] of resourceIdsByPath(tree)) {
+      if (!idToPath.has(id)) idToPath.set(id, path);
+    }
     const out = new Set<string>();
     for (const d of denies) {
       if (sharePrincipalType(d) !== "org") continue;
@@ -327,7 +334,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
       if (path) out.add(path);
     }
     return out;
-  }, [tree, denies]);
+  }, [entries, tree, denies]);
   /** The nearest ANCESTOR of `path` that is Private, or null. */
   const privateSourcePath = (path: string): string | null => {
     const parts = path.split("/");

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1008,6 +1008,20 @@ export function AuthDialog({
         </form>
 
         {authError && <div className="auth-error">{authError}</div>}
+        {/* The one trap this form can't detect: an account created THROUGH
+            Google has no password at all, so email sign-in answers "Invalid
+            email or password" and sign-up answers "already exists" — a dead end
+            unless someone says the words. Shown only on that failure, and only
+            when Google is actually offered. */}
+        {authError != null &&
+          googleAvailable &&
+          mode === "sign-in" &&
+          /invalid email or password/i.test(authError) && (
+            <p className="auth-hint">
+              First joined with Google? That account has no password — use
+              “Continue with Google” above.
+            </p>
+          )}
 
         <details className="server-config">
           <summary>Server settings</summary>

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -368,7 +368,7 @@ export function FileTree() {
     // Shared with the single-item delete below. It used to be a hand-copied loop
     // that removed the files but never told the server, so every deleted note
     // came back as an empty file on the next registry pull.
-    const { deleted } = await deletePaths(paths, {
+    const { deleted, failed } = await deletePaths(paths, {
       // Pinned to the vault this bulk delete was asked for: every lap after the
       // first runs past an await, and a delete that landed in the vault the user
       // switched to would destroy a same-named file they never selected.
@@ -377,6 +377,16 @@ export function FileTree() {
       unregister: (p) => syncManager.registry.deletePath(p),
       onProgress: (done, total) => setBulkProgress({ done, total }),
     });
+    // A refused delete (offline, or no permission on the server) leaves the item
+    // in place everywhere — silence here is what used to read as "it came back".
+    if (failed.length > 0) {
+      toast(
+        failed.length === 1
+          ? `Couldn't delete "${failed[0].path}" — ${failed[0].reason}`
+          : `Couldn't delete ${failed.length} items — ${failed[0].reason}`,
+        "error",
+      );
+    }
     let order = store.itemOrder;
     for (const p of deleted) {
       order = removeFromOrder(order, p);
@@ -1126,11 +1136,14 @@ export function FileTree() {
     // Same helper as `bulkDelete`, including the epoch pin this call was missing:
     // an unpinned delete that lands after a vault switch destroys a same-named
     // file in a vault the user wasn't even looking at.
-    const { deleted } = await deletePaths([node.data.path], {
+    const { deleted, failed } = await deletePaths([node.data.path], {
       epoch: store.vault?.epoch,
       deleteDisk: (p, epoch) => ipc.deletePath(p, epoch),
       unregister: (p) => syncManager.registry.deletePath(p),
     });
+    if (failed.length > 0) {
+      toast(`Couldn't delete "${failed[0].path}" — ${failed[0].reason}`, "error");
+    }
     if (deleted.length === 0) return;
     store.setItemOrder(removeFromOrder(store.itemOrder, node.data.path));
     if (openNote && (openNote.path === node.data.path || openNote.path.startsWith(node.data.path + "/"))) {
@@ -1644,7 +1657,7 @@ function peersForNode(
 
 /**
  * The row's sync tell: one quiet dot, or — for a folder that hasn't settled — the
- * percentage of the notes inside it that are on the server.
+ * count of notes inside it still waiting to reach the server.
  *
  * Sized and positioned like `.tree-lock` (its neighbour) and built from the same
  * `.sync-dot` element and semantic tone tokens the vault-level `.sync-badge`
@@ -1662,8 +1675,8 @@ function TreeSyncMark({
   if (!mark) return null;
   return (
     <span className={`tree-sync ${mark.state}`} title={mark.title} aria-label={mark.title}>
-      {mark.percent != null ? (
-        <span className="tree-sync-pct">{mark.percent}%</span>
+      {mark.count != null ? (
+        <span className="tree-sync-pct">{mark.count}</span>
       ) : (
         <span className="sync-dot" aria-hidden="true" />
       )}

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -1675,8 +1675,10 @@ function TreeSyncMark({
   if (!mark) return null;
   return (
     <span className={`tree-sync ${mark.state}`} title={mark.title} aria-label={mark.title}>
-      {mark.count != null ? (
-        <span className="tree-sync-pct">{mark.count}</span>
+      {mark.progress != null ? (
+        <span className="tree-sync-pct">
+          {mark.progress.synced}/{mark.progress.total}
+        </span>
       ) : (
         <span className="sync-dot" aria-hidden="true" />
       )}

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -127,13 +127,13 @@ export function syncBadgeLabel(args: {
   }
   if (progress && isSyncRunActive(progress)) {
     if (progress.total <= 0) return "Syncing…";
-    // "Downloading" is the one direction we genuinely know (the inbound
-    // backfill). The content pass is NOT called "Uploading": it pulls each
-    // note's server state first and only then pushes what's missing, so on a
-    // vault that was already synced it is a verification sweep — calling that
-    // "Uploading files" told people their synced vault was being re-sent.
-    const verb = progress.phase === "downloading" ? "Downloading" : "Syncing";
-    return `${verb} ${progress.done}/${progress.total}`;
+    // One verb for every phase. The old per-phase labels ("Uploading",
+    // "Downloading") described the mechanism, not the user's situation — the
+    // content pass pulls each note's server state before pushing anything, so
+    // on an already-synced vault "Uploading files" read as "my synced vault is
+    // being re-sent". Done is clamped so a racing denominator can never render
+    // an impossible "585/164".
+    return `Syncing ${Math.min(progress.done, progress.total)}/${progress.total}`;
   }
   // A run that finished with failures must not read "Synced". `failed` is the
   // number of notes that are still only on this device.

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -127,14 +127,12 @@ export function syncBadgeLabel(args: {
   }
   if (progress && isSyncRunActive(progress)) {
     if (progress.total <= 0) return "Syncing…";
-    // Name the direction: a freshly invited teammate watching their vault arrive
-    // should read "Downloading", not a generic "Syncing".
-    const verb =
-      progress.phase === "downloading"
-        ? "Downloading"
-        : progress.phase === "uploading"
-          ? "Uploading"
-          : "Syncing";
+    // "Downloading" is the one direction we genuinely know (the inbound
+    // backfill). The content pass is NOT called "Uploading": it pulls each
+    // note's server state first and only then pushes what's missing, so on a
+    // vault that was already synced it is a verification sweep — calling that
+    // "Uploading files" told people their synced vault was being re-sent.
+    const verb = progress.phase === "downloading" ? "Downloading" : "Syncing";
     return `${verb} ${progress.done}/${progress.total}`;
   }
   // A run that finished with failures must not read "Synced". `failed` is the
@@ -194,6 +192,7 @@ export function SyncBadge({
   pending,
   progress,
   noteOpen,
+  onRetry,
 }: {
   status: string;
   enabled?: boolean;
@@ -207,6 +206,9 @@ export function SyncBadge({
   /** False when the pill stands for the vault, not an open note: socket-derived
    *  states are skipped and the label comes from `progress` alone. */
   noteOpen?: boolean;
+  /** When set, a run that ended with failures ("N not synced") renders as a
+   *  button that retries the whole sync — the remedy lives on the message. */
+  onRetry?: () => void;
 }) {
   const running = isSyncRunActive(progress);
   // Only tick the relative clock once we're settled (synced, nothing pending, no
@@ -228,12 +230,16 @@ export function SyncBadge({
   // indeterminate slide covers "working, size unknown" (connecting, saving).
   const percent = running ? syncRunPercent(progress) : null;
   // Hover answers "how far along?" in the same shape as the folder tooltips.
-  const title =
+  const runTitle =
     running && progress && percent != null
       ? `${progress.done} of ${progress.total} notes · ${percent}%`
       : undefined;
-  return (
-    <span className={`sync-badge ${tone}${pending ? " pending" : ""}`} title={title}>
+  // A run that ended with failures is actionable when the caller gave us the
+  // action: the pill becomes a button and one click retries everything.
+  const retryable = onRetry != null && !running && progress?.phase === "error";
+  const title = retryable ? "Click to sync now" : runTitle;
+  const body = (
+    <>
       {tone === "connecting" || (tone === "synced" && pending) ? (
         <span
           className={`sync-progress${percent != null ? " determinate" : ""}`}
@@ -266,6 +272,24 @@ export function SyncBadge({
         <span className="sync-dot" aria-hidden="true" />
       )}
       {label}
+    </>
+  );
+  if (retryable) {
+    return (
+      <button
+        type="button"
+        className={`sync-badge sync-badge-retry ${tone}`}
+        title={title}
+        onClick={onRetry}
+      >
+        {body}
+        <span className="sync-retry-cta">Sync now</span>
+      </button>
+    );
+  }
+  return (
+    <span className={`sync-badge ${tone}${pending ? " pending" : ""}`} title={title}>
+      {body}
     </span>
   );
 }

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -91,11 +91,12 @@ export function syncRunPercent(progress: SyncProgress | null | undefined): numbe
 
 /**
  * Pure label for the sync pill. Extracted so the (surprisingly load-bearing)
- * "Saving…" vs "Synced · just now" logic is unit-testable without a DOM.
+ * "Syncing…" vs "Synced · just now" logic is unit-testable without a DOM.
  *
  * `pending` (local edits not yet acked) wins over the timestamp: while flushing
- * we show "Saving…"; once acked, the caller has bumped `lastSyncedAt`, so it
- * reads "Synced · just now" and counts up from there.
+ * we show "Syncing…" — the pill speaks exactly two words, Syncing and Synced,
+ * so nobody has to learn what a third ("Saving") means. Once acked, the caller
+ * has bumped `lastSyncedAt`, so it reads "Synced · just now" and counts up.
  *
  * `progress` is the VAULT's bulk run, and it outranks `status` (the open note's
  * CONNECTION) whenever it is live. Those two are genuinely independent: the
@@ -144,7 +145,7 @@ export function syncBadgeLabel(args: {
     return progress?.phase === "done" ? "Synced" : "Syncing…";
   }
   if (status === "synced") {
-    if (pending) return "Saving…";
+    if (pending) return "Syncing…";
     return lastSyncedAt != null ? `Synced · ${relativeAgo(lastSyncedAt, now)}` : "Synced";
   }
   if (status === "connecting") return "Syncing…";
@@ -198,7 +199,7 @@ export function SyncBadge({
   enabled?: boolean;
   /** When set and status is "synced", the badge reads "Synced · 1m ago". */
   lastSyncedAt?: number | null;
-  /** True while local edits are still flushing to the server → "Saving…". */
+  /** True while local edits are still flushing to the server → "Syncing…". */
   pending?: boolean;
   /** The open vault's bulk sync run — turns the pill into "Syncing 128/500"
    *  with a determinate bar. Omit for a pill that only tracks the connection. */

--- a/app/apps/desktop/src/components/ShareNoteButton.tsx
+++ b/app/apps/desktop/src/components/ShareNoteButton.tsx
@@ -33,7 +33,10 @@ export function ShareNoteButton({ docId }: { docId: string }) {
   if (!orgId) return null;
 
   const copy = async () => {
-    const link = buildNoteLink({ orgId, docId });
+    // Built on the server URL so it's an https link — chat apps make those
+    // clickable, where a bare baalda:// scheme had to be copy-pasted. The
+    // server's /open/note page bounces the click into the app.
+    const link = buildNoteLink({ orgId, docId }, useStore.getState().serverUrl);
     try {
       await navigator.clipboard.writeText(link);
       setCopied(true);

--- a/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
+++ b/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
@@ -9,14 +9,14 @@ import type { SyncProgress } from "../../lib/sync/vaultScope";
 
 // The sync pill is the user-facing "is my work safe?" signal. These lock in the
 // fix for the bug where it drifted to "Synced · 5m ago" while actively editing:
-// pending edits must read "Saving…", and a fresh flush must read "just now".
+// pending edits must read "Syncing…", and a fresh flush must read "just now".
 describe("syncBadgeLabel", () => {
   const now = 1_000_000_000_000;
 
-  it("shows Saving… while local edits are pending, ignoring the timestamp", () => {
+  it("shows Syncing… while local edits are pending, ignoring the timestamp", () => {
     expect(
       syncBadgeLabel({ status: "synced", pending: true, lastSyncedAt: now - 300_000, now }),
-    ).toBe("Saving…");
+    ).toBe("Syncing…");
   });
 
   it("reads 'Synced · just now' immediately after a flush", () => {

--- a/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
+++ b/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
@@ -67,7 +67,7 @@ describe("syncBadgeLabel with a bulk sync run", () => {
         now,
         progress: run({ phase: "uploading", done: 128, total: 500 }),
       }),
-    ).toBe("Uploading 128/500");
+    ).toBe("Syncing 128/500");
   });
 
   it("counts the registering and downloading phases too, named by direction", () => {
@@ -193,7 +193,7 @@ describe("syncBadgeLabel with a bulk sync run", () => {
         noteOpen: false,
         progress: run({ phase: "uploading", done: 1, total: 9 }),
       }),
-    ).toBe("Uploading 1/9");
+    ).toBe("Syncing 1/9");
   });
 
   it("keeps the vault-wide tone consistent with the vault-wide words", () => {

--- a/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
+++ b/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
@@ -70,7 +70,17 @@ describe("syncBadgeLabel with a bulk sync run", () => {
     ).toBe("Syncing 128/500");
   });
 
-  it("counts the registering and downloading phases too, named by direction", () => {
+  it("clamps a racing counter so it can never read 585/164", () => {
+    expect(
+      syncBadgeLabel({
+        status: "synced",
+        now,
+        progress: run({ phase: "registering", done: 585, total: 164 }),
+      }),
+    ).toBe("Syncing 164/164");
+  });
+
+  it("counts the registering and downloading phases too, all under one verb", () => {
     expect(
       syncBadgeLabel({
         status: "connecting",
@@ -78,14 +88,16 @@ describe("syncBadgeLabel with a bulk sync run", () => {
         progress: run({ phase: "registering", done: 3, total: 40 }),
       }),
     ).toBe("Syncing 3/40");
-    // A freshly invited teammate watching their vault arrive reads "Downloading".
+    // Every phase reads "Syncing" — the per-phase verbs described mechanism,
+    // not the user's situation ("Uploading files" on an already-synced vault
+    // read as "my vault is being re-sent").
     expect(
       syncBadgeLabel({
         status: "synced",
         now,
         progress: run({ phase: "downloading", done: 9, total: 10 }),
       }),
-    ).toBe("Downloading 9/10");
+    ).toBe("Syncing 9/10");
   });
 
   it("falls back to the indeterminate label when the run has no total yet", () => {
@@ -168,7 +180,7 @@ describe("syncBadgeLabel with a bulk sync run", () => {
         noteOpen: false,
         progress: run({ phase: "downloading", done: 128, total: 500 }),
       }),
-    ).toBe("Downloading 128/500");
+    ).toBe("Syncing 128/500");
     expect(
       syncBadgeLabel({
         status: "offline",

--- a/app/apps/desktop/src/lib/__tests__/registryNoteMeta.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/registryNoteMeta.test.ts
@@ -37,6 +37,7 @@ function fakeApi(notes: RegisteredNote[]) {
     listVaults: vi.fn(async () => [VAULT]),
     createVault: vi.fn(async () => VAULT),
     listFolders: vi.fn(async () => []),
+    listFolderRegistry: vi.fn(async () => ({ folders: [], tombstones: [] })),
     createFolder: vi.fn(async (input: { path: string }) => ({ id: `folder-${input.path}` })),
     listNotes: vi.fn(async () => notes),
     listNoteRegistry: vi.fn(async () => ({ notes, tombstones: [] as string[] })),

--- a/app/apps/desktop/src/lib/__tests__/registryOrgStamp.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/registryOrgStamp.test.ts
@@ -35,6 +35,7 @@ function fakeApi() {
     listVaults: vi.fn(async () => [VAULT]),
     createVault: vi.fn(async () => VAULT),
     listFolders: vi.fn(async () => []),
+    listFolderRegistry: vi.fn(async () => ({ folders: [], tombstones: [] })),
     createFolder: vi.fn(async (input: { path: string }) => ({ id: `folder-${input.path}` })),
     listNotes: vi.fn(async () => []),
     listNoteRegistry: vi.fn(async () => ({ notes: [], tombstones: [] as string[] })),

--- a/app/apps/desktop/src/lib/__tests__/shareLink.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/shareLink.test.ts
@@ -30,9 +30,35 @@ describe("share links", () => {
     });
   });
 
+  it("builds a clickable https link when a server base is known", () => {
+    // Chat apps linkify https; a bare baalda:// scheme just sits there as text.
+    // The server's /open/note page bounces the click into the app.
+    const target = { orgId: "org_123", docId: "d0c-4bcd" };
+    expect(buildNoteLink(target, "https://api.baalda.com")).toBe(
+      "https://api.baalda.com/open/note/org_123/d0c-4bcd",
+    );
+    // A reverse-proxy sub-path prefix on the server URL is preserved.
+    expect(buildNoteLink(target, "https://example.com/baalda/")).toBe(
+      "https://example.com/baalda/open/note/org_123/d0c-4bcd",
+    );
+    // A malformed base falls back to the raw scheme rather than a broken link.
+    expect(buildNoteLink(target, "not a url")).toBe(`${SHARE_SCHEME}://note/org_123/d0c-4bcd`);
+  });
+
+  it("parses the https form, host-agnostic (self-hosted servers mint links too)", () => {
+    const target = { orgId: "org_123", docId: "d0c-4bcd" };
+    expect(parseNoteLink(buildNoteLink(target, "https://api.baalda.com"))).toEqual(target);
+    expect(parseNoteLink("https://my.selfhost.io/prefix/open/note/o1/d1")).toEqual({
+      orgId: "o1",
+      docId: "d1",
+    });
+  });
+
   it("rejects anything that isn't one of ours", () => {
     for (const url of [
-      "https://example.com/note/org/doc",
+      "https://example.com/note/org/doc", // https without /open/note
+      "https://example.com/open/vault/org_1", // wrong resource
+      "https://example.com/open/note/org_1", // no doc id
       "baalda://vault/org_1",
       "baalda://note/org_1", // no doc id
       "baalda://note", // no ids at all

--- a/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
@@ -166,11 +166,11 @@ describe("buildTreeSyncIndex", () => {
 });
 
 describe("rowSyncMark", () => {
-  it("shows a dot for a note and never a percentage", () => {
+  it("shows a dot for a note and never a count", () => {
     const index = indexOf({ "a.md": "syncing" });
     expect(rowSyncMark(file("a.md"), index)).toEqual({
       state: "syncing",
-      percent: null,
+      count: null,
       title: "Syncing…",
     });
   });
@@ -183,34 +183,34 @@ describe("rowSyncMark", () => {
     expect(rowSyncMark(file("page.html"), index)).toBeNull();
   });
 
-  it("shows a folder's percentage while it works and a dot once settled", () => {
+  it("shows how many notes a folder still has to sync, and a dot once settled", () => {
     const busy = indexOf({ "A/a.md": "synced", "A/b.md": "syncing" });
-    expect(rowSyncMark(dir("A"), busy)).toMatchObject({ state: "syncing", percent: 50 });
+    expect(rowSyncMark(dir("A"), busy)).toMatchObject({ state: "syncing", count: 1 });
 
     const done = indexOf({ "A/a.md": "synced", "A/b.md": "synced" });
-    expect(rowSyncMark(dir("A"), done)).toMatchObject({ state: "synced", percent: null });
+    expect(rowSyncMark(dir("A"), done)).toMatchObject({ state: "synced", count: null });
 
     const broken = indexOf({ "A/a.md": "synced", "A/b.md": "error" });
-    expect(rowSyncMark(dir("A"), broken)).toMatchObject({ state: "error", percent: null });
+    expect(rowSyncMark(dir("A"), broken)).toMatchObject({ state: "error", count: null });
   });
 
-  it("shows the percentage for a stalled partial folder too", () => {
+  it("shows the count for a stalled partial folder too", () => {
     // Nothing in flight, not everything synced: the number is the only honest
     // answer, and it is what tells the user which folder to look at.
     const index = indexOf({ "A/a.md": "synced" }, ["A/b.md", "A/c.md"]);
-    expect(rowSyncMark(dir("A"), index)).toMatchObject({ state: "unsynced", percent: 33 });
+    expect(rowSyncMark(dir("A"), index)).toMatchObject({ state: "unsynced", count: 2 });
   });
 
   it("resolves the vault root folder to the whole-vault roll-up", () => {
     const index = indexOf({ "A/a.md": "synced", "b.md": "synced" });
-    expect(rowSyncMark(dir(""), index)).toMatchObject({ state: "synced", percent: null });
+    expect(rowSyncMark(dir(""), index)).toMatchObject({ state: "synced", count: null });
   });
 });
 
 describe("folderSyncTitle", () => {
   it("states the real counts rather than a rounded claim", () => {
     const index = indexOf({ "A/a.md": "synced", "A/b.md": "syncing", "A/c.md": "syncing" });
-    expect(folderSyncTitle(index.folders.get("A")!)).toBe("1 of 3 notes synced (33%)");
+    expect(folderSyncTitle(index.folders.get("A")!)).toBe("1 of 3 notes synced");
   });
 
   it("names the failures when there are any", () => {

--- a/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
@@ -166,11 +166,11 @@ describe("buildTreeSyncIndex", () => {
 });
 
 describe("rowSyncMark", () => {
-  it("shows a dot for a note and never a count", () => {
+  it("shows a dot for a note and never a fraction", () => {
     const index = indexOf({ "a.md": "syncing" });
     expect(rowSyncMark(file("a.md"), index)).toEqual({
       state: "syncing",
-      count: null,
+      progress: null,
       title: "Syncing…",
     });
   });
@@ -183,27 +183,33 @@ describe("rowSyncMark", () => {
     expect(rowSyncMark(file("page.html"), index)).toBeNull();
   });
 
-  it("shows how many notes a folder still has to sync, and a dot once settled", () => {
+  it("shows a folder's synced/total counts, and a dot once settled", () => {
     const busy = indexOf({ "A/a.md": "synced", "A/b.md": "syncing" });
-    expect(rowSyncMark(dir("A"), busy)).toMatchObject({ state: "syncing", count: 1 });
+    expect(rowSyncMark(dir("A"), busy)).toMatchObject({
+      state: "syncing",
+      progress: { synced: 1, total: 2 },
+    });
 
     const done = indexOf({ "A/a.md": "synced", "A/b.md": "synced" });
-    expect(rowSyncMark(dir("A"), done)).toMatchObject({ state: "synced", count: null });
+    expect(rowSyncMark(dir("A"), done)).toMatchObject({ state: "synced", progress: null });
 
     const broken = indexOf({ "A/a.md": "synced", "A/b.md": "error" });
-    expect(rowSyncMark(dir("A"), broken)).toMatchObject({ state: "error", count: null });
+    expect(rowSyncMark(dir("A"), broken)).toMatchObject({ state: "error", progress: null });
   });
 
-  it("shows the count for a stalled partial folder too", () => {
+  it("shows the counts for a stalled partial folder too", () => {
     // Nothing in flight, not everything synced: the number is the only honest
     // answer, and it is what tells the user which folder to look at.
     const index = indexOf({ "A/a.md": "synced" }, ["A/b.md", "A/c.md"]);
-    expect(rowSyncMark(dir("A"), index)).toMatchObject({ state: "unsynced", count: 2 });
+    expect(rowSyncMark(dir("A"), index)).toMatchObject({
+      state: "unsynced",
+      progress: { synced: 1, total: 3 },
+    });
   });
 
   it("resolves the vault root folder to the whole-vault roll-up", () => {
     const index = indexOf({ "A/a.md": "synced", "b.md": "synced" });
-    expect(rowSyncMark(dir(""), index)).toMatchObject({ state: "synced", count: null });
+    expect(rowSyncMark(dir(""), index)).toMatchObject({ state: "synced", progress: null });
   });
 });
 

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -879,6 +879,27 @@ export class ApiClient {
     return data.folders ?? [];
   }
 
+  /**
+   * The registry pull's view of a vault's folders: the folders the server will
+   * show us, plus the folder ids it says are **deleted**.
+   *
+   * Same `null`-vs-`[]` contract as {@link listNoteRegistry}: `tombstones: null`
+   * means the server did not answer (an older server), and the reconciler must
+   * never remove or suppress a folder on the strength of "I don't know".
+   */
+  async listFolderRegistry(
+    vaultId: string,
+  ): Promise<{ folders: RegisteredFolder[]; tombstones: string[] | null }> {
+    const { data } = await this.request<{
+      folders: RegisteredFolder[];
+      tombstones?: string[];
+    }>("GET", "/api/folders", { query: { vaultId } });
+    return {
+      folders: data.folders ?? [],
+      tombstones: Array.isArray(data.tombstones) ? data.tombstones : null,
+    };
+  }
+
   async createFolder(input: {
     vaultId: string;
     name: string;

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -282,6 +282,13 @@ export const trashNote = (path: string, stamp: string, expectedEpoch?: VaultEpoc
   invoke<string>("trash_note", { path, stamp, expectedEpoch: expectedEpoch ?? null });
 export const deletePath = (path: string, expectedEpoch?: VaultEpoch) =>
   invoke<void>("delete_path", { path, expectedEpoch: expectedEpoch ?? null });
+/**
+ * Remove a folder the server has deleted — only if it is empty by now. Resolves
+ * true when removed (or already gone); false when anything still lives inside,
+ * in which case the folder stays, deliberately.
+ */
+export const deleteFolderIfEmpty = (path: string, expectedEpoch?: VaultEpoch) =>
+  invoke<boolean>("delete_folder_if_empty", { path, expectedEpoch: expectedEpoch ?? null });
 
 /** Import external files/folders (absolute host paths) into `dest` (vault-relative). */
 export const importPaths = (dest: string, sources: string[], expectedEpoch?: VaultEpoch) =>

--- a/app/apps/desktop/src/lib/shareLink.ts
+++ b/app/apps/desktop/src/lib/shareLink.ts
@@ -23,11 +23,31 @@ export interface NoteLinkTarget {
   docId: string;
 }
 
-/** Build the link a user copies. */
-export function buildNoteLink(target: NoteLinkTarget): string {
-  return `${SHARE_SCHEME}://note/${encodeURIComponent(target.orgId)}/${encodeURIComponent(
-    target.docId,
-  )}`;
+/**
+ * Build the link a user copies.
+ *
+ * With a server base URL this is an **https** link (`<server>/open/note/…`):
+ * chat apps linkify https where a bare `baalda://` scheme just sits there as
+ * text, so the recipient can click instead of copy-pasting. The server's
+ * `/open/note` page bounces straight into the `baalda://` deep link. Without a
+ * base (unit tests, no server configured) it falls back to the raw scheme,
+ * which still opens the app directly.
+ */
+export function buildNoteLink(target: NoteLinkTarget, serverBase?: string | null): string {
+  const ids = `note/${encodeURIComponent(target.orgId)}/${encodeURIComponent(target.docId)}`;
+  if (serverBase) {
+    try {
+      const u = new URL(serverBase);
+      const prefix = u.pathname.replace(/\/+$/, "");
+      u.pathname = `${prefix}/open/${ids}`;
+      u.search = "";
+      u.hash = "";
+      return u.toString();
+    } catch {
+      /* malformed base — fall back to the scheme link */
+    }
+  }
+  return `${SHARE_SCHEME}://${ids}`;
 }
 
 /**
@@ -44,11 +64,15 @@ export function parseNoteLink(url: string): NoteLinkTarget | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== `${SHARE_SCHEME}:`) return null;
+  const isScheme = parsed.protocol === `${SHARE_SCHEME}:`;
+  const isWeb = parsed.protocol === "https:" || parsed.protocol === "http:";
+  if (!isScheme && !isWeb) return null;
   // `baalda://note/<org>/<doc>` parses with host "note" and pathname
   // "/<org>/<doc>". Some platforms hand the URL over with the host folded into
-  // the path instead, so accept both rather than depending on which.
-  const segments = [parsed.host, ...parsed.pathname.split("/")]
+  // the path instead, so accept both rather than depending on which. The https
+  // form is `https://<server>[/prefix]/open/note/<org>/<doc>` — host-agnostic,
+  // because self-hosted servers mint these links too.
+  const segments = [...(isScheme ? [parsed.host] : []), ...parsed.pathname.split("/")]
     .filter((p) => p.length > 0)
     .map((p) => {
       try {
@@ -57,8 +81,16 @@ export function parseNoteLink(url: string): NoteLinkTarget | null {
         return p;
       }
     });
-  if (segments[0] !== "note") return null;
-  const [, orgId, docId] = segments;
+  // For the web form, anchor on the trailing `/open/note/<org>/<doc>` so a
+  // reverse-proxy path prefix in front of it doesn't matter.
+  const at = isWeb ? segments.lastIndexOf("open") : -1;
+  const rest = isWeb
+    ? at !== -1 && segments[at + 1] === "note"
+      ? segments.slice(at + 1)
+      : []
+    : segments;
+  if (rest[0] !== "note") return null;
+  const [, orgId, docId] = rest;
   if (!orgId || !docId) return null;
   return { orgId, docId };
 }

--- a/app/apps/desktop/src/lib/sync/__tests__/bulkRegistry.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/bulkRegistry.test.ts
@@ -115,6 +115,10 @@ function fakeApi(opts: FakeApiOpts = {}) {
       organization_id: ORG,
     })),
     listFolders: vi.fn(async () => opts.serverFolders ?? []),
+    listFolderRegistry: vi.fn(async () => ({
+      folders: opts.serverFolders ?? [],
+      tombstones: [],
+    })),
     listNotes: vi.fn(async () => opts.serverNotes ?? []),
     listNoteRegistry: vi.fn(async () => ({
       notes: opts.serverNotes ?? [],

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionVaultScope.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionVaultScope.test.ts
@@ -20,7 +20,9 @@ const fakeRegistry = vi.hoisted(() => {
   const reg = {
     vaultId: null as string | null,
     reconcile: vi.fn(async () => ({ seeded: false })),
-    pull: vi.fn(async () => {}),
+    // Resolves true ("something changed") so the tests can assert the tree
+    // refresh fires — a false pull deliberately skips it to avoid flicker.
+    pull: vi.fn(async () => true),
     reset: vi.fn(),
     getMapping: vi.fn(() => null),
     pathForDocId: vi.fn(() => null),

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -21,6 +21,8 @@ const empty = {
   local: new Map<string, string>(),
   serverFolders: new Set<string>(),
   localFolders: new Set<string>(),
+  folderTombstones: new Set<string>() as Set<string> | null,
+  localFolderIds: new Map<string, string>(),
 };
 
 function plan(over: Partial<typeof empty>) {
@@ -49,12 +51,55 @@ describe("planInbound — folders", () => {
     expect(p.createFolders).toEqual([]);
   });
 
-  it("never deletes a local folder the server no longer lists", () => {
-    // Folders are hard-deleted server-side with no tombstone, and the folder
-    // listing is permission-filtered, so "absent" is irreducibly ambiguous.
-    // Inbound folders are create-only, permanently.
+  it("never deletes a local folder the server merely no longer lists", () => {
+    // The folder listing is permission-filtered, so "absent" alone is
+    // irreducibly ambiguous — only a tombstone proves a delete.
     const p = plan({ localFolders: new Set(["Gone"]) });
-    expect(p).toMatchObject({ createFolders: [], trash: [], renames: [] });
+    expect(p).toMatchObject({ createFolders: [], removeFolders: [], trash: [], renames: [] });
+  });
+
+  it("removes a local folder whose recorded id is tombstoned, children first", () => {
+    // THE reappearing-folder bug: a device still holding the folder locally used
+    // to re-register it on its next pull, resurrecting it for the whole team.
+    const p = plan({
+      localFolders: new Set(["A", "A/B", "Keep"]),
+      localFolderIds: new Map([
+        ["A", "fa"],
+        ["A/B", "fb"],
+        ["Keep", "fk"],
+      ]),
+      folderTombstones: new Set(["fa", "fb"]),
+    });
+    expect(p.removeFolders).toEqual(["A/B", "A"]);
+  });
+
+  it("does not remove on a tombstone when the server did not answer (null)", () => {
+    const p = plan({
+      localFolders: new Set(["A"]),
+      localFolderIds: new Map([["A", "fa"]]),
+      folderTombstones: null,
+    });
+    expect(p.removeFolders).toEqual([]);
+  });
+
+  it("leaves a folder re-created at the same path alone", () => {
+    // The successor has a fresh server id; the old id's tombstone must not take
+    // the new folder down with it.
+    const p = plan({
+      localFolders: new Set(["A"]),
+      serverFolders: new Set(["A"]),
+      localFolderIds: new Map([["A", "fa-old"]]),
+      folderTombstones: new Set(["fa-old"]),
+    });
+    expect(p.removeFolders).toEqual([]);
+  });
+
+  it("skips a tombstoned folder that is already gone locally", () => {
+    const p = plan({
+      localFolderIds: new Map([["A", "fa"]]),
+      folderTombstones: new Set(["fa"]),
+    });
+    expect(p.removeFolders).toEqual([]);
   });
 
   it("refuses an unsafe folder path", () => {

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../ipc", () => ({
   renamePath: vi.fn(),
   trashNote: vi.fn(),
   deletePath: vi.fn(),
+  deleteFolderIfEmpty: vi.fn(),
   isVaultMismatch: vi.fn(() => false),
 }));
 vi.mock("../../vault/seed", () => ({ seedWelcomeContent: vi.fn(async () => {}) }));
@@ -103,6 +104,16 @@ function install(disk: FakeDisk) {
     }
     return to;
   }) as never);
+  vi.mocked(ipc.deleteFolderIfEmpty).mockImplementation((async (p: string) => {
+    if (!disk.folders.has(p)) return true; // already gone — the goal state
+    const prefix = p + "/";
+    const occupied =
+      [...disk.notes.keys()].some((n) => n.startsWith(prefix)) ||
+      [...disk.folders].some((f) => f.startsWith(prefix));
+    if (occupied) return false;
+    disk.folders.delete(p);
+    return true;
+  }) as never);
   vi.mocked(ipc.trashNote).mockImplementation((async (p: string, stamp: string) => {
     if (!disk.notes.has(p)) throw new Error("path does not exist");
     disk.notes.delete(p);
@@ -117,6 +128,7 @@ interface ServerState {
   notes: Array<{ id: string; rel_path: string }>;
   tombstones?: string[] | null;
   folders?: Array<{ id: string; path: string }>;
+  folderTombstones?: string[] | null;
 }
 
 function fakeApi(state: ServerState) {
@@ -124,6 +136,10 @@ function fakeApi(state: ServerState) {
     listVaults: vi.fn(async () => [{ id: VAULT, name: "v", organization_id: ORG }]),
     createVault: vi.fn(),
     listFolders: vi.fn(async () => state.folders ?? []),
+    listFolderRegistry: vi.fn(async () => ({
+      folders: state.folders ?? [],
+      tombstones: state.folderTombstones === undefined ? [] : state.folderTombstones,
+    })),
     createFolder: vi.fn(async (i: { path: string }) => ({ id: `folder-${i.path}`, path: i.path })),
     listNotes: vi.fn(async () => state.notes),
     listNoteRegistry: vi.fn(async () => ({
@@ -134,6 +150,8 @@ function fakeApi(state: ServerState) {
       id: i.docId ?? `note-${i.relPath}`,
       rel_path: i.relPath,
     })),
+    deleteNote: vi.fn(async () => {}),
+    deleteFolder: vi.fn(async () => {}),
   } as unknown as ApiClient;
 }
 
@@ -466,3 +484,69 @@ describe("inbound delete", () => {
   });
 });
 
+
+describe("inbound folder deletion", () => {
+  it("removes an emptied local folder the server deleted and does not re-register it", async () => {
+    // THE reappearing-folder bug, end to end: without a tombstone this device
+    // saw "missing from the server" and re-registered the folder, resurrecting
+    // it for the whole team on every pull.
+    const disk = new FakeDisk();
+    disk.folders.add("Team");
+    disk.notes.set("Team/plan.md", "d1");
+    const { api } = await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Team/plan.md" }],
+        folders: [{ id: "f1", path: "Team" }],
+      },
+      then: { notes: [], tombstones: ["d1"], folders: [], folderTombstones: ["f1"] },
+    });
+
+    // The note left via its own tombstone first, then the emptied folder.
+    expect(disk.trashed.map((t) => t.from)).toEqual(["Team/plan.md"]);
+    expect(disk.folders.has("Team")).toBe(false);
+    expect(vi.mocked(api.createFolder)).not.toHaveBeenCalled();
+  });
+
+  it("keeps a deleted folder that still holds content, re-registering it fresh", async () => {
+    // An unconfirmed note blocks its folder's removal — content must live
+    // somewhere — so the folder stays and goes back up under a NEW id.
+    const disk = new FakeDisk();
+    disk.folders.add("Team");
+    disk.notes.set("Team/mine.md", "d1");
+    disk.bodies.set("Team/mine.md", "words nobody else has");
+    const { api } = await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Team/mine.md" }],
+        folders: [{ id: "f1", path: "Team" }],
+      },
+      then: { notes: [], tombstones: ["d1"], folders: [], folderTombstones: ["f1"] },
+    });
+
+    expect(disk.folders.has("Team")).toBe(true);
+    expect(vi.mocked(api.createFolder)).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "Team" }),
+    );
+  });
+
+  it("does nothing on folder tombstones the server did not answer about (null)", async () => {
+    const disk = new FakeDisk();
+    disk.folders.add("Team");
+    disk.notes.set("a.md", "d1");
+    await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "a.md" }],
+        folders: [{ id: "f1", path: "Team" }],
+      },
+      then: {
+        notes: [{ id: "d1", rel_path: "a.md" }],
+        folders: [],
+        folderTombstones: null,
+      },
+    });
+    expect(disk.folders.has("Team")).toBe(true);
+    expect(ipc.deleteFolderIfEmpty).not.toHaveBeenCalled();
+  });
+});

--- a/app/apps/desktop/src/lib/sync/__tests__/registry.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/registry.test.ts
@@ -41,6 +41,7 @@ function fakeApi(opts: {
     listVaults: vi.fn(async () => opts.vaults),
     createVault,
     listFolders: vi.fn(async () => []),
+    listFolderRegistry: vi.fn(async () => ({ folders: [], tombstones: [] })),
     createFolder: vi.fn(async (input: { path: string }) => ({ id: `folder-${input.path}` })),
     listNotes: vi.fn(async () => opts.notes ?? []),
     listNoteRegistry: vi.fn(async () => ({ notes: opts.notes ?? [], tombstones: [] })),

--- a/app/apps/desktop/src/lib/sync/__tests__/vaultScope.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/vaultScope.test.ts
@@ -173,6 +173,7 @@ describe("VaultRegistry.reconcile across a vault switch", () => {
         return { notes: [{ id: "server-only", rel_path: "FromA.md" }], tombstones: [] };
       }),
       listFolders: vi.fn(async () => []),
+      listFolderRegistry: vi.fn(async () => ({ folders: [], tombstones: [] })),
       createFolder,
       createNote,
     } as unknown as ApiClient;
@@ -212,6 +213,7 @@ describe("VaultRegistry.reconcile across a vault switch", () => {
         tombstones: [],
       })),
       listFolders: vi.fn(async () => []),
+      listFolderRegistry: vi.fn(async () => ({ folders: [], tombstones: [] })),
       createFolder: vi.fn(async (i: { path: string }) => ({ id: `f-${i.path}` })),
       createNote,
     } as unknown as ApiClient;
@@ -240,6 +242,7 @@ describe("VaultRegistry.reconcile across a vault switch", () => {
       listNotes: vi.fn(async () => []),
       listNoteRegistry: vi.fn(async () => ({ notes: [], tombstones: [] })),
       listFolders: vi.fn(async () => []),
+      listFolderRegistry: vi.fn(async () => ({ folders: [], tombstones: [] })),
       createFolder: vi.fn(),
       createNote: vi.fn(),
     } as unknown as ApiClient;
@@ -271,6 +274,7 @@ describe("VaultRegistry.reconcile across a vault switch", () => {
         tombstones: [],
       })),
       listFolders: vi.fn(async () => [{ id: "f1", path: "Docs" }]),
+      listFolderRegistry: vi.fn(async () => ({ folders: [{ id: "f1", path: "Docs" }], tombstones: [] })),
       createFolder: vi.fn(),
       createNote: vi.fn(),
     } as unknown as ApiClient;

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -442,9 +442,13 @@ export class SyncManager implements InboundHost {
       if (!scope.isCurrent()) return;
       void this.registry
         .pull()
-        .then(() => {
+        .then((changed) => {
           if (!scope.isCurrent()) return;
-          this.onRegistryChanged?.();
+          // Only poke the sidebar when the pull actually changed something it
+          // can see. A refresh replaces the tree's row objects, which reads as
+          // a flicker under the pointer — needless on the common "nothing new"
+          // pull (e.g. the catch-up pull every reconnect now makes).
+          if (changed) this.onRegistryChanged?.();
           this.settleAfterPull(scope);
         })
         .catch((e) => console.warn("[sync] registry pull failed", e));
@@ -594,7 +598,27 @@ export class SyncManager implements InboundHost {
       onDocState: (patch) => this.onDocState?.(patch),
     });
     this.progress = progress;
-    this.registry.setProgressSink(progress);
+    // The registry writes into the SHARED reporter, but its COUNTERS are muted
+    // while a content run or the download phase owns the pill: a pull that lands
+    // mid-run re-stamps `registering` with its own (tiny) total while the
+    // uploader keeps ticking `done` against it — which once rendered the header
+    // as "Syncing 585/164". Per-doc badge states stay through in all cases:
+    // they are keyed by docId, so concurrent writers cannot garble them.
+    const counterOwned = (): boolean =>
+      (this.uploader?.isRunning() ?? false) || this.downloadPhase;
+    this.registry.setProgressSink({
+      phase: (p, t) => {
+        if (!counterOwned()) progress.phase(p, t);
+      },
+      addTotal: (n) => {
+        if (!counterOwned()) progress.addTotal(n);
+      },
+      item: (o) => {
+        if (!counterOwned()) progress.item(o);
+      },
+      doc: (docId, state) => progress.doc(docId, state),
+      flush: () => progress.flush(),
+    });
     try {
       // The registry reads the vault tree itself (the FULL recursive walk); it
       // deliberately does not take one from here, because the tree this layer
@@ -651,13 +675,14 @@ export class SyncManager implements InboundHost {
     // Show life immediately — the pull below can take a moment on a big vault.
     this.progress?.phase("registering", 0);
     this.progress?.flush();
+    let changed = false;
     try {
-      await this.registry.pull();
+      changed = await this.registry.pull();
     } catch (e) {
       console.warn("[sync] manual retry pull failed", e);
     }
     if (!scope.isCurrent()) return;
-    this.onRegistryChanged?.();
+    if (changed) this.onRegistryChanged?.();
     this.settleAfterPull(scope);
   }
 

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -635,6 +635,33 @@ export class SyncManager implements InboundHost {
   }
 
   /**
+   * User-triggered "sync now": re-pull the registry and re-run the content pass,
+   * so notes stranded by a transient failure get another chance without a
+   * sign-out/relaunch. Backs the sync pill's retry button.
+   *
+   * No-op while a run is already in flight — that run will pick everything up.
+   */
+  async retrySync(): Promise<void> {
+    const scope = this.scope;
+    if (!this.enabled || !scope || !scope.isCurrent()) return;
+    if (this.uploader?.isRunning()) return;
+    // The old uploader's failure list belongs to the run being retried; keeping
+    // it would let `completeRun` re-report failures the retry just fixed.
+    this.uploader = null;
+    // Show life immediately — the pull below can take a moment on a big vault.
+    this.progress?.phase("registering", 0);
+    this.progress?.flush();
+    try {
+      await this.registry.pull();
+    } catch (e) {
+      console.warn("[sync] manual retry pull failed", e);
+    }
+    if (!scope.isCurrent()) return;
+    this.onRegistryChanged?.();
+    this.settleAfterPull(scope);
+  }
+
+  /**
    * Push every registered note's CONTENT to the server, then wait out the inbound
    * backfill, then report a terminal phase.
    *
@@ -996,6 +1023,14 @@ export class SyncManager implements InboundHost {
         this.vaultStatus = s;
         this.emitStatus();
         this.onVaultStatus?.(s);
+        // Every (re)connect re-pulls the registry. `registry` control frames only
+        // reach clients that were CONNECTED when the change happened — anything a
+        // teammate created/renamed/deleted while this device was offline (or
+        // between reconcile and the socket coming up) was announced to nobody
+        // here. Without this, those changes surfaced only on the next sign-in or
+        // relaunch. Debounced + idempotent, so the extra pull on a healthy
+        // connect costs one listing round trip.
+        if (s === "synced") this.handleRegistryChanged();
       },
       // An ACL change in this vault may have flipped the open note's grant
       // (view↔edit, lock/unlock). Re-mint its token so the editor becomes

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -41,6 +41,19 @@ export interface InboundInput {
   serverFolders: Set<string>;
   /** Folder paths that exist on disk. */
   localFolders: Set<string>;
+  /**
+   * Folder ids the server says are DELETED (`folder_tombstones`). Same contract
+   * as note `tombstones`: `null` means the server did not answer (an older
+   * server), and "I don't know" must never remove or suppress anything.
+   */
+  folderTombstones?: Set<string> | null;
+  /**
+   * The server folder id this device last recorded per local folder path
+   * (the persisted `folders` map in `.context/config.json`). An id match against
+   * a tombstone is proof the local folder IS the deleted one — a folder the
+   * user re-created at the same path gets a fresh id and never matches.
+   */
+  localFolderIds?: Map<string, string>;
 }
 
 export interface InboundRename {
@@ -77,6 +90,15 @@ export interface InboundRejection {
 export interface InboundPlan {
   /** Folder paths to create locally, parents before children. */
   createFolders: string[];
+  /**
+   * Local folder paths the server has DELETED (tombstoned by id), children
+   * before parents. The executor removes each one only if it is empty by then —
+   * the notes inside leave via their own tombstones in {@link trash} first, and
+   * a folder still holding anything (an unconfirmed orphan, a stray image, a
+   * new local note) stays on disk and re-registers under a fresh id, which is
+   * the safe direction: content must live somewhere.
+   */
+  removeFolders: string[];
   renames: InboundRename[];
   trash: InboundTrash[];
   /**
@@ -203,6 +225,7 @@ function byDepth(a: string, b: string): number {
 export function planInbound(input: InboundInput): InboundPlan {
   const plan: InboundPlan = {
     createFolders: [],
+    removeFolders: [],
     renames: [],
     trash: [],
     revoked: new Set(),
@@ -210,15 +233,14 @@ export function planInbound(input: InboundInput): InboundPlan {
     rejected: [],
   };
 
-  // ---- folders: CREATE-ONLY, and that is permanent ------------------------
+  // ---- folders ------------------------------------------------------------
   //
-  // Not an oversight — inbound folder DELETE is undecidable. The `folders` table
-  // has no `deleted_at` (delete is a hard DELETE with ON DELETE CASCADE), and
-  // `GET /api/folders` is permission-filtered, so "absent from the listing" means
-  // deleted OR not-visible-to-me with no tombstone available even in principle.
-  // A folder that was deleted remotely therefore lingers locally once empty:
-  // cosmetic divergence, zero data loss, which is the right trade. The notes
-  // inside it DO leave, via their own tombstones.
+  // Creation is unconditional; DELETION requires a tombstone. "Absent from the
+  // listing" alone is undecidable — `GET /api/folders` is permission-filtered,
+  // so absence means deleted OR not-visible-to-me. `folder_tombstones` (keyed by
+  // folder id, exactly like note tombstones) is what makes the delete provable;
+  // without it, a device still holding the folder locally re-registered it on
+  // its next pull and the deleted folder came back for the whole team.
   for (const path of input.serverFolders) {
     if (input.localFolders.has(path)) continue;
     if (!isSafeFolderPath(path)) {
@@ -233,6 +255,29 @@ export function planInbound(input: InboundInput): InboundPlan {
     plan.createFolders.push(path);
   }
   plan.createFolders.sort(byDepth);
+
+  // A local folder whose recorded server id is tombstoned was deleted remotely.
+  // Gated on the id match (a same-path successor has a fresh id and never
+  // matches) and on the path not having been re-created on the server since.
+  if (input.folderTombstones && input.localFolderIds) {
+    for (const [path, id] of input.localFolderIds) {
+      if (!input.folderTombstones.has(id)) continue;
+      if (!input.localFolders.has(path)) continue; // already gone locally
+      if (input.serverFolders.has(path)) continue; // re-created server-side
+      if (!isSafeFolderPath(path)) {
+        plan.rejected.push({
+          kind: "folder",
+          path,
+          docId: null,
+          reason: "unsafe local folder path",
+        });
+        continue;
+      }
+      plan.removeFolders.push(path);
+    }
+  }
+  // Children before parents, so an emptied subtree unwinds bottom-up.
+  plan.removeFolders.sort((a, b) => byDepth(b, a));
 
   // ---- notes --------------------------------------------------------------
   // Every note path on disk, for the "we lost this doc's local identity" case

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -1022,25 +1022,48 @@ export class VaultRegistry {
   }
 
   /**
+   * The tail of the pull chain. Pulls are SERIALIZED: two interleaved
+   * `syncStructure` passes feed the shared progress reporter from both sides at
+   * once (each resets the denominator the other is still counting against),
+   * which is how the header once read "Syncing 585/164".
+   */
+  private pullChain: Promise<boolean> = Promise.resolve(false);
+
+  /**
    * Re-pull the server's folder/note set and reconcile it against the current
    * local tree WITHOUT re-resolving the vault or seeding. Called when the vault
    * channel signals a `registry` change (a teammate created/renamed/moved/
-   * deleted something) so this device's tree catches up live. Idempotent.
+   * deleted something) so this device's tree catches up live. Idempotent, and
+   * serialized — a pull that arrives while one is running waits its turn.
+   *
+   * Resolves TRUE only when the pass actually changed something this device can
+   * see (disk moved, rows created, notes materialized), so callers can skip a
+   * sidebar refresh — and the re-render flicker it causes — for the common
+   * "nothing new" pull.
    */
-  async pull(): Promise<void> {
+  pull(): Promise<boolean> {
+    const run = this.pullChain.then(
+      () => this.pullOnce(),
+      () => this.pullOnce(),
+    );
+    this.pullChain = run.catch(() => false);
+    return run;
+  }
+
+  private async pullOnce(): Promise<boolean> {
     // Scope-guarded because this is THE historical corruption path: a debounced
     // pull that survived a vault switch still held vault A's `serverVaultId`
     // while `listTree()` returned vault B's tree, so B's folders/notes were
     // created under A and A's doc map was written into B's config.json.
-    if (this.stale()) return;
-    if (!this.serverVaultId) return;
+    if (this.stale()) return false;
+    if (!this.serverVaultId) return false;
     const vaultId = this.serverVaultId;
     const tree = await this.readFullTree();
-    if (this.stale()) return;
+    if (this.stale()) return false;
     // The vault id must not have moved on either (a reconcile for another vault
     // could have re-pointed it while we were reading the tree).
-    if (this.serverVaultId !== vaultId) return;
-    await this.syncStructure(vaultId, tree, { inbound: true });
+    if (this.serverVaultId !== vaultId) return false;
+    return this.syncStructure(vaultId, tree, { inbound: true });
   }
 
   /**
@@ -1057,8 +1080,11 @@ export class VaultRegistry {
     vaultId: string,
     workingTree: FullTree,
     opts: { inbound: boolean },
-  ): Promise<void> {
-    if (this.stale()) return;
+  ): Promise<boolean> {
+    if (this.stale()) return false;
+    // Did this pass change anything the sidebar can see? Returned so a pull
+    // that found nothing new can skip the tree refresh (and its flicker).
+    let mutated = false;
     // Failures describe THIS pass. They used to accumulate across pulls — every
     // registry signal re-recorded the same refusals, so a vault could never come
     // back from "N not synced" even after the underlying cause was gone.
@@ -1068,7 +1094,7 @@ export class VaultRegistry {
       this.api.listFolderRegistry(vaultId),
       this.api.listNoteRegistry(vaultId),
     ]);
-    if (this.stale()) return;
+    if (this.stale()) return false;
     const serverFolders = folderRegistry.folders;
     let serverNotes = noteRegistry.notes;
     let { folders, notes } = flattenTree(workingTree);
@@ -1078,7 +1104,7 @@ export class VaultRegistry {
     // can match by docId rather than by path (a rename changes the path, which is
     // exactly why path-matching produced duplicates).
     let titles = await ipc.listNoteTitles(this.epoch());
-    if (this.stale()) return;
+    if (this.stale()) return false;
 
     // 1. Inbound: apply the server's structural changes to disk. Runs first so the
     //    outbound steps below see a tree that already agrees about paths.
@@ -1092,8 +1118,9 @@ export class VaultRegistry {
         tombstones: noteRegistry.tombstones,
         folderTombstones: folderRegistry.tombstones,
       });
-      if (this.stale()) return;
+      if (this.stale()) return false;
       if (applied.changedDisk) {
+        mutated = true;
         // One re-read, only when we actually moved something. Without it the steps
         // below still see the OLD path as a local note missing from the server (so
         // they re-register it) and the NEW path as server-only (so they materialize
@@ -1101,14 +1128,14 @@ export class VaultRegistry {
         // Patching the in-memory lists by hand instead is the dual-bookkeeping that
         // caused this class of bug in the first place.
         const reread = await this.readFullTree();
-        if (this.stale()) return;
+        if (this.stale()) return false;
         ({ folders, notes } = flattenTree(reread));
         titles = await ipc.listNoteTitles(this.epoch());
-        if (this.stale()) return;
+        if (this.stale()) return false;
         // Re-read the server's notes too: `move_note` bumps rows we may have just
         // raced, and a stale list here would undo the move we just applied.
         const fresh = await this.api.listNoteRegistry(vaultId);
-        if (this.stale()) return;
+        if (this.stale()) return false;
         serverNotes = fresh.notes;
       }
       this.inboundSuppressed = applied.suppress;
@@ -1190,6 +1217,7 @@ export class VaultRegistry {
           if (out.ok) {
             this.folderByPath.set(f.path, out.value.id);
             checkpoint.touch();
+            mutated = true;
             this.sink.item("ok");
           } else {
             this.recordFailure({
@@ -1205,7 +1233,7 @@ export class VaultRegistry {
         { concurrency: REGISTRY_CONCURRENCY, shouldStop: () => this.stopRun() },
       );
     }
-    if (this.stale()) return;
+    if (this.stale()) return mutated;
 
     // ---- notes, one flat pool (parentIds are all resolved by now) ----
     await runPool(
@@ -1230,6 +1258,7 @@ export class VaultRegistry {
           this.setMapping(rp, noteDocId(out.value), vaultId);
           resolvedNotePaths.add(rp);
           checkpoint.touch();
+          mutated = true;
           this.sink.item("ok");
           return;
         }
@@ -1250,7 +1279,7 @@ export class VaultRegistry {
       },
       { concurrency: REGISTRY_CONCURRENCY, shouldStop: () => this.stopRun() },
     );
-    if (this.stale()) return;
+    if (this.stale()) return mutated;
 
     // 4. Prune mappings for notes that no longer exist anywhere (deleted on the
     //    server AND absent locally), then checkpoint the map.
@@ -1276,7 +1305,7 @@ export class VaultRegistry {
     }
     checkpoint.touch();
     await checkpoint.flush();
-    if (this.stale()) return;
+    if (this.stale()) return mutated;
 
     // 5. Materialize server-only notes locally. This is what makes a folder
     //    that's empty on this device (a just-joined vault, or a fresh
@@ -1306,6 +1335,7 @@ export class VaultRegistry {
         // vault B's folder).
         try {
           await ipc.writeNoteIfMissing(rp, "", this.epoch());
+          mutated = true;
           this.sink.item("ok");
         } catch (e) {
           if (ipc.isVaultMismatch(e)) return; // the vault moved on — not a failure
@@ -1336,6 +1366,7 @@ export class VaultRegistry {
     // can't happen after a relaunch.
     checkpoint.touch();
     await checkpoint.flush();
+    return mutated;
   }
 
   /**

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -614,6 +614,7 @@ export class VaultRegistry {
       serverFolders: Array<{ path: string }>;
       serverNotes: RegisteredNote[];
       tombstones: string[] | null;
+      folderTombstones: string[] | null;
     },
   ): Promise<{ changedDisk: boolean; suppress: Set<string> }> {
     const none = { changedDisk: false, suppress: new Set<string>() };
@@ -675,6 +676,10 @@ export class VaultRegistry {
       local,
       serverFolders: new Set(args.serverFolders.map((f) => f.path)),
       localFolders: new Set(args.folders.map((f) => f.path)),
+      folderTombstones: args.folderTombstones ? new Set(args.folderTombstones) : null,
+      // The persisted path → server-folder-id join: an id match against a
+      // tombstone is proof the local folder IS the deleted one.
+      localFolderIds: new Map(this.folderByPath),
     });
 
     for (const r of plan.rejected) {
@@ -774,6 +779,39 @@ export class VaultRegistry {
           reason: reasonOf(e),
           code: null,
         });
+      }
+    }
+
+    // Folders the server has deleted, children before parents, AFTER the trash
+    // loop above has moved their notes out. Empty-only removal (`remove_dir`,
+    // never recursive): a folder still holding anything stays on disk and — its
+    // dead mapping dropped below — re-registers under a fresh id, because
+    // content must live somewhere. Either way the stale id leaves the map, so
+    // nothing can later rename/color/re-register against a deleted server row.
+    for (const path of plan.removeFolders) {
+      if (this.stopRun()) break;
+      try {
+        const removed = await ipc.deleteFolderIfEmpty(path, this.epoch());
+        if (removed) changedDisk = true;
+      } catch (e) {
+        if (ipc.isVaultMismatch(e)) return { changedDisk, suppress: plan.suppress };
+        this.recordFailure({
+          kind: "inbound",
+          path,
+          docId: null,
+          reason: reasonOf(e),
+          code: null,
+        });
+      }
+      this.folderByPath.delete(path);
+    }
+    // Drop EVERY mapping whose id is tombstoned, not just the ones whose dir
+    // still existed: a surviving dead entry would make `registerFolder` at the
+    // same path adopt the deleted row's id and silently skip creating.
+    if (args.folderTombstones) {
+      const dead = new Set(args.folderTombstones);
+      for (const [rp, id] of [...this.folderByPath]) {
+        if (dead.has(id)) this.folderByPath.delete(rp);
       }
     }
 
@@ -904,8 +942,10 @@ export class VaultRegistry {
     // Publish the resolved collection id on the scope for the layers above.
     if (this.bound) this.bound.serverVaultId = vaultId;
     // Adopt the previous run's content-push checkpoint. This is what makes a
-    // killed backfill resume instead of re-walking the whole vault.
-    this.pushed = new Set(cfg.pushed ?? []);
+    // killed backfill resume instead of re-walking the whole vault. Guarded on
+    // the collection matching, like everything else read back from config: a
+    // pushed-set recorded against another collection says nothing about this one.
+    this.pushed = new Set(cfg.serverVaultId === vaultId ? (cfg.pushed ?? []) : []);
     // Adopt the baseline ONLY if the config we just read describes the collection
     // we actually resolved. Anything else (a first run, a config from another
     // vault, a rewritten `.context`) leaves it empty, which disables inbound for
@@ -938,6 +978,15 @@ export class VaultRegistry {
     if (cfg.serverVaultId === vaultId && cfg.docs) {
       for (const [rp, docId] of Object.entries(cfg.docs)) {
         if (typeof docId === "string" && docId) this.setMapping(rp, docId, vaultId);
+      }
+    }
+    // Restore the folder path → server-id join too (same collection guard). It
+    // was written every pass and read back by nobody — so after a relaunch a
+    // folder the server had DELETED could not be recognised as the deleted one
+    // (the tombstone match is by id), and the outbound half re-registered it.
+    if (cfg.serverVaultId === vaultId && cfg.folders) {
+      for (const [rp, id] of Object.entries(cfg.folders)) {
+        if (typeof id === "string" && id) this.folderByPath.set(rp, id);
       }
     }
 
@@ -1010,11 +1059,17 @@ export class VaultRegistry {
     opts: { inbound: boolean },
   ): Promise<void> {
     if (this.stale()) return;
-    const [serverFolders, noteRegistry] = await Promise.all([
-      this.api.listFolders(vaultId),
+    // Failures describe THIS pass. They used to accumulate across pulls — every
+    // registry signal re-recorded the same refusals, so a vault could never come
+    // back from "N not synced" even after the underlying cause was gone.
+    this.failed = [];
+    this.limitReached = null;
+    const [folderRegistry, noteRegistry] = await Promise.all([
+      this.api.listFolderRegistry(vaultId),
       this.api.listNoteRegistry(vaultId),
     ]);
     if (this.stale()) return;
+    const serverFolders = folderRegistry.folders;
     let serverNotes = noteRegistry.notes;
     let { folders, notes } = flattenTree(workingTree);
     const checkpoint = this.checkpoint ?? this.newCheckpointer();
@@ -1028,7 +1083,15 @@ export class VaultRegistry {
     // 1. Inbound: apply the server's structural changes to disk. Runs first so the
     //    outbound steps below see a tree that already agrees about paths.
     if (opts.inbound) {
-      const applied = await this.applyInbound(vaultId, { folders, notes, titles, serverFolders, serverNotes, tombstones: noteRegistry.tombstones });
+      const applied = await this.applyInbound(vaultId, {
+        folders,
+        notes,
+        titles,
+        serverFolders,
+        serverNotes,
+        tombstones: noteRegistry.tombstones,
+        folderTombstones: folderRegistry.tombstones,
+      });
       if (this.stale()) return;
       if (applied.changedDisk) {
         // One re-read, only when we actually moved something. Without it the steps
@@ -1198,9 +1261,18 @@ export class VaultRegistry {
         this.notifyMapChanged();
       }
     }
-    // The push checkpoint only ever describes docs we still track.
+    // The push checkpoint describes docs we still track OR still remember in the
+    // baseline. The baseline part is load-bearing: a note deleted remotely leaves
+    // the server listing (and hence `byDocId`) on the pass that LEARNS about the
+    // delete, but its file may only be trashed on a LATER pass — and the trash
+    // executor refuses any doc whose content was never confirmed upstream.
+    // Pruning `pushed` by `byDocId` alone erased that confirmation in between,
+    // which is how already-synced notes turned into permanent "left on disk"
+    // orphans with an error badge that never cleared.
     for (const docId of [...this.pushed]) {
-      if (!this.byDocId.has(docId)) this.pushed.delete(docId);
+      if (!this.byDocId.has(docId) && !this.baselineDocs.has(docId)) {
+        this.pushed.delete(docId);
+      }
     }
     checkpoint.touch();
     await checkpoint.flush();
@@ -1394,7 +1466,15 @@ export class VaultRegistry {
     }
   }
 
-  /** Propagate a local delete of a folder subtree or a note to the server. */
+  /**
+   * Propagate a delete of a folder subtree or a note to the server.
+   *
+   * THROWS when the server refused (offline, 403): callers run server-first —
+   * `deletePaths` only removes the local files once the server rows are gone —
+   * so a swallowed failure here would let the local delete proceed and the next
+   * pull resurrect the item as an empty ghost. A 404 is treated as success: the
+   * row is already gone, which is the goal state.
+   */
   async deletePath(path: string): Promise<void> {
     if (this.stale()) return;
     const vaultId = this.serverVaultId;
@@ -1404,8 +1484,7 @@ export class VaultRegistry {
       try {
         await this.api.deleteFolder(folderId);
       } catch (e) {
-        console.error("[registry] deleteFolder failed", path, e);
-        return;
+        if (!(e instanceof ApiError && e.status === 404)) throw e;
       }
       if (this.stale() || this.serverVaultId !== vaultId) return;
       this.folderByPath = dropPrefix(this.folderByPath, path);
@@ -1421,8 +1500,7 @@ export class VaultRegistry {
       try {
         await this.api.deleteNote(mapping.docId);
       } catch (e) {
-        console.error("[registry] deleteNote failed", path, e);
-        return;
+        if (!(e instanceof ApiError && e.status === 404)) throw e;
       }
       if (this.stale() || this.serverVaultId !== vaultId) return;
       this.byPath.delete(path);
@@ -1439,10 +1517,14 @@ export class VaultRegistry {
     for (const [rp, m] of this.byPath) this.byDocId.set(m.docId, rp);
   }
 
-  /** Drop push-checkpoint entries for docs we no longer track. */
+  /** Drop push-checkpoint entries for docs we neither track nor remember in the
+   *  baseline (see the pass-end prune in `syncStructure` for why the baseline
+   *  keeps a confirmation alive until the file actually leaves). */
   private prunePushed(): void {
     for (const docId of [...this.pushed]) {
-      if (!this.byDocId.has(docId)) this.pushed.delete(docId);
+      if (!this.byDocId.has(docId) && !this.baselineDocs.has(docId)) {
+        this.pushed.delete(docId);
+      }
     }
   }
 

--- a/app/apps/desktop/src/lib/syncRollup.ts
+++ b/app/apps/desktop/src/lib/syncRollup.ts
@@ -152,10 +152,10 @@ export function buildTreeSyncIndex(input: TreeSyncInput): TreeSyncIndex {
 /** What to draw on one sidebar row. `null` ⇒ draw nothing at all. */
 export interface RowSyncMark {
   state: DocSyncState;
-  /** Render this count of not-yet-synced notes instead of a dot (folders that
-   *  aren't settled). A count, not a percentage: "2" answers "how much is left?"
-   *  directly, where "0%" on a one-note folder read as gibberish. */
-  count: number | null;
+  /** Render "synced/total" (e.g. "1/2") instead of a dot, for folders that
+   *  aren't settled. Real counts, not a percentage: "0%" on a one-note folder
+   *  read as gibberish, where "1/2" answers the actual question. */
+  progress: { synced: number; total: number } | null;
   /** Tooltip / accessible label. */
   title: string;
 }
@@ -189,11 +189,11 @@ export function folderSyncTitle(s: FolderSyncSummary): string {
  * a file that isn't a synced note (an image, an unmapped page), or a folder that
  * contains no notes at all.
  *
- * A folder shows the COUNT of notes still to sync until it is settled, then a
- * single dot — which is what makes "are all my folders synced?" answerable at a
- * glance: a column of quiet dots means yes, any number in it means "this many
- * left". (Previously a percentage, which read as gibberish on small folders —
- * one unsynced note out of one rendered "0%".)
+ * A folder shows "synced/total" until it is settled, then a single dot — which
+ * is what makes "are all my folders synced?" answerable at a glance: a column
+ * of quiet dots means yes, any "1/2" in it says exactly where things stand.
+ * (Previously a percentage, which read as gibberish on small folders — one
+ * unsynced note out of one rendered "0%".)
  */
 export function rowSyncMark(
   row: { path: string; isDir: boolean },
@@ -205,11 +205,11 @@ export function rowSyncMark(
     const settled = summary.state === "synced" || summary.state === "error";
     return {
       state: summary.state,
-      count: settled ? null : summary.total - summary.synced,
+      progress: settled ? null : { synced: summary.synced, total: summary.total },
       title: folderSyncTitle(summary),
     };
   }
   const state = index.notes.get(row.path);
   if (!state) return null;
-  return { state, count: null, title: DOC_SYNC_TITLES[state] };
+  return { state, progress: null, title: DOC_SYNC_TITLES[state] };
 }

--- a/app/apps/desktop/src/lib/syncRollup.ts
+++ b/app/apps/desktop/src/lib/syncRollup.ts
@@ -152,8 +152,10 @@ export function buildTreeSyncIndex(input: TreeSyncInput): TreeSyncIndex {
 /** What to draw on one sidebar row. `null` ⇒ draw nothing at all. */
 export interface RowSyncMark {
   state: DocSyncState;
-  /** Render this percentage instead of a dot (folders that aren't settled). */
-  percent: number | null;
+  /** Render this count of not-yet-synced notes instead of a dot (folders that
+   *  aren't settled). A count, not a percentage: "2" answers "how much is left?"
+   *  directly, where "0%" on a one-note folder read as gibberish. */
+  count: number | null;
   /** Tooltip / accessible label. */
   title: string;
 }
@@ -179,7 +181,7 @@ export function folderSyncTitle(s: FolderSyncSummary): string {
   if (s.synced === s.total) {
     return `All ${plural(s.total, "note")} synced`;
   }
-  return `${s.synced} of ${plural(s.total, "note")} synced (${s.percent}%)`;
+  return `${s.synced} of ${plural(s.total, "note")} synced`;
 }
 
 /**
@@ -187,9 +189,11 @@ export function folderSyncTitle(s: FolderSyncSummary): string {
  * a file that isn't a synced note (an image, an unmapped page), or a folder that
  * contains no notes at all.
  *
- * A folder shows a PERCENTAGE until it is settled, then a single dot — which is
- * what makes "are all my folders synced?" answerable at a glance: a column of
- * quiet dots means yes, any number in it means not yet.
+ * A folder shows the COUNT of notes still to sync until it is settled, then a
+ * single dot — which is what makes "are all my folders synced?" answerable at a
+ * glance: a column of quiet dots means yes, any number in it means "this many
+ * left". (Previously a percentage, which read as gibberish on small folders —
+ * one unsynced note out of one rendered "0%".)
  */
 export function rowSyncMark(
   row: { path: string; isDir: boolean },
@@ -201,11 +205,11 @@ export function rowSyncMark(
     const settled = summary.state === "synced" || summary.state === "error";
     return {
       state: summary.state,
-      percent: settled ? null : summary.percent,
+      count: settled ? null : summary.total - summary.synced,
       title: folderSyncTitle(summary),
     };
   }
   const state = index.notes.get(row.path);
   if (!state) return null;
-  return { state, percent: null, title: DOC_SYNC_TITLES[state] };
+  return { state, count: null, title: DOC_SYNC_TITLES[state] };
 }

--- a/app/apps/desktop/src/lib/updater.ts
+++ b/app/apps/desktop/src/lib/updater.ts
@@ -133,6 +133,24 @@ export function currentVersion(): Promise<string> {
   return getVersion();
 }
 
+/**
+ * Updates are REQUIRED: is the app currently blocked behind one?
+ *
+ * True for every live stage of an update — discovered, downloading, installing.
+ * The `error` phase is deliberately NOT blocking on its own: a failed background
+ * CHECK (offline launch, dev build without the updater) must never wall off the
+ * app. The gate component latches the version once it has seen `available`, so
+ * an error *during the install* keeps the wall up with a retry instead of
+ * silently letting a known-stale build back in.
+ */
+export function isUpdateBlocking(state: UpdateState): boolean {
+  return (
+    state.phase === "available" ||
+    state.phase === "downloading" ||
+    state.phase === "installing"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // The post-restart "Updated to vX" banner.
 //

--- a/app/apps/desktop/src/lib/vault/__tests__/mutatePaths.test.ts
+++ b/app/apps/desktop/src/lib/vault/__tests__/mutatePaths.test.ts
@@ -40,32 +40,48 @@ describe("deletePaths", () => {
     expect(res.deleted.sort()).toEqual(["a.md", "b.md"]);
   });
 
-  it("does NOT unregister when the disk delete failed", async () => {
-    // Unregistering without deleting leaves a live local file with a dead mapping,
-    // which then re-registers as a brand-new note.
+  it("unregisters BEFORE touching disk (server-first is the self-healing order)", async () => {
+    const order: string[] = [];
     const d = deps({
-      deleteDisk: vi.fn(async () => {
-        throw new Error("permission denied");
+      unregister: vi.fn(async (p: string) => {
+        order.push(`server:${p}`);
+      }),
+      deleteDisk: vi.fn(async (p: string) => {
+        order.push(`disk:${p}`);
       }),
     });
-    const res = await deletePaths(["a.md"], d.all);
-    expect(d.unregister).not.toHaveBeenCalled();
-    expect(res.deleted).toEqual([]);
-    expect(res.failed).toEqual([{ path: "a.md", reason: "permission denied" }]);
+    await deletePaths(["a.md"], d.all);
+    expect(order).toEqual(["server:a.md", "disk:a.md"]);
   });
 
-  it("keeps the local delete when the server call fails", async () => {
-    // The file is already gone; the row is reconciled on the next pull. Reporting
-    // this as a failure would be honest but useless — there is nothing to retry
-    // locally, and the delete did happen.
+  it("does NOT delete locally when the server call fails", async () => {
+    // A live server row plus a deleted local file is the reappearing-ghost bug:
+    // the next pull materializes the "deleted" item back. If the server refused
+    // (offline, or no permission), nothing may happen anywhere — and the user is
+    // told, instead of watching their delete silently not count.
     const d = deps({
       unregister: vi.fn(async () => {
         throw new Error("offline");
       }),
     });
     const res = await deletePaths(["a.md"], d.all);
-    expect(res.deleted).toEqual(["a.md"]);
-    expect(res.failed).toEqual([]);
+    expect(d.deleteDisk).not.toHaveBeenCalled();
+    expect(res.deleted).toEqual([]);
+    expect(res.failed).toEqual([{ path: "a.md", reason: "offline" }]);
+  });
+
+  it("reports a disk failure after a successful unregister", async () => {
+    // The server side is tombstoned, so the next inbound pull cleans the file
+    // up — but the caller still hears that this path isn't done.
+    const d = deps({
+      deleteDisk: vi.fn(async () => {
+        throw new Error("permission denied");
+      }),
+    });
+    const res = await deletePaths(["a.md"], d.all);
+    expect(d.unregister).toHaveBeenCalledWith("a.md");
+    expect(res.deleted).toEqual([]);
+    expect(res.failed).toEqual([{ path: "a.md", reason: "permission denied" }]);
   });
 
   it("passes the pinned epoch to every disk call", async () => {

--- a/app/apps/desktop/src/lib/vault/mutatePaths.ts
+++ b/app/apps/desktop/src/lib/vault/mutatePaths.ts
@@ -1,5 +1,5 @@
 /**
- * Deleting vault paths: on disk AND on the server, in that order, once.
+ * Deleting vault paths: on the server AND on disk, in that order, once.
  *
  * This exists because the two delete paths in the sidebar were hand-copied and
  * drifted. The single-item delete removed the file and told the server; the
@@ -29,18 +29,23 @@ export interface DeletePathsResult {
 }
 
 /**
- * Delete each path locally and then on the server.
+ * Delete each path on the server and then locally.
  *
  * Deepest-first, so a folder's children are gone before the folder itself.
  *
- * The server call runs ONLY after the disk delete succeeded, and that order is
- * the whole point: unregistering without deleting leaves a live local file with a
- * dead mapping, while deleting without unregistering leaves a live server row
- * that comes back as an empty file on the next pull. Of the two, the second is
- * the one that actually shipped.
+ * SERVER FIRST, and that order is the whole point — it is the self-healing one:
  *
- * A failed server call is recorded but does not undo the local delete — the file
- * is already gone, and the next reconcile is what reconciles it.
+ *   • Server delete succeeds, disk delete fails (or the app dies in between):
+ *     the row is tombstoned, so the next inbound pull trashes the local file.
+ *     The delete still sticks.
+ *   • Server delete FAILS (offline, or a 403 — no permission): nothing happened
+ *     anywhere. The item stays visible and the failure is reported, instead of
+ *     the old behaviour — disk deleted, server row alive — where the next pull
+ *     resurrected the "deleted" item as an empty ghost and the user learned
+ *     their delete silently hadn't counted.
+ *
+ * The old disk-first ordering predates inbound deletion; with tombstones on
+ * both notes and folders, server-first is strictly safer.
  */
 export async function deletePaths(
   paths: string[],
@@ -51,17 +56,23 @@ export async function deletePaths(
   let done = 0;
   for (const path of ordered) {
     try {
-      await deps.deleteDisk(path, deps.epoch);
+      await deps.unregister(path);
     } catch (e) {
+      // The server refused (or is unreachable): the row is still live, so a
+      // local delete would only produce the reappearing ghost. Leave the item
+      // alone and say so.
       result.failed.push({ path, reason: e instanceof Error ? e.message : String(e) });
       deps.onProgress?.(++done, ordered.length);
       continue;
     }
     try {
-      await deps.unregister(path);
+      await deps.deleteDisk(path, deps.epoch);
     } catch (e) {
-      // The local delete stands; the server row is retried by the next reconcile.
-      console.warn("[vault] failed to unregister deleted path", path, e);
+      // The server side is already done (tombstoned), so the next inbound pull
+      // cleans this file up — recorded for honesty, not for retry.
+      result.failed.push({ path, reason: e instanceof Error ? e.message : String(e) });
+      deps.onProgress?.(++done, ordered.length);
+      continue;
     }
     result.deleted.push(path);
     deps.onProgress?.(++done, ordered.length);

--- a/app/apps/server/migrations/019_folder_tombstones.sql
+++ b/app/apps/server/migrations/019_folder_tombstones.sql
@@ -1,0 +1,21 @@
+-- Folder tombstones: the missing half of inbound structural deletes.
+--
+-- Notes soft-delete (`notes.deleted_at`), so every client can tell "deleted"
+-- from "never seen" and remove its local file. Folders were hard-deleted with
+-- ON DELETE CASCADE and left NO trace — so any device still holding the folder
+-- locally saw "missing from the server" on its next pull and re-registered it,
+-- resurrecting the folder for the whole team. Deleting a folder was
+-- structurally impossible to make stick.
+--
+-- One row per folder in a deleted subtree, keyed by the folder's id (ids are
+-- what clients persist in .context/config.json, so an id match is proof the
+-- local folder IS the deleted one, not a same-named successor).
+CREATE TABLE IF NOT EXISTS folder_tombstones (
+  id TEXT PRIMARY KEY,
+  vault_id TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+  path TEXT NOT NULL,
+  deleted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_folder_tombstones_vault
+  ON folder_tombstones (vault_id);

--- a/app/apps/server/src/http/app.ts
+++ b/app/apps/server/src/http/app.ts
@@ -4,6 +4,7 @@ import { oAuthDiscoveryMetadata, oAuthProtectedResourceMetadata } from "better-a
 import { config } from "../config.js";
 import { auth } from "../auth/auth.js";
 import { oauthConnectRoutes } from "./routes/oauth-connect.js";
+import { openLinkRoutes } from "./routes/open-link.js";
 import { blobRoutes } from "./routes/blobs.js";
 import { createRegistryRoutes, ORIGIN_HEADER } from "./routes/registry.js";
 import { syncTokenRoutes } from "./routes/sync-token.js";
@@ -129,6 +130,10 @@ export function createApp(deps: AppDeps): Hono {
   );
   // The human-facing login + consent screens of that OAuth flow.
   app.route("/", oauthConnectRoutes);
+
+  // Clickable share links: https://<server>/open/note/… bounces into the app's
+  // baalda:// deep link. Public — the URL carries identity, never access.
+  app.route("/", openLinkRoutes);
 
   // Better Auth owns everything under /api/auth (web-standard Request handler).
   app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));

--- a/app/apps/server/src/http/routes/open-link.ts
+++ b/app/apps/server/src/http/routes/open-link.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { BRAND_NAME } from "../../brand.js";
+
+/**
+ * Clickable share links — `GET /open/note/:orgId/:docId`.
+ *
+ * A `baalda://` link is dead weight in most chat apps: schemes nobody has
+ * allow-listed don't linkify, so the recipient had to copy-paste it into a
+ * browser. Share links are therefore `https://<server>/open/note/…` — every
+ * chat app makes those clickable — and this page is the landing spot: it
+ * immediately bounces to the `baalda://` deep link (which the OS hands to the
+ * installed app) and shows a button + install pointer as the fallback.
+ *
+ * Public and unauthenticated ON PURPOSE. The URL carries identity, not access:
+ * two opaque ids and nothing else. Whoever clicks it still resolves both
+ * against their own signed-in session in the app — a stranger gets the same
+ * "no access" they'd get typing the ids by hand. Nothing here reads the
+ * database, so this page can't leak whether the ids even exist.
+ */
+export const openLinkRoutes = new Hono();
+
+/** Better Auth ids and client doc_ids (UUIDs) — one conservative shape. */
+const ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+}
+
+openLinkRoutes.get("/open/note/:orgId/:docId", (c) => {
+  const orgId = c.req.param("orgId");
+  const docId = c.req.param("docId");
+  if (!ID_RE.test(orgId) || !ID_RE.test(docId)) {
+    return c.text("Malformed link", 400);
+  }
+  // Re-encoded on the way out even after the shape check, so the deep link is
+  // inert as markup no matter what future id shapes are allowed through.
+  const deepLink = `baalda://note/${encodeURIComponent(orgId)}/${encodeURIComponent(docId)}`;
+  return c.html(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Open note · ${esc(BRAND_NAME)}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         display: grid; place-items: center; min-height: 100vh; margin: 0;
+         background: #f6f5f2; color: #2a2a28; }
+  main { text-align: center; padding: 2rem; }
+  h1 { font-size: 1.2rem; font-weight: 600; }
+  p { color: #6b6b66; max-width: 34rem; }
+  a.button { display: inline-block; margin-top: 1rem; padding: 0.6rem 1.4rem;
+             border-radius: 999px; background: #2a2a28; color: #fff;
+             text-decoration: none; font-weight: 600; }
+  a.plain { color: #6b6b66; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Opening this note in ${esc(BRAND_NAME)}…</h1>
+  <p>If nothing happens, ${esc(BRAND_NAME)} may not be installed on this device.</p>
+  <a class="button" href="${esc(deepLink)}">Open in ${esc(BRAND_NAME)}</a>
+  <p><a class="plain" href="https://baalda.com" rel="noopener">Get ${esc(BRAND_NAME)}</a></p>
+  <script>location.href = ${JSON.stringify(deepLink)};</script>
+</main>
+</body>
+</html>`);
+});

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -295,7 +295,16 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // Private-by-default: only folders the caller may see (created / shared /
     // path-to-a-shared-note). Owner/admin + Open vaults see everything.
     const folders = await listVisibleFolders(session.userId, vaultId);
-    return c.json({ folders });
+    // Folder tombstones ride the same response as note tombstones do on
+    // GET /api/notes, and for the same reason: the client subtracts one set
+    // from the other, so both must come from one snapshot. Ids only — an id is
+    // the minimum that lets a client stop re-registering (and remove) a local
+    // folder, and it leaks nothing about what the folder was called.
+    const { rows: tombstones } = await pool.query<{ id: string }>(
+      "SELECT id FROM folder_tombstones WHERE vault_id = $1",
+      [vaultId],
+    );
+    return c.json({ folders, tombstones: tombstones.map((t) => t.id) });
   });
 
   // Rename / move a folder. Rewrites the folder's own row AND every descendant

--- a/app/apps/server/src/registry/tree-ops.ts
+++ b/app/apps/server/src/registry/tree-ops.ts
@@ -280,6 +280,23 @@ export async function deleteFolderCascade(
       RETURNING id`,
     [folderId, folder.path, likeEscape(folder.path), folder.vault_id],
   );
+  // Tombstone EVERY folder in the subtree before the cascade removes the rows.
+  // Notes soft-delete and therefore announce their own deletion; folders were
+  // erased without a trace, so any device still holding one locally
+  // re-registered it on its next pull — the "deleted folder keeps coming back"
+  // bug. Keyed by folder id (what clients persist), so an id match proves the
+  // local folder is THIS deleted one and not a same-named successor.
+  await db.query(
+    `WITH RECURSIVE subtree AS (
+        SELECT id, vault_id, path FROM folders WHERE id = $1
+        UNION
+        SELECT f.id, f.vault_id, f.path FROM folders f JOIN subtree s ON f.parent_id = s.id
+     )
+     INSERT INTO folder_tombstones (id, vault_id, path)
+     SELECT id, vault_id, path FROM subtree
+     ON CONFLICT (id) DO NOTHING`,
+    [folderId],
+  );
   await db.query("DELETE FROM folders WHERE id = $1", [folderId]);
   return {
     vaultId: folder.vault_id,

--- a/app/apps/server/tests/open-link.test.ts
+++ b/app/apps/server/tests/open-link.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { testAppDeps } from "./helpers/app.js";
+
+/**
+ * The clickable share-link landing page (`GET /open/note/:orgId/:docId`).
+ *
+ * Chat apps linkify https where a bare `baalda://` scheme just sits there as
+ * text, so share links are web URLs and this page bounces them into the app's
+ * deep link. It is public by design — the URL carries identity, not access —
+ * so these tests pin the two properties that make that safe: it touches no
+ * data (any well-formed ids get the same page), and hostile ids can't smuggle
+ * markup into the HTML.
+ */
+describe("GET /open/note/:orgId/:docId", () => {
+  const app = createApp(testAppDeps());
+
+  it("serves a page that deep-links into the app", async () => {
+    const res = await app.request("/open/note/org_123/7dfc7a21-310c-41bd-840f-d4c37f8d5db3");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("baalda://note/org_123/7dfc7a21-310c-41bd-840f-d4c37f8d5db3");
+  });
+
+  it("is public — no session required", async () => {
+    // No Authorization header at all; the ids resolve against whoever is
+    // signed in on the DEVICE that opens the deep link, never here.
+    const res = await app.request("/open/note/a/b");
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses ids that don't look like ids (nothing to reflect)", async () => {
+    for (const path of [
+      "/open/note/%3Cscript%3E/doc",
+      "/open/note/org/%22onload%3D",
+      `/open/note/${"x".repeat(200)}/doc`,
+    ]) {
+      const res = await app.request(path);
+      expect(res.status).toBe(400);
+      expect(await res.text()).not.toContain("<script>");
+    }
+  });
+});

--- a/app/apps/server/tests/registry.test.ts
+++ b/app/apps/server/tests/registry.test.ts
@@ -132,10 +132,36 @@ describe("registry structure sync", () => {
       notes: Array<{ id: string }>;
       tombstones: string[];
     };
-    // Folders are hard-deleted with no tombstone of their own, so the notes'
-    // tombstones are the ONLY way a client learns the subtree is gone.
     expect(body.tombstones.sort()).toEqual([a, b].sort());
     expect(body.notes).toEqual([]);
+  });
+
+  it("tombstones every FOLDER a folder delete cascaded over", async () => {
+    // Without these, a device still holding the folder locally re-registered it
+    // on its next pull — the "deleted folder keeps coming back" bug.
+    const parent = await seedFolder(vault, null, "Old", "Old");
+    const child = await seedFolder(vault, parent, "Sub", "Old/Sub");
+    const keep = await seedFolder(vault, null, "Keep", "Keep");
+    expect((await req(owner, "DELETE", `/api/folders/${parent}`)).status).toBe(200);
+
+    const body = (await (await req(owner, "GET", `/api/folders?vaultId=${vault}`)).json()) as {
+      folders: Array<{ id: string }>;
+      tombstones: string[];
+    };
+    // The whole subtree is announced dead — including the cascade's victims —
+    // and the surviving folder is not.
+    expect(body.tombstones.sort()).toEqual([parent, child].sort());
+    expect(body.folders.map((f) => f.id)).toEqual([keep]);
+  });
+
+  it("a clean vault reports an empty FOLDER tombstone list, never a missing field", async () => {
+    await seedFolder(vault, null, "Here", "Here");
+    const body = (await (await req(owner, "GET", `/api/folders?vaultId=${vault}`)).json()) as {
+      tombstones: string[];
+    };
+    // Same contract as note tombstones: the client treats a MISSING field as
+    // "this server can't answer" and removes nothing on that basis.
+    expect(body.tombstones).toEqual([]);
   });
 
   it("a clean vault reports an empty tombstone list, never a missing field", async () => {


### PR DESCRIPTION
Fixes the batch of sync issues reported from real team usage:

## 1. Folder rows showed percentages ("0%", "3%")
Folder sync marks now show the **count of notes still to sync** (e.g. "2"), settling to the usual quiet dot. A percentage on a small folder read as gibberish — one unsynced note out of one rendered "0%". Tooltips keep the full "X of Y notes synced".

## 2. "5 not synced" with no way to act
- The header pill becomes a **button when a run ends with failures** — one click ("Sync now") re-pulls the registry and re-runs the content pass for everything unconfirmed (`SyncManager.retrySync`).
- Registry failures are now **reset per pass** instead of accumulating across pulls, so a vault can actually come back from "N not synced" once the cause is gone.

## 3. "Uploading files" on sign-in + stale tree until re-login
- The bulk content pass is pull-first per note (a verification sweep on an already-synced vault), so its label is now **"Syncing N/M"** — "Uploading" told people their synced vault was being re-sent.
- The vault channel now **re-pulls the registry on every (re)connect**. `registry` frames only reach connected clients, so anything a teammate created/renamed/deleted while a device was offline used to surface only on the next sign-in or relaunch. Remote structure lands first (inbound before outbound), which is the source-of-truth ordering the report asked for.

## 4. Previously-synced notes turning into red dots forever
The `pushed` confirmation set was pruned the moment a note left the server listing — but the file is often only trashed on a **later** pass, and the trash executor refuses unconfirmed docs. That turned already-synced notes into permanent "left on disk" orphans with an error badge that never cleared. Confirmations now live as long as the baseline remembers the doc. Also: `pushed` and the folder map are only adopted from config when it describes the same collection.

## 5. Deleted folders kept coming back
Two independent causes, both fixed:
- **No folder tombstones.** Notes soft-delete; folders were hard-deleted without a trace, so any device still holding the folder locally re-registered it on its next pull — resurrecting it for the whole team. New `folder_tombstones` table (migration 019), written by `deleteFolderCascade` for the whole subtree, returned by `GET /api/folders`, honored by the inbound planner: an id match proves the local folder is the deleted one, its emptied directories are removed bottom-up (`remove_dir`, never recursive — anything still inside keeps the folder, which then re-registers under a fresh id because content must live somewhere). Same `null ≠ []` contract as note tombstones.
- **Disk-first local deletes.** A failed/refused server delete (offline, no permission) was swallowed after the local file was already gone, so the next pull "resurrected" the item. Deletes are now **server-first** (self-healing: if the disk half fails, the tombstone cleans it up next pull), a refused server delete leaves everything in place and shows a toast, and `registry.deletePath` propagates failures (404 = already gone = success).

## 6. Email/password auth
Verified live against the running server: sign-up, sign-in, wrong-password (401 with clear message), duplicate sign-up (422), short password (400) — all correct. Found the actual dead-end behind "user can't sign in": an account **created through Google has no password**, so email sign-in answers "Invalid email or password" and sign-up answers "already exists". The auth dialog now shows a hint pointing such users at "Continue with Google" when that exact failure occurs.

## Tests
- Desktop: 618 passed (new planner/table cases for folder tombstones, end-to-end two-pass folder deletion, server-first delete ordering, count marks, relabels).
- Server: 287 passed against the scratch DB, incl. new folder-tombstone route tests.
- Rust: 82 passed, incl. new `delete_folder_if_empty` empty-only semantics test.

Version bumped to 0.1.33.