### PR TITLE
Table scrolling, instant read-only locks, frozen-root hardening

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.33"
+version = "0.1.34"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -1727,6 +1727,15 @@ body:has(.sidebar-resizer.dragging) {
   background: var(--accent-soft);
   color: var(--text-primary);
 }
+/* Unavailable action (e.g. create at a frozen root). Still clickable so the
+   refusal toast can explain why, but visibly not a live option. */
+.context-menu li.disabled {
+  opacity: 0.45;
+}
+.context-menu li.disabled:hover {
+  background: none;
+  color: inherit;
+}
 /* A thin rule above an item groups it apart from the ones above (Import/Export
    sit below the create actions). */
 .context-menu li.menu-sep-item {

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -15,6 +15,7 @@ import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { SidebarResizer } from "./components/SidebarResizer";
 import { Toasts } from "./components/Toasts";
+import { toast } from "./lib/toast";
 import { VaultPicker } from "./components/VaultPicker";
 import { VersionPanel } from "./components/VersionPanel";
 import { bridgeManager } from "./lib/bridge";
@@ -671,6 +672,16 @@ export default function App() {
     const onKey = async (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "n") {
         e.preventDefault();
+        // ⌘N creates at the vault root, so it honours the same freeze latch as
+        // the tree's New-note button — silently writing a root file here would
+        // leave it permanently unsyncable (the server refuses to register it).
+        if (useStore.getState().rootFrozen) {
+          toast(
+            "This vault's root is frozen — create this inside a folder instead.",
+            "error",
+          );
+          return;
+        }
         try {
           const path = await ipc.createNote("", `Untitled ${Date.now()}`);
           await useStore.getState().refreshTree();

--- a/app/apps/desktop/src/components/Editor.tsx
+++ b/app/apps/desktop/src/components/Editor.tsx
@@ -9,7 +9,7 @@ import type { Awareness } from "y-protocols/awareness";
 import { createEditorState } from "../lib/editor";
 import { setActiveView } from "../lib/editor/activeView";
 import { saveAttachment } from "../lib/attachments";
-import { bridgeManager } from "../lib/bridge";
+import { bridgeManager, type NoteBridge } from "../lib/bridge";
 import { effectiveLockForPath, lockScopesByPath } from "../lib/locks";
 import { playPingSound } from "../lib/presence/ping";
 import { syncManager } from "../lib/sync/docSession";
@@ -341,6 +341,13 @@ export function Editor() {
   // Editability is held in a Compartment so a lock applied while the note is
   // open can flip the live view read-only without rebuilding it.
   const editableRef = useRef<Compartment | null>(null);
+  // The open note's bridge — kept so the syncStatus effect can roll back
+  // keystrokes the server rejected (typed before its read-only verdict landed).
+  const bridgeRef = useRef<NoteBridge | null>(null);
+  // True once the server has confirmed edit access for THIS note session. Gates
+  // the rollback above: a live mid-session lock must never undo edits the
+  // server already accepted.
+  const hadEditAccessRef = useRef(false);
   const previewHostRef = useRef<HTMLDivElement | null>(null);
   const [rosterOpen, setRosterOpen] = useState(false);
   // Wraps the presence stack + its roster popover so an outside click can be
@@ -459,7 +466,21 @@ export function Editor() {
       }
       awareness = opened.awareness;
       awarenessRef.current = awareness;
-      const ro = opened.readOnly;
+      bridgeRef.current = bridge;
+      hadEditAccessRef.current = false;
+      // Locks come FIRST: `opened.readOnly` is optimistic (the server's token
+      // verdict arrives an HTTP round trip later), so anything we already know
+      // locally — a "locked" share on this note or an ancestor folder — makes
+      // the very first frame read-only. The verdict then confirms it
+      // ("read-only" status) or relaxes it ("synced" → editable).
+      const st = useStore.getState();
+      const lockedLocally =
+        syncEnabled &&
+        effectiveLockForPath(
+          lockScopesByPath(st.tree, st.locks, st.session?.user.id),
+          notePath,
+        ) != null;
+      const ro = opened.readOnly || opened.status === "no-access" || lockedLocally;
       setReadOnly(ro);
       const editable = new Compartment();
       editableRef.current = editable;
@@ -528,6 +549,8 @@ export function Editor() {
       if (view) view.destroy();
       viewRef.current = null;
       editableRef.current = null;
+      bridgeRef.current = null;
+      hadEditAccessRef.current = false;
       awarenessRef.current = null;
       seenPingsRef.current.clear();
       setPeers([]);
@@ -546,11 +569,22 @@ export function Editor() {
   // token on reconnect and the status flips to "read-only" here — no reopen
   // needed. Also refresh the lock list so the tree badge appears for us too.
   useEffect(() => {
-    if (syncStatus === "read-only") {
+    if (syncStatus === "read-only" || syncStatus === "no-access") {
       setReadOnly(true);
-      void useStore.getState().refreshLocks();
+      if (syncStatus === "read-only") void useStore.getState().refreshLocks();
+      // Anything typed before this verdict arrived was already rejected by the
+      // server (it drops updates from read-only connections), so those
+      // keystrokes exist only in the local doc — a silent fork that would
+      // egest to the .md file and diverge forever. Roll them back. Guarded by
+      // hadEditAccessRef: once "synced" confirmed edit access this session,
+      // a later lock must not undo edits the server accepted.
+      if (!hadEditAccessRef.current) {
+        const um = bridgeRef.current?.undoManager;
+        if (um) while (um.undoStack.length > 0) um.undo();
+      }
     } else if (syncStatus === "synced") {
       // Unlocked / edit grant restored — become editable again.
+      hadEditAccessRef.current = true;
       setReadOnly(false);
     }
   }, [syncStatus]);

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -1157,6 +1157,8 @@ export function FileTree() {
       ? menu.node.data.path
       : parentDir(menu.node.data.path)
     : "";
+  // Create/import from this menu would land at a frozen root.
+  const menuCreateBlocked = menuDir === "" && rootFrozen;
 
   // The lock applied DIRECTLY to the menu's node (not inherited), so the menu
   // can offer Unlock with the right share id.
@@ -1430,12 +1432,36 @@ export function FileTree() {
                 { left: menu.x, top: menu.y, visibility: "hidden" }
           }
         >
-          <li onClick={() => createUniqueNote(menuDir)}>New note</li>
-          <li onClick={() => createUniqueFolder(menuDir)}>New folder</li>
-          <li className="menu-sep-item" onClick={() => void importFilesInto(menuDir)}>
+          {/* Creating at a frozen root is refused; the items stay clickable so
+              the refusal toast can say why, but they read as unavailable. */}
+          <li
+            className={menuCreateBlocked ? "disabled" : undefined}
+            title={menuCreateBlocked ? ROOT_FROZEN_HINT : undefined}
+            onClick={() => createUniqueNote(menuDir)}
+          >
+            New note
+          </li>
+          <li
+            className={menuCreateBlocked ? "disabled" : undefined}
+            title={menuCreateBlocked ? ROOT_FROZEN_HINT : undefined}
+            onClick={() => createUniqueFolder(menuDir)}
+          >
+            New folder
+          </li>
+          <li
+            className={menuCreateBlocked ? "menu-sep-item disabled" : "menu-sep-item"}
+            title={menuCreateBlocked ? ROOT_FROZEN_HINT : undefined}
+            onClick={() => void importFilesInto(menuDir)}
+          >
             Import files…
           </li>
-          <li onClick={() => void importFolderInto(menuDir)}>Import folder…</li>
+          <li
+            className={menuCreateBlocked ? "disabled" : undefined}
+            title={menuCreateBlocked ? ROOT_FROZEN_HINT : undefined}
+            onClick={() => void importFolderInto(menuDir)}
+          >
+            Import folder…
+          </li>
           {menu.node && <li onClick={() => void exportNode(menu.node!)}>Export…</li>}
           {menu.node && (
             <li onClick={() => void revealNode(menu.node!)}>{ipc.revealLabel()}</li>

--- a/app/apps/desktop/src/lib/editor/theme.ts
+++ b/app/apps/desktop/src/lib/editor/theme.ts
@@ -171,13 +171,25 @@ export const editorTheme = EditorView.theme({
   },
   ".cm-md-table table": {
     borderCollapse: "collapse",
-    width: "100%",
+    // Natural column widths, capped at the prose measure: a table that fits
+    // stays put, a wide one overflows into the wrapper's horizontal scroll
+    // instead of crushing its columns (a table's min-content width beats
+    // max-width, which is exactly what lets it overflow).
+    width: "max-content",
+    maxWidth: "100%",
     fontSize: "0.95em",
   },
   ".cm-md-table th, .cm-md-table td": {
     border: "1px solid var(--border)",
     padding: "var(--sp-1) var(--sp-3)",
     textAlign: "left",
+    // Undo the editor's inherited `.cm-lineWrapping` (overflow-wrap: anywhere,
+    // word-break: break-word, white-space: break-spaces): those shrink a
+    // cell's min-content width to a single character, which is what let the
+    // layout crush columns and stack headers letter-by-letter.
+    whiteSpace: "normal",
+    overflowWrap: "normal",
+    wordBreak: "normal",
   },
   ".cm-md-table th": {
     backgroundColor: "var(--bg-subtle)",

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -127,6 +127,7 @@ export class SyncManager implements InboundHost {
   private onPending?: (pending: boolean) => void;
   private onFlushed?: () => void;
   private onRegistryChanged?: () => void;
+  private onAclChangedListener?: () => void;
   private onNotePathChanged?: (docId: string, from: string, to: string) => void;
   private onNoteRemoved?: (docId: string, path: string, trashedTo: string | null) => void;
   private onMemberJoined?: (name: string) => void;
@@ -313,6 +314,16 @@ export class SyncManager implements InboundHost {
    */
   setRegistryListener(cb: (() => void) | undefined): void {
     this.onRegistryChanged = cb;
+  }
+
+  /**
+   * UI subscribes here to refresh its lock/share overlay when a teammate
+   * changes the vault's ACL (lock/unlock, grant/revoke). Kept separate from the
+   * registry listener because a pure share change often leaves the listing
+   * untouched, so the registry pull would never poke that one.
+   */
+  setAclListener(cb: (() => void) | undefined): void {
+    this.onAclChangedListener = cb;
   }
 
   /**
@@ -1070,6 +1081,9 @@ export class SyncManager implements InboundHost {
         // the next structural change or an app restart - long enough to look
         // like the revocation hadn't worked.
         this.handleRegistryChanged();
+        // ...and the UI's lock overlay refreshes, so the NEXT open of a
+        // just-locked note starts read-only from its first frame.
+        this.onAclChangedListener?.();
       },
       // A teammate changed the folder/note structure — re-pull + refresh tree.
       onRegistryChanged: () => this.handleRegistryChanged(),

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -39,6 +39,7 @@ import { Checkpointer } from "./checkpoint";
 import { planInbound } from "./inbound";
 import { REGISTRY_CONCURRENCY, runPool, withRetry } from "./pool";
 import { nullProgressSink, type SyncProgressSink } from "./progress";
+import { toast } from "../toast";
 import { vaultScopes, type VaultScope, type VaultScopeSource } from "./vaultScope";
 
 export interface DocMapping {
@@ -160,6 +161,10 @@ export interface RegistryFailure {
   /** Server error code when it carried one (`vault_limit_reached`, …). */
   code: string | null;
 }
+
+/** Paths already toasted about a frozen-root refusal — reconcile re-runs and
+ *  retry clicks re-hit the same 403, and one sticky explanation is enough. */
+const frozenRootNotified = new Set<string>();
 
 /** Extensions treated as editable notes (reconciled to the server `notes` set).
  *  Images/PDFs surface in the tree but sync as embedded attachments, not notes. */
@@ -548,6 +553,16 @@ export class VaultRegistry {
     this.failed.push(f);
     if (f.code === "vault_limit_reached" || f.code === "member_limit_reached") {
       this.limitReached = f.code;
+    }
+    // A frozen-root refusal is the user's problem to fix (move the item into a
+    // folder), not a transient sync error — so say so, once per path. Without
+    // this the item just counts toward "N not synced" forever with no reason.
+    if (f.code === "root_frozen" && !frozenRootNotified.has(f.path)) {
+      frozenRootNotified.add(f.path);
+      toast(
+        `"${f.path}" can't sync — this vault's root is frozen. Move it into a folder to sync it.`,
+        "error",
+      );
     }
     if (f.docId) this.sink.doc(f.docId, "error");
     console.warn(`[registry] ${f.kind} ${f.path} failed — ${f.reason}`);

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -1153,6 +1153,12 @@ export const useStore = create<AppStore>((set, get) => ({
       // when it changes, so a teammate flipping it reaches this app live.
       void get().refreshVaultSettings();
     });
+    // A teammate changed shares (lock/unlock, grant/revoke). Fresh lock
+    // knowledge is what lets the editor open a just-locked note read-only from
+    // its very first frame instead of an HTTP round trip in.
+    syncManager.setAclListener(() => {
+      void get().refreshLocks();
+    });
     // A teammate renamed/moved or deleted a note we have on disk, and the registry
     // has just applied that to the file. The open editor's bridge was destroyed
     // before the move, so the view MUST be re-pointed or closed — leaving

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -611,6 +611,13 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "Not a member of this vault" }, 403);
     }
     const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
+    // Frozen root: same rule as notes — refuse only files that do not exist
+    // yet, so a device re-registering a root file that predates the latch
+    // still syncs.
+    if (!folderId && (await isRootFrozen(vaultId))) {
+      const { rowCount } = await pool.query("SELECT 1 FROM files WHERE id = $1", [id]);
+      if (!rowCount) return c.json(ROOT_FROZEN_ERROR, 403);
+    }
     await pool.query(
       "INSERT INTO files (id, vault_id, folder_id, path) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING",
       [id, vaultId, folderId ?? null, path],

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -139,7 +139,11 @@ export async function listFolders(ctx: McpContext, vaultId: string) {
  * the same reason: an assistant asked to "add a note" with no folder in mind is
  * one of the likelier ways a stray root file appears.
  */
-async function assertRootNotFrozen(vaultId: string, parentId: string | null): Promise<void> {
+async function assertRootNotFrozen(
+  vaultId: string,
+  parentId: string | null,
+  action: "create" | "move" = "create",
+): Promise<void> {
   if (parentId) return;
   const { rows } = await pool.query<{ root_frozen: boolean }>(
     "SELECT root_frozen FROM vaults WHERE id = $1",
@@ -147,7 +151,7 @@ async function assertRootNotFrozen(vaultId: string, parentId: string | null): Pr
   );
   if (rows[0]?.root_frozen) {
     throw new McpToolError(
-      "This vault's root is frozen — create this inside a folder instead.",
+      `This vault's root is frozen — ${action} this inside a folder instead.`,
     );
   }
 }
@@ -257,6 +261,11 @@ export async function moveFolderTool(
   if (input.parentId != null && (await folderWritePermission(ctx.auth, input.parentId)) !== "edit") {
     throw new McpToolError("You do not have edit access to the destination folder");
   }
+  // Moving a folder OUT to the root is a root creation by another name — the
+  // same latch the HTTP registry honours (a rename in place at root is fine).
+  if (input.parentId === null && folder.parent_id !== null) {
+    await assertRootNotFrozen(folder.vault_id, null, "move");
+  }
   try {
     const moved = await moveFolder(pool, input.folderId, {
       path: input.path,
@@ -286,6 +295,11 @@ export async function moveNoteTool(
     (await folderWritePermission(ctx.auth, input.folderId)) !== "edit"
   ) {
     throw new McpToolError("You do not have edit access to the destination folder");
+  }
+  // Same root-freeze latch as HTTP's PATCH /api/notes/:id: dragging a note out
+  // to a frozen root is refused; a rename in place at root is allowed.
+  if (input.folderId === null && note.folder_id !== null) {
+    await assertRootNotFrozen(note.vault_id, null, "move");
   }
   try {
     const moved = await moveNote(pool, input.docId, {

--- a/app/apps/server/tests/mcp.test.ts
+++ b/app/apps/server/tests/mcp.test.ts
@@ -4,6 +4,7 @@ import { pool } from "../src/db/pool.js";
 import { resetDb } from "./helpers/db.js";
 import { recordingAppDeps } from "./helpers/app.js";
 import {
+  freezeVaultRoot,
   seedFolder,
   seedLock,
   seedMember,
@@ -521,6 +522,51 @@ describe("MCP server", () => {
       vault = await seedVault(org);
       token = await tokenFor(owner, org);
       registryBroadcasts.length = 0;
+    });
+
+    it("refuses moving a note or folder OUT to a frozen root (HTTP parity)", async () => {
+      const folder = await call(token, "create_folder", {
+        vaultId: vault,
+        name: "Docs",
+        path: "Docs",
+      });
+      const folderId = folder.data.folderId as string;
+      const sub = await call(token, "create_folder", {
+        vaultId: vault,
+        name: "Specs",
+        path: "Docs/Specs",
+        parentId: folderId,
+      });
+      const subId = sub.data.folderId as string;
+      const note = await call(token, "create_note", {
+        vaultId: vault,
+        relPath: "Docs/n.md",
+        title: "N",
+        folderId,
+      });
+      const docId = note.data.docId as string;
+
+      await freezeVaultRoot(vault);
+
+      const movedFolder = await call(token, "move_folder", {
+        folderId: subId,
+        path: "Specs",
+        parentId: null,
+      });
+      expect(movedFolder.isError).toBe(true);
+      expect(movedFolder.text).toContain("root is frozen");
+
+      const movedNote = await call(token, "move_note", {
+        docId,
+        relPath: "n.md",
+        folderId: null,
+      });
+      expect(movedNote.isError).toBe(true);
+      expect(movedNote.text).toContain("root is frozen");
+
+      // A retitle that leaves the note in its folder is untouched by the latch.
+      const retitle = await call(token, "move_note", { docId, title: "Renamed" });
+      expect(retitle.isError).toBe(false);
     });
 
     it("renames a note in place, keeping its docId, and broadcasts", async () => {

--- a/app/apps/server/tests/vault-root-freeze.test.ts
+++ b/app/apps/server/tests/vault-root-freeze.test.ts
@@ -189,6 +189,46 @@ describe("frozen vault root", () => {
     });
     expect(rename.status).toBe(200);
   });
+
+  it("refuses a new root FILE too, but allows nested and re-registered ones", async () => {
+    const folder = await req(owner, "POST", "/api/folders", {
+      vaultId: vault,
+      name: "Assets",
+      path: "Assets",
+    });
+    const folderId = (await folder.json()).id as string;
+    const docId = crypto.randomUUID();
+    const pre = await req(owner, "POST", "/api/files", {
+      vaultId: vault,
+      path: "logo.svg",
+      docId,
+    });
+    expect(pre.status).toBe(201);
+
+    await freezeVaultRoot(vault);
+
+    const refused = await req(owner, "POST", "/api/files", {
+      vaultId: vault,
+      path: "stray.bin",
+    });
+    expect(refused.status).toBe(403);
+    expect((await refused.json()).code).toBe("root_frozen");
+
+    const nested = await req(owner, "POST", "/api/files", {
+      vaultId: vault,
+      folderId,
+      path: "Assets/pic.png",
+    });
+    expect(nested.status).toBe(201);
+
+    // Second device re-registering the pre-freeze root file still syncs.
+    const readopt = await req(owner, "POST", "/api/files", {
+      vaultId: vault,
+      path: "logo.svg",
+      docId,
+    });
+    expect(readopt.status).toBe(201);
+  });
 });
 
 /**


### PR DESCRIPTION
## Rendered tables: scroll, never crush

Live-preview tables inherited CodeMirror's line-wrapping CSS (`overflow-wrap: anywhere`), which let every column shrink to one character — headers stacked letter-by-letter — while `width: 100%` meant the existing scroll wrapper never had anything to scroll. Now the table takes its natural column widths, capped at the prose measure; a wide table overflows into the wrapper's horizontal scroll, and cells wrap at word boundaries only.

## Locks apply from the first frame

- Opening a note used to mount the editor editable **and focused**, then flip read-only one HTTP round trip (~20ms+) later when the sync token answered. The editor now consults the locally-known lock overlay (the same `locks` the tree badges use) before mounting, so a known-locked note renders read-only from its very first frame; the server verdict then confirms or relaxes it.
- `no-access` (403 at token mint) now also flips the editor read-only — previously it was left permanently editable locally.
- Anything typed in the remaining pre-verdict window (stale lock knowledge) was already rejected by the server (Hocuspocus drops updates from read-only connections) but silently forked the local doc and `.md` file forever. Those keystrokes are now rolled back via the bridge's UndoManager the moment the read-only verdict lands — guarded so a live mid-session lock never undoes edits the server already accepted.
- Teammate lock/unlock now refreshes the lock overlay live via a dedicated ACL listener on the vault channel (the registry listener only fires when the listing itself changed, which a pure lock flip doesn't).

Server-side enforcement was verified sound: read-only connections' updates never touch the doc, never persist, never broadcast.

## Frozen root: closed gaps + honest messaging

Server:
- `POST /api/files` (the generic file registration) now honours the latch like notes/folders do — refuses new root files, still re-adopts pre-freeze ones.
- MCP `move_folder` / `move_note` now refuse moving an item OUT to a frozen root, matching the HTTP registry (rename-in-place at root stays allowed).

Desktop:
- `⌘N` (which creates at root) now respects the latch with the same refusal toast instead of silently writing an unsyncable root file.
- Context-menu New note / New folder / Import at the root render dimmed with the freeze hint while frozen (still clickable so the toast can explain).
- A file that lands at the root anyway (terminal, Finder, another app) used to count toward "N not synced" forever with no reason given; the `root_frozen` refusal now raises a sticky toast naming the file and telling the user to move it into a folder. The file itself is deliberately **not** deleted — it never reaches the server or teammates (registration is refused), and auto-deleting a user's local file would be data loss.

## Tests
- Server: new coverage for `POST /api/files` under freeze and MCP move-to-frozen-root parity. Full suite: 292 passed.
- Desktop: full suite 621 passed; both workspaces typecheck clean.

Version bumped to 0.1.34.