### PR TITLE
Natural table columns with visible scroll + cleaner update wall

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.34"
+version = "0.1.35"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -5479,33 +5479,60 @@ button.is-done:disabled {
   -webkit-backdrop-filter: blur(14px);
 }
 .update-gate-card {
+  position: relative;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--sp-4);
-  max-width: 420px;
-  padding: var(--sp-8) var(--sp-8);
+  max-width: 440px;
+  padding: var(--sp-9, 44px) var(--sp-8) var(--sp-8);
   text-align: center;
   background: var(--bg-secondary);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
 }
+/* A thin accent thread across the top — enough identity without a logo. */
+.update-gate-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+}
+.update-gate-version {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 3px 12px;
+  border-radius: var(--radius-pill);
+}
 .update-gate-card h1 {
   margin: 0;
-  font-size: var(--fs-lg);
+  font-size: var(--fs-xl);
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 .update-gate-card p {
   margin: 0;
   color: var(--text-secondary);
-  line-height: 1.5;
+  line-height: 1.55;
+  max-width: 36ch;
 }
-.update-gate-logo {
-  height: 22px;
+.update-gate-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-top: var(--sp-2);
 }
 .update-gate-cta {
-  min-width: 180px;
+  min-width: 160px;
 }
 .update-gate .update-progress {
   width: 240px;

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -10,7 +10,6 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FileTree } from "./components/FileTree";
 import { GraphView } from "./components/GraphView";
 import { SyncBadge } from "./components/Identity";
-import { Wordmark } from "./components/Logo";
 import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { SidebarResizer } from "./components/SidebarResizer";
@@ -293,21 +292,39 @@ function UpdateGate() {
       ? Math.round((update.downloaded / update.total) * 100)
       : null;
 
+  const version = ("version" in update ? update.version : null) ?? required;
+
+  // Escape hatch beside the install CTA: flush the open note, then reboot the
+  // webview — same as the reload shortcut. Useful when a wall raised by a
+  // half-failed check would otherwise strand the window.
+  const reload = async () => {
+    try {
+      await bridgeManager.currentBridge()?.flushEgest();
+    } catch {
+      // Best-effort: reload regardless, notes are already on disk.
+    }
+    window.location.reload();
+  };
+
   return (
     <div className="update-gate" role="alertdialog" aria-modal="true" aria-label="Update required">
       <div className="update-gate-card">
-        <Wordmark className="update-gate-logo" />
+        {version && <span className="update-gate-version">Version {version}</span>}
         <h1>Update required</h1>
         {update.phase === "available" && (
           <>
             <p>
-              {BRAND_NAME} <strong>v{update.version}</strong> is ready. Install the update to
-              continue using the app — it takes a moment and your notes stay right where they
-              are, on your disk.
+              A new version of {BRAND_NAME} is ready. Installing takes a moment, and your
+              notes stay right where they are — on your disk.
             </p>
-            <AsyncButton className="primary update-gate-cta" onClick={() => installUpdate()}>
-              Install &amp; Restart
-            </AsyncButton>
+            <div className="update-gate-actions">
+              <AsyncButton className="primary update-gate-cta" onClick={() => installUpdate()}>
+                Install Update
+              </AsyncButton>
+              <button className="ghost-pill lg" onClick={() => void reload()}>
+                Reload
+              </button>
+            </div>
           </>
         )}
         {(update.phase === "downloading" || update.phase === "installing") && (
@@ -342,16 +359,21 @@ function UpdateGate() {
               {update.message ? ` — ${update.message}` : ""}. Check your connection and try
               again.
             </p>
-            <AsyncButton
-              className="primary update-gate-cta"
-              onClick={async () => {
-                // Re-discover then install: the failed attempt may have died at
-                // either stage, and checkForUpdate re-arms the pending update.
-                if (await checkForUpdate()) await installUpdate();
-              }}
-            >
-              Try again
-            </AsyncButton>
+            <div className="update-gate-actions">
+              <AsyncButton
+                className="primary update-gate-cta"
+                onClick={async () => {
+                  // Re-discover then install: the failed attempt may have died at
+                  // either stage, and checkForUpdate re-arms the pending update.
+                  if (await checkForUpdate()) await installUpdate();
+                }}
+              >
+                Try again
+              </AsyncButton>
+              <button className="ghost-pill lg" onClick={() => void reload()}>
+                Reload
+              </button>
+            </div>
           </>
         )}
       </div>

--- a/app/apps/desktop/src/lib/editor/livePreview.ts
+++ b/app/apps/desktop/src/lib/editor/livePreview.ts
@@ -216,7 +216,14 @@ class TableWidget extends WidgetType {
       const head = i === 0 && rows[1] && isDelim(rows[1]);
       for (const c of cells(line)) {
         const cell = document.createElement(head ? "th" : "td");
-        cell.textContent = c;
+        // Inner block, not textContent on the cell: `max-width` on a table
+        // cell is unreliable in auto table layout, but on a block child it
+        // reliably caps the column's natural width so long prose wraps at a
+        // readable measure while short columns keep their natural size.
+        const inner = document.createElement("div");
+        inner.className = "cm-md-cell";
+        inner.textContent = c;
+        cell.appendChild(inner);
         tr.appendChild(cell);
       }
       if (head) {

--- a/app/apps/desktop/src/lib/editor/theme.ts
+++ b/app/apps/desktop/src/lib/editor/theme.ts
@@ -168,16 +168,38 @@ export const editorTheme = EditorView.theme({
   ".cm-md-table": {
     margin: "var(--sp-3) 0",
     overflowX: "auto",
+    // Without inline-size containment the table's natural width propagates
+    // into `.cm-content`'s intrinsic size (it's a flex item that sizes from
+    // its contents), widening the WHOLE sheet past the window — the prose
+    // shifts and clips instead of just this wrapper scrolling. Containment
+    // keeps the overflow here, where the scrollbar is.
+    contain: "inline-size",
   },
   ".cm-md-table table": {
     borderCollapse: "collapse",
-    // Natural column widths, capped at the prose measure: a table that fits
-    // stays put, a wide one overflows into the wrapper's horizontal scroll
-    // instead of crushing its columns (a table's min-content width beats
-    // max-width, which is exactly what lets it overflow).
+    // Natural column widths, uncapped: a wide table overflows into the
+    // wrapper's horizontal scroll instead of squeezing its columns to fit.
+    // (An earlier `max-width: 100%` here compressed every column toward its
+    // minimum before overflowing — the exact crushing this exists to avoid.)
     width: "max-content",
-    maxWidth: "100%",
     fontSize: "0.95em",
+  },
+  // The block inside each cell (see TableWidget). Its max-width is what bounds
+  // a column's natural size: long prose wraps at a readable measure, short
+  // columns stay as wide as their content — nothing is squeezed below it.
+  ".cm-md-table .cm-md-cell": {
+    maxWidth: "42ch",
+  },
+  // A visible (non-overlay) scrollbar, so a table that CAN scroll shows it.
+  ".cm-md-table::-webkit-scrollbar": {
+    height: "8px",
+  },
+  ".cm-md-table::-webkit-scrollbar-thumb": {
+    backgroundColor: "var(--border)",
+    borderRadius: "4px",
+  },
+  ".cm-md-table::-webkit-scrollbar-track": {
+    background: "transparent",
   },
   ".cm-md-table th, .cm-md-table td": {
     border: "1px solid var(--border)",


### PR DESCRIPTION
## Tables: natural column widths, visible scroll

Follow-up to #64 — the `max-width: 100%` cap made the layout compress every column toward its minimum before overflowing. Now:

- The table takes its natural width and scrolls horizontally inside its own wrapper (`contain: inline-size` keeps that width from inflating the whole sheet).
- Each cell's content is capped at a readable 42ch measure via an inner block (`max-width` on the cell itself is unreliable in auto table layout), so long prose wraps comfortably and short columns stay content-sized.
- The wrapper shows a persistent slim scrollbar instead of the invisible macOS overlay bar, so a scrollable table looks scrollable.

## Update wall redesign

- Logo removed — a version pill and a thin accent gradient across the card top carry the identity instead.
- Title, short description, and two actions: **Install Update** (primary) and **Reload** (ghost), the latter flushing the open note before rebooting the webview. Reload also appears next to Try again in the error state.
- Larger title, tighter copy measure, wider card.

Desktop suite: 621 passed, typecheck clean. Version bumped to 0.1.35.