### PR TITLE
External writes sync live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,13 @@ Pure TS with dependency-injected I/O so it runs under vitest in Node. `adapter.t
 - `registry.ts` — reconciles local vault ↔ server vault/folders/notes, persists the doc-id map to
   `.context/config.json`, materializes server-only notes as empty files (hydrate lazily).
 - `tokenRefresh.ts` — re-mint 60s before JWT expiry. `attachments.ts` — content-hash (sha256) diff, upload/download.
+- **External writers are first-class** (`handleLocalFileChanged` in `docSession.ts`): a watcher event for a
+  non-open note routes to the sync layer — unmapped/structural changes trigger the debounced registry pull
+  (register + upload), mapped notes get a debounced `ContentUploader` run with `force` + `ingestFromFile`
+  (diff-merge the file into the CRDT via `NoteBridge.ingestNow`, echo-guarded fast-path skips our own egest
+  echoes; the `divergedDocs` set forces a connect for out-of-band merges by resident bridges / cold applies).
+  `NoteBridge.hydrate` also ingests the file on reopen when it moved on while the doc was closed. Disk
+  deletions are deliberately NOT propagated to the server.
 
 ### Desktop — React (`src/`)
 `store.ts` is a Zustand **UI view-state mirror only** (vault, tree, open note, auth/session, org members,

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.35",
+  "version": "0.1.36",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.35"
+version = "0.1.36"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -644,6 +644,12 @@ export default function App() {
             // and merges genuine external edits live into the open Y.Text.
             bridgeManager.handleFileChanged(e.path);
           }
+        } else {
+          // Everything that is NOT the open note goes to the sync layer: an
+          // external writer (an AI with the vault folder open, another editor)
+          // creating or changing files must reach the server live — not on the
+          // next sign-in reconcile, and not only once someone opens the note.
+          syncManager.handleLocalFileChanged(e.path, e.kind);
         }
 
         // Refresh tree + titles + backlinks (coalesced for bursts).

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -31,6 +31,7 @@ import { LOCK_TITLES, lockScopesByPath, type LockScope } from "../lib/locks";
 import { previewKind } from "../lib/preview";
 import {
   buildTreeSyncIndex,
+  FolderWaveTracker,
   rowSyncMark,
   type TreeSyncIndex,
 } from "../lib/syncRollup";
@@ -255,17 +256,28 @@ export function FileTree() {
   // Note the denominator comes from `titles` + `docIdByPath`, NOT from `tree`:
   // the tree is lazily loaded, so a folder nobody expanded would roll up nothing
   // and read as fully synced.
-  const syncIndex = useMemo<TreeSyncIndex | null>(
-    () =>
-      syncEnabled
-        ? buildTreeSyncIndex({
-            docIdByPath,
-            docSyncState,
-            localNotePaths: titles.map((t) => t.path),
-          })
-        : null,
-    [syncEnabled, docIdByPath, docSyncState, titles],
-  );
+  // Wave memory for the folder badges: "1/2" counts progress through the notes
+  // that actually need syncing, which takes remembering how big the wave was
+  // across renders. Reset whenever the vault (or sync itself) changes — a wave
+  // from another vault's folders says nothing about this one's.
+  const wavesRef = useRef(new FolderWaveTracker());
+  const vaultPath = useStore((s) => s.vault?.path ?? null);
+  const lastWaveKeyRef = useRef<string | null>(null);
+  const syncIndex = useMemo<TreeSyncIndex | null>(() => {
+    const waveKey = syncEnabled ? vaultPath : null;
+    if (lastWaveKeyRef.current !== waveKey) {
+      wavesRef.current.reset();
+      lastWaveKeyRef.current = waveKey;
+    }
+    if (!syncEnabled) return null;
+    const index = buildTreeSyncIndex({
+      docIdByPath,
+      docSyncState,
+      localNotePaths: titles.map((t) => t.path),
+    });
+    wavesRef.current.apply(index);
+    return index;
+  }, [syncEnabled, docIdByPath, docSyncState, titles, vaultPath]);
 
   // Resolve lock rows (server resource ids) to tree paths for the badges.
   const lockByPath = useMemo(
@@ -1703,7 +1715,7 @@ function TreeSyncMark({
     <span className={`tree-sync ${mark.state}`} title={mark.title} aria-label={mark.title}>
       {mark.progress != null ? (
         <span className="tree-sync-pct">
-          {mark.progress.synced}/{mark.progress.total}
+          {mark.progress.done}/{mark.progress.total}
         </span>
       ) : (
         <span className="sync-dot" aria-hidden="true" />

--- a/app/apps/desktop/src/components/editor.css
+++ b/app/apps/desktop/src/components/editor.css
@@ -490,13 +490,13 @@
    open effect needs `hostRef.current` in the DOM to attach CodeMirror to.
 
    The padding deliberately mirrors `.cm-content` in `lib/editor/theme.ts`
-   (`--sp-8` top, the same centred 76ch measure) so the skeleton lines sit
-   exactly where the real text lands. Getting this wrong is worse than no
-   skeleton at all — the content appears to jump sideways as it loads. */
+   (`--sp-8` top, the same centred `--editor-measure` column) so the skeleton
+   lines sit exactly where the real text lands. Getting this wrong is worse than
+   no skeleton at all — the content appears to jump sideways as it loads. */
 .editor-skeleton {
   position: absolute;
   inset: 0;
-  padding: var(--sp-8) max(var(--sp-8), calc((100% - 76ch) / 2));
+  padding: var(--sp-8) max(var(--editor-gutter), calc((100% - var(--editor-measure)) / 2));
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);

--- a/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildTreeSyncIndex,
+  FolderWaveTracker,
   folderSyncTitle,
   rowSyncMark,
   type TreeSyncIndex,
@@ -183,11 +184,14 @@ describe("rowSyncMark", () => {
     expect(rowSyncMark(file("page.html"), index)).toBeNull();
   });
 
-  it("shows a folder's synced/total counts, and a dot once settled", () => {
+  it("shows a folder's wave counts (not its population), and a dot once settled", () => {
+    // One of two notes is still moving: the badge counts the WAVE (the one note
+    // that needs syncing), not the folder's whole population — a single new
+    // file in a 1114-note folder must read "0/1", never "1113/1114".
     const busy = indexOf({ "A/a.md": "synced", "A/b.md": "syncing" });
     expect(rowSyncMark(dir("A"), busy)).toMatchObject({
       state: "syncing",
-      progress: { synced: 1, total: 2 },
+      progress: { done: 0, total: 1 },
     });
 
     const done = indexOf({ "A/a.md": "synced", "A/b.md": "synced" });
@@ -203,13 +207,70 @@ describe("rowSyncMark", () => {
     const index = indexOf({ "A/a.md": "synced" }, ["A/b.md", "A/c.md"]);
     expect(rowSyncMark(dir("A"), index)).toMatchObject({
       state: "unsynced",
-      progress: { synced: 1, total: 3 },
+      progress: { done: 0, total: 2 },
     });
   });
 
   it("resolves the vault root folder to the whole-vault roll-up", () => {
     const index = indexOf({ "A/a.md": "synced", "b.md": "synced" });
     expect(rowSyncMark(dir(""), index)).toMatchObject({ state: "synced", progress: null });
+  });
+});
+
+describe("FolderWaveTracker", () => {
+  it("pins the wave's denominator while notes sync, so progress reads forward", () => {
+    const waves = new FolderWaveTracker();
+
+    // Two new files land: wave is 0/2.
+    const start = indexOf({ "A/a.md": "queued", "A/b.md": "queued", "A/c.md": "synced" });
+    waves.apply(start);
+    expect(rowSyncMark(dir("A"), start)!.progress).toEqual({ done: 0, total: 2 });
+
+    // One of them syncs: 1/2 — NOT 0/1, which would erase the progress made.
+    const half = indexOf({ "A/a.md": "synced", "A/b.md": "syncing", "A/c.md": "synced" });
+    waves.apply(half);
+    expect(rowSyncMark(dir("A"), half)!.progress).toEqual({ done: 1, total: 2 });
+  });
+
+  it("forgets a settled folder, so the next wave starts fresh at 0/1", () => {
+    const waves = new FolderWaveTracker();
+    const busy = indexOf({ "A/a.md": "syncing", "A/b.md": "syncing" });
+    waves.apply(busy);
+
+    // Everything lands — the folder settles (dot; no progress stamped).
+    const done = indexOf({ "A/a.md": "synced", "A/b.md": "synced" });
+    waves.apply(done);
+    expect(rowSyncMark(dir("A"), done)!.progress).toBeNull();
+
+    // One NEW file later: a fresh 0/1 wave, not a resumed 2/3.
+    const next = indexOf({ "A/a.md": "synced", "A/b.md": "synced", "A/c.md": "queued" });
+    waves.apply(next);
+    expect(rowSyncMark(dir("A"), next)!.progress).toEqual({ done: 0, total: 1 });
+  });
+
+  it("grows the wave when more work arrives mid-flight", () => {
+    const waves = new FolderWaveTracker();
+    const one = indexOf({ "A/a.md": "syncing" });
+    waves.apply(one);
+    expect(one.folders.get("A")!.wave).toEqual({ done: 0, total: 1 });
+
+    // A second file lands before the first finishes: the wave widens to 2.
+    const two = indexOf({ "A/a.md": "syncing", "A/b.md": "queued" });
+    waves.apply(two);
+    expect(two.folders.get("A")!.wave).toEqual({ done: 0, total: 2 });
+  });
+
+  it("tracks the vault root under its own key and resets on demand", () => {
+    const waves = new FolderWaveTracker();
+    const busy = indexOf({ "a.md": "syncing", "b.md": "synced" });
+    waves.apply(busy);
+    expect(busy.vault!.wave).toEqual({ done: 0, total: 1 });
+
+    waves.reset();
+    const again = indexOf({ "a.md": "syncing", "b.md": "syncing" });
+    waves.apply(again);
+    // After a reset nothing is remembered: the wave is exactly what's unsynced now.
+    expect(again.vault!.wave).toEqual({ done: 0, total: 2 });
   });
 });
 

--- a/app/apps/desktop/src/lib/bridge/__tests__/echo.test.ts
+++ b/app/apps/desktop/src/lib/bridge/__tests__/echo.test.ts
@@ -85,3 +85,95 @@ describe("echo-loop suppression", () => {
     }
   });
 });
+
+describe("ingestNow — the sync layer's immediate ingest", () => {
+  const PATH2 = "closed.md";
+
+  it("merges an external edit synchronously and reports the change", async () => {
+    const { io, fs } = makeHarness({ [PATH2]: "one two three" });
+    const bridge = await NoteBridge.open(io, { docId: "doc-2", path: PATH2 });
+
+    fs.externalWrite(PATH2, "one two three four");
+    await expect(bridge.ingestNow()).resolves.toBe(true);
+    expect(bridge.serialize()).toBe("one two three four");
+
+    bridge.destroy();
+  });
+
+  it("reports no change for our own echo and for an already-converged file", async () => {
+    const { io, fs } = makeHarness({ [PATH2]: "steady" });
+    const bridge = await NoteBridge.open(io, { docId: "doc-2", path: PATH2 });
+
+    // Nothing changed on disk: converged → false, and no ops.
+    const ops = bridge.updatesObserved;
+    await expect(bridge.ingestNow()).resolves.toBe(false);
+    expect(bridge.updatesObserved).toBe(ops);
+    expect(fs.get(PATH2)).toBe("steady");
+
+    bridge.destroy();
+  });
+
+  it("supersedes a pending debounced ingest (no double apply afterwards)", async () => {
+    vi.useFakeTimers();
+    try {
+      const { io, fs, persistence } = makeHarness({ [PATH2]: "base" });
+      const bridge = await NoteBridge.open(io, { docId: "doc-2", path: PATH2 });
+
+      fs.externalWrite(PATH2, "base plus");
+      bridge.ingest(); // watcher path arms the 150ms timer…
+      await expect(bridge.ingestNow()).resolves.toBe(true); // …sync layer wants it NOW
+      expect(bridge.serialize()).toBe("base plus");
+      const log = persistence.logLength("doc-2");
+
+      // The armed timer must not fire a second apply.
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(bridge.serialize()).toBe("base plus");
+      expect(persistence.logLength("doc-2")).toBe(log);
+
+      bridge.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("reopen after an external edit while the doc was closed", () => {
+  it("ingests the file's newer content on hydrate (disk is the durable truth)", async () => {
+    vi.useFakeTimers();
+    try {
+      const { io, fs } = makeHarness({ "n.md": "original" });
+      const first = await NoteBridge.open(io, { docId: "d", path: "n.md" });
+      expect(first.serialize()).toBe("original");
+      first.destroy();
+
+      // An AI (or any external editor) rewrites the file while no bridge exists —
+      // the watcher event it caused had nothing to ingest into.
+      fs.externalWrite("n.md", "original, then edited outside the app");
+
+      const second = await NoteBridge.open(io, { docId: "d", path: "n.md" });
+      await vi.advanceTimersByTimeAsync(150); // the hydrate-scheduled ingest
+      expect(second.serialize()).toBe("original, then edited outside the app");
+      second.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not spuriously ingest when file and doc already agree", async () => {
+    vi.useFakeTimers();
+    try {
+      const { io, persistence } = makeHarness({ "n.md": "same" });
+      const first = await NoteBridge.open(io, { docId: "d", path: "n.md" });
+      first.destroy();
+
+      const second = await NoteBridge.open(io, { docId: "d", path: "n.md" });
+      const log = persistence.logLength("d");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(second.serialize()).toBe("same");
+      expect(persistence.logLength("d")).toBe(log); // zero new ops
+      second.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/app/apps/desktop/src/lib/bridge/noteBridge.ts
+++ b/app/apps/desktop/src/lib/bridge/noteBridge.ts
@@ -157,6 +157,15 @@ export class NoteBridge {
       // Baseline the echo guard at the current content so an identical file
       // doesn't trigger a spurious ingest, but a genuine external change does.
       this.lastWrittenHash = await this.hash(this.text.toString());
+      // The file may have moved on while this doc was closed — an AI editing
+      // the vault directly, or the app relaunching after external edits. The
+      // CRDT we just hydrated describes the LAST session; the .md on disk is
+      // the durable source of truth (spec 00), so reconcile against it now
+      // rather than waiting for a watcher event that already fired (or never
+      // will). Converged content no-ops. Guarded on a non-empty doc: an empty
+      // doc must go through the deferred pull-before-seed path, never a
+      // pre-sync ingest (that's the note-doubling bug).
+      if (this.text.length > 0) this.ingest();
       if (state.updateCount > this.cfg.compactThreshold) await this.compact();
     } else {
       // No CRDT yet. Normally seed Y.Text from the file in a 'disk' transaction
@@ -230,8 +239,27 @@ export class NoteBridge {
     }, this.cfg.ingestDebounceMs);
   }
 
-  private async drainIngest(): Promise<void> {
-    if (this.destroyed || !this.ingestDirty) return;
+  /**
+   * Merge the file's current bytes into the CRDT immediately (no debounce), for
+   * the background sync of a note nobody has open: an external writer (an AI
+   * working in the vault folder, another editor) changed the file, and the sync
+   * layer needs the diff in the doc NOW so it can push it. Returns true iff the
+   * doc actually changed — false covers our own egest echoing back and an
+   * already-converged file, which is what lets the caller skip the network
+   * round-trip entirely.
+   */
+  async ingestNow(): Promise<boolean> {
+    if (this.destroyed) return false;
+    if (this.ingestTimer != null) {
+      this.clearT(this.ingestTimer);
+      this.ingestTimer = null;
+    }
+    this.ingestDirty = true;
+    return this.drainIngest();
+  }
+
+  private async drainIngest(): Promise<boolean> {
+    if (this.destroyed || !this.ingestDirty) return false;
     this.ingestDirty = false;
 
     let fileText: string;
@@ -239,17 +267,17 @@ export class NoteBridge {
       fileText = await this.io.readFile(this._path);
     } catch (e) {
       this.reportError(e, "ingest:readFile");
-      return;
+      return false;
     }
 
     const fileHash = await this.hash(fileText);
-    if (fileHash === this.lastWrittenHash) return; // our own write echoing back → DROP
+    if (fileHash === this.lastWrittenHash) return false; // our own write echoing back → DROP
 
     const current = this.text.toString();
     if (current === fileText) {
       // Already converged (e.g. we ingested this exact change already).
       this.lastWrittenHash = fileHash;
-      return;
+      return false;
     }
 
     const diffs = computeDiff(current, fileText);
@@ -274,6 +302,7 @@ export class NoteBridge {
     this.doc.transact(() => {
       applyDiff(this.text, diffs);
     }, ORIGIN_DISK);
+    return true;
   }
 
   // ---- B. CRDT → DISK (egest) ------------------------------------------

--- a/app/apps/desktop/src/lib/editor/theme.ts
+++ b/app/apps/desktop/src/lib/editor/theme.ts
@@ -28,11 +28,12 @@ export const editorTheme = EditorView.theme({
   // Full-width content box so a click *anywhere* in the sheet lands on
   // `.cm-content` (CodeMirror only maps clicks/drag-selection that hit the
   // content element — a centred column via `margin:auto` leaves the side
-  // margins as dead `.cm-scroller` zones). We centre the 76ch measure with
-  // symmetric auto-ish padding instead, and keep the tall bottom pad so there's
-  // always somewhere to click below the last line.
+  // margins as dead `.cm-scroller` zones). We centre the `--editor-measure`
+  // column with symmetric auto-ish padding instead, and keep the tall bottom
+  // pad so there's always somewhere to click below the last line.
   ".cm-content": {
-    padding: "var(--sp-8) max(var(--sp-8), calc((100% - 76ch) / 2)) 40vh",
+    padding:
+      "var(--sp-8) max(var(--editor-gutter), calc((100% - var(--editor-measure)) / 2)) 40vh",
     minHeight: "100%",
     caretColor: "var(--accent)",
   },

--- a/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
@@ -130,6 +130,9 @@ interface RigOptions {
   shouldStop?: () => boolean;
   concurrency?: number;
   failureStreakLimit?: number;
+  force?: boolean;
+  ingestFromFile?: boolean;
+  mustConnect?: (docId: string) => boolean;
   /** Reuse a previous rig's CRDT store, to model a SECOND run on one device. */
   harness?: ReturnType<typeof makeHarness>;
   onAcquire?: (docId: string, store: VaultDocStore) => void;
@@ -168,6 +171,9 @@ function rig(opts: RigOptions) {
       pushedSet.add(id);
     },
     skip: opts.skip,
+    force: opts.force,
+    ingestFromFile: opts.ingestFromFile,
+    mustConnect: opts.mustConnect,
     shouldStop: opts.shouldStop,
     progress: sink.sink,
     concurrency: opts.concurrency,
@@ -446,5 +452,154 @@ describe("ContentUploader — resume and honest failures", () => {
     expect(result).toMatchObject({ total: 2, pushed: 1, failed: 1 });
     expect(r.server.text("d2")).toBe("here");
     expect(r.uploader.failedDocs()[0].docId).toBe("d1");
+  });
+});
+
+describe("ContentUploader — local-change runs (force + ingestFromFile)", () => {
+  // The live sync of externally-written files (an AI with the vault folder open
+  // in Claude/Cursor writing .md files directly): the doc is already confirmed
+  // on the server ("pushed"), but its file just changed underneath us.
+
+  it("pushes an external edit to an already-pushed note", async () => {
+    const notes = [{ docId: "d1", relPath: "Note.md" }];
+    const first = rig({ files: { "Note.md": "v1" }, notes });
+    await first.uploader.run();
+    expect(first.server.text("d1")).toBe("v1");
+
+    // Claude rewrites the file on disk while nobody has the note open.
+    first.harness.fs.externalWrite("Note.md", "v1 plus an AI edit");
+    const second = rig({
+      files: {},
+      notes,
+      harness: first.harness,
+      server: first.server,
+      pushed: new Set(["d1"]),
+      force: true,
+      ingestFromFile: true,
+    });
+    const result = await second.uploader.run();
+
+    expect(result).toMatchObject({ total: 1, pushed: 1, failed: 0 });
+    expect(second.server.text("d1")).toBe("v1 plus an AI edit");
+  });
+
+  it("skips the network entirely when the file matches the doc (egest echo)", async () => {
+    const notes = [{ docId: "d1", relPath: "Note.md" }];
+    const first = rig({ files: { "Note.md": "steady" }, notes });
+    await first.uploader.run();
+
+    // The watcher fires for our OWN background write: same bytes, no diff.
+    const second = rig({
+      files: {},
+      notes,
+      harness: first.harness,
+      server: first.server,
+      pushed: new Set(["d1"]),
+      force: true,
+      ingestFromFile: true,
+    });
+    const result = await second.uploader.run();
+
+    expect(result).toMatchObject({ total: 1, pushed: 1, failed: 0 });
+    expect(second.connects).toEqual([]); // no provider was ever opened
+    expect(second.server.text("d1")).toBe("steady");
+    expect(second.store.hotSize()).toBe(0); // bridge released on the skip path
+  });
+
+  it("merges an external edit instead of doubling when the server moved too", async () => {
+    const notes = [{ docId: "d1", relPath: "Note.md" }];
+    const first = rig({ files: { "Note.md": "alpha beta" }, notes });
+    await first.uploader.run();
+
+    // A teammate appends on the server; Claude appends in the file. Both must
+    // survive the push (CRDT merge), and nothing may double.
+    first.server.doc("d1").getText("content").insert(0, "THEIRS ");
+    first.harness.fs.externalWrite("Note.md", "alpha beta OURS");
+    const second = rig({
+      files: {},
+      notes,
+      harness: first.harness,
+      server: first.server,
+      pushed: new Set(["d1"]),
+      force: true,
+      ingestFromFile: true,
+    });
+    await second.uploader.run();
+
+    const merged = second.server.text("d1");
+    expect(merged).toContain("THEIRS");
+    expect(merged).toContain("OURS");
+    expect(merged.match(/alpha beta/g)).toHaveLength(1);
+    // The merged text landed back on disk too.
+    expect(second.harness.fs.get("Note.md")).toBe(merged);
+  });
+
+  it("still seeds an empty doc AFTER the pull on ingest runs (split-brain rule)", async () => {
+    // A brand-new file (doc empty, never pushed) going through the local-change
+    // path must behave exactly like the bulk path: pull first, then seed — the
+    // pre-connect ingest is only for docs that already hold content.
+    const server = new FakeServer();
+    server.seed("d1", "server truth");
+    const r = rig({
+      files: { "Note.md": "" },
+      notes: [{ docId: "d1", relPath: "Note.md" }],
+      server,
+      force: true,
+      ingestFromFile: true,
+    });
+    await r.uploader.run();
+
+    expect(r.server.text("d1")).toBe("server truth"); // no doubling, no clobber
+    expect(r.harness.fs.get("Note.md")).toBe("server truth");
+  });
+});
+
+describe("ContentUploader — mustConnect (out-of-band merges)", () => {
+  it("connects and pushes even when file == doc, when the doc is marked diverged", async () => {
+    // A cold apply (or resident bridge) already merged the external edit into
+    // the doc and egested it back, so the file matches the doc — but the merged
+    // ops never reached the server. `mustConnect` is the marker that forces the
+    // flush the fast-path would otherwise skip.
+    const notes = [{ docId: "d1", relPath: "Note.md" }];
+    const first = rig({ files: { "Note.md": "v1" }, notes });
+    await first.uploader.run();
+    expect(first.server.text("d1")).toBe("v1");
+
+    // Simulate the out-of-band merge: local ops land in the CRDT store and the
+    // file, without any provider seeing them (exactly what coldApply's ingest
+    // does when the server sent an unrelated delta).
+    const { NoteBridge } = await import("../../bridge/noteBridge");
+    first.harness.fs.externalWrite("Note.md", "v1 merged-out-of-band");
+    const b = await NoteBridge.open(first.harness.io, { docId: "d1", path: "Note.md" });
+    await b.ingestNow();
+    b.destroy();
+
+    const second = rig({
+      files: {},
+      notes,
+      harness: first.harness,
+      server: first.server,
+      pushed: new Set(["d1"]),
+      force: true,
+      ingestFromFile: true,
+    });
+    // Without the marker: the fast-path skips, and the server never learns.
+    await second.uploader.run();
+    expect(second.server.text("d1")).toBe("v1");
+    expect(second.connects).toEqual([]);
+
+    const third = rig({
+      files: {},
+      notes,
+      harness: first.harness,
+      server: first.server,
+      pushed: new Set(["d1"]),
+      force: true,
+      ingestFromFile: true,
+      mustConnect: () => true,
+    });
+    await third.uploader.run();
+    expect(third.connects).toEqual(["d1"]);
+    expect(third.server.text("d1")).toBe("v1 merged-out-of-band");
   });
 });

--- a/app/apps/desktop/src/lib/sync/contentUpload.ts
+++ b/app/apps/desktop/src/lib/sync/contentUpload.ts
@@ -9,7 +9,11 @@
 //
 // ── The idempotency guarantee (the single most important property) ────────────
 // Re-running this must NOT duplicate a note's text. It cannot, because the only
-// way text ever enters a doc here is `NoteBridge.seedFromFileIfEmpty()`, and:
+// ways text ever enters a doc here are `NoteBridge.seedFromFileIfEmpty()` and —
+// on `ingestFromFile` runs — `NoteBridge.ingestNow()`, whose echo-hash +
+// converged-content guards make a re-run of the same file bytes a no-op (it
+// applies a DIFF against the doc's current text, never an insert of the whole
+// file). For the seed path:
 //
 //   1. it inserts nothing when the Y.Text is already non-empty; and
 //   2. it is called ONLY after the provider's initial server sync has genuinely
@@ -77,6 +81,27 @@ export interface ContentUploaderOptions {
   /** Docs to leave alone — currently the open note, whose own editor session
    *  owns its provider (two providers on one doc is the one thing to avoid). */
   skip?: (docId: string) => boolean;
+  /** Queue every note regardless of the pushed checkpoint. For local-change
+   *  runs: the doc IS confirmed on the server, but its .md just changed on disk
+   *  underneath us, so "pushed" says nothing about the new bytes. */
+  force?: boolean;
+  /**
+   * Merge each note's current file bytes into its doc (`NoteBridge.ingestNow`)
+   * as part of the push — the local-change run's whole reason to exist. Without
+   * it this engine only ever *seeds an empty doc*, so an edit to a note that
+   * already has CRDT content would silently push nothing.
+   *
+   * Split-brain safe: the pre-connect ingest runs ONLY when the doc already has
+   * content (a diff-merge, same as the open editor's ingest); an empty doc
+   * waits for the server pull + `seedFromFileIfEmpty`, exactly like the bulk
+   * path, and a post-sync ingest then folds in any bytes the seed didn't cover.
+   */
+  ingestFromFile?: boolean;
+  /** Veto for the ingest fast-path (see below): true means this doc holds
+   *  local-only ops from an OUT-OF-BAND merge (a resident bridge or a cold
+   *  apply already folded the external edit in), so "the file matches the doc"
+   *  does not mean "nothing to send" — connect and flush regardless. */
+  mustConnect?: (docId: string) => boolean;
   progress?: SyncProgressSink;
   /** Abandon the run (vault switch). Checked before every doc. */
   shouldStop?: () => boolean;
@@ -161,7 +186,9 @@ export class ContentUploader {
     this.aborted = false;
     try {
       const queue = this.opts.notes.filter(
-        (n) => !this.opts.isPushed(n.docId) && !(this.opts.skip?.(n.docId) ?? false),
+        (n) =>
+          (this.opts.force === true || !this.opts.isPushed(n.docId)) &&
+          !(this.opts.skip?.(n.docId) ?? false),
       );
       // Everything already confirmed reads as synced straight away, so the badge
       // for a resumed vault is correct before a single socket opens.
@@ -224,6 +251,26 @@ export class ContentUploader {
       return false;
     }
 
+    let preIngested = false;
+    if (this.opts.ingestFromFile && bridge.serialize().length > 0) {
+      preIngested = true;
+      // Diff-merge the file into the already-populated doc BEFORE any network
+      // work. When nothing changed (our own background egest echoing back
+      // through the watcher, or an edit a previous run already merged) and the
+      // server has confirmed this doc before, there is nothing to send — skip
+      // the socket entirely. That check is what keeps a teammate's every remote
+      // update (which we egest to disk, which fires the watcher) from costing a
+      // provider connect apiece.
+      const changed = await bridge.ingestNow();
+      if (!changed && this.opts.isPushed(docId) && !(this.opts.mustConnect?.(docId) ?? false)) {
+        await this.releaseQuietly(docId);
+        this.streak = 0;
+        this.progress.doc(docId, "synced");
+        this.progress.item("ok");
+        return true;
+      }
+    }
+
     const push = this.opts.deps.connect({ docId, vaultId: this.opts.vaultId, doc: bridge.doc });
     try {
       // PULL FIRST. This is the split-brain rule (spec 03 §5): the server's state
@@ -243,11 +290,21 @@ export class ContentUploader {
       if (!push.readOnly) {
         // Seeds ONLY a genuine orphan (empty Y.Text) — see the module header.
         await bridge.seedFromFileIfEmpty();
+        // A doc that was empty before the pull couldn't take the pre-connect
+        // ingest (that would seed before the server's state — the doubling
+        // bug). Now the server's canonical state is in, fold in whatever the
+        // file holds that the seed didn't cover: e.g. an external write into a
+        // still-unhydrated placeholder file. ONLY when the pre-connect ingest
+        // didn't run: after it has, the file is one merge behind the doc (the
+        // pull just landed server ops the file has never seen), and diffing the
+        // stale file against the merged doc would DELETE those server ops.
+        if (this.opts.ingestFromFile && !preIngested) await bridge.ingestNow();
       }
       const flushed = await push.whenFlushed(this.flushTimeoutMs);
       // Whatever the server had for this doc has landed in the Y.Doc by now;
-      // write it out so the .md on disk matches. (Only the OPEN note ingests
-      // file changes, so this background write has no ingest side to echo off.)
+      // write it out so the .md on disk matches. (The watcher will see this
+      // write, but every ingest side runs behind the bridge's echo-hash guard —
+      // the local-change path recognizes its own bytes and stays quiet.)
       await bridge.flushEgest();
       if (!flushed) {
         this.fail(docId, relPath, "server did not acknowledge the content");

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -59,6 +59,15 @@ function baseName(relPath: string): string {
  */
 const REGISTRY_MAP_PUBLISH_MS = 100;
 
+/**
+ * Quiet window before pushing locally-changed (externally-written) notes. Long
+ * enough that an AI writing a batch of files coalesces into one run; short
+ * enough that a single saved file is on the server within ~a second.
+ */
+const LOCAL_CHANGE_DEBOUNCE_MS = 800;
+/** Re-check interval while a bulk run holds the uploader slot. */
+const LOCAL_CHANGE_RETRY_MS = 2_000;
+
 export interface OpenedDoc {
   awareness: Awareness;
   sync: DocSync | null;
@@ -174,6 +183,17 @@ export class SyncManager implements InboundHost {
   private onDocState?: (patch: Record<string, DocSyncState | null>) => void;
   /** The content upload for the current scope, while one is running. */
   private uploader: ContentUploader | null = null;
+  /** Locally-changed MAPPED notes awaiting a content push (docId → relPath):
+   *  the watcher saw an external writer (an AI, another editor) change their
+   *  .md on disk. Drained by {@link runLocalChangePush}, debounced so a burst
+   *  (an AI writing many files) coalesces into one run. */
+  private localChanges = new Map<string, string>();
+  private localChangeTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Docs holding local-only ops from an out-of-band merge (a resident bridge
+   *  or a cold apply ingested an external edit). For these, "file == doc" does
+   *  NOT mean "nothing to send", so the push must connect regardless. Cleared
+   *  per doc when a push confirms it, wholesale on teardown. */
+  private divergedDocs = new Set<string>();
   /** True while the run is reporting the vault channel's inbound queue. */
   private downloadPhase = false;
   private lastInboundDone = 0;
@@ -471,6 +491,131 @@ export class SyncManager implements InboundHost {
     return this.registryPullTimer != null;
   }
 
+  /**
+   * A watcher `file-changed` event for something OTHER than the open note (App
+   * routes the open note's events into its bridge, whose own provider pushes).
+   *
+   * This is what makes an external writer a first-class editor: people open the
+   * vault folder in an AI tool (Claude, Cursor, a script) that creates and edits
+   * `.md` files directly on disk. Before this hook, those files reached the
+   * server only when a human opened each note — or at the next sign-in's full
+   * reconcile, which is why "sign out and back in" appeared to find unsynced
+   * files. Now:
+   *
+   *  - a path the registry doesn't map (a NEW note), or any structural change
+   *    (`tree`: folders, non-md note files) → the same debounced registry pull a
+   *    teammate's change triggers, which registers it and — via `settleAfterPull`
+   *    — uploads its content;
+   *  - a change to a note we DO map → a debounced content push that diff-merges
+   *    the file into the note's CRDT and sends it (`runLocalChangePush`);
+   *  - a removal → nothing. Deleting a server note stays an explicit act (UI or
+   *    MCP): auto-propagating disk deletions would let `git checkout`-style tree
+   *    churn delete a team's notes.
+   */
+  handleLocalFileChanged(relPath: string, kind: "modified" | "removed" | "tree"): void {
+    const scope = this.scope;
+    if (!this.enabled || !scope || !scope.isCurrent()) return;
+    if (kind === "removed") return;
+    if (kind === "tree") {
+      this.handleRegistryChanged();
+      return;
+    }
+    const mapping = this.registry.getMapping(relPath);
+    if (!mapping) {
+      this.handleRegistryChanged();
+      return;
+    }
+    // Belt and braces with the uploader's own `skip`: the open note's editor
+    // session owns its provider, and its bridge already ingests watcher events.
+    if (this.docStore?.suppressedDoc() === mapping.docId) return;
+    this.localChanges.set(mapping.docId, relPath);
+    this.armLocalChangeDrain(scope, LOCAL_CHANGE_DEBOUNCE_MS);
+    // A doc resident in the hot tier has a LIVE bridge, and its next egest (a
+    // remote update landing) would overwrite the file's new bytes before the
+    // drain runs — merge them into the doc NOW. A genuine merge goes into the
+    // diverged set: the drain's own ingest will then find file == doc, and only
+    // this marker tells it the doc still holds unsent ops.
+    const resident = this.docStore?.peekResident(mapping.docId);
+    if (resident) {
+      void resident
+        .ingestNow()
+        .then((changed) => {
+          if (changed && scope.isCurrent()) this.divergedDocs.add(mapping.docId);
+        })
+        .catch((e) => console.warn("[sync] resident ingest failed", e));
+    }
+  }
+
+  private armLocalChangeDrain(scope: VaultScope, delayMs: number): void {
+    if (this.localChangeTimer) clearTimeout(this.localChangeTimer);
+    this.localChangeTimer = setTimeout(() => {
+      this.localChangeTimer = null;
+      if (!scope.isCurrent()) return;
+      // A bulk run (enable's backfill, or a settle pass) is single-writer on the
+      // uploader slot AND may be about to push these very docs. Wait it out; the
+      // queue survives, so nothing is dropped.
+      if (this.uploader?.isRunning()) {
+        this.armLocalChangeDrain(scope, LOCAL_CHANGE_RETRY_MS);
+        return;
+      }
+      void this.runLocalChangePush(scope).catch((e) =>
+        console.warn("[sync] local change push failed", e),
+      );
+    }, delayMs);
+  }
+
+  /**
+   * Push the queued locally-changed notes: same engine as the bulk backfill, but
+   * `force` (these docs are already "pushed" — that checkpoint says nothing
+   * about the new bytes) and `ingestFromFile` (the change lives in the file, not
+   * the doc). The uploader's echo guard keeps this cheap: a file write that was
+   * our own background egest merges to "no change" and never opens a socket.
+   */
+  private async runLocalChangePush(scope: VaultScope): Promise<void> {
+    const vaultId = this.registry.vaultId;
+    const store = this.docStore;
+    const progress = this.progress;
+    if (!vaultId || !store || !progress) return;
+    const notes = [...this.localChanges].map(([docId, relPath]) => ({ docId, relPath }));
+    this.localChanges.clear();
+    if (notes.length === 0) return;
+
+    const uploader: ContentUploader = new ContentUploader({
+      vaultId,
+      notes,
+      deps: {
+        acquire: (docId, relPath) =>
+          store.promote(docId, relPath, {
+            seedFromFile: false, // pull-before-seed, exactly like the bulk run
+            markRecent: true, // an externally-edited note is genuinely recent
+            pin: true,
+          }),
+        release: (docId) => store.demote(docId),
+        connect: ({ docId, vaultId: collectionId, doc }) =>
+          new DocSync({ api, doc, docId, vaultId: collectionId }),
+      },
+      isPushed: (docId) => this.registry.isPushed(docId),
+      markPushed: (docId) => {
+        this.registry.markPushed(docId);
+        this.divergedDocs.delete(docId); // its local-only ops are now on the server
+      },
+      skip: (docId) => store.suppressedDoc() === docId,
+      force: true,
+      ingestFromFile: true,
+      mustConnect: (docId) => this.divergedDocs.has(docId),
+      progress,
+      shouldStop: (): boolean => !scope.isCurrent() || this.uploader !== uploader,
+    });
+    this.uploader = uploader;
+
+    const result = await uploader.run();
+    if (!scope.isCurrent() || this.uploader !== uploader) return;
+    await this.registry.flushCheckpoint();
+    if (!scope.isCurrent() || this.uploader !== uploader) return;
+    if (result.cancelled) return;
+    this.completeRun(scope);
+  }
+
   // ---- InboundHost: letting go of a doc before its path moves --------------
   //
   // The registry is about to rename or remove a file. Anything still holding the
@@ -730,7 +875,10 @@ export class SyncManager implements InboundHost {
           new DocSync({ api, doc, docId, vaultId: collectionId }),
       },
       isPushed: (docId) => this.registry.isPushed(docId),
-      markPushed: (docId) => this.registry.markPushed(docId),
+      markPushed: (docId) => {
+        this.registry.markPushed(docId);
+        this.divergedDocs.delete(docId); // a confirmed push carries any merged ops
+      },
       // Never touch the open note: its editor session owns a provider for that doc.
       skip: (docId) => store.suppressedDoc() === docId,
       progress,
@@ -861,6 +1009,12 @@ export class SyncManager implements InboundHost {
       clearTimeout(this.registryPullTimer);
       this.registryPullTimer = null;
     }
+    if (this.localChangeTimer) {
+      clearTimeout(this.localChangeTimer);
+      this.localChangeTimer = null;
+    }
+    this.localChanges.clear();
+    this.divergedDocs.clear();
     // The bulk run before the engine it borrows from: `stop()` makes every pool
     // lane drop at its next checkpoint, so nothing is still promoting a bridge
     // when `stopVaultEngine` destroys the store underneath it.
@@ -1045,6 +1199,19 @@ export class SyncManager implements InboundHost {
       // epoch-pinned for the same reason. Without it the engine's `hello` was empty
       // on every launch and the server re-sent the full state of every doc, forever.
       manifest: createIpcManifestStore(scope.vaultEpoch),
+      // A cold apply merged an external disk edit into the doc: those ops are
+      // local-only until pushed, and the local-change drain's own ingest will
+      // see file == doc and try to skip — the diverged set is what forces the
+      // connect (see `handleLocalFileChanged`).
+      onExternalMerge: (docId) => {
+        if (!scope.isCurrent()) return;
+        this.divergedDocs.add(docId);
+        const relPath = this.registry.pathForDocId(docId);
+        if (relPath) {
+          this.localChanges.set(docId, relPath);
+          this.armLocalChangeDrain(scope, LOCAL_CHANGE_DEBOUNCE_MS);
+        }
+      },
     });
     this.docStore = store;
     this.vaultEngine = new VaultSyncEngine({

--- a/app/apps/desktop/src/lib/sync/vaultDocStore.ts
+++ b/app/apps/desktop/src/lib/sync/vaultDocStore.ts
@@ -13,9 +13,13 @@
 //     transient headless bridge, applies + flushes to disk + persists, then
 //     evicts. Cost is paid only when a cold doc actually changes.
 //
-// Background egest can't echo-loop: only the OPEN note ingests file changes
-// (BridgeManager.handleFileChanged), so a background write to a closed note's
-// .md has no ingest side to react to it.
+// Background egest can't echo-loop: the ingest sides that CAN see a background
+// write (the open note's bridge via BridgeManager.handleFileChanged, a resident
+// bridge via the session's local-change routing, and this store's own cold
+// applies) all run behind the bridge's echo-hash guard, which drops the exact
+// bytes egest just wrote. Genuine external writes — an AI editing the vault
+// folder directly — take the same ingest paths and DO merge (see
+// `SyncManager.handleLocalFileChanged` and `onExternalMerge`).
 //
 // The manifest is DURABLE (see `ManifestStore`). It used to be in-memory only, so
 // the engine's `hello` was empty on every launch and the server re-sent the full
@@ -67,6 +71,12 @@ export interface VaultDocStoreOptions {
   resolvePath: (docId: string) => string | null;
   io?: BridgeIO;
   hotCap?: number;
+  /** A cold apply found (and merged) an EXTERNAL edit on disk — bytes the doc
+   *  had never seen, written by something outside the app while no bridge was
+   *  alive. The merged ops are local-only until a provider connects, so the
+   *  session must schedule a content push for this doc (its own local-change
+   *  drain would otherwise see file == doc and skip the network). */
+  onExternalMerge?: (docId: string) => void;
   /** Durable manifest. Defaults to {@link nullManifestStore}. */
   manifest?: ManifestStore;
   /** Injected in tests. */
@@ -85,6 +95,7 @@ interface HotEntry {
 export class VaultDocStore implements DocUpdateSink {
   private readonly io: BridgeIO;
   private readonly resolvePath: (docId: string) => string | null;
+  private readonly onExternalMerge?: (docId: string) => void;
   private readonly hotCap: number;
   private readonly manifest: ManifestStore;
   private readonly setT: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
@@ -118,6 +129,7 @@ export class VaultDocStore implements DocUpdateSink {
   constructor(opts: VaultDocStoreOptions) {
     this.io = opts.io ?? createTauriBridgeIO();
     this.resolvePath = opts.resolvePath;
+    this.onExternalMerge = opts.onExternalMerge;
     this.hotCap = opts.hotCap ?? HOT_DOC_CAP;
     this.manifest = opts.manifest ?? nullManifestStore;
     this.setT = opts.setTimeoutImpl ?? ((fn, ms) => setTimeout(fn, ms));
@@ -383,6 +395,14 @@ export class VaultDocStore implements DocUpdateSink {
     return [...this.coldChains.keys()];
   }
 
+  /** The live resident bridge for a doc, or null. A PEEK — no open, no LRU
+   *  touch, no pin. For routing watcher events into already-hot docs: a
+   *  resident bridge's next egest would overwrite an un-ingested external edit,
+   *  so the session merges the file in the moment the watcher reports it. */
+  peekResident(docId: string): NoteBridge | null {
+    return this.hot.get(docId)?.bridge ?? null;
+  }
+
   private async coldApply(docId: string, update: Uint8Array): Promise<void> {
     const path = this.resolvePath(docId);
     if (!path) return; // unknown doc (not yet materialised) — skip; next reconnect retries
@@ -390,6 +410,16 @@ export class VaultDocStore implements DocUpdateSink {
     // evict. seedFromFile:false — the server feed is the source for background docs.
     const bridge = await NoteBridge.open(this.io, { docId, path, seedFromFile: false });
     try {
+      // Fold in any external edit sitting on disk BEFORE the remote delta lands
+      // and gets egested: the flush below rewrites the file from the doc, and a
+      // file the doc has never ingested (an AI edited it while no bridge was
+      // alive) would be silently overwritten. The doc-non-empty guard keeps an
+      // unhydrated placeholder on the pull-before-seed path (never a pre-sync
+      // seed); converged content makes this a no-op read. A genuine merge is
+      // reported up so the session pushes it (see `onExternalMerge`).
+      if (bridge.serialize().length > 0 && (await bridge.ingestNow())) {
+        this.onExternalMerge?.(docId);
+      }
       bridge.applyRemote(update);
       await bridge.flushEgest();
       this.rememberSv(docId, Y.encodeStateVector(bridge.doc));

--- a/app/apps/desktop/src/lib/syncRollup.ts
+++ b/app/apps/desktop/src/lib/syncRollup.ts
@@ -35,6 +35,12 @@ export interface FolderSyncSummary {
   /** `synced / total` as a whole percentage, floored (so it reads 99% at 499/500
    *  and only ever reads 100% when everything really is synced). */
   percent: number;
+  /** Progress through the CURRENT wave of not-yet-synced notes, stamped by
+   *  {@link FolderWaveTracker.apply}. Absent when no tracker ran or the folder
+   *  is settled. This is what the row badge renders: "1/2" meaning "1 of the 2
+   *  notes that need syncing", never "1113/1114" — the folder's whole
+   *  population is the tooltip's job, not the badge's. */
+  wave?: { done: number; total: number };
 }
 
 export interface TreeSyncIndex {
@@ -149,13 +155,61 @@ export function buildTreeSyncIndex(input: TreeSyncInput): TreeSyncIndex {
   return { notes, folders, vault };
 }
 
+/**
+ * Remembers, per folder, how big the CURRENT wave of not-yet-synced notes got,
+ * so the badge can show progress through the files that actually need syncing.
+ *
+ * Stateless roll-ups can't do this: once a note syncs it stops being "remaining",
+ * so remaining-only counts run 2 → 1 → dot with no sense of progress, and
+ * whole-population counts ("1113/1114") drown one new file in the folder's
+ * entire history. The tracker pins the wave's denominator at the largest
+ * remaining count seen since the folder was last settled; a folder that settles
+ * (everything synced) forgets its wave, so the next external write starts a
+ * fresh "0/1" rather than resuming an old count.
+ *
+ * One instance should live as long as the vault view (the sidebar keeps one in
+ * a ref and resets it on vault switch).
+ */
+export class FolderWaveTracker {
+  /** folder path ("" = vault root) → the wave's pinned denominator. */
+  private waves = new Map<string, number>();
+
+  /** Forget everything (vault switch / sync toggled off). */
+  reset(): void {
+    this.waves.clear();
+  }
+
+  /** Stamp `wave` progress onto every unsettled folder of a freshly-built
+   *  index, and forget folders that settled or disappeared. Call once per
+   *  {@link buildTreeSyncIndex} result, before rendering rows from it. */
+  apply(index: TreeSyncIndex): void {
+    // Prune first: a settled folder's next wave must start from zero, and a
+    // deleted folder must not pin memory forever.
+    for (const key of [...this.waves.keys()]) {
+      const s = key === "" ? index.vault : index.folders.get(key);
+      if (!s || s.total - s.synced <= 0) this.waves.delete(key);
+    }
+    const stamp = (path: string, s: FolderSyncSummary): void => {
+      const remaining = s.total - s.synced;
+      if (remaining <= 0) return;
+      const wave = Math.max(this.waves.get(path) ?? 0, remaining);
+      this.waves.set(path, wave);
+      s.wave = { done: wave - remaining, total: wave };
+    };
+    for (const [path, s] of index.folders) stamp(path, s);
+    if (index.vault) stamp("", index.vault);
+  }
+}
+
 /** What to draw on one sidebar row. `null` ⇒ draw nothing at all. */
 export interface RowSyncMark {
   state: DocSyncState;
-  /** Render "synced/total" (e.g. "1/2") instead of a dot, for folders that
-   *  aren't settled. Real counts, not a percentage: "0%" on a one-note folder
-   *  read as gibberish, where "1/2" answers the actual question. */
-  progress: { synced: number; total: number } | null;
+  /** Render "done/total" (e.g. "1/2") instead of a dot, for folders that
+   *  aren't settled. Counts the current WAVE of notes needing sync (see
+   *  {@link FolderWaveTracker}), not the folder's whole population. Real
+   *  counts, not a percentage: "0%" on a one-note folder read as gibberish,
+   *  where "1/2" answers the actual question. */
+  progress: { done: number; total: number } | null;
   /** Tooltip / accessible label. */
   title: string;
 }
@@ -189,11 +243,12 @@ export function folderSyncTitle(s: FolderSyncSummary): string {
  * a file that isn't a synced note (an image, an unmapped page), or a folder that
  * contains no notes at all.
  *
- * A folder shows "synced/total" until it is settled, then a single dot — which
- * is what makes "are all my folders synced?" answerable at a glance: a column
- * of quiet dots means yes, any "1/2" in it says exactly where things stand.
- * (Previously a percentage, which read as gibberish on small folders — one
- * unsynced note out of one rendered "0%".)
+ * A folder shows "done/total" of its current sync wave until it is settled,
+ * then a single dot — which is what makes "are all my folders synced?"
+ * answerable at a glance: a column of quiet dots means yes, any "1/2" in it
+ * says exactly where things stand. (Previously the folder's whole population —
+ * "1113/1114" — which buried the one file that was actually moving; and before
+ * that a percentage, which read as gibberish on small folders.)
  */
 export function rowSyncMark(
   row: { path: string; isDir: boolean },
@@ -205,7 +260,11 @@ export function rowSyncMark(
     const settled = summary.state === "synced" || summary.state === "error";
     return {
       state: summary.state,
-      progress: settled ? null : { synced: summary.synced, total: summary.total },
+      progress: settled
+        ? null
+        : // No tracker ran (no `apply` call) ⇒ fall back to the wave a fresh
+          // tracker would report: everything unsynced right now, none done.
+          (summary.wave ?? { done: 0, total: summary.total - summary.synced }),
       title: folderSyncTitle(summary),
     };
   }

--- a/app/apps/desktop/src/lib/vault/seed.ts
+++ b/app/apps/desktop/src/lib/vault/seed.ts
@@ -11,6 +11,11 @@
 // rather than `create_note` (which would prepend its own H1), so we control the
 // exact Markdown. `write_note` creates any missing parent folder, so each note
 // materializes its folder on its own.
+//
+// Prose is deliberately NOT hard-wrapped: the editor renders a source newline
+// as a line break, so wrapped-at-80 templates froze every paragraph at an old
+// column width. One logical line per paragraph / list item lets the text flow
+// to whatever measure the editor has.
 
 import * as ipc from "../ipc";
 import type { TreeNode } from "../ipc";
@@ -30,17 +35,13 @@ export const STARTER_NOTES: ReadonlyArray<{ path: string; body: string }> = [
     path: WELCOME_NOTE_PATH,
     body: `# Welcome to Baalda 👋
 
-Baalda is your **local-first second brain** — notes that live as plain Markdown
-files on your own computer.
+Baalda is your **local-first second brain** — notes that live as plain Markdown files on your own computer.
 
 What makes it different:
 
-- **Your files, your disk.** Every note is a real \`.md\` file in this folder. No
-  lock-in — open them in any editor, back them up, sync them however you like.
-- **Write together, live.** Invite teammates and edit the same note at the same
-  time, with cursors and presence — like a shared doc, but still just files.
-- **Your AI can edit too.** Connect an assistant like Claude and let it read and
-  write these notes directly, right alongside you.
+- **Your files, your disk.** Every note is a real \`.md\` file in this folder. No lock-in — open them in any editor, back them up, sync them however you like.
+- **Write together, live.** Invite teammates and edit the same note at the same time, with cursors and presence — like a shared doc, but still just files.
+- **Your AI can edit too.** Connect an assistant like Claude and let it read and write these notes directly, right alongside you.
 
 Most tools give you one of these. Baalda is the bridge between all three.
 
@@ -50,8 +51,7 @@ Most tools give you one of these. Baalda is the bridge between all three.
 - 🚀 [[How Baalda works]] — a two-minute tour of the essentials.
 - 🕸️ [[The graph view]] — see how these notes connect.
 
-> These starter notes are already linked together, which is why your graph
-> isn't empty. Delete them whenever you like — this is your space.
+> These starter notes are already linked together, which is why your graph isn't empty. Delete them whenever you like — this is your space.
 
 Happy writing. ✍️
 `,
@@ -61,9 +61,7 @@ Happy writing. ✍️
     path: "Map of Content.md",
     body: `# Map of Content
 
-A **Map of Content** (MOC) is a note whose only job is to link to other notes.
-It's how you navigate a vault by hand instead of by folders. This one indexes
-your starter set — see [[Maps of Content]] for the idea behind it.
+A **Map of Content** (MOC) is a note whose only job is to link to other notes. It's how you navigate a vault by hand instead of by folders. This one indexes your starter set — see [[Maps of Content]] for the idea behind it.
 
 ## Getting started
 
@@ -99,27 +97,19 @@ your starter set — see [[Maps of Content]] for the idea behind it.
     path: "Getting Started/How Baalda works.md",
     body: `# How Baalda works
 
-A quick tour of the essentials. This whole note is just a Markdown file — try
-editing it as you read.
+A quick tour of the essentials. This whole note is just a Markdown file — try editing it as you read.
 
 ## 1. Everything is a file
 
-Notes are plain \`.md\` files in this folder. Create one with **⌘N**, organise
-them in the sidebar, and connect them with [[Wikilinks and backlinks]]. See
-[[Local-first notes]] for why that matters, and [[Keyboard shortcuts]] to move
-faster.
+Notes are plain \`.md\` files in this folder. Create one with **⌘N**, organise them in the sidebar, and connect them with [[Wikilinks and backlinks]]. See [[Local-first notes]] for why that matters, and [[Keyboard shortcuts]] to move faster.
 
 ## 2. Work together in real time
 
-This vault starts out **local** — just files on this computer. Sign in and
-turn on sync to keep it updated across your own devices, or accept a
-teammate's invite to collaborate on theirs — more in
-[[Collaborating with your team]].
+This vault starts out **local** — just files on this computer. Sign in and turn on sync to keep it updated across your own devices, or accept a teammate's invite to collaborate on theirs — more in [[Collaborating with your team]].
 
 ## 3. Bring in your AI
 
-Baalda speaks **MCP**, so an assistant like Claude can work in your vault
-directly — see [[Working with your AI]].
+Baalda speaks **MCP**, so an assistant like Claude can work in your vault directly — see [[Working with your AI]].
 
 When you're ready, the [[Map of Content]] links to everything else.
 `,
@@ -138,39 +128,37 @@ The handful worth memorising first:
 | Bold / italic | **⌘B** / **⌘I** |
 | Insert a \`[[wikilink]]\` | type \`[[\` |
 
-Typing \`[[\` starts a link — that's the core move behind
-[[Wikilinks and backlinks]]. Back to [[How Baalda works]].
+Typing \`[[\` anywhere starts a link.
+
+That's the core move behind [[Wikilinks and backlinks]]. Back to [[How Baalda works]].
 `,
   },
   {
     path: "Getting Started/Working with your AI.md",
     body: `# Working with your AI
 
-Baalda exposes your vault over **MCP**, so an assistant like **Claude** (in
-Claude Desktop or Cowork) can read and write these notes directly.
+Baalda exposes your vault over **MCP**, so an assistant like **Claude** (in Claude Desktop or Cowork) can read and write these notes directly.
 
 1. Open **Vault Settings → MCP** and create a connection token.
 2. Add it to Claude as an MCP server.
-3. Ask Claude to search, summarise, and write notes — its edits appear here
-   live, exactly the way a teammate's would (see [[Collaborating with your team]]).
+3. Ask Claude to search, summarise, and write notes — its edits appear here live, exactly the way a teammate's would (see [[Collaborating with your team]]).
 
-Good first tasks: turn your [[Ideas inbox]] into [[Atomic notes]], or draft a
-[[Weekly review]]. Back to [[How Baalda works]].
+You can also just open this folder in a coding assistant like Claude Code — files it writes here sync like any other edit.
+
+Good first tasks: turn your [[Ideas inbox]] into [[Atomic notes]], or draft a [[Weekly review]]. Back to [[How Baalda works]].
 `,
   },
   {
     path: "Getting Started/Collaborating with your team.md",
     body: `# Collaborating with your team
 
-Turn on sync and this vault stops being local-only — it stays updated across
-your own devices and with everyone you invite, live.
+Turn on sync and this vault stops being local-only — it stays updated across your own devices and with everyone you invite, live.
 
 - Open the same note as a teammate and you'll see each other's cursors.
 - Edits **merge** in real time — nothing gets overwritten.
 - Share a single folder or the whole vault; permissions are per-folder.
 
-Try it on [[Meeting notes]] or a [[Website launch]] plan. Your AI joins the same
-way — see [[Working with your AI]]. Back to [[How Baalda works]].
+Try it on [[Meeting notes]] or a [[Website launch]] plan. Your AI joins the same way — see [[Working with your AI]]. Back to [[How Baalda works]].
 `,
   },
 
@@ -179,75 +167,54 @@ way — see [[Working with your AI]]. Back to [[How Baalda works]].
     path: "Concepts/Local-first notes.md",
     body: `# Local-first notes
 
-**Local-first** means the source of truth lives on *your* device, not a server.
-Your notes are plain \`.md\` files you fully own — they work offline, open in any
-editor, and sync only when you choose.
+**Local-first** means the source of truth lives on *your* device, not a server. Your notes are plain \`.md\` files you fully own — they work offline, open in any editor, and sync only when you choose.
 
-Syncing is additive, not a dependency: turn it on for
-[[Collaborating with your team]], turn it off and everything still works. This is
-the foundation the rest of [[How Baalda works]] builds on.
+Syncing is additive, not a dependency: turn it on for [[Collaborating with your team]], turn it off and everything still works. This is the foundation the rest of [[How Baalda works]] builds on.
 `,
   },
   {
     path: "Concepts/Wikilinks and backlinks.md",
     body: `# Wikilinks and backlinks
 
-A **wikilink** connects one note to another: write \`[[Atomic notes]]\` and it
-becomes a link. The note you link *to* automatically gains a **backlink** —
-a list of everything pointing at it.
+A **wikilink** connects one note to another: write \`[[Atomic notes]]\` and it becomes a link. The note you link *to* automatically gains a **backlink** — a list of everything pointing at it.
 
-Links are the real structure of a vault (folders are secondary). Enough of them
-and you get [[The graph view]], and you can curate them by hand with
-[[Maps of Content]]. This idea powers [[Atomic notes]] and [[Daily notes]].
+Links are the real structure of a vault (folders are secondary). Enough of them and you get [[The graph view]], and you can curate them by hand with [[Maps of Content]]. This idea powers [[Atomic notes]] and [[Daily notes]].
 `,
   },
   {
     path: "Concepts/Maps of Content.md",
     body: `# Maps of Content
 
-A **Map of Content** (MOC) is a note that links to a cluster of related notes —
-a table of contents you write by hand. Use one whenever a topic grows past a few
-notes.
+A **Map of Content** (MOC) is a note that links to a cluster of related notes — a table of contents you write by hand. Use one whenever a topic grows past a few notes.
 
-They pair naturally with [[Wikilinks and backlinks]]: the MOC links out, the
-backlinks point home. Your vault's top-level MOC is the [[Map of Content]]. See
-also [[Atomic notes]].
+They pair naturally with [[Wikilinks and backlinks]]: the MOC links out, the backlinks point home. Your vault's top-level MOC is the [[Map of Content]]. See also [[Atomic notes]].
 `,
   },
   {
     path: "Concepts/Atomic notes.md",
     body: `# Atomic notes
 
-An **atomic note** holds *one* idea, titled so you can link to it later. Small
-notes recombine — one idea can support many others through
-[[Wikilinks and backlinks]].
+An **atomic note** holds *one* idea, titled so you can link to it later. Small notes recombine — one idea can support many others through [[Wikilinks and backlinks]].
 
-It's the core habit from [[How to Take Smart Notes]]. Capture rough thoughts in
-your [[Ideas inbox]] first, then split them into atomic notes. Gather related
-ones under [[Maps of Content]].
+It's the core habit from [[How to Take Smart Notes]]. Capture rough thoughts in your [[Ideas inbox]] first, then split them into atomic notes. Gather related ones under [[Maps of Content]].
 `,
   },
   {
     path: "Concepts/Daily notes.md",
     body: `# Daily notes
 
-A **daily note** is one page per day — a log, a scratchpad, a landing spot for
-whatever comes up. Link out from it liberally with [[Wikilinks and backlinks]].
+A **daily note** is one page per day — a log, a scratchpad, a landing spot for whatever comes up. Link out from it liberally with [[Wikilinks and backlinks]].
 
-Daily notes feed two rhythms: drop half-formed thoughts into your
-[[Ideas inbox]], and roll the week up in your [[Weekly review]].
+Daily notes feed two rhythms: drop half-formed thoughts into your [[Ideas inbox]], and roll the week up in your [[Weekly review]].
 `,
   },
   {
     path: "Concepts/The graph view.md",
     body: `# The graph view
 
-The **graph** draws every note as a node and every [[Wikilinks and backlinks]]
-connection as an edge. Press **⌘G** (see [[Keyboard shortcuts]]) to open it.
+The **graph** draws every note as a node and every [[Wikilinks and backlinks]] connection as an edge. Press **⌘G** (see [[Keyboard shortcuts]]) to open it.
 
-It's a fast way to *see* your thinking: clusters are topics, hubs are your
-[[Maps of Content]], and lonely nodes are notes worth linking. The vault you're
-reading now is why your graph isn't empty. Back to the [[Map of Content]].
+It's a fast way to *see* your thinking: clusters are topics, hubs are your [[Maps of Content]], and lonely nodes are notes worth linking. The vault you're reading now is why your graph isn't empty. Back to the [[Map of Content]].
 `,
   },
 
@@ -256,8 +223,7 @@ reading now is why your graph isn't empty. Back to the [[Map of Content]].
     path: "Examples/Reading list.md",
     body: `# Reading list
 
-A living list. Each book becomes its own note once you start taking
-[[Atomic notes]] from it.
+A living list. Each book becomes its own note once you start taking [[Atomic notes]] from it.
 
 - 📖 [[How to Take Smart Notes]] — Sönke Ahrens *(reading)*
 - 📕 *Building a Second Brain* — Tiago Forte *(next)*
@@ -275,10 +241,8 @@ Notes on Sönke Ahrens' book — the case for the *Zettelkasten* method.
 ## Key ideas
 
 - Write **[[Atomic notes]]** in your own words — one idea each.
-- Link every note to others so ideas find each other later
-  ([[Wikilinks and backlinks]]).
-- Don't file by folder; let structure emerge, then curate with
-  [[Maps of Content]].
+- Link every note to others so ideas find each other later ([[Wikilinks and backlinks]]).
+- Don't file by folder; let structure emerge, then curate with [[Maps of Content]].
 
 Part of the [[Reading list]].
 `,
@@ -295,8 +259,7 @@ A tiny project note, to show how work lives in the vault.
 - [ ] Design review — notes in [[Meeting notes]]
 - [ ] Ship 🚀
 
-Progress gets summarised in the [[Weekly review]]; coordinate with the team via
-[[Collaborating with your team]].
+Progress gets summarised in the [[Weekly review]]; coordinate with the team via [[Collaborating with your team]].
 `,
   },
   {
@@ -322,15 +285,13 @@ Everyone edits this live — see [[Collaborating with your team]].
     path: "Examples/Ideas inbox.md",
     body: `# Ideas inbox
 
-A single place to dump raw thoughts fast, so nothing gets lost. Process it later
-into [[Atomic notes]] — that's the habit from [[How to Take Smart Notes]].
+A single place to dump raw thoughts fast, so nothing gets lost. Process it later into [[Atomic notes]] — that's the habit from [[How to Take Smart Notes]].
 
 - A graph filter for orphan notes?
 - Blog post: what "local-first" really means → [[Local-first notes]]
 - Follow up on the [[Website launch]] copy
 
-Empty this out during your [[Weekly review]]; it often fills from your
-[[Daily notes]].
+Empty this out during your [[Weekly review]]; it often fills from your [[Daily notes]].
 `,
   },
   {

--- a/app/apps/desktop/src/styles/tokens.css
+++ b/app/apps/desktop/src/styles/tokens.css
@@ -81,6 +81,15 @@
   --sp-8: 32px;
   --sp-10: 40px;
 
+  /* The editor's prose column. One pair of tokens so the CM6 theme
+     (`lib/editor/theme.ts`) and the loading skeleton (`components/editor.css`)
+     can never drift — the skeleton must land exactly where the real text does.
+     Wide on purpose: the content should fill most of the window, with
+     `--editor-gutter` as the minimum breathing room at each edge on narrow
+     windows (see the `max(...)` the consumers wrap these in). */
+  --editor-measure: 120ch;
+  --editor-gutter: 64px;
+
   /* Height to keep clear at the very top of the window for system window
      controls. Zero everywhere the OS still draws its own title bar above the
      webview; only macOS runs `titleBarStyle: "Overlay"`, where the webview owns


### PR DESCRIPTION
Files created or edited directly on disk by an external tool (an AI with the vault folder open in Claude Code/Cowork/Cursor, another editor, a script) now reach the server live — previously they synced only when the note was opened in the editor or at the next sign-in's full reconcile, which is why sign-out/sign-in appeared to \"find\" unsynced files.

## Sync
- `SyncManager.handleLocalFileChanged`: watcher events for non-open notes route to the sync layer. Unmapped paths and structural changes trigger the debounced registry pull (register + upload via the settle pass); mapped notes get a debounced content push.
- `ContentUploader` gains `force`, `ingestFromFile`, and `mustConnect`: local-change runs diff-merge the file into the CRDT (`NoteBridge.ingestNow`) and push. The echo-hash fast path keeps our own background egest writes from opening sockets.
- `NoteBridge.hydrate` ingests the file on reopen when it changed while the doc was closed (disk is the durable source of truth).
- Cold applies ingest pending external disk edits before egesting, so a remote update can no longer overwrite an un-ingested external edit; out-of-band merges land in a diverged-docs set that forces the next push to connect even when file == doc.
- Disk deletions are deliberately NOT propagated to the server — deletes stay explicit (UI/MCP).

## UI
- Folder sync badges count the current wave of files that need syncing (0/1, 1/2 → dot) instead of the folder's whole population (1113/1114). Tooltip keeps the full counts.
- Editor prose column widened to a 120ch measure with a 64px minimum gutter, shared via tokens so the skeleton can't drift.
- Starter notes unwrapped: hard-wrapped-at-80 templates froze paragraphs at the old column width; one logical line per paragraph lets them flow to any measure.

## Tests
15 new tests: ingestNow semantics (immediate merge, echo drop, debounce supersede), local-change uploader runs (external edit push, echo skip without a socket, concurrent server+local merge without doubling, split-brain seed ordering, mustConnect), reopen-after-external-edit, and wave-tracker badge behavior. 635 desktop tests pass.

Version bumped to 0.1.36 (all four files) so the merge ships.