### PR TITLE
Share popover copy hotfix

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.37"
+version = "0.1.38"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -172,17 +172,14 @@ button.primary.hero:hover:not(:disabled) {
   bottom: auto;
   right: 0;
   left: auto;
-  width: 280px;
+  width: 400px;
 }
-.share-fallback-url {
+/* The minted url as a click-to-copy row (shown only when the automatic
+   clipboard write failed). The label carries the FULL url — the click copies
+   that, never the ellipsized text. */
+.share-fallback-url .menu-item-label {
   font-size: var(--fs-xs);
   color: var(--text-secondary);
-  padding: var(--sp-1) var(--sp-2);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  user-select: all;
-  -webkit-user-select: all;
 }
 .share-btn.copied {
   color: var(--success);

--- a/app/apps/desktop/src/components/ShareNoteButton.tsx
+++ b/app/apps/desktop/src/components/ShareNoteButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ApiError, type PublicLink } from "../lib/api";
 import { authManager } from "../lib/auth/authManager";
+import { copyText } from "../lib/clipboard";
 import { buildNoteLink } from "../lib/shareLink";
 import { toast } from "../lib/toast";
 import { useStore } from "../store";
@@ -29,9 +30,10 @@ export function ShareNoteButton({ docId }: { docId: string }) {
   const [copied, setCopied] = useState(false);
   const [existing, setExisting] = useState<PublicLink | null | "loading">(null);
   const [publicBusy, setPublicBusy] = useState(false);
-  // Clipboard write failed after the link was minted: show the url for a
-  // manual copy instead of losing it behind an error toast.
+  // Clipboard write failed after the link was minted: show the url as a
+  // click-to-copy row instead of losing it behind an error toast.
   const [fallbackUrl, setFallbackUrl] = useState<string | null>(null);
+  const [fallbackCopied, setFallbackCopied] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
   // The tick is a state, so it has to be cleared — otherwise switching notes
@@ -45,7 +47,13 @@ export function ShareNoteButton({ docId }: { docId: string }) {
     setCopied(false);
     setOpen(false);
     setFallbackUrl(null);
+    setFallbackCopied(false);
   }, [docId]);
+  useEffect(() => {
+    if (!fallbackCopied) return;
+    const id = window.setTimeout(() => setFallbackCopied(false), 1600);
+    return () => window.clearTimeout(id);
+  }, [fallbackCopied]);
 
   // Close on outside click or Escape (the AccountMenu popover pattern).
   useEffect(() => {
@@ -90,12 +98,11 @@ export function ShareNoteButton({ docId }: { docId: string }) {
     // clickable, where a bare baalda:// scheme had to be copy-pasted. The
     // server's /open/note page bounces the click into the app.
     const link = buildNoteLink({ orgId, docId }, useStore.getState().serverUrl);
-    try {
-      await navigator.clipboard.writeText(link);
+    if (await copyText(link)) {
       setCopied(true);
       setOpen(false);
       toast("Link copied — anyone on your team with access can open it");
-    } catch {
+    } else {
       toast("Couldn't copy the link", "error");
     }
   };
@@ -106,11 +113,10 @@ export function ShareNoteButton({ docId }: { docId: string }) {
     try {
       const link = await authManager.api.createPublicLink(docId);
       setExisting(link);
-      try {
-        await navigator.clipboard.writeText(link.url);
-      } catch {
-        // The link exists now even though the clipboard write failed — surface
-        // it in the popover rather than stranding it behind an error.
+      if (!(await copyText(link.url))) {
+        // The link exists now even though both clipboard paths failed —
+        // surface it as a click-to-copy row rather than stranding it behind
+        // an error (the fresh click carries its own user activation).
         setFallbackUrl(link.url);
         return;
       }
@@ -191,9 +197,23 @@ export function ShareNoteButton({ docId }: { docId: string }) {
             )}
           </button>
           {fallbackUrl && (
-            <div className="share-fallback-url" title={fallbackUrl}>
-              {fallbackUrl}
-            </div>
+            <button
+              className="menu-item share-fallback-url"
+              title="Copy the public link"
+              onClick={() => {
+                void copyText(fallbackUrl).then((ok) => {
+                  if (ok) {
+                    setFallbackCopied(true);
+                    toast("Public link copied — anyone with this link can view this note");
+                  } else {
+                    toast("Couldn't copy the link", "error");
+                  }
+                });
+              }}
+            >
+              <span className="menu-item-label">{fallbackUrl}</span>
+              {fallbackCopied ? <CheckMark size="xs" /> : <span className="menu-hint">Copy</span>}
+            </button>
           )}
           {existing !== null && existing !== "loading" && (
             <>

--- a/app/apps/desktop/src/lib/clipboard.ts
+++ b/app/apps/desktop/src/lib/clipboard.ts
@@ -1,0 +1,33 @@
+/**
+ * Clipboard write that survives an `await` before it.
+ *
+ * WebKit ties `navigator.clipboard.writeText` to transient user activation,
+ * and an async hop (e.g. the API call that MINTS the link being copied) can
+ * outlive it — the write then rejects even though the user really did click.
+ * The hidden-textarea + `execCommand("copy")` path doesn't carry that
+ * restriction in the wkwebview, so it is the fallback. Returns whether ANY
+ * path succeeded; callers decide what to show when both fail.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    /* fall through to execCommand */
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    // Off-screen but focusable; `readonly` stops the iOS-style keyboard flash.
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
+- Copying a public link now lands on the clipboard reliably — and if the popover ever shows the link itself, clicking it copies the full URL with a checkmark
 - The share button now offers two links: **Private** for teammates, and **Public** — a read-only page anyone can open in a browser, images included
 - Public links can be disabled anytime from the same menu — the old link stops working immediately
 - Opening a shared link while signed out now brings up sign-in and opens the note right after, instead of dropping you on the home screen
 - Shared links now ride out a vault's first sync (and say so), instead of failing on big or slow vaults
-- Access is now your whole vault as a tree — expand a folder and set permissions on the notes inside it


### PR DESCRIPTION
Hotfix for the share popover shipped in #67:

- **Copy actually copies.** `navigator.clipboard.writeText` was rejected in the wkwebview because the `await` that mints the public link outlives WebKit's transient user activation — so the copy failed every time and the raw URL row appeared. New `lib/clipboard.ts` `copyText()` falls back to the hidden-textarea `execCommand("copy")` path, which doesn't carry that restriction. Both copy rows use it.
- **The fallback URL row is now click-to-copy** — it copies the full URL (never the ellipsized text) and shows a checkmark, instead of being an inert selectable label.
- **Wider popover** (280px → 400px) so the hints and URL aren't truncated to uselessness.
- Version bump → **0.1.38**, release notes updated (new item on top, capped at 5).

Tests: desktop 645/645 pass, typecheck clean.