### PR TITLE
Public page polish, one-click copy, frozen-root feedback

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -28,6 +28,7 @@
     "@lezer/highlight": "^1.2.3",
     "@lezer/markdown": "^1.7.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -69,6 +69,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +511,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -761,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "keyring",
  "notify",
@@ -774,6 +810,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
@@ -881,12 +918,18 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1014,6 +1057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1163,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1348,6 +1415,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,6 +1607,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1837,6 +1934,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2252,6 +2363,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2422,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "notify"
@@ -2386,6 +2516,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2624,6 +2755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +2837,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2908,6 +3060,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3970,6 +4134,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,6 +4453,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4614,6 +4807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4897,6 +5101,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,6 +5280,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5546,6 +5826,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5615,6 +5913,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -5807,6 +6122,21 @@ name = "zmij"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.38"
+version = "0.1.39"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"
@@ -21,6 +21,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-process = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/app/apps/desktop/src-tauri/capabilities/default.json
+++ b/app/apps/desktop/src-tauri/capabilities/default.json
@@ -20,6 +20,10 @@
     "updater:default",
     "process:default",
     {
+      "identifier": "clipboard-manager:allow-write-text",
+      "comment": "Write-only clipboard for copy-link actions. navigator.clipboard rejects writes once an await has outlived WebKit's transient user activation (exactly what happens when the click first mints the link server-side); the native call is gesture-free. Read stays ungranted — the app never needs to see the clipboard."
+    },
+    {
       "identifier": "core:window:allow-set-focus",
       "comment": "A `baalda://` note link has to bring the window forward — a link that navigates a window the user can't see is the same as a link that did nothing. `core:default` grants only read-only window commands, so the three commands the deep-link handler needs are listed explicitly rather than by widening it."
     },

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -36,6 +36,10 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
+        // Native clipboard: the webview's navigator.clipboard is tied to
+        // WebKit's transient user activation, which an await (e.g. minting a
+        // share link) outlives — a native call has no such rule.
+        .plugin(tauri_plugin_clipboard_manager::init())
         // `baalda://` links. A teammate pastes one into chat; clicking it hands
         // the URL to this app, which resolves it against the *recipient's* own
         // account and access — the link carries ids, never content or a grant.

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -172,7 +172,7 @@ button.primary.hero:hover:not(:disabled) {
   bottom: auto;
   right: 0;
   left: auto;
-  width: 400px;
+  width: 340px;
 }
 /* The minted url as a click-to-copy row (shown only when the automatic
    clipboard write failed). The label carries the FULL url — the click copies
@@ -1131,6 +1131,12 @@ body:has(.sidebar-resizer.dragging) {
   transition:
     background var(--t-fast) var(--ease),
     color var(--t-fast) var(--ease);
+}
+/* Frozen-root: reads as unavailable but still takes the click, so the toast
+   in `rootBlocked` can say WHY instead of the button silently doing nothing. */
+.filetree-actions .tree-tool.blocked {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 .filetree-actions .tree-tool:hover {
   background: var(--bg-hover);

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -1202,20 +1202,24 @@ export function FileTree() {
       <div className="filetree-head">
         <span className="section-label">Notes</span>
         <div className="filetree-actions">
+          {/* Dimmed but NOT `disabled` while the root is frozen: a disabled
+              button swallows the click, so the only explanation was a tooltip
+              that needs a patient hover. The click routes through
+              `rootBlocked("")`, which toasts the reason immediately. */}
           <button
-            className="tree-tool"
+            className={`tree-tool${rootFrozen ? " blocked" : ""}`}
             title={rootFrozen ? ROOT_FROZEN_HINT : "New note"}
             aria-label="New note"
-            disabled={rootFrozen}
+            aria-disabled={rootFrozen}
             onClick={() => createUniqueNote("")}
           >
             {ICON_NEW_NOTE}
           </button>
           <button
-            className="tree-tool"
+            className={`tree-tool${rootFrozen ? " blocked" : ""}`}
             title={rootFrozen ? ROOT_FROZEN_HINT : "New folder"}
             aria-label="New folder"
-            disabled={rootFrozen}
+            aria-disabled={rootFrozen}
             onClick={() => createUniqueFolder("")}
           >
             {ICON_NEW_FOLDER}

--- a/app/apps/desktop/src/lib/clipboard.ts
+++ b/app/apps/desktop/src/lib/clipboard.ts
@@ -4,11 +4,19 @@
  * WebKit ties `navigator.clipboard.writeText` to transient user activation,
  * and an async hop (e.g. the API call that MINTS the link being copied) can
  * outlive it — the write then rejects even though the user really did click.
- * The hidden-textarea + `execCommand("copy")` path doesn't carry that
- * restriction in the wkwebview, so it is the fallback. Returns whether ANY
- * path succeeded; callers decide what to show when both fail.
+ * The native Tauri clipboard has no such rule, so it goes first; the web API
+ * and the hidden-textarea `execCommand("copy")` path are fallbacks (and what
+ * runs under vitest, where the plugin import fails). Returns whether ANY path
+ * succeeded; callers decide what to show when all fail.
  */
 export async function copyText(text: string): Promise<boolean> {
+  try {
+    const { writeText } = await import("@tauri-apps/plugin-clipboard-manager");
+    await writeText(text);
+    return true;
+  } catch {
+    /* not running under Tauri (tests, plain browser) — fall through */
+  }
   try {
     await navigator.clipboard.writeText(text);
     return true;

--- a/app/apps/server/src/http/routes/public-links.ts
+++ b/app/apps/server/src/http/routes/public-links.ts
@@ -200,25 +200,60 @@ function esc(s: string): string {
 }
 
 const PAGE_CSS = `
-  :root { color-scheme: light; }
+  :root {
+    --bg-app: #ececf0; --bg-surface: #ffffff;
+    --text-primary: #1a1a1e; --text-secondary: #6b6b76;
+    --border: rgba(20, 20, 40, 0.09); --code-bg: #f1f1f4;
+    --accent: #6d5ae6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg-app: #101014; --bg-surface: #1d1d24;
+      --text-primary: #f2f2f5; --text-secondary: #a6a6b2;
+      --border: rgba(255, 255, 255, 0.09); --code-bg: #26262e;
+      --accent: #8d7cf0;
+    }
+  }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-         margin: 0; background: #f6f5f2; color: #2a2a28; line-height: 1.6; }
-  main { max-width: 44rem; margin: 0 auto; padding: 3rem 1.5rem 4rem; }
+         margin: 0; background: var(--bg-app); color: var(--text-primary);
+         line-height: 1.65; -webkit-font-smoothing: antialiased; }
+  /* The app's editor sheet: a centred column at the same measure. */
+  main { max-width: min(120ch, calc(100vw - 32px)); margin: 24px auto 48px;
+         background: var(--bg-surface); border: 1px solid var(--border);
+         border-radius: 14px; padding: 48px 64px 56px; }
+  @media (max-width: 760px) { main { padding: 28px 20px 36px; margin: 0 auto 24px;
+         border-radius: 0; border-left: none; border-right: none; } }
+  .page-top { display: flex; align-items: center; gap: 12px; justify-content: space-between;
+              margin-bottom: 20px; }
+  a.open-app { display: inline-block; padding: 7px 16px; border-radius: 999px;
+               background: var(--text-primary); color: var(--bg-surface);
+               text-decoration: none; font-weight: 600; font-size: 0.9rem;
+               white-space: nowrap; }
   article h1, article h2, article h3 { line-height: 1.3; }
   article img { max-width: 100%; height: auto; border-radius: 6px; }
-  article pre { background: #eceae5; padding: 0.8rem 1rem; border-radius: 8px;
+  article pre { background: var(--code-bg); padding: 0.8rem 1rem; border-radius: 8px;
                 overflow-x: auto; }
-  article code { background: #eceae5; padding: 0.1em 0.35em; border-radius: 4px;
-                 font-size: 0.92em; }
+  article code { background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px;
+                 font-size: 0.92em; font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace; }
   article pre code { background: none; padding: 0; }
-  article blockquote { margin: 0; padding-left: 1rem; border-left: 3px solid #d8d5cd;
-                       color: #6b6b66; }
-  article a { color: #2a5db0; }
-  .wikilink { color: #6b6b66; border-bottom: 1px dotted #b5b2aa; }
-  footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e3e0d9;
-           font-size: 0.85rem; color: #6b6b66; }
+  article blockquote { margin: 0; padding-left: 1rem; border-left: 3px solid var(--border);
+                       color: var(--text-secondary); }
+  article a { color: var(--accent); }
+  .wikilink { color: var(--text-secondary); border-bottom: 1px dotted var(--border); }
+  /* Tables — the editor's exact treatment: natural column widths, cells wrap
+     at a readable measure, a wide table scrolls in its wrapper. */
+  .md-table { margin: 12px 0; overflow-x: auto; contain: inline-size; }
+  .md-table table { border-collapse: collapse; width: max-content; font-size: 0.95em; }
+  .md-table th, .md-table td { border: 1px solid var(--border); padding: 4px 12px;
+                               text-align: left; vertical-align: top; max-width: 42ch; }
+  .md-table th { font-weight: 600; }
+  .md-table::-webkit-scrollbar { height: 8px; }
+  .md-table::-webkit-scrollbar-thumb { background-color: var(--border); border-radius: 4px; }
+  .md-table::-webkit-scrollbar-track { background: transparent; }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border);
+           font-size: 0.85rem; color: var(--text-secondary); }
   footer a { color: inherit; }
-  h1.doc-title { font-size: 1.7rem; margin: 0 0 1.5rem; }
+  h1.doc-title { font-size: 1.7rem; margin: 0; }
 `;
 
 function pageShell(title: string, inner: string): string {
@@ -263,6 +298,7 @@ const NOT_FOUND_HTML = pageShell(
 interface PublicNoteRow {
   doc_id: string;
   vault_id: string;
+  org_id: string;
   title: string | null;
   rel_path: string;
 }
@@ -270,7 +306,7 @@ interface PublicNoteRow {
 async function noteForToken(token: string): Promise<PublicNoteRow | null> {
   if (!TOKEN_RE.test(token)) return null;
   const { rows } = await pool.query<PublicNoteRow>(
-    `SELECT pl.doc_id, pl.vault_id, n.title, n.rel_path
+    `SELECT pl.doc_id, pl.vault_id, pl.org_id, n.title, n.rel_path
        FROM public_links pl
        JOIN notes n ON n.id = pl.doc_id AND n.deleted_at IS NULL
       WHERE pl.token = $1`,
@@ -314,10 +350,14 @@ export function createPublicPageRoutes(deps: PublicPageDeps): Hono {
         `/p/${token}/a/${rel.split("/").map(encodeURIComponent).join("/")}`,
     });
     const title = noteTitle(row);
+    // The private-link flow, one click away: /open/note bounces into the app,
+    // where the viewer's own session and ACL decide what they see — the button
+    // grants nothing the ids don't already carry.
+    const openHref = `/open/note/${encodeURIComponent(row.org_id)}/${encodeURIComponent(row.doc_id)}`;
     return c.html(
       pageShell(
         title,
-        `<article><h1 class="doc-title">${esc(title)}</h1>\n${bodyHtml}</article>`,
+        `<div class="page-top"><h1 class="doc-title">${esc(title)}</h1><a class="open-app" href="${esc(openHref)}">Open in ${esc(BRAND_NAME)}</a></div>\n<article>${bodyHtml}</article>`,
       ),
       200,
       PAGE_HEADERS,

--- a/app/apps/server/src/render/note-html.ts
+++ b/app/apps/server/src/render/note-html.ts
@@ -124,6 +124,28 @@ interface ListFrame {
 const LIST_ITEM_RE = /^(\s*)(?:[-*+]|\d+[.)])\s+(.*)$/;
 const ORDERED_RE = /^\s*\d+[.)]\s/;
 
+/** `| --- | :---: |` — the row that makes the line above it a table header. */
+const TABLE_SEP_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+
+function splitRow(line: string): string[] {
+  let cells = line.split("|").map((c) => c.trim());
+  // GFM rows usually open and close with a pipe — those outer splits are
+  // empty and are frame, not cells.
+  if (cells.length > 0 && cells[0] === "") cells = cells.slice(1);
+  if (cells.length > 0 && cells[cells.length - 1] === "") cells = cells.slice(0, -1);
+  return cells;
+}
+
+function columnAligns(sep: string): Array<"left" | "center" | "right"> {
+  return splitRow(sep).map((c) => {
+    const l = c.startsWith(":");
+    const r = c.endsWith(":");
+    if (l && r) return "center";
+    if (r) return "right";
+    return "left";
+  });
+}
+
 /** Block-level pass over escaped lines. Recursion only for blockquote bodies. */
 function renderBlocks(lines: string[], opts: RenderOptions): string {
   const out: string[] = [];
@@ -189,6 +211,32 @@ function renderBlocks(lines: string[], opts: RenderOptions): string {
       continue;
     }
 
+    // GFM table: a pipe row whose NEXT line is the ---|--- separator.
+    if (line.includes("|") && i + 1 < lines.length && TABLE_SEP_RE.test(lines[i + 1])) {
+      closeAllLists();
+      const aligns = columnAligns(lines[i + 1]);
+      const cell = (text: string, tag: "th" | "td", col: number): string => {
+        const align = aligns[col] ?? "left";
+        const style = align === "left" ? "" : ` style="text-align:${align}"`;
+        return `<${tag}${style}>${renderInline(text, opts)}</${tag}>`;
+      };
+      const header = splitRow(line);
+      const rows: string[][] = [];
+      i += 2;
+      while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
+        rows.push(splitRow(lines[i]));
+        i++;
+      }
+      const thead = `<thead><tr>${header.map((h, c) => cell(h, "th", c)).join("")}</tr></thead>`;
+      const tbody = rows
+        .map((r) => `<tr>${r.map((v, c) => cell(v, "td", c)).join("")}</tr>`)
+        .join("");
+      // Same shape the app's editor renders: a scroll wrapper so a wide table
+      // scrolls here instead of stretching the page.
+      out.push(`<div class="md-table"><table>${thead}${tbody ? `<tbody>${tbody}</tbody>` : ""}</table></div>`);
+      continue;
+    }
+
     const item = LIST_ITEM_RE.exec(line);
     if (item) {
       const indent = item[1].length;
@@ -224,7 +272,8 @@ function renderBlocks(lines: string[], opts: RenderOptions): string {
       !LIST_ITEM_RE.test(lines[i]) &&
       !lines[i].trimStart().startsWith("&#62;") &&
       !/^(```|~~~)/.test(lines[i].trim()) &&
-      !/^\s*([-*_])\s*(\1\s*){2,}$/.test(lines[i])
+      !/^\s*([-*_])\s*(\1\s*){2,}$/.test(lines[i]) &&
+      !(lines[i].includes("|") && i + 1 < lines.length && TABLE_SEP_RE.test(lines[i + 1]))
     ) {
       para.push(renderInline(lines[i], opts));
       i++;

--- a/app/apps/server/tests/public-links.test.ts
+++ b/app/apps/server/tests/public-links.test.ts
@@ -95,6 +95,9 @@ describe("public note links", () => {
     const html = await res.text();
     expect(html).toContain("<strong>shared</strong>");
     expect(html).toContain("<h1>Hello</h1>");
+    // The private-link flow rides along: an Open in Baalda button through the
+    // same /open/note landing (ids carry identity, never access).
+    expect(html).toContain(`/open/note/${orgId}/${docId}`);
   });
 
   it("hostile note content is never reflected as markup", async () => {

--- a/app/apps/server/tests/render-note-html.test.ts
+++ b/app/apps/server/tests/render-note-html.test.ts
@@ -80,6 +80,31 @@ describe("renderNoteHtml — markdown subset", () => {
     expect(bodyHtml).not.toContain("<a ");
   });
 
+  it("renders GFM tables with alignment, header, and safe cells", () => {
+    const md = [
+      "| Part | Points |",
+      "|---|:---:|",
+      "| **one** | a · b |",
+      "| <script>x</script> | [s](https://e.com) |",
+    ].join("\n");
+    const { bodyHtml } = renderNoteHtml(md, noAssets);
+    expect(bodyHtml).toContain('<div class="md-table"><table>');
+    expect(bodyHtml).toContain("<th>Part</th>");
+    expect(bodyHtml).toContain('<th style="text-align:center">Points</th>');
+    expect(bodyHtml).toContain("<td><strong>one</strong></td>");
+    expect(bodyHtml).not.toContain("<script>");
+    expect(bodyHtml).toContain('href="https://e.com"');
+  });
+
+  it("a table straight after prose is a table, and a lone pipe line is prose", () => {
+    const { bodyHtml } = renderNoteHtml("intro line\n| a | b |\n|---|---|\n| 1 | 2 |", noAssets);
+    expect(bodyHtml).toContain("<p>intro line</p>");
+    expect(bodyHtml).toContain("<td>1</td>");
+    const lone = renderNoteHtml("just a | pipe in prose", noAssets).bodyHtml;
+    expect(lone).toContain("<p>just a | pipe in prose</p>");
+    expect(lone).not.toContain("<table>");
+  });
+
   it("strips frontmatter", () => {
     const { bodyHtml } = renderNoteHtml("---\ntags: [x]\n---\nBody here", noAssets);
     expect(bodyHtml).not.toContain("tags:");

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-deep-link':
         specifier: ^2.4.9
         version: 2.4.9
@@ -1297,6 +1300,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
@@ -3097,6 +3103,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     dependencies:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
+- The public note page now looks like Baalda — the app's theme (dark mode included), a full-width sheet, proper tables, and an **Open in Baalda** button for teammates
+- Copy link now goes straight to the clipboard in one click, with a checkmark — no more intermediate link to copy by hand
+- Clicking New note / New folder while the vault root is frozen now tells you why immediately, instead of silently doing nothing
 - Copying a public link now lands on the clipboard reliably — and if the popover ever shows the link itself, clicking it copies the full URL with a checkmark
 - The share button now offers two links: **Private** for teammates, and **Public** — a read-only page anyone can open in a browser, images included
-- Public links can be disabled anytime from the same menu — the old link stops working immediately
-- Opening a shared link while signed out now brings up sign-in and opens the note right after, instead of dropping you on the home screen
-- Shared links now ride out a vault's first sync (and say so), instead of failing on big or slow vaults


### PR DESCRIPTION
Follow-ups from live testing of #67/#68:

### Public page (`GET /p/<token>`)
- **Tables render** — GFM pipe tables now parse (alignment included) and get the app editor's exact treatment: natural column widths, 42ch cell measure, horizontal scroll in a wrapper instead of stretching the page.
- **Styled like the app** — the page now uses the app's design tokens (light `#ececf0` canvas + white sheet, dark mode via `prefers-color-scheme`), the editor's 120ch measure with 64px gutters, matching code/blockquote/link colors.
- **Open in Baalda button** — routes through the existing `/open/note/<orgId>/<docId>` landing, so a signed-in teammate with access gets the exact private-link flow (vault switch and all). Ids carry identity, never access.

### Desktop
- **One-click copy, for real this time** — adds `tauri-plugin-clipboard-manager` (write-text permission only) and puts the native call first in `copyText`. The webview clipboard is bound to WebKit's transient user activation, which the link-minting `await` outlives; the native call has no such rule, so the fallback URL row should never appear again. Web-API and execCommand remain as fallbacks (and for tests).
- **Share popover** 400px → 340px.
- **Frozen root feedback** — the New note / New folder header buttons were `disabled`, which swallows clicks; now they stay clickable (dimmed, `aria-disabled`) and the click hits the existing `rootBlocked` toast, so the user is told immediately why nothing was created. Tooltip kept.

Version bump → **0.1.39**, release notes refreshed (new items on top, capped at 5).

Tests: server 315/315 (2 new table tests + Open-in-Baalda assertion), desktop 645/645, `cargo check` clean with the new plugin.