### PR TITLE
Tabs for open files, instant sidebar presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ## [Unreleased]
 
 ### Added
+- **Tabs for open files.** Every note you open now stays open as a tab in a
+  strip under the header — click to switch, × or middle-click to close, and
+  closing the active tab lands on its neighbour. Tabs follow renames and moves
+  (yours and teammates'), close when their file is deleted, and are scoped to
+  the vault (switching vaults starts a fresh strip).
+
+### Fixed
+- **Sidebar presence no longer waits out the backfill.** A client announced
+  which note it was viewing only after the server's `ready` — i.e. after the
+  entire vault download — and the roster round that reveals everyone *else* is
+  triggered by that same first announce. On any real vault that read as
+  "teammates don't show up" for many seconds on every launch and reconnect. The
+  announce now rides right behind `hello`, and the server parks a frame that
+  races its auth I/O and replays it once the connection is subscribed.
 - **Public note links.** The share button now offers Private and Public: Public
   mints `https://<server>/p/<token>` — a server-rendered read-only page anyone
   with the link can open (images included, served token-scoped; never SVG).

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.38",
+  "version": "0.1.40",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.38"
+version = "0.1.40"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.38"
+version = "0.1.40"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.38",
+  "version": "0.1.40",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -2374,6 +2374,91 @@ body:has(.sidebar-resizer.dragging) {
   white-space: nowrap;
   margin-right: auto;
 }
+/* ---- Open-file tabs (TabBar) ---- */
+.tab-strip {
+  display: flex;
+  align-items: stretch;
+  gap: var(--sp-1);
+  flex: none;
+  padding: 0 var(--sp-3);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  /* The strip scrolls (wheel/trackpad/drag-into-view), but a scrollbar under
+     a row of tabs reads as clutter, so it's hidden in both engines. */
+  scrollbar-width: none;
+}
+.tab-strip::-webkit-scrollbar {
+  display: none;
+}
+.tab {
+  display: flex;
+  align-items: center;
+  flex: none;
+  max-width: 220px;
+  margin: var(--sp-1) 0;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+}
+.tab:hover {
+  background: var(--bg-hover);
+}
+/* Same selected idiom as the sidebar's .tree-row.selected. */
+.tab.active {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+.tab.active:hover {
+  background: var(--accent-soft-hover);
+}
+/* Click acknowledged, open in flight (same signal as the sidebar row). */
+.tab.opening {
+  opacity: 0.6;
+}
+.tab-label {
+  background: none;
+  border: 0;
+  padding: var(--sp-1) 2px var(--sp-1) var(--sp-2);
+  font: inherit;
+  font-size: var(--fs-sm);
+  color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.tab.active .tab-label {
+  font-weight: 500;
+}
+.tab-close {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 18px;
+  height: 18px;
+  margin-right: 4px;
+  border: 0;
+  border-radius: 5px;
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  /* Transparent, not absent: the space stays reserved so tabs don't change
+     width as the pointer moves across the strip. */
+  opacity: 0;
+}
+.tab:hover .tab-close,
+.tab.active .tab-close,
+.tab-close:focus-visible {
+  opacity: 1;
+}
+.tab-close:hover {
+  background: var(--bg-active);
+  color: var(--text-primary);
+}
+.tab-close svg {
+  width: 11px;
+  height: 11px;
+}
+
 .save-indicator {
   font-size: var(--fs-sm);
   color: var(--text-tertiary);

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -13,6 +13,7 @@ import { SyncBadge } from "./components/Identity";
 import { SearchPanel } from "./components/SearchPanel";
 import { SidebarHeader } from "./components/SidebarHeader";
 import { SidebarResizer } from "./components/SidebarResizer";
+import { TabBar } from "./components/TabBar";
 import { Toasts } from "./components/Toasts";
 import { toast } from "./lib/toast";
 import { VaultPicker } from "./components/VaultPicker";
@@ -99,7 +100,16 @@ function RemovedBanner() {
         <strong>{openNote?.title}</strong> was deleted on disk.
       </span>
       <div className="banner-actions">
-        <button className="primary" onClick={() => useStore.getState().closeNote()}>
+        <button
+          className="primary"
+          onClick={() => {
+            // The file is gone — drop its tab too, and let the neighbour tab
+            // (if any) take the screen rather than an empty editor.
+            const open = useStore.getState().openNote;
+            if (open) useStore.getState().closeTab(open.path);
+            else useStore.getState().closeNote();
+          }}
+        >
           Close note
         </button>
       </div>
@@ -926,6 +936,7 @@ export default function App() {
               </svg>
             </button>
           </header>
+          <TabBar />
           <RemovedBanner />
           <DeletedByTeammateBanner />
           <div className="editor-wrap">

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -406,6 +406,7 @@ export function FileTree() {
         store.closeNote();
       }
     }
+    store.pruneTabs(deleted);
     store.setItemOrder(order);
     await refreshAll();
     setBulkProgress(null);
@@ -758,6 +759,7 @@ export function FileTree() {
       // Keep the item's rank (and its subtree's arrangement) across the rename.
       const store = useStore.getState();
       store.setItemOrder(renameInOrder(store.itemOrder, oldPath, newPath));
+      store.remapTabs(oldPath, newPath);
       if (openNote && (openNote.path === oldPath || openNote.path.startsWith(oldPath + "/"))) {
         const updated = openNote.path.replace(oldPath, newPath);
         await useStore.getState().openNoteByPath(updated);
@@ -832,6 +834,7 @@ export function FileTree() {
           console.warn("[sync] move propagate failed", from[i], e);
         }
         movedOnDisk = true;
+        useStore.getState().remapTabs(from[i], to[i]);
         if (openNote && (openNote.path === from[i] || openNote.path.startsWith(from[i] + "/"))) {
           await useStore.getState().openNoteByPath(openNote.path.replace(from[i], to[i]));
         }
@@ -1158,6 +1161,7 @@ export function FileTree() {
     }
     if (deleted.length === 0) return;
     store.setItemOrder(removeFromOrder(store.itemOrder, node.data.path));
+    store.pruneTabs([node.data.path]);
     if (openNote && (openNote.path === node.data.path || openNote.path.startsWith(node.data.path + "/"))) {
       store.closeNote();
     }

--- a/app/apps/desktop/src/components/TabBar.tsx
+++ b/app/apps/desktop/src/components/TabBar.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useStore } from "../store";
+
+/** Tab label: the note's indexed title when we have one, else the filename.
+ *  Notes/pages hide their extension (same rule as the rename input); other
+ *  file types keep it, since the extension is how you tell two previews apart. */
+function tabLabel(path: string, titleByPath: Map<string, string>): string {
+  const title = titleByPath.get(path);
+  if (title) return title;
+  const base = path.split("/").pop() ?? path;
+  return base.replace(/\.(md|html?)$/i, "");
+}
+
+/**
+ * The open-files strip under the main header. Every `openNoteByPath` keeps its
+ * file as a tab (store `openTabs`), so moving between notes no longer loses
+ * where you were — click to switch back, × or middle-click to close.
+ *
+ * The ACTIVE tab is derived from `openNote.path`, never tracked separately, so
+ * the strip can't disagree with the editor about what's on screen.
+ */
+export function TabBar() {
+  const openTabs = useStore((s) => s.openTabs);
+  const activePath = useStore((s) => s.openNote?.path ?? null);
+  const activeTitle = useStore((s) => s.openNote?.title ?? null);
+  const openingPath = useStore((s) => s.openingNotePath);
+  const titles = useStore((s) => s.titles);
+
+  const titleByPath = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const t of titles) m.set(t.path, t.title);
+    // The open note's own title is fresher than the index while its H1 is
+    // being typed — let it win for the active tab.
+    if (activePath && activeTitle) m.set(activePath, activeTitle);
+    return m;
+  }, [titles, activePath, activeTitle]);
+
+  // Vault machinery can reset the list while a note is still open (see
+  // `vaultScopedSyncReset`) — the file on screen always earns a tab.
+  const tabs =
+    activePath && !openTabs.includes(activePath) ? [...openTabs, activePath] : openTabs;
+
+  // Keep the active tab in view when it changes off-screen (many tabs open).
+  const activeRef = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activePath]);
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="tab-strip" role="tablist" aria-label="Open files">
+      {tabs.map((path) => {
+        const active = path === activePath;
+        // The openingNotePath acknowledgement, same as the sidebar row: a tab
+        // click in a synced vault takes a round trip before the editor swaps.
+        const opening = path === openingPath && !active;
+        const label = tabLabel(path, titleByPath);
+        return (
+          <div
+            key={path}
+            className={`tab${active ? " active" : ""}${opening ? " opening" : ""}`}
+            role="tab"
+            aria-selected={active}
+            title={path}
+            // Middle-click closes, the platform-wide tab convention.
+            onAuxClick={(e) => {
+              if (e.button === 1) useStore.getState().closeTab(path);
+            }}
+          >
+            <button
+              ref={active ? activeRef : undefined}
+              className="tab-label"
+              tabIndex={active ? 0 : -1}
+              onClick={() => {
+                if (!active) void useStore.getState().openNoteByPath(path);
+              }}
+            >
+              {label}
+            </button>
+            <button
+              className="tab-close"
+              title="Close tab"
+              aria-label={`Close ${label}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                useStore.getState().closeTab(path);
+              }}
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                aria-hidden="true"
+              >
+                <path d="M6 6l12 12M18 6L6 18" />
+              </svg>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
@@ -126,6 +126,34 @@ describe("VaultSyncEngine", () => {
     expect((hello.manifest as Record<string, string>).A).toBe("AQI=");
   });
 
+  it("announces presence right behind hello — before ready, so the sidebar dots don't wait out the backfill", async () => {
+    const sink = new MemSink();
+    let ws: FakeWs | null = null;
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => (ws = new FakeWs()),
+    });
+    engine.setPresence({ docId: "D", name: "Ada", color: "#6366f1", status: "online" });
+    engine.start();
+    ws!.onopen?.(null);
+    await awaitHello(ws!);
+
+    // No `ready` has been delivered, yet the announce is already on the wire.
+    const texts = ws!.sent
+      .filter((x): x is string => typeof x === "string")
+      .map((s) => JSON.parse(s) as Record<string, unknown>);
+    expect(texts.map((t) => t.t)).toEqual(["hello", "presence"]);
+    expect(texts[1].docId).toBe("D");
+
+    // A presence CHANGE mid-backfill goes out live too (the old gate held it
+    // back until ready).
+    engine.setPresence({ docId: "E", name: "Ada", color: "#6366f1", status: "online" });
+    const last = ws!.sent[ws!.sent.length - 1];
+    expect(JSON.parse(last as string).docId).toBe("E");
+  });
+
   it("routes a binary update frame to the sink and flips to synced on ready", async () => {
     const sink = new MemSink();
     let ws: FakeWs | null = null;

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -209,6 +209,11 @@ export class VaultSyncEngine {
   // the moment the channel is ready — including after a reconnect.
   private localPresence: LocalPresence | null = null;
   private ready = false;
+  // True from the moment `hello` is on the wire until the socket drops. Presence
+  // frames are valid this early — the server parks one that races its auth I/O —
+  // and announcing here instead of on `ready` is what puts this user on
+  // teammates' sidebars during the backfill rather than after it.
+  private helloSent = false;
 
   // ---- inbound (download) queue ----
   //
@@ -274,7 +279,7 @@ export class VaultSyncEngine {
    */
   setPresence(presence: LocalPresence | null): void {
     this.localPresence = presence;
-    if (this.ready) this.sendPresence();
+    if (this.helloSent) this.sendPresence();
   }
 
   private sendPresence(): void {
@@ -422,6 +427,13 @@ export class VaultSyncEngine {
         caps: CLIENT_CAPS,
       }),
     );
+    this.helloSent = true;
+    // First announce rides right behind the hello. Waiting for `ready` meant a
+    // teammate connecting to a big vault stayed invisible — and saw nobody,
+    // because the roster re-announce round is triggered by this very frame —
+    // until the entire backfill drained. The `ready` re-send below still runs,
+    // which also covers an older server that drops this pre-auth frame.
+    this.sendPresence();
   }
 
   private async buildManifest(): Promise<Record<string, string>> {
@@ -595,6 +607,7 @@ export class VaultSyncEngine {
   private onDisconnect(): void {
     if (this.stopped) return;
     this.ready = false; // must re-announce presence after we reconnect
+    this.helloSent = false;
     this.closeSocket();
     this.setStatus("error");
     this.scheduleReconnect();

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -99,6 +99,10 @@ interface AppStore {
   vault: ipc.VaultInfo | null;
   tree: ipc.TreeNode | null;
   openNote: OpenNote | null;
+  /** Paths of the files held open as tabs, in the order they were opened. The
+   *  ACTIVE tab is `openNote.path` — this list is only which tabs exist, so the
+   *  two never disagree about what's on screen. Session-only, vault-scoped. */
+  openTabs: string[];
   /** True when the open note's file was deleted out from under us. */
   noteRemoved: boolean;
   /**
@@ -282,6 +286,13 @@ interface AppStore {
   refreshBacklinks: () => Promise<void>;
   setNoteRemoved: (removed: boolean) => void;
   closeNote: () => void;
+  /** Close one tab. Closing the active one activates its right-hand neighbour
+   *  (left-hand when it was last); closing the only tab clears the editor. */
+  closeTab: (path: string) => void;
+  /** Drop the tabs at (or under — folders) the given deleted paths. */
+  pruneTabs: (paths: string[]) => void;
+  /** Re-point tabs across a rename/move of a file or a folder subtree. */
+  remapTabs: (from: string, to: string) => void;
 
   // Auth actions
   initAuth: () => Promise<void>;
@@ -836,6 +847,9 @@ function vaultScopedSyncReset() {
     checkpoints: null,
     // A latch belongs to the vault it was read from; a local vault has none.
     rootFrozen: false,
+    // Tabs are paths, and paths only mean something inside the vault that
+    // minted them — every vault leave/switch spreads this reset.
+    openTabs: [] as string[],
   } satisfies Partial<AppStore>;
 }
 
@@ -1090,10 +1104,13 @@ export const useStore = create<AppStore>((set, get) => ({
         }
         if (!sameVault(get, epoch)) return;
       }
-      set({
+      set((s) => ({
         openNote: { path, id: meta?.id ?? null, title },
         noteRemoved: false,
-      });
+        // Every open gets (or keeps) a tab; switching tabs re-runs this path,
+        // so membership is checked rather than blindly appended.
+        openTabs: s.openTabs.includes(path) ? s.openTabs : [...s.openTabs, path],
+      }));
       // Tell teammates which note we're now viewing (drives their sidebar dots).
       // The announced id must be the SERVER doc_id — see `viewingDocId`, which
       // exists to hold that reasoning and a regression test for it.
@@ -1217,6 +1234,9 @@ export const useStore = create<AppStore>((set, get) => ({
    * someone else initiated that's an acceptable trade for not forking the note.
    */
   followNoteRename: (from, to) => {
+    // Background tabs follow the move too, open note or not — a stale tab path
+    // would reopen a file that no longer exists.
+    get().remapTabs(from, to);
     const open = get().openNote;
     if (!open) return;
     if (open.path === from) {
@@ -1230,6 +1250,39 @@ export const useStore = create<AppStore>((set, get) => ({
   closeNote: () => {
     syncManager.setViewing(null);
     set({ openNote: null, backlinks: [], noteRemoved: false, noteRemovedByTeammate: null });
+  },
+
+  closeTab: (path) => {
+    const { openTabs, openNote } = get();
+    const idx = openTabs.indexOf(path);
+    const next = idx === -1 ? openTabs : openTabs.filter((p) => p !== path);
+    if (idx !== -1) set({ openTabs: next });
+    if (openNote?.path !== path) return;
+    // The closed tab was on screen: land on the neighbour that slid into its
+    // slot (i.e. the tab to its right; the new last one when it WAS last).
+    const neighbor = next.length > 0 ? next[Math.min(Math.max(idx, 0), next.length - 1)] : null;
+    if (neighbor) void get().openNoteByPath(neighbor);
+    else get().closeNote();
+  },
+
+  pruneTabs: (paths) => {
+    const tabs = get().openTabs;
+    const gone = (p: string) => paths.some((d) => p === d || p.startsWith(d + "/"));
+    const next = tabs.filter((p) => !gone(p));
+    if (next.length !== tabs.length) set({ openTabs: next });
+  },
+
+  remapTabs: (from, to) => {
+    const tabs = get().openTabs;
+    const mapped = tabs.map((p) =>
+      p === from ? to : p.startsWith(from + "/") ? to + p.slice(from.length) : p,
+    );
+    // A move onto a path that already has a tab would leave twins — keep the first.
+    const seen = new Set<string>();
+    const next = mapped.filter((p) => !seen.has(p) && (seen.add(p), true));
+    if (next.length !== tabs.length || next.some((p, i) => p !== tabs[i])) {
+      set({ openTabs: next });
+    }
   },
 
   // ---- Auth ----
@@ -1262,6 +1315,7 @@ export const useStore = create<AppStore>((set, get) => ({
     syncManager.setInboundListeners({
       onNotePathChanged: (_docId, from, to) => get().followNoteRename(from, to),
       onNoteRemoved: (_docId, path, trashedTo) => {
+        get().pruneTabs([path]);
         const open = get().openNote;
         if (open && (open.path === path || open.path.startsWith(path + "/"))) {
           get().closeNote();

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -299,6 +299,10 @@ class VaultConnection {
   // kept so we can re-broadcast it when a newcomer asks, and clear it on close.
   private myPresence: { docId: string | null; name: string; color: string; status: string } | null =
     null;
+  /** A presence frame that arrived before auth finished; replayed right after
+   *  the pub/sub subscribe so the announce (and the roster query it triggers)
+   *  doesn't wait for the backfill. */
+  private pendingPresence: PresenceFrame | null = null;
   private announced = false;
   // ---- inbound voice budget ----
   // Nothing else on this channel is client-*originated* bulk traffic, so voice
@@ -430,6 +434,15 @@ class VaultConnection {
     }
     this.unsubscribe = off;
 
+    // Replay the announce that raced the auth I/O — BEFORE the backfill, so the
+    // rest of the vault sees this user (and this user gets the re-announce
+    // round) seconds before their own download finishes.
+    if (this.pendingPresence) {
+      const parked = this.pendingPresence;
+      this.pendingPresence = null;
+      this.handlePresence(parked);
+    }
+
     await this.backfill(hello.manifest, hello.priority ?? []);
     this.send({ t: "ready" });
   }
@@ -446,7 +459,15 @@ class VaultConnection {
    *  first announce — ask everyone else to re-announce so this newcomer learns
    *  the current roster (the channel holds no shared presence state). */
   private handlePresence(frame: PresenceFrame): void {
-    if (!this.userId || !this.vaultId) return;
+    if (!this.userId || !this.vaultId) {
+      // Clients announce right behind `hello` so teammates' sidebars light up
+      // during backfill, not after it — which lands the frame here while the
+      // token verify / ACL resolve is still in flight. Park it (last one wins)
+      // and onText replays it the moment auth completes; dropping it instead
+      // is what made presence wait out the whole backfill.
+      this.pendingPresence = frame;
+      return;
+    }
     this.myPresence = {
       docId: frame.docId,
       name: frame.name,

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -224,6 +224,29 @@ describe("VaultChannel relay (spec 05 §3.1)", () => {
     await waitFor(() => b.controls().some((c) => c.t === "presence" && c.docId === "A"));
   });
 
+  it("parks a presence frame that races the hello auth and replays it once subscribed", async () => {
+    const { channel } = channelWith(() => new Set(["A", "B"]));
+    const a = new FakeWs();
+    const b = new FakeWs();
+    channel.handleConnection(b as never);
+    b.hello("good");
+    await waitFor(() => b.controls().some((c) => c.t === "ready"));
+    b.presence("B"); // B is already here before A joins
+
+    // Clients announce right behind hello (they don't wait for ready), so this
+    // presence frame lands while A's token verify / ACL resolve is still in
+    // flight. It must be parked and replayed — not dropped — or A stays
+    // invisible until its whole backfill drains.
+    channel.handleConnection(a as never);
+    a.hello("good");
+    a.presence("A");
+
+    await waitFor(() => b.controls().some((c) => c.t === "presence" && c.docId === "A"));
+    // The replayed announce still counts as A's first: it triggers the roster
+    // query round, so A learns B is on "B" without waiting for its own ready.
+    await waitFor(() => a.controls().some((c) => c.t === "presence" && c.docId === "B"));
+  });
+
   it("drops a doc when an acl change removes it from the readable set", async () => {
     let set = new Set(["A", "B"]);
     const { channel } = channelWith(() => set);

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,3 @@
-- Copying a public link now lands on the clipboard reliably — and if the popover ever shows the link itself, clicking it copies the full URL with a checkmark
-- The share button now offers two links: **Private** for teammates, and **Public** — a read-only page anyone can open in a browser, images included
-- Public links can be disabled anytime from the same menu — the old link stops working immediately
-- Opening a shared link while signed out now brings up sign-in and opens the note right after, instead of dropping you on the home screen
-- Shared links now ride out a vault's first sync (and say so), instead of failing on big or slow vaults
+- Notes now open in **tabs** across the top — switch with a click, close with × or a middle-click, and jump back to where you were
+- Tabs follow renames and moves, and close themselves when a note is deleted
+- Teammates now show up in the sidebar the moment they open the app, instead of after their vault finishes syncing


### PR DESCRIPTION
## Tabs
Every note opened stays open as a tab in a strip under the main header: click to switch, × or middle-click to close, closing the active tab lands on its neighbour. Tabs follow renames and moves (local and inbound), close when their file is deleted, and reset on vault switch. Active tab is derived from `openNote.path`, never tracked separately.

## Sidebar presence latency fix
Presence dots appeared only after the whole vault backfill: the client announced its viewing state on the server's `ready`, and the roster re-announce round is triggered by that first announce. Now the client announces right behind `hello`, and the server parks an announce that races its auth I/O and replays it once subscribed. Regression tests on both sides.

Bumps 0.1.40; changelog + release notes updated.