### PR TITLE
Never fork a note's identity on register, add a note size ceiling

### DIFF
--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -29,6 +29,12 @@ SYNC_TOKEN_TTL_SECONDS=600
 # Compaction threshold: merge doc_updates into a snapshot when the log exceeds this.
 COMPACTION_THRESHOLD=50
 
+# Hard ceiling for one note's markdown TEXT, in MB (sync messages + MCP writes).
+# A circuit breaker against runaway growth (e.g. a writer looping on one note);
+# real notes are far smaller. Images don't count — embedded screenshots live in
+# attachments/ and sync through the blob store, not the note body.
+MAX_NOTE_MB=10
+
 # Quiet time after a note's last edit before a version is auto-captured (ms).
 # Default 600000 (10 minutes). Lower it in local dev to test version history.
 # VERSION_IDLE_MS=600000

--- a/app/apps/server/migrations/021_unique_live_note_paths.sql
+++ b/app/apps/server/migrations/021_unique_live_note_paths.sql
@@ -1,0 +1,30 @@
+-- A path must belong to exactly ONE live note per vault. Two live rows for one
+-- rel_path is a forked identity: different devices map the same file to
+-- different docs, and every external write then bounces between the two,
+-- duplicating the note's content on each cycle until the update log is tens of
+-- MB and rebuilding the doc OOMs the server (the 2026-08-25 runaway-daily-notes
+-- incident). POST /api/notes now adopts the existing live row for a same-path
+-- register; this index backstops the concurrent race.
+
+-- De-dupe first or the index cannot build: per (vault_id, rel_path), keep the
+-- oldest live row that actually holds CRDT data (else simply the oldest) and
+-- soft-delete the rest. The losers' doc_updates/doc_snapshots are deliberately
+-- left in place — soft-deleted rows keep their history recoverable.
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY vault_id, rel_path
+           ORDER BY (EXISTS (SELECT 1 FROM doc_updates u WHERE u.doc_id = notes.id)
+                  OR EXISTS (SELECT 1 FROM doc_snapshots s WHERE s.doc_id = notes.id)) DESC,
+                    created_at ASC,
+                    id ASC
+         ) AS rn
+  FROM notes
+  WHERE deleted_at IS NULL
+)
+UPDATE notes SET deleted_at = now()
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notes_live_path_uq
+  ON notes (vault_id, rel_path)
+  WHERE deleted_at IS NULL;

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -158,6 +158,12 @@ export const config = {
    *  product rather than the moment it stops being a pair. */
   freeMaxVaults: int("FREE_MAX_VAULTS", 3),
   freeMaxMembers: int("FREE_MAX_MEMBERS", 10),
+  /** Hard ceiling on a single note-sync message / note body, in MB. Real notes
+   *  are tiny (production p99 ≈ 600 kB; the largest legitimate page ≈ 7 MB), so
+   *  anything past this is a runaway — most likely a forked-note feedback loop
+   *  duplicating content on every bounce (2026-08-25: single updates reached
+   *  17 MB and OOM-crash-looped the server). The cap is the circuit breaker. */
+  maxNoteMb: int("MAX_NOTE_MB", 10),
 } as const;
 
 /**

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -410,6 +410,35 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // Client may supply a stable doc_id (generated locally); else we mint one.
     const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
 
+    // A live note already at this path IS this note — return it so the caller
+    // adopts its doc_id. Registering the same path under a DIFFERENT id used to
+    // create a second live row, forking the note's identity: two devices then
+    // map one file to two docs, and every external write bounces between them,
+    // duplicating the content each cycle (the 2026-08-25 runaway-daily-notes
+    // incident). The unique index `notes_live_path_uq` backstops the race below.
+    const { rows: samePath } = await pool.query<{
+      id: string;
+      folder_id: string | null;
+      title: string | null;
+    }>(
+      "SELECT id, folder_id, title FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL",
+      [vaultId, relPath],
+    );
+    if (samePath.length > 0) {
+      const row = samePath[0];
+      return c.json(
+        {
+          id: row.id,
+          docId: row.id,
+          vaultId,
+          folderId: row.folder_id,
+          title: row.title,
+          relPath,
+        },
+        200,
+      );
+    }
+
     // Frozen root: refuse only notes that do not exist yet. Re-registering a
     // root note that predates the latch (a second device, a repeat reconcile)
     // has to keep working, or freezing the root would break sync for the very
@@ -425,21 +454,45 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // against a doc it has no grant on: /api/sync-token 403s forever, the provider
     // reconnects on every rejection, and the note never loads. A doc_id is global,
     // so a collision across vaults has to be reported, not swallowed.
-    const inserted = await pool.query(
-      `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by, color)
-       VALUES ($1, $2, $3, $4, $5, $1, $6, $7)
-       ON CONFLICT (id) DO NOTHING
-       RETURNING id`,
-      [
-        id,
-        vaultId,
-        folderId ?? null,
-        title ?? null,
-        relPath,
-        session.userId,
-        normalizeColor(body.color) ?? null,
-      ],
-    );
+    let inserted;
+    try {
+      inserted = await pool.query(
+        `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by, color)
+         VALUES ($1, $2, $3, $4, $5, $1, $6, $7)
+         ON CONFLICT (id) DO NOTHING
+         RETURNING id`,
+        [
+          id,
+          vaultId,
+          folderId ?? null,
+          title ?? null,
+          relPath,
+          session.userId,
+          normalizeColor(body.color) ?? null,
+        ],
+      );
+    } catch (err) {
+      // Lost the race against a concurrent register of the same path
+      // (notes_live_path_uq). The winner's row is this note — adopt it.
+      if ((err as { code?: string }).code === "23505") {
+        const { rows } = await pool.query<{
+          id: string;
+          folder_id: string | null;
+          title: string | null;
+        }>(
+          "SELECT id, folder_id, title FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL",
+          [vaultId, relPath],
+        );
+        const row = rows[0];
+        if (row) {
+          return c.json(
+            { id: row.id, docId: row.id, vaultId, folderId: row.folder_id, title: row.title, relPath },
+            200,
+          );
+        }
+      }
+      throw err;
+    }
     if (inserted.rowCount === 0) {
       const { rows: existing } = await pool.query<{ vault_id: string; rel_path: string }>(
         "SELECT vault_id, rel_path FROM notes WHERE id = $1",

--- a/app/apps/server/src/mcp/doc-writer.ts
+++ b/app/apps/server/src/mcp/doc-writer.ts
@@ -4,6 +4,7 @@ import { formatDocName } from "../sync/doc-name.js";
 import type { SyncContext } from "../sync/hocuspocus.js";
 import { appendUpdate, loadDocState } from "../yjs/persistence.js";
 import { indexDoc } from "../index/indexer.js";
+import { config } from "../config.js";
 
 /**
  * Server-side writer for a note's shared Y.Text `content` — the bridge between
@@ -187,12 +188,26 @@ export function createDocWriter(
     }
   }
 
+  // The note-size ceiling, enforced where the resulting length is knowable.
+  // Guards especially against a WRITER IN A LOOP — an agent appending to the
+  // same note forever grows it unboundedly, and past a few MB the doc starts
+  // OOM-ing every rebuild (index backfill, compaction, backfill sends).
+  const capChars = () => config.maxNoteMb * 1024 * 1024;
+  const requireUnderCap = (resulting: number): void => {
+    if (resulting > capChars()) {
+      throw new Error(
+        `note would exceed the ${config.maxNoteMb} MB size ceiling — split the content across smaller notes`,
+      );
+    }
+  };
+
   return {
     setContent: (vaultId, docId, content, actor) =>
       mutate(
         vaultId,
         docId,
         (text) => {
+          requireUnderCap(content.length);
           if (text.length > 0) text.delete(0, text.length);
           if (content) text.insert(0, content);
         },
@@ -204,6 +219,7 @@ export function createDocWriter(
         vaultId,
         docId,
         (text) => {
+          requireUnderCap(text.length + appended.length);
           text.insert(text.length, appended);
         },
         actor,

--- a/app/apps/server/src/sync/hocuspocus.ts
+++ b/app/apps/server/src/sync/hocuspocus.ts
@@ -74,6 +74,25 @@ export function createSyncServer(
     // (spec 05 §5). Empty (single-instance) otherwise — no behaviour change.
     extensions: redisExtensions(config.redisUrl),
 
+    /**
+     * Circuit breaker: refuse any sync message larger than the note ceiling.
+     * A legitimate note never comes close (see `config.maxNoteMb`); a message
+     * this big means runaway growth — historically a forked-note feedback loop
+     * duplicating the content on every bounce. Throwing rejects the message and
+     * closes the connection BEFORE the update is applied or broadcast, so the
+     * oversized state can neither persist nor fan out.
+     */
+    async beforeHandleMessage(data) {
+      const cap = config.maxNoteMb * 1024 * 1024;
+      if (data.update.byteLength > cap) {
+        console.error(
+          `Rejecting oversized sync message for ${data.documentName}: ` +
+            `${data.update.byteLength} bytes (cap ${cap})`,
+        );
+        throw new Error("note exceeds the maximum size");
+      }
+    },
+
     async onAuthenticate(data) {
       const parsed = parseDocName(data.documentName);
       if (!parsed) {

--- a/app/apps/server/tests/mcp-doc-writer.test.ts
+++ b/app/apps/server/tests/mcp-doc-writer.test.ts
@@ -155,4 +155,24 @@ describe("MCP doc writer (no client connected)", () => {
     await writer.setContent("vault-1", "doc-6", "round trip");
     expect(await writer.readContent("vault-1", "doc-6")).toBe("round trip");
   });
+
+  it("refuses to grow a note past the size ceiling (the runaway-writer circuit breaker)", async () => {
+    const writer = writerThatRecords();
+    const overCap = "x".repeat(11 * 1024 * 1024); // MAX_NOTE_MB defaults to 10
+
+    // A single oversized write is rejected outright — nothing persists, nothing
+    // fans out.
+    await expect(writer.setContent("vault-1", "doc-7", overCap)).rejects.toThrow(/size ceiling/);
+    expect(await persistedText("doc-7")).toBe("");
+    expect(published).toHaveLength(0);
+
+    // A writer in a LOOP (append, append, append…) is what actually produced a
+    // runaway note in production: the cap is on the RESULTING length, so the
+    // append that would cross it fails even though its own chunk is small.
+    await writer.setContent("vault-1", "doc-7", "start");
+    const chunk = "y".repeat(6 * 1024 * 1024);
+    await expect(writer.appendContent("vault-1", "doc-7", chunk)).resolves.toBeUndefined();
+    await expect(writer.appendContent("vault-1", "doc-7", chunk)).rejects.toThrow(/size ceiling/);
+    expect(await persistedText("doc-7")).toBe("start" + chunk);
+  });
 });

--- a/app/apps/server/tests/registry.test.ts
+++ b/app/apps/server/tests/registry.test.ts
@@ -59,6 +59,47 @@ describe("registry structure sync", () => {
     expect(changed()).toEqual([vault, vault]);
   });
 
+  it("registering a path that already has a live note ADOPTS it — even under a different doc_id", async () => {
+    const first = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "Daily/2026-08-10.md",
+      docId: crypto.randomUUID(),
+    });
+    expect(first.status).toBe(201);
+    const { id: original } = (await first.json()) as { id: string };
+
+    // A second device whose doc-id map was lost re-registers the same path
+    // under a fresh local id. This used to create a SECOND live row — a forked
+    // identity whose two docs then ping-pong the file's content between them
+    // (the 2026-08-25 runaway-daily-notes incident).
+    const again = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "Daily/2026-08-10.md",
+      docId: crypto.randomUUID(),
+    });
+    expect(again.status).toBe(200);
+    const body = (await again.json()) as { id: string; docId: string };
+    expect(body.id).toBe(original); // adopted, not forked
+    expect(body.docId).toBe(original);
+
+    const { rows } = await pgPool.query(
+      "SELECT count(*)::int AS n FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL",
+      [vault, "Daily/2026-08-10.md"],
+    );
+    expect(rows[0].n).toBe(1);
+
+    // A DELETED note frees its path: the next register is a fresh create.
+    await req(owner, "DELETE", `/api/notes/${original}`);
+    const remade = await req(owner, "POST", "/api/notes", {
+      vaultId: vault,
+      relPath: "Daily/2026-08-10.md",
+      docId: crypto.randomUUID(),
+    });
+    expect(remade.status).toBe(201);
+    const remadeBody = (await remade.json()) as { id: string };
+    expect(remadeBody.id).not.toBe(original);
+  });
+
   it("renaming a folder rewrites its own + descendant paths, keeping doc_ids", async () => {
     const folderId = await seedFolder(vault, null, "Docs", "Docs");
     await seedFolder(vault, folderId, "Sub", "Docs/Sub");

--- a/app/apps/server/tests/vault-root-freeze.test.ts
+++ b/app/apps/server/tests/vault-root-freeze.test.ts
@@ -139,7 +139,9 @@ describe("frozen vault root", () => {
       relPath: "readme.md",
       docId,
     });
-    expect(renote.status).toBe(201);
+    // 200, not 201: a live note already owns this path, so the register adopts
+    // it (same as the folder above) rather than reporting a fresh create.
+    expect(renote.status).toBe(200);
   });
 
   it("refuses a move OUT to the root, but allows a rename in place", async () => {


### PR DESCRIPTION
## No more forked notes
`POST /api/notes` was idempotent only on doc_id, so a device re-registering an existing path under a fresh id created a second live note. Two devices then mapped one file to two docs and every external write bounced between them, duplicating the content each cycle — the runaway-daily-notes incident (single updates reached 17 MB and OOM-crash-looped the server).

- Registering a path that already has a live note now **adopts** it (200 with the existing id), matching folder semantics; a deleted note still frees its path.
- Migration 021 de-dupes defensively, then adds a unique index on live `(vault_id, rel_path)` as the race backstop; the insert handles the 23505 by adopting the winner.

## Note size ceiling
New `MAX_NOTE_MB` (default 10) — a circuit breaker against runaway growth:
- Hocuspocus `beforeHandleMessage` rejects oversized sync messages before apply/broadcast.
- The MCP doc-writer refuses a write/append whose **resulting** length crosses the cap, so a looping appender trips it.
- Markdown text only: images sync via attachments/blobs and don't count. Production p99 is 0.6 MB; largest legit page ~7 MB.

Server suite: 318 passing.