### PR TITLE
Keep a note's path and folder in agreement; repair drifted rows and duplicate folders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,11 @@ change in prod) · `BETTER_AUTH_URL` · `PORT` (3010) · `HOCUSPOCUS_PORT` (3011
 ## Conventions & gotchas
 
 - **`doc_id` is identity.** Never resolve or store a note by path across layers.
+- **`rel_path` and `folder_id` must agree.** A note/file/folder's location is stored twice; the server
+  derives or validates the parent from the path on every create and move
+  (`registry/tree-ops.ts` `resolveParentFolder` / `planNoteMove` / `planFolderMove`; mismatch → 400
+  `path_folder_mismatch`) and the root-freeze latch judges the *resolved* parent. Migration 022 repaired
+  the drift that let a phantom root folder appear (2026-08-27).
 - **`.context/` is sacred and hidden** — never walk, sync, or index it. It holds `index.sqlite`, the CRDT
   store, and `config.json` (server vault id + doc-id map; travels with the vault).
 - **Reuse patterns, not code.** We study OSS references (Noteriv, Relay, Hocuspocus, Better Auth) but write

--- a/app/apps/server/migrations/022_note_folder_consistency.sql
+++ b/app/apps/server/migrations/022_note_folder_consistency.sql
@@ -1,0 +1,63 @@
+-- A note's location is stored twice — rel_path (what clients render and write to
+-- disk) and folder_id (what every ACL walk and the root-freeze latch read) — and
+-- nothing kept them in agreement. The server now derives/validates folder_id from
+-- rel_path on every create and move (registry/tree-ops.ts resolveParentFolder);
+-- this migration repairs the rows written before that.
+--
+-- Found in production on 2026-08-27: 104 live notes with folder_id NULL and a
+-- nested rel_path (registered without a folder id — "at the root" for permissions,
+-- so folder shares never reached them, and refused as root creations once the
+-- root was frozen), plus 3 whose folder_id pointed at a folder other than the one
+-- at their path — one of them rendering a phantom root-level folder on every
+-- desktop that no folder row backed and that re-materialized after every delete.
+
+-- 1. A folder exists at the path's directory → the path wins; re-point folder_id.
+--    Covers folder_id NULL + nested path, and folder_id pointing elsewhere.
+UPDATE notes n
+   SET folder_id = f.id, updated_at = now()
+  FROM folders f
+ WHERE n.deleted_at IS NULL
+   AND position('/' IN n.rel_path) > 0
+   AND f.vault_id = n.vault_id
+   AND f.path = regexp_replace(n.rel_path, '/[^/]*$', '')
+   AND n.folder_id IS DISTINCT FROM f.id;
+
+-- 2. No folder exists at the path's directory but folder_id names a real folder →
+--    the folder wins; move the file under it, keeping its name. If that name is
+--    taken there, suffix the doc id's first 8 chars before the extension so the
+--    live-path unique index (migration 021) is honoured and no content is lost.
+--    (dirname of a root-level path is '', which a bare regexp_replace would not
+--    give — hence the CASE.)
+UPDATE notes n
+   SET rel_path = f.path || '/' ||
+       CASE
+         WHEN EXISTS (
+           SELECT 1 FROM notes o
+            WHERE o.vault_id = n.vault_id AND o.deleted_at IS NULL AND o.id <> n.id
+              AND o.rel_path = f.path || '/' || regexp_replace(n.rel_path, '^.*/', '')
+         )
+         THEN regexp_replace(regexp_replace(n.rel_path, '^.*/', ''), '(\.[^./]*)?$', '-' || left(n.id, 8) || '\1')
+         ELSE regexp_replace(n.rel_path, '^.*/', '')
+       END,
+       updated_at = now()
+  FROM folders f
+ WHERE n.deleted_at IS NULL
+   AND n.folder_id = f.id
+   AND f.path <> (CASE WHEN position('/' IN n.rel_path) > 0
+                       THEN regexp_replace(n.rel_path, '/[^/]*$', '') ELSE '' END)
+   AND NOT EXISTS (
+     SELECT 1 FROM folders g
+      WHERE g.vault_id = n.vault_id
+        AND g.path = (CASE WHEN position('/' IN n.rel_path) > 0
+                           THEN regexp_replace(n.rel_path, '/[^/]*$', '') ELSE '' END)
+   );
+
+-- 3. Same as (1) for binary files (path column). None mismatched in production;
+--    kept so the two tables can't drift apart in shape.
+UPDATE files fi
+   SET folder_id = f.id
+  FROM folders f
+ WHERE position('/' IN fi.path) > 0
+   AND f.vault_id = fi.vault_id
+   AND f.path = regexp_replace(fi.path, '/[^/]*$', '')
+   AND fi.folder_id IS DISTINCT FROM f.id;

--- a/app/apps/server/migrations/022_note_folder_consistency.sql
+++ b/app/apps/server/migrations/022_note_folder_consistency.sql
@@ -11,6 +11,33 @@
 -- at their path — one of them rendering a phantom root-level folder on every
 -- desktop that no folder row backed and that re-materialized after every delete.
 
+-- 0. Duplicate folder rows at one path. Nothing enforced (vault_id, path)
+--    uniqueness, and two devices reconciling the same new folder at once (the
+--    adopt-by-path SELECT races the INSERT) left 2–5 rows per path in production —
+--    the desktop's path→id map then picked one at random, so notes and children
+--    were split across twins. Keep the OLDEST row, re-point everything at it,
+--    delete the rest. No tombstones for the losers: a tombstone tells clients to
+--    remove the local folder, and the local folder IS the keeper's.
+CREATE TEMP TABLE folder_dupes AS
+SELECT f.id AS loser,
+       (SELECT k.id FROM folders k
+         WHERE k.vault_id = f.vault_id AND k.path = f.path
+         ORDER BY k.created_at ASC, k.id ASC LIMIT 1) AS keeper
+  FROM folders f;
+DELETE FROM folder_dupes WHERE loser = keeper;
+
+UPDATE notes n SET folder_id = d.keeper FROM folder_dupes d WHERE n.folder_id = d.loser;
+UPDATE files fi SET folder_id = d.keeper FROM folder_dupes d WHERE fi.folder_id = d.loser;
+UPDATE folders c SET parent_id = d.keeper FROM folder_dupes d WHERE c.parent_id = d.loser;
+-- Children were re-pointed above, so ON DELETE CASCADE has nothing to cascade.
+DELETE FROM folders f USING folder_dupes d WHERE f.id = d.loser;
+DROP TABLE folder_dupes;
+
+-- One path, one folder — the backstop the dedupe above should never be needed
+-- again for. Both create surfaces adopt by path first; a lost race now surfaces
+-- as 23505, which they catch and adopt.
+CREATE UNIQUE INDEX IF NOT EXISTS folders_vault_path_uq ON folders (vault_id, path);
+
 -- 1. A folder exists at the path's directory → the path wins; re-point folder_id.
 --    Covers folder_id NULL + nested path, and folder_id pointing elsewhere.
 UPDATE notes n

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -10,10 +10,16 @@ import {
 } from "../../permissions/vault-docs.js";
 import { purgeNoteIndex } from "../../index/indexer.js";
 import {
+  TreeOpError,
   deleteFolderCascade,
+  findFolder,
+  findNote,
   moveFolder,
   moveNote,
-  TreeOpError,
+  planFolderMove,
+  planNoteMove,
+  resolveFolderParent,
+  resolveParentFolder,
 } from "../../registry/tree-ops.js";
 import { getSession } from "../session.js";
 
@@ -63,6 +69,13 @@ const ROOT_FROZEN_ERROR = {
   error: "This vault's root is frozen — create this inside a folder instead.",
   code: "root_frozen",
 } as const;
+
+/** 400 body for a path that disagrees with its folder (or names a folder that
+ *  does not exist). Terminal for the desktop's `withRetry`, which is right: the
+ *  request is wrong, not the network. */
+function pathFolderMismatch(err: TreeOpError) {
+  return { error: err.message, code: "path_folder_mismatch" } as const;
+}
 
 /** Colors are a short id from the client's palette (`lib/appearance`), or null
  *  to clear. Anything else is ignored rather than stored. */
@@ -265,10 +278,22 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ id: existing.rows[0].id, vaultId, parentId: parentId ?? null, name, path }, 200);
     }
 
+    // `path` is authoritative; `parentId` must be the folder at its dirname (or
+    // is resolved from it when absent). See `resolveParentFolder` for the
+    // incident this closes.
+    let resolvedParent: string | null;
+    try {
+      resolvedParent = await resolveFolderParent(pool, vaultId, path, parentId ?? null);
+    } catch (err) {
+      if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
+      throw err;
+    }
+
     // Frozen root: only NEW root folders are refused. The adopt path above
     // already returned, so an existing folder still reconciles from every
-    // device after the latch goes on.
-    if (!parentId && (await isRootFrozen(vaultId))) {
+    // device after the latch goes on. Judged on the RESOLVED parent, so a nested
+    // path with no parentId is not mistaken for a root creation.
+    if (resolvedParent === null && (await isRootFrozen(vaultId))) {
       return c.json(ROOT_FROZEN_ERROR, 403);
     }
 
@@ -277,10 +302,10 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     await pool.query(
       `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by, color)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-      [id, vaultId, parentId ?? null, name, path, body.sort ?? 0, session.userId, color],
+      [id, vaultId, resolvedParent, name, path, body.sort ?? 0, session.userId, color],
     );
     changed(c, vaultId);
-    return c.json({ id, vaultId, parentId: parentId ?? null, name, path, color }, 201);
+    return c.json({ id, vaultId, parentId: resolvedParent, name, path, color }, 201);
   });
 
   registryRoutes.get("/folders", async (c) => {
@@ -328,14 +353,34 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "You cannot modify this folder" }, 403);
     }
     const newParentId = body.parentId === undefined ? undefined : (body.parentId ?? null);
+    const moveInput = {
+      path: typeof body.path === "string" ? body.path : undefined,
+      name: typeof body.name === "string" ? body.name : undefined,
+      parentId: newParentId,
+    };
+    // Resolve where the folder will land BEFORE gating: a `path`-only move to
+    // another directory (or to the root) is a re-parent whether or not the
+    // caller said `parentId`, and both gates below must see the real target.
+    const current = (await findFolder(pool, id))!;
+    let plan;
+    try {
+      plan = await planFolderMove(pool, current, moveInput);
+    } catch (err) {
+      if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
+      throw err;
+    }
     // Re-parenting under another folder must not be a way to change inherited
     // access: require edit on the destination parent too (root/null is fine).
-    if (newParentId != null && !(await canEditFolder(session.userId, newParentId))) {
+    if (
+      plan.parentId != null &&
+      plan.parentId !== current.parent_id &&
+      !(await canEditFolder(session.userId, plan.parentId))
+    ) {
       return c.json({ error: "You cannot move this folder there" }, 403);
     }
 
     // Moving a folder OUT to the root is a root creation by another name.
-    if (newParentId === null && (await isRootFrozen(row.vault_id))) {
+    if (plan.parentId === null && current.parent_id !== null && (await isRootFrozen(row.vault_id))) {
       return c.json(ROOT_FROZEN_ERROR, 403);
     }
 
@@ -347,11 +392,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
 
     try {
-      const moved = await moveFolder(pool, id, {
-        path: typeof body.path === "string" ? body.path : undefined,
-        name: typeof body.name === "string" ? body.name : undefined,
-        parentId: newParentId,
-      });
+      const moved = await moveFolder(pool, id, moveInput);
       changed(c, moved.vaultId);
       return c.json(
         { id, vaultId: moved.vaultId, name: moved.name, path: moved.path, color },
@@ -439,11 +480,24 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       );
     }
 
+    // `relPath` is authoritative; `folderId` must be the folder at its dirname
+    // (or is resolved from it when the client sent none). A desktop whose
+    // folder map missed a parent, or an assistant that computed the two
+    // inconsistently, otherwise writes a row every client renders in one place
+    // and every ACL walk reads in another (2026-08-27 phantom-root-folder).
+    let resolvedFolder: string | null;
+    try {
+      resolvedFolder = await resolveParentFolder(pool, vaultId, relPath, folderId ?? null);
+    } catch (err) {
+      if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
+      throw err;
+    }
+
     // Frozen root: refuse only notes that do not exist yet. Re-registering a
     // root note that predates the latch (a second device, a repeat reconcile)
     // has to keep working, or freezing the root would break sync for the very
-    // notes the team froze it to protect.
-    if (!folderId && (await isRootFrozen(vaultId))) {
+    // notes the team froze it to protect. Judged on the RESOLVED parent.
+    if (resolvedFolder === null && (await isRootFrozen(vaultId))) {
       const { rowCount } = await pool.query("SELECT 1 FROM notes WHERE id = $1", [id]);
       if (!rowCount) return c.json(ROOT_FROZEN_ERROR, 403);
     }
@@ -464,7 +518,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
         [
           id,
           vaultId,
-          folderId ?? null,
+          resolvedFolder,
           title ?? null,
           relPath,
           session.userId,
@@ -514,7 +568,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
     changed(c, vaultId);
     return c.json(
-      { id, docId: id, vaultId, folderId: folderId ?? null, title: title ?? null, relPath },
+      { id, docId: id, vaultId, folderId: resolvedFolder, title: title ?? null, relPath },
       201,
     );
   });
@@ -579,16 +633,36 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "You cannot modify this note" }, 403);
     }
     const folderId = body.folderId === undefined ? undefined : (body.folderId ?? null);
+    const moveInput = {
+      relPath: typeof body.relPath === "string" ? body.relPath : undefined,
+      title: body.title,
+      folderId,
+    };
+    // Resolve the destination from the PATH first: a `relPath`-only move to
+    // another folder (or out to the root) is a re-parent whether or not the
+    // client also said `folderId`, and both gates below must judge the real one.
+    const note = (await findNote(pool, id))!;
+    let plan;
+    try {
+      plan = await planNoteMove(pool, note, moveInput);
+    } catch (err) {
+      if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
+      throw err;
+    }
     // Same rule the folder route has always had, applied here too: moving a note
     // INTO a folder must not be a way to hand out access to it. Folder grants
     // inherit down, so without this a member could take a note only they can read
     // and drop it into a team-shared folder, granting the whole team edit on it.
-    if (folderId != null && !(await canEditFolder(session.userId, folderId))) {
+    if (
+      plan.folderId != null &&
+      plan.folderId !== row.folder_id &&
+      !(await canEditFolder(session.userId, plan.folderId))
+    ) {
       return c.json({ error: "You cannot move this note there" }, 403);
     }
     // Dragging a note out to the root is a root creation by another name —
     // unless it already lives there, which is a rename, not a move.
-    if (folderId === null && row.folder_id !== null && (await isRootFrozen(row.vault_id))) {
+    if (plan.folderId === null && row.folder_id !== null && (await isRootFrozen(row.vault_id))) {
       return c.json(ROOT_FROZEN_ERROR, 403);
     }
 
@@ -598,11 +672,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
 
     try {
-      const moved = await moveNote(pool, id, {
-        relPath: typeof body.relPath === "string" ? body.relPath : undefined,
-        title: body.title,
-        folderId,
-      });
+      const moved = await moveNote(pool, id, moveInput);
       changed(c, moved.vaultId);
       return c.json(
         {
@@ -664,19 +734,26 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       return c.json({ error: "Not a member of this vault" }, 403);
     }
     const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
+    let resolvedFolder: string | null;
+    try {
+      resolvedFolder = await resolveParentFolder(pool, vaultId, path, folderId ?? null);
+    } catch (err) {
+      if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
+      throw err;
+    }
     // Frozen root: same rule as notes — refuse only files that do not exist
     // yet, so a device re-registering a root file that predates the latch
     // still syncs.
-    if (!folderId && (await isRootFrozen(vaultId))) {
+    if (resolvedFolder === null && (await isRootFrozen(vaultId))) {
       const { rowCount } = await pool.query("SELECT 1 FROM files WHERE id = $1", [id]);
       if (!rowCount) return c.json(ROOT_FROZEN_ERROR, 403);
     }
     await pool.query(
       "INSERT INTO files (id, vault_id, folder_id, path) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING",
-      [id, vaultId, folderId ?? null, path],
+      [id, vaultId, resolvedFolder, path],
     );
     changed(c, vaultId);
-    return c.json({ id, docId: id, vaultId, folderId: folderId ?? null, path }, 201);
+    return c.json({ id, docId: id, vaultId, folderId: resolvedFolder, path }, 201);
   });
 
   return registryRoutes;

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -299,11 +299,27 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
 
     const id = randomUUID();
     const color = normalizeColor(body.color) ?? null;
-    await pool.query(
-      `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by, color)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-      [id, vaultId, resolvedParent, name, path, body.sort ?? 0, session.userId, color],
-    );
+    try {
+      await pool.query(
+        `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by, color)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [id, vaultId, resolvedParent, name, path, body.sort ?? 0, session.userId, color],
+      );
+    } catch (err) {
+      // Lost the race against another device registering the same path: the
+      // unique index `folders_vault_path_uq` (migration 022) refused the twin.
+      // Adopt the winner — before that index, this race produced 2–5 rows per
+      // path and split a folder's notes across them.
+      if ((err as { code?: string }).code === "23505") {
+        const winner = await pool.query<{ id: string; parent_id: string | null; name: string }>(
+          "SELECT id, parent_id, name FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+          [vaultId, path],
+        );
+        const w = winner.rows[0];
+        if (w) return c.json({ id: w.id, vaultId, parentId: w.parent_id, name: w.name, path }, 200);
+      }
+      throw err;
+    }
     changed(c, vaultId);
     return c.json({ id, vaultId, parentId: resolvedParent, name, path, color }, 201);
   });

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -197,15 +197,31 @@ export async function createFolder(
   await assertRootNotFrozen(input.vaultId, parentId);
 
   const id = randomUUID();
-  await pool.query(
-    // `created_by` matters beyond bookkeeping: it's what `canEditFolder` and
-    // `listVisibleFolders` use to give a non-admin rights over folders they made.
-    // Omitting it (as this did) meant a member who created a folder through an
-    // assistant couldn't see it in their own sidebar or rename it in the app.
-    `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by)
-     VALUES ($1, $2, $3, $4, $5, 0, $6)`,
-    [id, input.vaultId, parentId, input.name, input.path, ctx.auth.userId],
-  );
+  try {
+    await pool.query(
+      // `created_by` matters beyond bookkeeping: it's what `canEditFolder` and
+      // `listVisibleFolders` use to give a non-admin rights over folders they made.
+      // Omitting it (as this did) meant a member who created a folder through an
+      // assistant couldn't see it in their own sidebar or rename it in the app.
+      `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by)
+       VALUES ($1, $2, $3, $4, $5, 0, $6)`,
+      [id, input.vaultId, parentId, input.name, input.path, ctx.auth.userId],
+    );
+  } catch (err) {
+    // Lost the race against a concurrent create at this path (unique index
+    // `folders_vault_path_uq`): adopt the winner, same as the HTTP route.
+    if ((err as { code?: string }).code === "23505") {
+      const winner = await pool.query<{ id: string; name: string }>(
+        "SELECT id, name FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+        [input.vaultId, input.path],
+      );
+      const w = winner.rows[0];
+      if (w) {
+        return { folderId: w.id, parentId, name: w.name, path: input.path, adopted: true };
+      }
+    }
+    throw err;
+  }
   ctx.onRegistryChanged?.(input.vaultId);
   return { folderId: id, parentId, name: input.name, path: input.path, adopted: false };
 }

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -5,12 +5,17 @@ import { effectivePermission, type Permission } from "../permissions/resolver.js
 import { listReadableDocsInVault } from "../permissions/vault-docs.js";
 import { canEditFolder } from "../permissions/http-gates.js";
 import {
+  TreeOpError,
   deleteFolderCascade,
   findFolder,
+  findNote,
   folderIsEmpty,
   moveFolder,
   moveNote,
-  TreeOpError,
+  planFolderMove,
+  planNoteMove,
+  resolveFolderParent,
+  resolveParentFolder,
 } from "../registry/tree-ops.js";
 import { purgeNoteIndex, searchNoteIndex } from "../index/indexer.js";
 import type { McpAuth } from "./tokens.js";
@@ -161,7 +166,16 @@ export async function createFolder(
   input: { vaultId: string; name: string; path: string; parentId?: string | null },
 ) {
   await requireVaultInScope(ctx.auth, input.vaultId);
-  const parentId = input.parentId ?? null;
+  // `path` is authoritative; `parentId` must be the folder at its dirname or is
+  // resolved from it. Done before the permission check so the check judges the
+  // real parent (see `resolveParentFolder`).
+  let parentId: string | null;
+  try {
+    parentId = await resolveFolderParent(pool, input.vaultId, input.path, input.parentId ?? null);
+  } catch (err) {
+    if (err instanceof TreeOpError) throw new McpToolError(err.message);
+    throw err;
+  }
   if ((await folderWritePermission(ctx.auth, parentId)) !== "edit") {
     throw new McpToolError("You do not have edit access to create a folder here");
   }
@@ -258,20 +272,29 @@ export async function moveFolderTool(
   // means the vault root, which `folderWritePermission` treats as admin-only;
   // applying that here would make moving to the root admin-only over MCP while
   // HTTP allows it for the same user (it short-circuits on null the same way).
-  if (input.parentId != null && (await folderWritePermission(ctx.auth, input.parentId)) !== "edit") {
+  const moveInput = { path: input.path, name: input.name, parentId: input.parentId };
+  // Judge the RESOLVED destination: a `path`-only move is a re-parent too.
+  let plan;
+  try {
+    plan = await planFolderMove(pool, folder, moveInput);
+  } catch (err) {
+    if (err instanceof TreeOpError) throw new McpToolError(err.message);
+    throw err;
+  }
+  if (
+    plan.parentId != null &&
+    plan.parentId !== folder.parent_id &&
+    (await folderWritePermission(ctx.auth, plan.parentId)) !== "edit"
+  ) {
     throw new McpToolError("You do not have edit access to the destination folder");
   }
   // Moving a folder OUT to the root is a root creation by another name — the
   // same latch the HTTP registry honours (a rename in place at root is fine).
-  if (input.parentId === null && folder.parent_id !== null) {
+  if (plan.parentId === null && folder.parent_id !== null) {
     await assertRootNotFrozen(folder.vault_id, null, "move");
   }
   try {
-    const moved = await moveFolder(pool, input.folderId, {
-      path: input.path,
-      name: input.name,
-      parentId: input.parentId,
-    });
+    const moved = await moveFolder(pool, input.folderId, moveInput);
     ctx.onRegistryChanged?.(moved.vaultId);
     return { folderId: moved.id, name: moved.name, path: moved.path };
   } catch (err) {
@@ -286,27 +309,34 @@ export async function moveNoteTool(
   input: { docId: string; relPath?: string; title?: string; folderId?: string | null },
 ) {
   const note = await requireEditableNote(ctx.auth, input.docId);
+  const moveInput = { relPath: input.relPath, title: input.title, folderId: input.folderId };
+  // Judge the RESOLVED destination: `relPath` alone can move the note to another
+  // folder or out to the root, and both gates below must see that.
+  const row = (await findNote(pool, input.docId))!;
+  let plan;
+  try {
+    plan = await planNoteMove(pool, row, moveInput);
+  } catch (err) {
+    if (err instanceof TreeOpError) throw new McpToolError(err.message);
+    throw err;
+  }
   // Moving a note INTO a folder inherits that folder's grants, so it needs edit
   // on the destination as well as on the note. Same null-is-the-root carve-out as
   // `moveFolderTool`.
   if (
-    input.folderId != null &&
-    input.folderId !== note.folder_id &&
-    (await folderWritePermission(ctx.auth, input.folderId)) !== "edit"
+    plan.folderId != null &&
+    plan.folderId !== note.folder_id &&
+    (await folderWritePermission(ctx.auth, plan.folderId)) !== "edit"
   ) {
     throw new McpToolError("You do not have edit access to the destination folder");
   }
   // Same root-freeze latch as HTTP's PATCH /api/notes/:id: dragging a note out
   // to a frozen root is refused; a rename in place at root is allowed.
-  if (input.folderId === null && note.folder_id !== null) {
+  if (plan.folderId === null && note.folder_id !== null) {
     await assertRootNotFrozen(note.vault_id, null, "move");
   }
   try {
-    const moved = await moveNote(pool, input.docId, {
-      relPath: input.relPath,
-      title: input.title,
-      folderId: input.folderId,
-    });
+    const moved = await moveNote(pool, input.docId, moveInput);
     ctx.onRegistryChanged?.(moved.vaultId);
     return {
       docId: moved.id,
@@ -421,7 +451,18 @@ export async function createNote(
   },
 ) {
   await requireVaultInScope(ctx.auth, input.vaultId);
-  const folderId = input.folderId ?? null;
+  // `relPath` is authoritative; `folderId` must be the folder at its dirname or
+  // is resolved from it. An assistant that computes the two inconsistently
+  // (the 2026-08-27 phantom-root-folder: `folderId` of `Team/BenAI/…/Daily`,
+  // `relPath` without the `Team/`) is told so instead of writing a row every
+  // client renders at the root while the root-freeze latch sees a parent.
+  let folderId: string | null;
+  try {
+    folderId = await resolveParentFolder(pool, input.vaultId, input.relPath, input.folderId ?? null);
+  } catch (err) {
+    if (err instanceof TreeOpError) throw new McpToolError(err.message);
+    throw err;
+  }
   if ((await folderWritePermission(ctx.auth, folderId)) !== "edit") {
     throw new McpToolError("You do not have edit access to create a note here");
   }

--- a/app/apps/server/src/mcp/tools.ts
+++ b/app/apps/server/src/mcp/tools.ts
@@ -157,14 +157,14 @@ export const TOOLS: McpTool[] = [
   {
     name: "create_note",
     description:
-      "Create a new markdown note. relPath is the vault-relative path ending in .md (e.g. 'Ideas/draft.md'). Optionally seed its content.",
+      "Create a new markdown note. relPath is the vault-relative path ending in .md (e.g. 'Ideas/draft.md'); every folder in it must already exist (see list_folders / create_folder). If you also pass folderId it must be the folder whose path is relPath's directory. Optionally seed its content.",
     inputSchema: {
       type: "object",
       properties: {
         vaultId: S("Vault id from list_vaults"),
         relPath: S("Vault-relative path ending in .md, e.g. 'Ideas/draft.md'"),
         title: S("Optional display title (defaults to the filename)"),
-        folderId: S("Optional folder id the note belongs to"),
+        folderId: S("Optional folder id; must match relPath's directory. Usually omit it — the folder is resolved from relPath."),
         content: S("Optional initial markdown content"),
       },
       required: ["vaultId", "relPath"],
@@ -267,7 +267,7 @@ export const TOOLS: McpTool[] = [
   {
     name: "move_note",
     description:
-      "Rename, move, or retitle a note. relPath moves the file, folderId re-parents it (null for the vault root), title changes the display title. The note keeps its docId and its full history, so links and edits survive.",
+      "Rename, move, or retitle a note. relPath moves the file (its directory must be an existing folder, which becomes the note's folder); folderId alone re-parents it keeping its filename (null for the vault root); title changes the display title. The note keeps its docId and its full history, so links and edits survive.",
     inputSchema: {
       type: "object",
       properties: {

--- a/app/apps/server/src/registry/tree-ops.ts
+++ b/app/apps/server/src/registry/tree-ops.ts
@@ -25,6 +25,117 @@ export function basename(path: string): string {
   return i === -1 ? path : path.slice(i + 1);
 }
 
+/** dirname of a `/`-separated vault-relative path; `""` for a root-level path. */
+export function dirname(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? "" : path.slice(0, i);
+}
+
+/**
+ * A vault-relative path the tree can hold: non-empty, no leading/trailing `/`,
+ * no empty, `.` or `..` segments. Same shape the desktop's `resolve_in_vault`
+ * enforces on disk, so a path the server accepts is one every client can write.
+ */
+export function assertValidRelPath(path: string, what = "path"): void {
+  const bad =
+    path.length === 0 ||
+    path.startsWith("/") ||
+    path.endsWith("/") ||
+    path.split("/").some((seg) => seg === "" || seg === "." || seg === "..");
+  if (bad) throw new TreeOpError(`Invalid ${what} "${path}"`);
+}
+
+/** Load the folder at exactly `path` in `vaultId`, or null. */
+export async function findFolderByPath(
+  db: Queryable,
+  vaultId: string,
+  path: string,
+): Promise<FolderRow | null> {
+  const { rows } = await db.query<FolderRow>(
+    "SELECT id, vault_id, path, parent_id FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+    [vaultId, path],
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * The folder a note (or file) at `relPath` belongs to — derived from the path,
+ * and checked against the caller's `folderId` when one is given.
+ *
+ * A note's location is stored twice: `rel_path` (what every client renders and
+ * writes to disk) and `folder_id` (what every ACL walk and the root-freeze latch
+ * read). Nothing used to tie them together, and the two surfaces that create
+ * notes took both as independent inputs. The 2026-08-27 phantom-root-folder
+ * incident is what that allows: an assistant passed `folderId` of
+ * `Team/BenAI/…/Daily` with a `relPath` that dropped the `Team/` prefix. The
+ * freeze saw a parent and let it through; every desktop then rendered a
+ * root-level `BenAI/` folder that no folder row backed, materialized an empty
+ * placeholder for it, and re-created it after every local delete (disk
+ * deletions never propagate). Separately, 100+ notes had been registered with
+ * `folderId: null` and a nested path — "at the root" for permissions, so
+ * folder shares never reached them.
+ *
+ * Rules:
+ *  - `folderId` given → that folder must exist in this vault AND its path must
+ *    equal `dirname(relPath)`. A mismatch is refused, not silently repaired —
+ *    the caller (usually an LLM) needs to learn which of its two inputs is wrong.
+ *  - `folderId` absent/null → resolve by `dirname(relPath)`: `""` is the root
+ *    (null); otherwise the folder at that path must already exist.
+ * Returns the resolved parent id (null = vault root).
+ */
+export async function resolveParentFolder(
+  db: Queryable,
+  vaultId: string,
+  relPath: string,
+  folderId: string | null | undefined,
+): Promise<string | null> {
+  assertValidRelPath(relPath);
+  const dir = dirname(relPath);
+  if (folderId != null) {
+    const folder = await findFolder(db, folderId);
+    if (!folder) throw new TreeOpError("Unknown folder");
+    if (folder.vault_id !== vaultId) throw new TreeOpError("Folder is in a different vault");
+    if (folder.path !== dir) {
+      throw new TreeOpError(
+        `"${relPath}" is not inside folder "${folder.path}" — use relPath "${folder.path}/${basename(relPath)}" or the folder whose path is "${dir}"`,
+      );
+    }
+    return folder.id;
+  }
+  if (dir === "") return null;
+  const byPath = await findFolderByPath(db, vaultId, dir);
+  if (!byPath) throw new TreeOpError(`No folder at "${dir}" — create it first`);
+  return byPath.id;
+}
+
+/**
+ * Folder twin of {@link resolveParentFolder}: the parent of a folder at `path`,
+ * checked against `parentId` when given. `folders.path`/`parent_id` carry the
+ * same duplicated-location hazard as notes.
+ */
+export async function resolveFolderParent(
+  db: Queryable,
+  vaultId: string,
+  path: string,
+  parentId: string | null | undefined,
+): Promise<string | null> {
+  assertValidRelPath(path, "folder path");
+  const dir = dirname(path);
+  if (parentId != null) {
+    const parent = await findFolder(db, parentId);
+    if (!parent) throw new TreeOpError("Unknown parent folder");
+    if (parent.vault_id !== vaultId) throw new TreeOpError("Parent folder is in a different vault");
+    if (parent.path !== dir) {
+      throw new TreeOpError(`Folder path "${path}" is not inside its parent "${parent.path}"`);
+    }
+    return parent.id;
+  }
+  if (dir === "") return null;
+  const byPath = await findFolderByPath(db, vaultId, dir);
+  if (!byPath) throw new TreeOpError(`No folder at "${dir}" — create it first`);
+  return byPath.id;
+}
+
 /** Escape SQL LIKE metacharacters (\ % _) so a value is matched literally under
  *  `LIKE … ESCAPE '\'`. Single home: a folder named `100%_done` must not widen a
  *  subtree rewrite or a cascade delete into unrelated notes. */
@@ -120,6 +231,44 @@ export interface MoveFolderInput {
 }
 
 /**
+ * Where a folder ends up after `input`, with `path` and `parentId` agreeing:
+ *  - `path` given → it is authoritative; a `parentId`, when also given, must be
+ *    the folder at `dirname(path)`, else the parent is resolved from the path.
+ *  - only `parentId` given → the folder keeps its name and follows the parent
+ *    (`null` = the vault root).
+ *  - neither → unchanged.
+ */
+export async function planFolderMove(
+  db: Queryable,
+  folder: FolderRow,
+  input: MoveFolderInput,
+): Promise<{ path: string; parentId: string | null }> {
+  if (input.path !== undefined) {
+    const parentId = await resolveFolderParent(db, folder.vault_id, input.path, input.parentId);
+    return { path: input.path, parentId };
+  }
+  if (input.parentId !== undefined) {
+    const name = input.name ?? basename(folder.path);
+    if (input.parentId === null) return { path: name, parentId: null };
+    const parent = await findFolder(db, input.parentId);
+    if (!parent) throw new TreeOpError("Unknown destination folder");
+    // A cross-vault parent would put a folder in one vault under a tree in
+    // another, so the subtree's paths and its ACL would resolve in different
+    // collections.
+    if (parent.vault_id !== folder.vault_id) {
+      throw new TreeOpError("Destination folder is in a different vault");
+    }
+    return { path: `${parent.path}/${name}`, parentId: parent.id };
+  }
+  if (input.name !== undefined && input.name !== basename(folder.path)) {
+    // A rename in place: same parent, new last segment.
+    const dir = dirname(folder.path);
+    return { path: dir ? `${dir}/${input.name}` : input.name, parentId: folder.parent_id };
+  }
+  return { path: folder.path, parentId: folder.parent_id };
+}
+
+/**
  * Rename and/or move a folder, rewriting every descendant path in place. Ids are
  * never touched, so open CRDT docs and backlinks survive the move (the spec
  * invariant: key by doc_id, never by path).
@@ -133,19 +282,14 @@ export async function moveFolder(
   if (!folder) throw new TreeOpError("Unknown folder");
 
   const oldPath = folder.path;
-  const newPath = input.path ?? oldPath;
+  const plan = await planFolderMove(db, folder, input);
+  const newPath = plan.path;
   const newName = input.name ?? basename(newPath);
-  const newParentId = input.parentId;
+  // Always written: `path` and `parent_id` are resolved together (see
+  // `planFolderMove`), so re-parenting by path alone lands on the right parent.
+  const newParentId: string | null = plan.parentId;
 
-  if (newParentId != null) {
-    const parent = await findFolder(db, newParentId);
-    if (!parent) throw new TreeOpError("Unknown destination folder");
-    // A cross-vault parent would put a folder in one vault under a tree in
-    // another, so the subtree's paths and its ACL would resolve in different
-    // collections.
-    if (parent.vault_id !== folder.vault_id) {
-      throw new TreeOpError("Destination folder is in a different vault");
-    }
+  if (newParentId != null && newParentId !== folder.parent_id) {
     if (await wouldCycle(db, folderId, newParentId)) {
       throw new TreeOpError("Cannot move a folder inside itself");
     }
@@ -162,11 +306,8 @@ export async function moveFolder(
   }
 
   await db.query(
-    `UPDATE folders SET path = $1, name = $2${newParentId === undefined ? "" : ", parent_id = $4"}
-      WHERE id = $3`,
-    newParentId === undefined
-      ? [newPath, newName, folderId]
-      : [newPath, newName, folderId, newParentId],
+    "UPDATE folders SET path = $1, name = $2, parent_id = $4 WHERE id = $3",
+    [newPath, newName, folderId, newParentId],
   );
   if (newPath !== oldPath) {
     await rewriteDescendantPaths(db, folder.vault_id, oldPath, newPath);
@@ -200,6 +341,39 @@ export interface MoveNoteInput {
   folderId?: string | null;
 }
 
+/**
+ * Where a note ends up after `input`, with `rel_path` and `folder_id` agreeing
+ * (see {@link resolveParentFolder} for why that is not optional):
+ *  - `relPath` given → authoritative; `folderId`, when also given, must be the
+ *    folder at `dirname(relPath)`, else the parent is resolved from the path.
+ *  - only `folderId` given → the note keeps its filename and follows the folder
+ *    (`null` = the vault root).
+ *  - neither → unchanged.
+ * Callers gate the root-freeze latch and destination permissions on the
+ * RESOLVED parent, which is why this is exported separately from the write.
+ */
+export async function planNoteMove(
+  db: Queryable,
+  note: NoteRow,
+  input: MoveNoteInput,
+): Promise<{ relPath: string; folderId: string | null }> {
+  if (input.relPath !== undefined) {
+    const folderId = await resolveParentFolder(db, note.vault_id, input.relPath, input.folderId);
+    return { relPath: input.relPath, folderId };
+  }
+  if (input.folderId !== undefined) {
+    const name = basename(note.rel_path);
+    if (input.folderId === null) return { relPath: name, folderId: null };
+    const parent = await findFolder(db, input.folderId);
+    if (!parent) throw new TreeOpError("Unknown destination folder");
+    if (parent.vault_id !== note.vault_id) {
+      throw new TreeOpError("Destination folder is in a different vault");
+    }
+    return { relPath: `${parent.path}/${name}`, folderId: parent.id };
+  }
+  return { relPath: note.rel_path, folderId: note.folder_id };
+}
+
 /** Rename, retitle, and/or move a single note. Its doc_id never changes. */
 export async function moveNote(
   db: Queryable,
@@ -209,16 +383,17 @@ export async function moveNote(
   const note = await findNote(db, docId);
   if (!note) throw new TreeOpError("Unknown note");
 
-  const relPath = input.relPath ?? note.rel_path;
   const title = input.title === undefined ? note.title : input.title;
-  const folderId = input.folderId === undefined ? note.folder_id : input.folderId;
+  const { relPath, folderId } = await planNoteMove(db, note, input);
 
-  if (folderId != null && folderId !== note.folder_id) {
-    const parent = await findFolder(db, folderId);
-    if (!parent) throw new TreeOpError("Unknown destination folder");
-    if (parent.vault_id !== note.vault_id) {
-      throw new TreeOpError("Destination folder is in a different vault");
-    }
+  if (relPath !== note.rel_path) {
+    // Surface the collision as a refusal rather than letting the partial unique
+    // index (`notes_live_path_uq`, migration 021) throw a bare 23505.
+    const clash = await db.query(
+      "SELECT 1 FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL AND id <> $3 LIMIT 1",
+      [note.vault_id, relPath, docId],
+    );
+    if ((clash.rowCount ?? 0) > 0) throw new TreeOpError("A note already exists at that path");
   }
 
   await db.query(

--- a/app/apps/server/tests/mcp.test.ts
+++ b/app/apps/server/tests/mcp.test.ts
@@ -418,6 +418,9 @@ describe("MCP server", () => {
     });
 
     it("create_note broadcasts to the vault", async () => {
+      // The folder must exist: a nested relPath is resolved to its folder row
+      // (path/folder consistency), never left dangling at the root.
+      await seedFolder(vault, null, "Daily", "Daily");
       const created = await call(token, "create_note", {
         vaultId: vault,
         relPath: "Daily/today.md",
@@ -577,6 +580,7 @@ describe("MCP server", () => {
         content: "body",
       });
       const docId = created.data.docId as string;
+      await seedFolder(vault, null, "Archive", "Archive");
       registryBroadcasts.length = 0;
 
       const moved = await call(token, "move_note", {
@@ -611,6 +615,7 @@ describe("MCP server", () => {
         folderId: sub.data.folderId as string,
       });
       const docId = note.data.docId as string;
+      await seedFolder(vault, null, "Archive", "Archive");
       registryBroadcasts.length = 0;
 
       const moved = await call(token, "move_folder", {
@@ -624,7 +629,7 @@ describe("MCP server", () => {
         "SELECT path FROM folders WHERE vault_id = $1 ORDER BY path",
         [vault],
       );
-      expect(folders.map((f) => f.path)).toEqual(["Archive/Ideas", "Archive/Ideas/Drafts"]);
+      expect(folders.map((f) => f.path)).toEqual(["Archive", "Archive/Ideas", "Archive/Ideas/Drafts"]);
       const { rows: notes } = await pool.query<{ id: string; rel_path: string }>(
         "SELECT id, rel_path FROM notes WHERE vault_id = $1",
         [vault],

--- a/app/apps/server/tests/path-folder-consistency.test.ts
+++ b/app/apps/server/tests/path-folder-consistency.test.ts
@@ -1,0 +1,263 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { freezeVaultRoot, seedFolder, seedNote, seedVault } from "./helpers/seed.js";
+import { recordingAppDeps } from "./helpers/app.js";
+import { createMcpToken } from "../src/mcp/tokens.js";
+
+/**
+ * `rel_path` and `folder_id` must agree — on every surface that creates or
+ * moves a note or folder (HTTP registry + MCP), and retroactively for the rows
+ * written before the rule existed (migration 022).
+ *
+ * The 2026-08-27 incident: an assistant created a note with `folderId` of
+ * `Team/BenAI/Profiles/Vault-Operator/Daily` and a `relPath` that dropped the
+ * `Team/` prefix. The root-freeze latch saw a parent and let it through; every
+ * desktop rendered a phantom root-level `BenAI/` folder, materialized an empty
+ * placeholder, and re-created it after every local delete. 104 more notes had
+ * `folder_id NULL` with a nested path — invisible to folder shares.
+ */
+
+const rec = recordingAppDeps();
+const app = createApp(rec.deps);
+
+afterAll(async () => {
+  await pool.end();
+});
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+let rpcId = 0;
+async function call(token: string, name: string, args: Record<string, unknown>) {
+  const res = await app.fetch(
+    new Request("http://local/api/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcId, method: "tools/call", params: { name, arguments: args } }),
+    }),
+  );
+  const body = (await res.json()) as {
+    result?: { structuredContent?: unknown; isError?: boolean; content?: Array<{ text: string }> };
+  };
+  return {
+    isError: body.result?.isError ?? false,
+    data: body.result?.structuredContent as any,
+    text: body.result?.content?.[0]?.text ?? "",
+  };
+}
+
+async function noteRow(docId: string) {
+  const { rows } = await pool.query<{ rel_path: string; folder_id: string | null }>(
+    "SELECT rel_path, folder_id FROM notes WHERE id = $1",
+    [docId],
+  );
+  return rows[0];
+}
+
+describe("rel_path ↔ folder_id consistency", () => {
+  let owner: TestUser;
+  let org: string;
+  let vault: string;
+  let team: string;
+  let daily: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+    owner = await signUp("owner@paths.test");
+    org = (await createOrg(owner, "Paths Co", "paths-co")).id;
+    vault = await seedVault(org);
+    team = await seedFolder(vault, null, "Team", "Team");
+    daily = await seedFolder(vault, team, "Daily", "Team/Daily");
+  });
+
+  describe("HTTP registry", () => {
+    it("refuses a note whose relPath is not inside the folderId it names (the incident)", async () => {
+      await freezeVaultRoot(vault);
+      const res = await req(owner, "POST", "/api/notes", {
+        vaultId: vault,
+        relPath: "BenAI/Daily/2026-08-27-daily.md", // dropped the `Team/` prefix
+        folderId: daily,
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe("path_folder_mismatch");
+      expect(body.error).toContain("Team/Daily");
+      // Nothing was written — no phantom root folder for every client to render.
+      const { rows } = await pool.query("SELECT 1 FROM notes WHERE vault_id = $1", [vault]);
+      expect(rows).toHaveLength(0);
+    });
+
+    it("resolves the folder from the path when the client sends no folderId", async () => {
+      await freezeVaultRoot(vault);
+      const res = await req(owner, "POST", "/api/notes", {
+        vaultId: vault,
+        relPath: "Team/Daily/note.md",
+      });
+      // Not a root creation, so the frozen root does not apply…
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      // …and the row is parented where its path says, so folder shares reach it.
+      expect(body.folderId).toBe(daily);
+      expect((await noteRow(body.docId)).folder_id).toBe(daily);
+    });
+
+    it("refuses a nested path whose folder does not exist (create the folder first)", async () => {
+      const res = await req(owner, "POST", "/api/notes", {
+        vaultId: vault,
+        relPath: "Nowhere/note.md",
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).code).toBe("path_folder_mismatch");
+    });
+
+    it("a folder's parentId must be the folder at its path's directory", async () => {
+      const wrong = await req(owner, "POST", "/api/folders", {
+        vaultId: vault,
+        name: "Specs",
+        path: "Specs", // root-level path…
+        parentId: team, // …claiming a nested parent
+      });
+      expect(wrong.status).toBe(400);
+      expect((await wrong.json()).code).toBe("path_folder_mismatch");
+
+      const resolved = await req(owner, "POST", "/api/folders", {
+        vaultId: vault,
+        name: "Specs",
+        path: "Team/Specs", // no parentId: resolved from the path
+      });
+      expect(resolved.status).toBe(201);
+      expect((await resolved.json()).parentId).toBe(team);
+    });
+
+    it("moving a note by relPath alone re-parents it, and out to a frozen root is refused", async () => {
+      const docId = await seedNote(vault, daily, "Team/Daily/a.md", owner.userId);
+      const moved = await req(owner, "PATCH", `/api/notes/${docId}`, { relPath: "Team/a.md" });
+      expect(moved.status).toBe(200);
+      expect((await moved.json()).folderId).toBe(team);
+      expect(await noteRow(docId)).toEqual({ rel_path: "Team/a.md", folder_id: team });
+
+      await freezeVaultRoot(vault);
+      // A relPath-only move to the root used to slip past the latch, which only
+      // looked at an explicit `folderId: null`.
+      const toRoot = await req(owner, "PATCH", `/api/notes/${docId}`, { relPath: "a.md" });
+      expect(toRoot.status).toBe(403);
+      expect((await toRoot.json()).code).toBe("root_frozen");
+      expect(await noteRow(docId)).toEqual({ rel_path: "Team/a.md", folder_id: team });
+    });
+
+    it("moving a note by folderId alone rewrites its path under that folder", async () => {
+      const docId = await seedNote(vault, team, "Team/b.md", owner.userId);
+      const moved = await req(owner, "PATCH", `/api/notes/${docId}`, { folderId: daily });
+      expect(moved.status).toBe(200);
+      expect(await noteRow(docId)).toEqual({ rel_path: "Team/Daily/b.md", folder_id: daily });
+    });
+
+    it("moving a folder by path alone re-parents it and its subtree", async () => {
+      const docId = await seedNote(vault, daily, "Team/Daily/c.md", owner.userId);
+      const archive = await seedFolder(vault, null, "Archive", "Archive");
+      const moved = await req(owner, "PATCH", `/api/folders/${daily}`, { path: "Archive/Daily" });
+      expect(moved.status).toBe(200);
+      const { rows } = await pool.query<{ parent_id: string; path: string }>(
+        "SELECT parent_id, path FROM folders WHERE id = $1",
+        [daily],
+      );
+      expect(rows[0]).toEqual({ parent_id: archive, path: "Archive/Daily" });
+      expect(await noteRow(docId)).toEqual({ rel_path: "Archive/Daily/c.md", folder_id: daily });
+    });
+  });
+
+  describe("MCP tools", () => {
+    let token: string;
+    beforeEach(async () => {
+      token = (await createMcpToken({ userId: owner.userId, organizationId: org }, "t")).token;
+    });
+
+    it("create_note refuses the incident's mismatched folderId/relPath pair", async () => {
+      await freezeVaultRoot(vault);
+      const out = await call(token, "create_note", {
+        vaultId: vault,
+        relPath: "BenAI/Daily/2026-08-27-daily.md",
+        folderId: daily,
+        content: "# Daily",
+      });
+      expect(out.isError).toBe(true);
+      expect(out.text).toContain("Team/Daily");
+      const { rows } = await pool.query("SELECT 1 FROM notes WHERE vault_id = $1", [vault]);
+      expect(rows).toHaveLength(0);
+    });
+
+    it("create_note without folderId lands in the folder its path names", async () => {
+      await freezeVaultRoot(vault);
+      const out = await call(token, "create_note", {
+        vaultId: vault,
+        relPath: "Team/Daily/2026-08-27-daily.md",
+        content: "# Daily",
+      });
+      expect(out.isError).toBe(false);
+      expect(out.data.folderId).toBe(daily);
+      expect((await noteRow(out.data.docId)).folder_id).toBe(daily);
+    });
+
+    it("move_note by relPath re-parents; folderId alone rewrites the path", async () => {
+      const docId = await seedNote(vault, daily, "Team/Daily/m.md", owner.userId);
+      const byPath = await call(token, "move_note", { docId, relPath: "Team/m.md" });
+      expect(byPath.isError).toBe(false);
+      expect(await noteRow(docId)).toEqual({ rel_path: "Team/m.md", folder_id: team });
+
+      const byFolder = await call(token, "move_note", { docId, folderId: daily });
+      expect(byFolder.isError).toBe(false);
+      expect(await noteRow(docId)).toEqual({ rel_path: "Team/Daily/m.md", folder_id: daily });
+    });
+
+    it("create_folder resolves the parent from the path", async () => {
+      const out = await call(token, "create_folder", { vaultId: vault, name: "Specs", path: "Team/Specs" });
+      expect(out.isError).toBe(false);
+      expect(out.data.parentId).toBe(team);
+    });
+  });
+
+  describe("migration 022 repairs pre-existing drift", () => {
+    const sql = readFileSync(new URL("../migrations/022_note_folder_consistency.sql", import.meta.url), "utf8");
+
+    it("re-points folder_id from the path, and moves a path under its folder when no folder exists there", async () => {
+      // (a) folder_id NULL, nested path → parented where the path says.
+      const orphan = await seedNote(vault, null, "Team/Daily/orphan.md", owner.userId);
+      // (b) the incident row: folder_id = Team/Daily, path at a root folder that
+      //     has no row; the correct name is already taken by a legitimate note.
+      await seedNote(vault, daily, "Team/Daily/2026-08-27-daily.md", owner.userId);
+      const stray = await seedNote(vault, daily, "BenAI/Daily/2026-08-27-daily.md", owner.userId);
+      // (c) folder_id points at Team, path under Team/Daily (a folder exists there) → path wins.
+      const mis = await seedNote(vault, team, "Team/Daily/mis.md", owner.userId);
+      // (d) a consistent note is untouched.
+      const fine = await seedNote(vault, team, "Team/fine.md", owner.userId);
+
+      await pool.query(sql);
+
+      expect(await noteRow(orphan)).toEqual({ rel_path: "Team/Daily/orphan.md", folder_id: daily });
+      expect(await noteRow(stray)).toEqual({
+        rel_path: `Team/Daily/2026-08-27-daily-${stray.slice(0, 8)}.md`,
+        folder_id: daily,
+      });
+      expect(await noteRow(mis)).toEqual({ rel_path: "Team/Daily/mis.md", folder_id: daily });
+      expect(await noteRow(fine)).toEqual({ rel_path: "Team/fine.md", folder_id: team });
+      // Idempotent: a second run changes nothing.
+      await pool.query(sql);
+      expect(await noteRow(stray)).toEqual({
+        rel_path: `Team/Daily/2026-08-27-daily-${stray.slice(0, 8)}.md`,
+        folder_id: daily,
+      });
+    });
+  });
+});

--- a/app/apps/server/tests/path-folder-consistency.test.ts
+++ b/app/apps/server/tests/path-folder-consistency.test.ts
@@ -231,6 +231,31 @@ describe("rel_path ↔ folder_id consistency", () => {
   describe("migration 022 repairs pre-existing drift", () => {
     const sql = readFileSync(new URL("../migrations/022_note_folder_consistency.sql", import.meta.url), "utf8");
 
+    it("collapses duplicate folder rows at one path onto the oldest, re-pointing notes and children", async () => {
+      // The unique index already exists in the test DB (migrations ran), so the
+      // twins are seeded with it dropped and the migration puts it back.
+      await pool.query("DROP INDEX IF EXISTS folders_vault_path_uq");
+      const twin = await seedFolder(vault, team, "Daily", "Team/Daily"); // newer twin of `daily`
+      const inTwin = await seedNote(vault, twin, "Team/Daily/twin.md", owner.userId);
+      const child = await seedFolder(vault, twin, "Sub", "Team/Daily/Sub");
+
+      await pool.query(sql);
+
+      const { rows } = await pool.query<{ id: string }>(
+        "SELECT id FROM folders WHERE vault_id = $1 AND path = 'Team/Daily'",
+        [vault],
+      );
+      expect(rows.map((r) => r.id)).toEqual([daily]); // oldest survives
+      expect(await noteRow(inTwin)).toEqual({ rel_path: "Team/Daily/twin.md", folder_id: daily });
+      const { rows: kid } = await pool.query<{ parent_id: string }>(
+        "SELECT parent_id FROM folders WHERE id = $1",
+        [child],
+      );
+      expect(kid[0].parent_id).toBe(daily); // child followed, not cascaded away
+      // …and the backstop is back: a second row at the same path is refused.
+      await expect(seedFolder(vault, team, "Daily", "Team/Daily")).rejects.toMatchObject({ code: "23505" });
+    });
+
     it("re-points folder_id from the path, and moves a path under its folder when no folder exists there", async () => {
       // (a) folder_id NULL, nested path → parented where the path says.
       const orphan = await seedNote(vault, null, "Team/Daily/orphan.md", owner.userId);

--- a/app/apps/server/tests/registry.test.ts
+++ b/app/apps/server/tests/registry.test.ts
@@ -60,6 +60,7 @@ describe("registry structure sync", () => {
   });
 
   it("registering a path that already has a live note ADOPTS it — even under a different doc_id", async () => {
+    await seedFolder(vault, null, "Daily", "Daily");
     const first = await req(owner, "POST", "/api/notes", {
       vaultId: vault,
       relPath: "Daily/2026-08-10.md",


### PR DESCRIPTION
## Why
A note's location is stored twice (`rel_path`, `folder_id`) and nothing kept them in agreement. On 2026-08-27 an MCP `create_note` arrived with `folderId` of `Team/BenAI/Profiles/Vault-Operator/Daily` and a `relPath` missing the `Team/` prefix. The root-freeze latch keyed off `folder_id`, saw a parent and allowed it; every desktop rendered a phantom root-level `BenAI/` folder, materialized an empty placeholder, and re-created it after every local delete (disk deletions never propagate). Prod had 107 such drifted notes across 3 vaults (104 with `folder_id NULL` + nested path → invisible to folder shares), plus 11 duplicate folder rows at 4 paths.

## What
- `registry/tree-ops.ts`: `resolveParentFolder` / `resolveFolderParent` / `planNoteMove` / `planFolderMove` — the path is authoritative; a supplied folder id must be the folder at the path's directory (400 `path_folder_mismatch`) or is resolved from the path. Used by `POST /api/notes|files|folders`, `PATCH /api/notes/:id`, `PATCH /api/folders/:id`, MCP `create_note`/`create_folder`/`move_note`/`move_folder`. Root freeze and destination-permission gates judge the resolved parent.
- Migration 022: dedupe folder rows (keep oldest, re-point notes/files/children), unique `(vault_id, path)` index, re-point `folder_id` from the path, move the stray note under its real folder (suffixed on collision).
- Both folder-create surfaces adopt the winner on a 23505 race.
- MCP tool descriptions steer assistants to omit `folderId` and create folders first.
- Tests: `tests/path-folder-consistency.test.ts` (HTTP, MCP, migration repair + idempotency); legacy tests fixed to create folders first.

Server-only; no desktop change, no version bump. The repair has been applied to the managed DB already (verified 0 mismatches / 0 duplicate paths); the migration is idempotent on deploy.