### PR TITLE
Bulk sync PR 1: heal server-empty notes, download before upload, doc-free backfill, batched indexing

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.40"
+version = "0.1.41"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -496,26 +496,34 @@ pub async fn import_paths(
     // it opened. Without the pin an import could copy files into a different vault.
     let (vault, index) = require_vault_at(&state, expected_epoch)?;
     let summary = import_export::import_paths(&vault, &dest, &sources);
-    // Index every new note under the imported top-level items.
-    let guard = index.lock().unwrap();
+    // Index every new note under the imported top-level items — collected FIRST,
+    // then handed to the index as ONE batch. Indexing them one at a time re-ran a
+    // whole-vault link-resolution pass per file, so importing a folder of 1000
+    // notes cost 1000 of them (see `Index::index_notes`).
+    let mut md_paths: Vec<PathBuf> = Vec::new();
     for rel in &summary.imported {
         if let Ok(abs) = vault::resolve_in_vault(&vault, rel) {
-            index_md_tree(&guard, &vault, &abs);
+            collect_md_tree(&abs, &mut md_paths);
         }
+    }
+    let guard = index.lock().unwrap();
+    for (path, err) in guard.index_notes(&vault, &md_paths)? {
+        eprintln!("[import] index failed for {}: {err}", path.display());
     }
     Ok(summary)
 }
 
-/// Recursively index every `.md` file at/under `abs` (best-effort).
-fn index_md_tree(index: &Index, vault: &Path, abs: &Path) {
+/// Collect every `.md` file at/under `abs` (best-effort; an unreadable dir is
+/// skipped rather than failing the whole import).
+fn collect_md_tree(abs: &Path, out: &mut Vec<PathBuf>) {
     if abs.is_dir() {
         if let Ok(entries) = std::fs::read_dir(abs) {
             for entry in entries.flatten() {
-                index_md_tree(index, vault, &entry.path());
+                collect_md_tree(&entry.path(), out);
             }
         }
     } else if abs.extension().and_then(|e| e.to_str()) == Some("md") {
-        let _ = index.index_note(vault, abs);
+        out.push(abs.to_path_buf());
     }
 }
 
@@ -684,10 +692,13 @@ pub async fn set_vault_config(
     expected_epoch: Option<u64>,
 ) -> AppResult<()> {
     let (vault, _) = require_vault_at(&state, expected_epoch)?;
-    let dir = vault.join(".context");
-    std::fs::create_dir_all(&dir)?;
-    std::fs::write(dir.join("config.json"), content)?;
-    Ok(())
+    // Atomic + fsync'd: this file is the ONLY copy of the vault's doc-id map, and
+    // it is rewritten on every registry pull. A bare `fs::write` truncates first,
+    // so a crash (or a full disk) mid-write leaves a half-written or empty map —
+    // which the sync layer reads as "this vault knows nothing about its notes"
+    // and re-registers everything. See `notefile::write_atomic_fsync`.
+    let target = vault.join(".context").join("config.json");
+    notefile::write_atomic_fsync(&target, content.as_bytes())
 }
 
 /// Persist the sync server base URL (app config, next to last_vault).

--- a/app/apps/desktop/src-tauri/src/index.rs
+++ b/app/apps/desktop/src-tauri/src/index.rs
@@ -7,19 +7,29 @@
 //! forks a note's identity. On rename we update the path column by id, so
 //! inbound links (which store `dst_note_id`) never break.
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::notefile::sha256_hex;
 use crate::parse::parse_note;
 use crate::vault::{is_ignored_name, rel_from_abs};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 use uuid::Uuid;
 use walkdir::WalkDir;
 
+/// Only log a batch's timing past this many files: a single-note save goes
+/// through the same code and must stay silent.
+const BATCH_LOG_MIN: usize = 50;
+
 pub struct Index {
     conn: Connection,
+    /// Test-only: how many times `resolve_all_links` has run. The entire point of
+    /// the batch entry points is ONE link pass per batch instead of one per file,
+    /// and that difference is only observable by counting.
+    #[cfg(test)]
+    resolve_calls: std::cell::Cell<usize>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -88,7 +98,15 @@ impl Index {
         // "database is locked" — a big index build and a concurrent read/sync
         // can briefly overlap, and a short wait is far better than an error.
         conn.pragma_update(None, "busy_timeout", 5000)?;
-        let idx = Index { conn };
+        // NORMAL, not the default FULL: under WAL this stops fsync'ing the WAL on
+        // every commit, which is what made a bulk index (one transaction per file)
+        // disk-bound. The safety trade is bounded and acceptable here — WAL+NORMAL
+        // can lose the last transaction(s) on an OS/power crash but never corrupts
+        // the database, and everything in this file is either derived from the
+        // `.md` files (rebuildable by `rebuild`) or a CRDT update log whose peer
+        // copies (the open Y.Doc and the server) re-supply anything lost.
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        let idx = Index::new(conn);
         idx.migrate()?;
         Ok(idx)
     }
@@ -96,9 +114,23 @@ impl Index {
     #[cfg(test)]
     pub fn open_in_memory() -> AppResult<Self> {
         let conn = Connection::open_in_memory()?;
-        let idx = Index { conn };
+        let idx = Index::new(conn);
         idx.migrate()?;
         Ok(idx)
+    }
+
+    fn new(conn: Connection) -> Self {
+        Index {
+            conn,
+            #[cfg(test)]
+            resolve_calls: std::cell::Cell::new(0),
+        }
+    }
+
+    /// Test-only accessor for the link-pass counter (see `resolve_calls`).
+    #[cfg(test)]
+    fn resolve_call_count(&self) -> usize {
+        self.resolve_calls.get()
     }
 
     fn migrate(&self) -> AppResult<()> {
@@ -192,6 +224,8 @@ impl Index {
     /// live edits are indexed by the file watcher through `index_note`, so this
     /// only governs changes made while the app was closed, where mtimes differ.
     pub fn rebuild(&self, vault: &Path) -> AppResult<()> {
+        let started = Instant::now();
+        let mut touched = 0usize;
         let tx = self.conn.unchecked_transaction()?;
 
         // Snapshot what's already indexed: path -> (id, mtime, rowid).
@@ -250,11 +284,13 @@ impl Index {
                 // Changed — re-index in place, preserving the doc_id.
                 Some((id, _, _)) => {
                     self.index_one(&tx, vault, abs, Some(id.clone()))?;
+                    touched += 1;
                     changed = true;
                 }
                 // New file.
                 None => {
                     self.index_one(&tx, vault, abs, None)?;
+                    touched += 1;
                     changed = true;
                 }
             }
@@ -286,48 +322,128 @@ impl Index {
             self.resolve_all_links(&tx)?;
         }
         tx.commit()?;
+        log_batch("rebuild", touched, started);
         Ok(())
     }
 
-    /// Incrementally (re)index a single note by absolute path.
-    pub fn index_note(&self, vault: &Path, abs: &Path) -> AppResult<()> {
+    /// (Re)index a BATCH of notes: ONE transaction, ONE link-resolution pass.
+    ///
+    /// Why this exists. `resolve_all_links` reads every row of `notes` and every
+    /// row of `links` and then rewrites every link row. Running it once *per
+    /// file* — which is what `index_note` did, and the watcher called it once per
+    /// dirty path — makes indexing N files O(N × links_in_vault), each pass in
+    /// its own transaction. Dropping 1000 notes into a vault meant 1000
+    /// whole-vault link passes and 1000 commits. `rebuild` has always had the
+    /// right shape (one tx, `index_one` per file, one link pass if anything
+    /// changed); this is that shape for an incremental batch.
+    ///
+    /// Per-path failures are RETURNED, not propagated: one unreadable file in a
+    /// 1000-file drop must not cost the other 999 their index rows. A file whose
+    /// read fails has written nothing to the transaction yet (`index_one` reads
+    /// and parses before it touches SQL), so skipping it leaves no partial row.
+    pub fn index_notes(
+        &self,
+        vault: &Path,
+        abs_paths: &[PathBuf],
+    ) -> AppResult<Vec<(PathBuf, AppError)>> {
+        if abs_paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        let started = Instant::now();
         let tx = self.conn.unchecked_transaction()?;
-        let rel = rel_from_abs(vault, abs)?;
-        let reuse_id = self.id_for_path(&tx, &rel)?;
-        self.index_one(&tx, vault, abs, reuse_id)?;
-        self.resolve_all_links(&tx)?;
+        let mut failures: Vec<(PathBuf, AppError)> = Vec::new();
+        let mut indexed = 0usize;
+        for abs in abs_paths {
+            let outcome = rel_from_abs(vault, abs)
+                .and_then(|rel| self.id_for_path(&tx, &rel))
+                .and_then(|reuse_id| self.index_one(&tx, vault, abs, reuse_id));
+            match outcome {
+                Ok(()) => indexed += 1,
+                Err(e) => failures.push((abs.clone(), e)),
+            }
+        }
+        // The single pass the whole batch shares.
+        if indexed > 0 {
+            self.resolve_all_links(&tx)?;
+        }
         tx.commit()?;
-        Ok(())
+        log_batch("index_notes", abs_paths.len(), started);
+        Ok(failures)
+    }
+
+    /// Incrementally (re)index a single note by absolute path — a one-element
+    /// [`Index::index_notes`], so the two paths can never drift.
+    pub fn index_note(&self, vault: &Path, abs: &Path) -> AppResult<()> {
+        let mut failures = self.index_notes(vault, &[abs.to_path_buf()])?;
+        match failures.pop() {
+            Some((_, e)) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Remove a BATCH of notes/folders: ONE transaction, ONE link pass — the
+    /// removal twin of [`Index::index_notes`] (same quadratic problem: a folder
+    /// delete arrives as many watcher paths at once).
+    pub fn remove_notes(
+        &self,
+        vault: &Path,
+        abs_paths: &[PathBuf],
+    ) -> AppResult<Vec<(PathBuf, AppError)>> {
+        if abs_paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        let mut failures: Vec<(PathBuf, AppError)> = Vec::new();
+        let mut removed = 0usize;
+        for abs in abs_paths {
+            match self.remove_one(&tx, vault, abs) {
+                Ok(()) => removed += 1,
+                Err(e) => failures.push((abs.clone(), e)),
+            }
+        }
+        if removed > 0 {
+            self.resolve_all_links(&tx)?;
+        }
+        tx.commit()?;
+        Ok(failures)
     }
 
     /// Remove a note by absolute path, OR every note under a deleted folder
-    /// (prefix match). Idempotent.
+    /// (prefix match). Idempotent. One-element [`Index::remove_notes`].
     pub fn remove_note(&self, vault: &Path, abs: &Path) -> AppResult<()> {
+        let mut failures = self.remove_notes(vault, &[abs.to_path_buf()])?;
+        match failures.pop() {
+            Some((_, e)) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// The row-level removal, inside a caller-owned transaction and WITHOUT a
+    /// link pass (the batch does that once at the end).
+    fn remove_one(&self, tx: &Connection, vault: &Path, abs: &Path) -> AppResult<()> {
         let rel = rel_from_abs(vault, abs)?;
-        let tx = self.conn.unchecked_transaction()?;
 
         // Exact-path note (a file delete).
-        if let Some((id, rowid)) = self.row_for_path(&tx, &rel)? {
-            Self::delete_note_rows(&tx, &id, rowid)?;
+        if let Some((id, rowid)) = self.row_for_path(tx, &rel)? {
+            Self::delete_note_rows(tx, &id, rowid)?;
         }
 
         // Any notes under a deleted folder (prefix delete).
         let prefix = format!("{rel}/");
         let victims: Vec<(String, i64)> = {
-            let mut stmt =
-                tx.prepare("SELECT id, rowid FROM notes WHERE path LIKE ?1 || '%'")?;
+            let mut stmt = tx.prepare("SELECT id, rowid FROM notes WHERE path LIKE ?1 || '%'")?;
             let rows = stmt.query_map(params![prefix], |r| {
                 Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
             })?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
         for (id, rowid) in victims {
-            Self::delete_note_rows(&tx, &id, rowid)?;
+            Self::delete_note_rows(tx, &id, rowid)?;
         }
-        tx.execute("DELETE FROM folders WHERE id = ?1 OR path LIKE ?2 || '%'", params![rel, prefix])?;
-
-        self.resolve_all_links(&tx)?;
-        tx.commit()?;
+        tx.execute(
+            "DELETE FROM folders WHERE id = ?1 OR path LIKE ?2 || '%'",
+            params![rel, prefix],
+        )?;
         Ok(())
     }
 
@@ -359,8 +475,7 @@ impl Index {
         // each note's doc_id stable.
         let old_prefix = format!("{old_rel}/");
         let children: Vec<(String, String)> = {
-            let mut stmt =
-                tx.prepare("SELECT id, path FROM notes WHERE path LIKE ?1 || '%'")?;
+            let mut stmt = tx.prepare("SELECT id, path FROM notes WHERE path LIKE ?1 || '%'")?;
             let rows = stmt.query_map(params![old_prefix], |r| {
                 Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
             })?;
@@ -369,7 +484,10 @@ impl Index {
         for (id, path) in children {
             let suffix = &path[old_prefix.len()..];
             let new_path = format!("{new_rel}/{suffix}");
-            tx.execute("UPDATE notes SET path = ?1 WHERE id = ?2", params![new_path, id])?;
+            tx.execute(
+                "UPDATE notes SET path = ?1 WHERE id = ?2",
+                params![new_path, id],
+            )?;
         }
 
         // Re-resolve links (a file rename can change the basename used to resolve).
@@ -407,9 +525,10 @@ impl Index {
             params![id, rel, parsed.title, mtime, sha, parsed.frontmatter_json],
         )?;
 
-        let rowid: i64 = tx.query_row("SELECT rowid FROM notes WHERE id = ?1", params![id], |r| {
-            r.get(0)
-        })?;
+        let rowid: i64 =
+            tx.query_row("SELECT rowid FROM notes WHERE id = ?1", params![id], |r| {
+                r.get(0)
+            })?;
 
         // FTS: replace the row (contentless_delete lets us DELETE by rowid).
         tx.execute("DELETE FROM notes_fts WHERE rowid = ?1", params![rowid])?;
@@ -421,7 +540,10 @@ impl Index {
         // Tags.
         tx.execute("DELETE FROM note_tags WHERE note_id = ?1", params![id])?;
         for tag in &parsed.tags {
-            tx.execute("INSERT OR IGNORE INTO tags (name) VALUES (?1)", params![tag])?;
+            tx.execute(
+                "INSERT OR IGNORE INTO tags (name) VALUES (?1)",
+                params![tag],
+            )?;
             let tag_id: i64 =
                 tx.query_row("SELECT id FROM tags WHERE name = ?1", params![tag], |r| {
                     r.get(0)
@@ -468,6 +590,8 @@ impl Index {
     /// note basenames (case-insensitive), then titles. Cheap enough for Phase 0
     /// and guarantees previously-dangling links resolve once a target appears.
     fn resolve_all_links(&self, tx: &Connection) -> AppResult<()> {
+        #[cfg(test)]
+        self.resolve_calls.set(self.resolve_calls.get() + 1);
         // Build lookup maps from all notes.
         let mut by_basename: HashMap<String, String> = HashMap::new();
         let mut by_title: HashMap<String, String> = HashMap::new();
@@ -499,11 +623,18 @@ impl Index {
         let links: Vec<(i64, String)> = {
             let mut stmt = tx.prepare("SELECT id, dst_path_raw FROM links")?;
             let rows = stmt.query_map([], |r| {
-                Ok((r.get::<_, i64>(0)?, r.get::<_, Option<String>>(1)?.unwrap_or_default()))
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                ))
             })?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
 
+        // Hoisted out of the loop: `Connection::execute` re-prepares (and
+        // re-parses) the statement on every call, which on a link-dense vault is
+        // tens of thousands of needless prepares per pass.
+        let mut update = tx.prepare("UPDATE links SET dst_note_id = ?1 WHERE id = ?2")?;
         for (link_id, raw) in links {
             // raw may contain alias/heading — strip for matching.
             let target = raw
@@ -522,10 +653,7 @@ impl Index {
                 .trim_end_matches(".md")
                 .to_string();
             let dst = by_basename.get(&base).or_else(|| by_title.get(&target));
-            tx.execute(
-                "UPDATE links SET dst_note_id = ?1 WHERE id = ?2",
-                params![dst, link_id],
-            )?;
+            update.execute(params![dst, link_id])?;
         }
         Ok(())
     }
@@ -685,7 +813,12 @@ impl Index {
         }
         let base = target.rsplit('/').next().unwrap_or(&target).to_string();
 
-        let map = |r: &rusqlite::Row| Ok(ResolvedLink { id: r.get(0)?, path: r.get(1)? });
+        let map = |r: &rusqlite::Row| {
+            Ok(ResolvedLink {
+                id: r.get(0)?,
+                path: r.get(1)?,
+            })
+        };
 
         // 1. Full relative path (e.g. "Projects/Baalda").
         let full_md = format!("{target}.md");
@@ -915,6 +1048,21 @@ fn file_mtime(abs: &Path) -> i64 {
         .unwrap_or(0)
 }
 
+/// Terse timing for the batch index paths. Silent for small batches so a normal
+/// single-note save logs nothing; a cold `rebuild` or a bulk file drop — the two
+/// places where the old one-link-pass-per-file behaviour showed up as seconds of
+/// stall — reports how long it took.
+fn log_batch(label: &str, files: usize, started: Instant) {
+    if files < BATCH_LOG_MIN {
+        return;
+    }
+    let ms = started.elapsed().as_millis();
+    eprintln!(
+        "[index] {label}: {files} files in {ms} ms ({:.2} ms/file)",
+        ms as f64 / files as f64
+    );
+}
+
 /// Turn free-form user input into a safe FTS5 MATCH query: each term becomes a
 /// prefix match, joined by AND. Quotes special chars to avoid syntax errors.
 fn build_fts_query(input: &str) -> String {
@@ -962,8 +1110,18 @@ mod tests {
     fn seed_vault() -> (tempfile::TempDir, std::path::PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
         let v = tmp.path().to_path_buf();
-        write_note(&v, "Alpha.md", "---\ntags: [project]\n---\n# Alpha\n\nLinks to [[Beta]] and #inline tag.").unwrap();
-        write_note(&v, "sub/Beta.md", "# Beta\n\nThe quick brown fox. Back to [[Alpha]].").unwrap();
+        write_note(
+            &v,
+            "Alpha.md",
+            "---\ntags: [project]\n---\n# Alpha\n\nLinks to [[Beta]] and #inline tag.",
+        )
+        .unwrap();
+        write_note(
+            &v,
+            "sub/Beta.md",
+            "# Beta\n\nThe quick brown fox. Back to [[Alpha]].",
+        )
+        .unwrap();
         write_note(&v, "Gamma.md", "# Gamma\n\nDangling [[Nonexistent]] link.").unwrap();
         (tmp, v)
     }
@@ -1021,7 +1179,10 @@ mod tests {
             .map(|t| t.path)
             .collect();
         assert!(paths.contains("Delta.md"), "new file should be indexed");
-        assert!(!paths.contains("Gamma.md"), "deleted file should be dropped");
+        assert!(
+            !paths.contains("Gamma.md"),
+            "deleted file should be dropped"
+        );
         assert_eq!(paths.len(), 3); // Alpha, sub/Beta, Delta
 
         // Alpha kept its identity through the edit, and its new link resolved
@@ -1031,6 +1192,250 @@ mod tests {
         let backlinks = idx.get_backlinks(&delta.id).unwrap();
         assert_eq!(backlinks.len(), 1);
         assert_eq!(backlinks[0].title, "Alpha");
+    }
+
+    // ---- batch indexing (the quadratic-link-pass fix) ---------------------
+
+    /// Every file-derived row a batch produces, in a form that is comparable
+    /// across two independently-built vaults (doc_ids are fresh UUIDs, and the
+    /// two vaults' mtimes can differ by a second, so neither is included).
+    #[allow(clippy::type_complexity)]
+    fn file_derived_snapshot(
+        idx: &Index,
+    ) -> (
+        Vec<(String, String, String)>,
+        Vec<(String, String)>,
+        Vec<(String, String, String)>,
+        Vec<(String, String)>,
+    ) {
+        let notes: Vec<(String, String, String)> = {
+            let mut stmt = idx
+                .conn
+                .prepare("SELECT path, title, sha256 FROM notes ORDER BY path")
+                .unwrap();
+            stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                    r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                ))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+        };
+        let fts: Vec<(String, String)> = {
+            let mut stmt = idx
+                .conn
+                .prepare(
+                    "SELECT n.path, f.body FROM notes_fts f
+                     JOIN notes n ON n.rowid = f.rowid ORDER BY n.path",
+                )
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        // Links joined back to PATHS on both ends: `dst_note_id` proves the link
+        // pass ran, and a path is stable across vaults where an id is not.
+        let links: Vec<(String, String, String)> = {
+            let mut stmt = idx
+                .conn
+                .prepare(
+                    "SELECT src.path, COALESCE(dst.path, '-'), l.dst_path_raw
+                     FROM links l
+                     JOIN notes src ON src.id = l.src_note_id
+                     LEFT JOIN notes dst ON dst.id = l.dst_note_id
+                     ORDER BY src.path, l.dst_path_raw",
+                )
+                .unwrap();
+            stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                ))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+        };
+        let tags: Vec<(String, String)> = {
+            let mut stmt = idx
+                .conn
+                .prepare(
+                    "SELECT n.path, t.name FROM note_tags nt
+                     JOIN notes n ON n.id = nt.note_id
+                     JOIN tags t ON t.id = nt.tag_id
+                     ORDER BY n.path, t.name",
+                )
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        (notes, fts, links, tags)
+    }
+
+    fn seed_batch_vault() -> (tempfile::TempDir, std::path::PathBuf, Vec<PathBuf>) {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        let files = [
+            (
+                "Alpha.md",
+                "---\ntags: [project]\n---\n# Alpha\n\nTo [[Beta]] and [[Gamma]]. #inline",
+            ),
+            (
+                "sub/Beta.md",
+                "# Beta\n\nBack to [[Alpha]] and out to [[Nowhere]].",
+            ),
+            (
+                "Gamma.md",
+                "# Gamma\n\nquick brown fox linking [[sub/Beta]].",
+            ),
+            (
+                "sub/deep/Delta.md",
+                "---\ntags: [a, b]\n---\n# Delta\n\n[[Alpha]] [[Gamma]]",
+            ),
+            ("Epsilon.md", "# Epsilon\n\nNo links here at all."),
+        ];
+        let mut abs = Vec::new();
+        for (rel, body) in files {
+            write_note(&v, rel, body).unwrap();
+            abs.push(v.join(rel));
+        }
+        (tmp, v, abs)
+    }
+
+    /// The batch entry point must be observationally identical to calling
+    /// `index_note` once per file — same notes, FTS rows, tags, and RESOLVED
+    /// links. Only the number of whole-vault link passes differs.
+    #[test]
+    fn index_notes_matches_one_index_note_per_file() {
+        let (_tmp_a, va, abs_a) = seed_batch_vault();
+        let idx_a = Index::open(&va).unwrap();
+        for abs in &abs_a {
+            idx_a.index_note(&va, abs).unwrap();
+        }
+
+        let (_tmp_b, vb, abs_b) = seed_batch_vault();
+        let idx_b = Index::open(&vb).unwrap();
+        assert!(idx_b.index_notes(&vb, &abs_b).unwrap().is_empty());
+
+        assert_eq!(file_derived_snapshot(&idx_a), file_derived_snapshot(&idx_b));
+
+        // And the snapshot is not trivially empty / unresolved.
+        let (notes, _, links, _) = file_derived_snapshot(&idx_b);
+        assert_eq!(notes.len(), 5);
+        assert!(
+            links.iter().any(|(_, dst, _)| dst != "-"),
+            "links should be resolved: {links:?}"
+        );
+        assert!(
+            links
+                .iter()
+                .any(|(_, dst, raw)| dst == "-" && raw == "Nowhere"),
+            "a dangling link stays dangling: {links:?}"
+        );
+    }
+
+    /// The whole point: ONE link pass for the batch, versus one per file.
+    #[test]
+    fn index_notes_runs_exactly_one_link_pass_per_batch() {
+        let (_tmp, v, abs) = seed_batch_vault();
+        let idx = Index::open(&v).unwrap();
+        assert_eq!(idx.resolve_call_count(), 0);
+
+        idx.index_notes(&v, &abs).unwrap();
+        assert_eq!(
+            idx.resolve_call_count(),
+            1,
+            "5 files must cost ONE whole-vault link pass"
+        );
+
+        // The old shape, for contrast: one pass per file.
+        for one in &abs {
+            idx.index_note(&v, one).unwrap();
+        }
+        assert_eq!(idx.resolve_call_count(), 1 + abs.len());
+
+        // Removals batch the same way.
+        idx.remove_notes(&v, &abs).unwrap();
+        assert_eq!(idx.resolve_call_count(), 2 + abs.len());
+
+        // An empty batch does no work at all (no transaction, no pass).
+        let before = idx.resolve_call_count();
+        assert!(idx.index_notes(&v, &[]).unwrap().is_empty());
+        assert!(idx.remove_notes(&v, &[]).unwrap().is_empty());
+        assert_eq!(idx.resolve_call_count(), before);
+    }
+
+    /// One bad file in a big drop must not cost the rest their index rows — it
+    /// comes back as a reported failure instead.
+    #[test]
+    fn index_notes_reports_a_bad_file_without_aborting_the_batch() {
+        let (_tmp, v, mut abs) = seed_batch_vault();
+        let idx = Index::open(&v).unwrap();
+
+        // Two failures of different shapes: a path that doesn't exist (read
+        // error) and one outside the vault (rel_from_abs error).
+        let missing = v.join("sub/Ghost.md");
+        let outside = std::path::PathBuf::from("/definitely/not/in/the/vault.md");
+        abs.insert(2, missing.clone());
+        abs.push(outside.clone());
+
+        let failures = idx.index_notes(&v, &abs).unwrap();
+        let failed: Vec<&PathBuf> = failures.iter().map(|(p, _)| p).collect();
+        assert_eq!(failures.len(), 2, "reported: {failed:?}");
+        assert!(failed.contains(&&missing));
+        assert!(failed.contains(&&outside));
+
+        // Every good file still landed, links and all.
+        assert_eq!(idx.list_note_titles().unwrap().len(), 5);
+        let alpha = idx.get_note_meta("Alpha.md").unwrap().unwrap();
+        assert!(!idx.get_backlinks(&alpha.id).unwrap().is_empty());
+        // Still exactly one link pass despite the failures.
+        assert_eq!(idx.resolve_call_count(), 1);
+    }
+
+    /// A folder delete arrives as several watcher paths; batching removals must
+    /// prune the subtree exactly as the per-path loop did.
+    #[test]
+    fn remove_notes_prunes_files_and_folder_subtrees() {
+        let (_tmp, v, _abs) = seed_batch_vault();
+        let idx = Index::open(&v).unwrap();
+        idx.rebuild(&v).unwrap();
+        assert_eq!(idx.list_note_titles().unwrap().len(), 5);
+
+        // One file plus a whole folder (which owns sub/Beta.md and sub/deep/Delta.md).
+        let victims = vec![v.join("Epsilon.md"), v.join("sub")];
+        assert!(idx.remove_notes(&v, &victims).unwrap().is_empty());
+
+        let left: Vec<String> = idx
+            .list_note_titles()
+            .unwrap()
+            .into_iter()
+            .map(|t| t.path)
+            .collect();
+        assert_eq!(left, vec!["Alpha.md".to_string(), "Gamma.md".to_string()]);
+        // Alpha's [[Beta]] is dangling again — the link pass ran after the batch.
+        let alpha = idx.get_note_meta("Alpha.md").unwrap().unwrap();
+        let dangling: i64 = idx
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM links WHERE src_note_id = ?1 AND dst_note_id IS NULL",
+                params![alpha.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dangling, 1);
+        // A path with nothing indexed under it is a no-op, not an error.
+        assert!(idx
+            .remove_notes(&v, &[v.join("never-existed")])
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -1064,13 +1469,22 @@ mod tests {
         let snip = &results[0].snippet;
         // The dangerous markup is escaped — no live tags survive.
         assert!(snip.contains("&lt;img"), "raw < must be escaped: {snip}");
-        assert!(!snip.contains("<img"), "no live <img> tag may survive: {snip}");
-        assert!(!snip.contains("onerror=\"alert"), "no live handler may survive: {snip}");
+        assert!(
+            !snip.contains("<img"),
+            "no live <img> tag may survive: {snip}"
+        );
+        assert!(
+            !snip.contains("onerror=\"alert"),
+            "no live handler may survive: {snip}"
+        );
         // The `"` around the handler is entity-escaped (proves the &-based
         // escaping path runs over the snippet).
         assert!(snip.contains("&quot;"), "raw \" must be escaped: {snip}");
         // The highlight markers are still present and are the only surviving tags.
-        assert!(snip.contains("<mark>") && snip.contains("</mark>"), "highlight preserved: {snip}");
+        assert!(
+            snip.contains("<mark>") && snip.contains("</mark>"),
+            "highlight preserved: {snip}"
+        );
     }
 
     #[test]
@@ -1101,7 +1515,12 @@ mod tests {
         let beta_id = beta.id.clone();
 
         // Move Beta on disk + update the index by id.
-        write_note(&v, "moved/BetaRenamedFile.md", "# Beta\n\nMoved body [[Alpha]].").unwrap();
+        write_note(
+            &v,
+            "moved/BetaRenamedFile.md",
+            "# Beta\n\nMoved body [[Alpha]].",
+        )
+        .unwrap();
         std::fs::remove_file(v.join("sub/Beta.md")).unwrap();
         idx.rename_note(
             &v,
@@ -1111,7 +1530,10 @@ mod tests {
         .unwrap();
 
         // The rule: rename preserves doc_id (identity never forks).
-        let moved = idx.get_note_meta("moved/BetaRenamedFile.md").unwrap().unwrap();
+        let moved = idx
+            .get_note_meta("moved/BetaRenamedFile.md")
+            .unwrap()
+            .unwrap();
         assert_eq!(moved.id, beta_id);
 
         // Inbound links keyed by dst_note_id are never touched by a move — so
@@ -1207,7 +1629,8 @@ mod tests {
         idx.append_yjs_update("doc-a", &[2]).unwrap();
         idx.append_yjs_update("doc-b", &[7]).unwrap();
 
-        idx.save_yjs_snapshot("doc-a", &[10, 20, 30], &[40]).unwrap();
+        idx.save_yjs_snapshot("doc-a", &[10, 20, 30], &[40])
+            .unwrap();
 
         let a = idx.load_yjs_state("doc-a").unwrap();
         assert_eq!(a.snapshot, Some(vec![10, 20, 30]));

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 //! Baalda — desktop Rust core (Phase 0).
 //! Rust owns all disk I/O; the React UI talks to it through the typed commands
-//! registered here and reacts to `file-changed` / `vault-opened` events.
+//! registered here and reacts to `files-changed` / `vault-opened` events.
 
 pub mod attachments;
 mod commands;

--- a/app/apps/desktop/src-tauri/src/notefile.rs
+++ b/app/apps/desktop/src-tauri/src/notefile.rs
@@ -34,6 +34,45 @@ pub fn write_note(vault: &Path, rel: &str, content: &str) -> AppResult<()> {
     Ok(())
 }
 
+/// Atomic write of an absolute path, with the data **fsync'd** before the
+/// rename. For files that have no second copy anywhere.
+///
+/// [`write_note`] deliberately skips the fsync: a note's bytes also live in the
+/// open Y.Doc and (when synced) on the server, so a crash that loses the tail of
+/// a write costs at most a re-egest. `.context/config.json` is the opposite —
+/// it is the ONLY copy of the vault's doc-id map, and a rename that lands before
+/// its data reaches disk leaves an empty or truncated map, which reads as "this
+/// vault knows nothing about its notes" and re-registers the whole vault.
+///
+/// The caller supplies an absolute path because the one caller writes inside
+/// `.context/`, which `resolve_in_vault` is not used for.
+pub fn write_atomic_fsync(target: &Path, content: &[u8]) -> AppResult<()> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| AppError::new("target has no parent directory"))?;
+    std::fs::create_dir_all(parent)?;
+    let file_name = target
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| AppError::new("invalid file name"))?;
+    let tmp = parent.join(format!(".{file_name}.tmp"));
+
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(content)?;
+        // Data on disk BEFORE the rename publishes it.
+        f.sync_all()?;
+    }
+    // Leave no debris behind if the rename fails (a full disk, a permissions
+    // change): the stale temp file would otherwise sit in `.context` forever.
+    if let Err(e) = std::fs::rename(&tmp, target) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
 /// Write a note ONLY if nothing is there yet. Returns true when the file was
 /// created, false when it already existed (left byte-for-byte untouched).
 ///
@@ -113,7 +152,9 @@ pub fn rename_path(vault: &Path, old_rel: &str, new_rel: &str) -> AppResult<Stri
 /// from a real failure is how idempotency quietly breaks.
 pub fn ensure_folder(vault: &Path, rel: &str) -> AppResult<()> {
     if crate::vault::rel_path_is_ignored(rel) {
-        return Err(AppError::new("refusing to create a folder in an ignored dir"));
+        return Err(AppError::new(
+            "refusing to create a folder in an ignored dir",
+        ));
     }
     let abs = resolve_in_vault(vault, rel)?;
     std::fs::create_dir_all(&abs)?;
@@ -143,7 +184,9 @@ pub fn trash_note(vault: &Path, rel: &str, stamp: &str) -> AppResult<String> {
         return Err(AppError::new("invalid trash stamp"));
     }
     if crate::vault::rel_path_is_ignored(rel) {
-        return Err(AppError::new("refusing to trash a path inside an ignored dir"));
+        return Err(AppError::new(
+            "refusing to trash a path inside an ignored dir",
+        ));
     }
     let abs = resolve_in_vault(vault, rel)?;
     if !abs.exists() {
@@ -280,6 +323,35 @@ mod tests {
     }
 
     #[test]
+    fn atomic_fsync_write_replaces_content_and_leaves_no_temp_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join(".context").join("config.json");
+
+        write_atomic_fsync(&target, br#"{"organizationId":"org-1"}"#).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            r#"{"organizationId":"org-1"}"#
+        );
+
+        // Overwrite in place (the doc-id map grows on every registry pull).
+        write_atomic_fsync(&target, br#"{"organizationId":"org-1","notes":{}}"#).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            r#"{"organizationId":"org-1","notes":{}}"#
+        );
+
+        // The temp file is gone — a `.config.json.tmp` left in `.context` would
+        // sit there forever (nothing walks that dir to clean it up).
+        let leftovers: Vec<_> = std::fs::read_dir(tmp.path().join(".context"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+    }
+
+    #[test]
     fn write_note_if_missing_creates_but_never_overwrites() {
         let tmp = tempfile::tempdir().unwrap();
 
@@ -288,7 +360,12 @@ mod tests {
         assert_eq!(read_note(tmp.path(), "Context/brand/kit.md").unwrap(), "");
 
         // A real note is then written there by the user.
-        write_note(tmp.path(), "Context/brand/kit.md", "# Brand kit\n\nreal content").unwrap();
+        write_note(
+            tmp.path(),
+            "Context/brand/kit.md",
+            "# Brand kit\n\nreal content",
+        )
+        .unwrap();
 
         // Materializing it again — the exact call that emptied 428 notes when it
         // was a plain write — reports "already there" and changes nothing.
@@ -399,7 +476,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_note(tmp.path(), "a.md", "x").unwrap();
         for bad in ["", "a/b", "../..", ".hidden", "a b"] {
-            assert!(trash_note(tmp.path(), "a.md", bad).is_err(), "stamp {bad:?}");
+            assert!(
+                trash_note(tmp.path(), "a.md", bad).is_err(),
+                "stamp {bad:?}"
+            );
         }
         // Nothing was moved by any of the rejected attempts.
         assert!(tmp.path().join("a.md").exists());

--- a/app/apps/desktop/src-tauri/src/watcher.rs
+++ b/app/apps/desktop/src-tauri/src/watcher.rs
@@ -1,6 +1,12 @@
 //! Debounced filesystem watcher (spec 01 §3). Raw `notify` events are funneled
-//! into a background thread that drains a dirty-set after ~150ms of quiet, then
-//! incrementally re-indexes each changed path and emits `file-changed` to the UI.
+//! into a background thread that drains a dirty-set, then re-indexes the whole
+//! batch in ONE index transaction and emits ONE `files-changed` event to the UI.
+//!
+//! Why batched. `Index::index_note`/`remove_note` each run a whole-vault link
+//! resolution pass in their own transaction, so the old per-path loop made a
+//! 1000-file drop cost 1000 whole-vault passes (and 1000 Tauri events, and 1000
+//! index-mutex acquisitions). `Index::index_notes`/`remove_notes` collapse that
+//! to one pass per batch; this module's job is to hand them the whole batch.
 //!
 //! `.context/` and dotfolders are ignored so the app's own state dir never
 //! feeds the note pipeline (spec 02 §2 hard rule).
@@ -13,18 +19,30 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
+/// Quiet period: flush once nothing has changed for this long.
 const DEBOUNCE: Duration = Duration::from_millis(150);
+/// Ceiling on how long the dirty set may keep growing before we flush anyway.
+/// Without it, a long copy (which never goes quiet for 150ms) defers ALL of the
+/// indexing to the moment it finishes, so the sidebar shows nothing meanwhile.
+const MAX_WINDOW: Duration = Duration::from_millis(1000);
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct FileChanged {
     /// Vault-relative path of the changed item.
     pub path: String,
     /// "modified" | "removed" | "tree" (folder/structure change).
     pub kind: String,
+}
+
+/// Payload of the single `files-changed` event emitted per batch.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilesChanged {
+    pub changes: Vec<FileChanged>,
 }
 
 /// Owns the live watcher. Dropping it stops watching and lets the drain thread
@@ -49,18 +67,31 @@ pub fn start(
     })?;
     watcher.watch(&vault, RecursiveMode::Recursive)?;
 
-    // Drain thread: collect until quiet, then process the dirty set.
+    // Drain thread: collect until quiet (or until the batch has been open for
+    // MAX_WINDOW), then process the dirty set as one batch.
     std::thread::spawn(move || {
         let mut dirty: HashSet<PathBuf> = HashSet::new();
+        let mut opened_at: Option<Instant> = None;
         loop {
             match rx.recv_timeout(DEBOUNCE) {
                 Ok(paths) => {
+                    if dirty.is_empty() {
+                        opened_at = Some(Instant::now());
+                    }
                     for p in paths {
                         dirty.insert(p);
+                    }
+                    // A sustained stream never goes quiet — flush on the ceiling.
+                    let stale = opened_at.is_some_and(|t| t.elapsed() >= MAX_WINDOW);
+                    if stale && !dirty.is_empty() {
+                        opened_at = None;
+                        let batch = std::mem::take(&mut dirty);
+                        process_batch(&vault, &index, &app, batch);
                     }
                 }
                 Err(RecvTimeoutError::Timeout) => {
                     if !dirty.is_empty() {
+                        opened_at = None;
                         let batch = std::mem::take(&mut dirty);
                         process_batch(&vault, &index, &app, batch);
                     }
@@ -73,49 +104,255 @@ pub fn start(
     Ok(VaultWatcher { _watcher: watcher })
 }
 
+/// One planned change: what the index must do, and what the UI is told.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedChange {
+    /// Absolute path, for the index calls.
+    pub abs: PathBuf,
+    /// Vault-relative path, for the UI event.
+    pub rel: String,
+    /// The `kind` reported to the UI: "modified" | "removed" | "tree".
+    pub kind: &'static str,
+    /// This path must be dropped from the index: a `.md` that's gone, or a
+    /// vanished non-markdown path that may have been a folder (whose notes are
+    /// pruned by prefix).
+    pub gone: bool,
+}
+
+/// The batch, partitioned by what each path needs. Pure enough to test: the only
+/// I/O is the existence check that decides modified-vs-removed.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Plan {
+    /// `.md` files present on disk → `Index::index_notes`.
+    pub modified: Vec<PathBuf>,
+    /// Everything to drop from the index → `Index::remove_notes`.
+    pub removed: Vec<PathBuf>,
+    /// The UI event payload, in a deterministic order.
+    pub changes: Vec<PlannedChange>,
+}
+
+/// Turn a dirty set into a [`Plan`]: drop ignored paths, sort for determinism,
+/// and split `.md` writes from `.md` deletions from structural changes.
+pub fn plan_batch<I: IntoIterator<Item = PathBuf>>(vault: &Path, batch: I) -> Plan {
+    let mut planned: Vec<PlannedChange> = Vec::new();
+    for abs in batch {
+        let Ok(rel) = rel_from_abs(vault, &abs) else {
+            continue;
+        };
+        if rel.is_empty() || rel_path_is_ignored(&rel) {
+            continue;
+        }
+        let is_md = rel.to_lowercase().ends_with(".md");
+        let exists = abs.exists();
+        let (kind, gone) = if is_md {
+            if exists && abs.is_file() {
+                ("modified", false)
+            } else {
+                ("removed", true)
+            }
+        } else {
+            // Directory or non-markdown file → structural refresh. If it's gone
+            // it may have been a folder, so prune its notes from the index too.
+            ("tree", !exists)
+        };
+        planned.push(PlannedChange {
+            abs,
+            rel,
+            kind,
+            gone,
+        });
+    }
+    // A HashSet iterates in an arbitrary order; sorting keeps the emitted event
+    // (and the index writes) reproducible, which is what makes this testable.
+    planned.sort_by(|a, b| (a.rel.as_str(), a.kind).cmp(&(b.rel.as_str(), b.kind)));
+
+    let modified = planned
+        .iter()
+        .filter(|c| c.kind == "modified")
+        .map(|c| c.abs.clone())
+        .collect();
+    let removed = planned
+        .iter()
+        .filter(|c| c.gone)
+        .map(|c| c.abs.clone())
+        .collect();
+    Plan {
+        modified,
+        removed,
+        changes: planned,
+    }
+}
+
 fn process_batch(
     vault: &Path,
     index: &Arc<Mutex<Index>>,
     app: &AppHandle,
     batch: HashSet<PathBuf>,
 ) {
-    for abs in batch {
-        let rel = match rel_from_abs(vault, &abs) {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
-        if rel.is_empty() || rel_path_is_ignored(&rel) {
-            continue;
+    let plan = plan_batch(vault, batch);
+    if plan.changes.is_empty() {
+        return;
+    }
+
+    // ONE lock, ONE transaction each way, ONE link-resolution pass each way.
+    if !plan.modified.is_empty() || !plan.removed.is_empty() {
+        let guard = index.lock().unwrap();
+        if let Ok(failures) = guard.index_notes(vault, &plan.modified) {
+            for (path, err) in failures {
+                eprintln!("[watcher] index failed for {}: {err}", path.display());
+            }
         }
-
-        let is_md = rel.to_lowercase().ends_with(".md");
-        let exists = abs.exists();
-
-        let kind = if is_md {
-            let guard = index.lock().unwrap();
-            if exists && abs.is_file() {
-                let _ = guard.index_note(vault, &abs);
-                "modified"
-            } else {
-                let _ = guard.remove_note(vault, &abs);
-                "removed"
+        if let Ok(failures) = guard.remove_notes(vault, &plan.removed) {
+            for (path, err) in failures {
+                eprintln!("[watcher] remove failed for {}: {err}", path.display());
             }
-        } else {
-            // Directory or non-markdown file changed → structural refresh.
-            // If it was a folder deletion, prune its notes from the index.
-            if !exists {
-                let guard = index.lock().unwrap();
-                let _ = guard.remove_note(vault, &abs);
-            }
-            "tree"
-        };
+        }
+    }
 
-        let _ = app.emit(
-            "file-changed",
-            FileChanged {
-                path: rel,
-                kind: kind.to_string(),
-            },
+    // ONE event for the whole batch. The UI used to receive one `file-changed`
+    // per path, so a bulk drop turned into a storm of tree refreshes.
+    let _ = app.emit(
+        "files-changed",
+        FilesChanged {
+            changes: plan
+                .changes
+                .into_iter()
+                .map(|c| FileChanged {
+                    path: c.rel,
+                    kind: c.kind.to_string(),
+                })
+                .collect(),
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::notefile::write_note;
+
+    fn kinds(plan: &Plan) -> Vec<(String, &'static str)> {
+        plan.changes
+            .iter()
+            .map(|c| (c.rel.clone(), c.kind))
+            .collect()
+    }
+
+    #[test]
+    fn plan_splits_modified_removed_and_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        write_note(&v, "Alpha.md", "# Alpha").unwrap();
+        write_note(&v, "sub/Beta.md", "# Beta").unwrap();
+        std::fs::create_dir_all(v.join("folder")).unwrap();
+        std::fs::write(v.join("image.png"), b"x").unwrap();
+
+        let batch: HashSet<PathBuf> = [
+            v.join("Alpha.md"),       // exists → modified
+            v.join("sub/Beta.md"),    // exists → modified
+            v.join("Gone.md"),        // absent → removed
+            v.join("folder"),         // dir → tree
+            v.join("image.png"),      // non-md file → tree
+            v.join("deleted-folder"), // absent, non-md → tree + prune
+        ]
+        .into_iter()
+        .collect();
+
+        let plan = plan_batch(&v, batch);
+
+        assert_eq!(
+            kinds(&plan),
+            vec![
+                ("Alpha.md".to_string(), "modified"),
+                ("Gone.md".to_string(), "removed"),
+                ("deleted-folder".to_string(), "tree"),
+                ("folder".to_string(), "tree"),
+                ("image.png".to_string(), "tree"),
+                ("sub/Beta.md".to_string(), "modified"),
+            ],
+            "sorted by rel path, so the batch is reproducible"
         );
+
+        assert_eq!(
+            plan.modified,
+            vec![v.join("Alpha.md"), v.join("sub/Beta.md")]
+        );
+        // A gone `.md` AND a gone folder both need pruning from the index.
+        assert_eq!(
+            plan.removed,
+            vec![v.join("Gone.md"), v.join("deleted-folder")]
+        );
+    }
+
+    #[test]
+    fn plan_drops_ignored_and_out_of_vault_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        write_note(&v, "Keep.md", "# Keep").unwrap();
+
+        let batch: HashSet<PathBuf> = [
+            v.join(".context/index.sqlite"), // the app's own state dir
+            v.join(".context/config.json"),
+            v.join(".git/HEAD"),
+            v.join("node_modules/pkg/readme.md"),
+            v.clone(),                                  // the vault root itself
+            PathBuf::from("/elsewhere/on/disk/foo.md"), // not in this vault
+            v.join("Keep.md"),
+        ]
+        .into_iter()
+        .collect();
+
+        let plan = plan_batch(&v, batch);
+        assert_eq!(kinds(&plan), vec![("Keep.md".to_string(), "modified")]);
+        assert!(plan.removed.is_empty());
+    }
+
+    #[test]
+    fn plan_coalesces_repeated_paths_and_survives_an_empty_batch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        write_note(&v, "Alpha.md", "# Alpha").unwrap();
+
+        // The drain thread's dirty set is a HashSet, so a file touched 500 times
+        // during a save storm reaches the plan exactly once.
+        let mut batch: HashSet<PathBuf> = HashSet::new();
+        for _ in 0..500 {
+            batch.insert(v.join("Alpha.md"));
+        }
+        let plan = plan_batch(&v, batch);
+        assert_eq!(plan.changes.len(), 1);
+        assert_eq!(plan.modified.len(), 1);
+
+        assert_eq!(plan_batch(&v, Vec::new()), Plan::default());
+    }
+
+    /// The plan feeds the batch index entry points directly; this pins that the
+    /// pairing actually indexes and prunes what it claims to.
+    #[test]
+    fn plan_applied_to_the_index_indexes_and_prunes_in_one_pass_each() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        write_note(&v, "Alpha.md", "# Alpha\n\n[[Beta]]").unwrap();
+        write_note(&v, "sub/Beta.md", "# Beta").unwrap();
+        let idx = Index::open(&v).unwrap();
+        idx.rebuild(&v).unwrap();
+
+        // Beta is deleted on disk; Alpha is edited. One batch.
+        std::fs::remove_file(v.join("sub/Beta.md")).unwrap();
+        write_note(&v, "Alpha.md", "# Alpha\n\nno more links").unwrap();
+        let batch: HashSet<PathBuf> = [v.join("Alpha.md"), v.join("sub/Beta.md")]
+            .into_iter()
+            .collect();
+        let plan = plan_batch(&v, batch);
+        assert!(idx.index_notes(&v, &plan.modified).unwrap().is_empty());
+        assert!(idx.remove_notes(&v, &plan.removed).unwrap().is_empty());
+
+        let paths: Vec<String> = idx
+            .list_note_titles()
+            .unwrap()
+            .into_iter()
+            .map(|t| t.path)
+            .collect();
+        assert_eq!(paths, vec!["Alpha.md".to_string()]);
     }
 }

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src-tauri/tests/data_volume_bench.rs
+++ b/app/apps/desktop/src-tauri/tests/data_volume_bench.rs
@@ -36,15 +36,51 @@ impl Rng {
 }
 
 const WORDS: &[&str] = &[
-    "vault", "note", "graph", "link", "crdt", "merge", "sync", "index", "search",
-    "folder", "markdown", "editor", "buffer", "snapshot", "debounce", "backlink",
-    "tag", "frontmatter", "atomic", "local", "first", "peer", "presence", "token",
-    "permission", "share", "collaborate", "rewrite", "ingest", "egest", "watcher",
-    "convergence", "identity", "durable", "source", "truth", "bridge", "operation",
+    "vault",
+    "note",
+    "graph",
+    "link",
+    "crdt",
+    "merge",
+    "sync",
+    "index",
+    "search",
+    "folder",
+    "markdown",
+    "editor",
+    "buffer",
+    "snapshot",
+    "debounce",
+    "backlink",
+    "tag",
+    "frontmatter",
+    "atomic",
+    "local",
+    "first",
+    "peer",
+    "presence",
+    "token",
+    "permission",
+    "share",
+    "collaborate",
+    "rewrite",
+    "ingest",
+    "egest",
+    "watcher",
+    "convergence",
+    "identity",
+    "durable",
+    "source",
+    "truth",
+    "bridge",
+    "operation",
 ];
 
 fn env_usize(key: &str, default: usize) -> usize {
-    std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
 }
 
 fn note_name(i: usize) -> String {
@@ -200,6 +236,77 @@ fn data_volume_bench() {
         t.elapsed().as_micros(),
         resolved.is_some()
     );
+
+    // ---- batch (re)index of an existing set of notes ----------------------
+    //
+    // The watcher path: N already-known files change at once. The old code ran
+    // `index_note` per path, and each call re-resolved EVERY link in the vault in
+    // its own transaction — O(N × links). `index_notes` does one pass for the
+    // batch. Both are timed here so the ratio is visible.
+    let batch_n = env_usize("BAALDA_BENCH_BATCH", 200).min(notes);
+    let batch: Vec<PathBuf> = (0..batch_n)
+        .map(|i| vault.join(format!("{}/{}.md", folder_for(i), note_name(i))))
+        .collect();
+
+    let t = Instant::now();
+    let failures = idx.index_notes(&vault, &batch).unwrap();
+    let batched_ms = t.elapsed().as_millis();
+    assert!(failures.is_empty(), "batch reported failures: {failures:?}");
+    println!(
+        "index_notes({batch_n}):  {batched_ms:>6} ms  ({:.2} ms/note, 1 link pass)",
+        batched_ms as f64 / batch_n as f64
+    );
+
+    // The same work the old way: one call, one transaction, one link pass each.
+    let per_file_n = batch_n.min(env_usize("BAALDA_BENCH_PER_FILE", 50));
+    let t = Instant::now();
+    for abs in batch.iter().take(per_file_n) {
+        idx.index_note(&vault, abs).unwrap();
+    }
+    let per_file_ms = t.elapsed().as_millis();
+    println!(
+        "index_note ×{per_file_n:<4}     {per_file_ms:>6} ms  ({:.2} ms/note, {per_file_n} link passes)",
+        per_file_ms as f64 / per_file_n as f64
+    );
+
+    // ---- the reported failure mode: drop N brand-new files at once ---------
+    //
+    // "Copy 1000 notes into the vault". Every file is new, so every one is a
+    // fresh insert AND (the old way) a whole-vault link pass.
+    let drop_n = env_usize("BAALDA_BENCH_DROP", 1000);
+    let mut dropped: Vec<PathBuf> = Vec::with_capacity(drop_n);
+    let mut rng = Rng(0xDEADBEEFCAFEF00D);
+    for i in 0..drop_n {
+        let name = format!("dropped-{i:05}");
+        let links: Vec<usize> = (0..links_per).map(|_| rng.below(notes)).collect();
+        let content = format!("# {name}\n\n{}", body(&mut rng, 600, &links));
+        let rel = format!("Dropped/batch-{:03}/{name}.md", i / 100);
+        notefile::write_note(&vault, &rel, &content).unwrap();
+        dropped.push(vault.join(&rel));
+    }
+    let t = Instant::now();
+    let failures = idx.index_notes(&vault, &dropped).unwrap();
+    let drop_ms = t.elapsed().as_millis();
+    assert!(failures.is_empty(), "drop reported failures: {failures:?}");
+    println!(
+        "drop {drop_n} + index:  {drop_ms:>6} ms  ({:.2} ms/note)",
+        drop_ms as f64 / drop_n as f64
+    );
+    assert_eq!(
+        idx.list_note_titles().unwrap().len(),
+        notes + drop_n,
+        "every dropped note should be indexed"
+    );
+
+    // And removing them again, batched.
+    let t = Instant::now();
+    idx.remove_notes(&vault, &dropped).unwrap();
+    let rm_ms = t.elapsed().as_millis();
+    println!(
+        "remove {drop_n}:        {rm_ms:>6} ms  ({:.2} ms/note)",
+        rm_ms as f64 / drop_n as f64
+    );
+    assert_eq!(idx.list_note_titles().unwrap().len(), notes);
 
     let sqlite_bytes = dir_size(&vault.join(".context"));
     println!(

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -658,33 +658,39 @@ export default function App() {
       }, 120);
     };
     (async () => {
-      unlistenFile = await ipc.onFileChanged(async (e) => {
-        // Attachments are content-synced, not indexed/CRDT-bridged. A change
-        // under `attachments/` triggers a debounced two-way blob reconcile.
-        if (e.path === "attachments" || e.path.startsWith("attachments/")) {
-          syncManager.handleAttachmentChanged();
-          scheduleRefresh();
-          return;
-        }
-
-        // Open-note reconciliation runs immediately (per event); the sidebar
-        // refresh is coalesced via scheduleRefresh below.
+      // Whole batches, not one event per file: the sync layer folds every
+      // unmapped/structural item in a batch into a SINGLE registry pull, which it
+      // cannot do when the items arrive one at a time.
+      unlistenFile = await ipc.onFilesChanged((changes) => {
+        if (changes.length === 0) return;
         const open = useStore.getState().openNote;
-        if (open && e.path === open.path) {
-          if (e.kind === "removed") {
-            useStore.getState().setNoteRemoved(true);
-          } else {
-            // Route the edit into the bridge; it debounces, drops our own echo,
-            // and merges genuine external edits live into the open Y.Text.
-            bridgeManager.handleFileChanged(e.path);
+        const forSync: ipc.FileChanged[] = [];
+        for (const e of changes) {
+          // Attachments are content-synced, not indexed/CRDT-bridged. A change
+          // under `attachments/` triggers a debounced two-way blob reconcile.
+          if (e.path === "attachments" || e.path.startsWith("attachments/")) {
+            syncManager.handleAttachmentChanged();
+            continue;
           }
-        } else {
+          // Open-note reconciliation runs immediately (per event); the sidebar
+          // refresh is coalesced via scheduleRefresh below.
+          if (open && e.path === open.path) {
+            if (e.kind === "removed") {
+              useStore.getState().setNoteRemoved(true);
+            } else {
+              // Route the edit into the bridge; it debounces, drops our own echo,
+              // and merges genuine external edits live into the open Y.Text.
+              bridgeManager.handleFileChanged(e.path);
+            }
+            continue;
+          }
           // Everything that is NOT the open note goes to the sync layer: an
           // external writer (an AI with the vault folder open, another editor)
           // creating or changing files must reach the server live — not on the
           // next sign-in reconcile, and not only once someone opens the note.
-          syncManager.handleLocalFileChanged(e.path, e.kind);
+          forSync.push(e);
         }
+        if (forSync.length > 0) syncManager.handleLocalFilesChanged(forSync);
 
         // Refresh tree + titles + backlinks (coalesced for bursts).
         scheduleRefresh();

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -139,7 +139,12 @@ export function syncBadgeLabel(args: {
   // A run that finished with failures must not read "Synced". `failed` is the
   // number of notes that are still only on this device.
   if (progress?.phase === "error") {
-    return progress.failed > 0 ? `${progress.failed} not synced` : "Sync incomplete";
+    if (progress.failed > 0) return `${progress.failed} not synced`;
+    // No note failed — the run itself could not proceed because the vault
+    // channel never connected (the download-phase watchdog). Name the situation
+    // the user can act on, not a mystery "incomplete".
+    if (status === "connecting" || status === "error") return "Retrying…";
+    return "Sync incomplete";
   }
   if (noteOpen === false) {
     return progress?.phase === "done" ? "Synced" : "Syncing…";

--- a/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
+++ b/app/apps/desktop/src/components/__tests__/syncBadge.test.ts
@@ -13,6 +13,18 @@ import type { SyncProgress } from "../../lib/sync/vaultScope";
 describe("syncBadgeLabel", () => {
   const now = 1_000_000_000_000;
 
+  it("reads 'Retrying…' when the run errored only because the channel never connected", () => {
+    const stalled: SyncProgress = { phase: "error", done: 0, total: 0, failed: 0 };
+    expect(syncBadgeLabel({ status: "connecting", now, progress: stalled })).toBe("Retrying…");
+    expect(syncBadgeLabel({ status: "error", now, progress: stalled })).toBe("Retrying…");
+    // A note that actually failed still names the count; a connected channel
+    // with an errored run still reads incomplete.
+    expect(
+      syncBadgeLabel({ status: "synced", now, progress: { ...stalled, failed: 2 } }),
+    ).toBe("2 not synced");
+    expect(syncBadgeLabel({ status: "synced", now, progress: stalled })).toBe("Sync incomplete");
+  });
+
   it("shows Syncing… while local edits are pending, ignoring the timestamp", () => {
     expect(
       syncBadgeLabel({ status: "synced", pending: true, lastSyncedAt: now - 300_000, now }),

--- a/app/apps/desktop/src/lib/__tests__/vaultDocStore.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultDocStore.test.ts
@@ -16,6 +16,79 @@ function updateSetting(text: string): Uint8Array {
   return u;
 }
 
+// ── the two ways a cold apply can end ───────────────────────────────────────
+// Converged (the file had nothing of its own) means the server HAS this doc, and
+// the session records the push — which is what stops the content run re-sending
+// every note the vault channel just delivered, over a socket apiece. A merge is
+// the opposite: those ops exist only here until a provider pushes them.
+
+describe("VaultDocStore — converged vs merged cold applies", () => {
+  it("reports a converged cold apply, so the doc is never re-uploaded", async () => {
+    const { io, fs } = makeHarness({ "note.md": "" });
+    const converged: string[] = [];
+    const merged: string[] = [];
+    const store = new VaultDocStore({
+      io,
+      resolvePath: () => "note.md",
+      onConverged: (id) => converged.push(id),
+      onExternalMerge: (id) => merged.push(id),
+    });
+
+    await store.applyUpdate("d1", updateSetting("from the server"));
+
+    expect(fs.get("note.md")).toBe("from the server");
+    expect(converged).toEqual(["d1"]);
+    expect(merged).toEqual([]);
+  });
+
+  it("reports a MERGE instead when the file held bytes the doc had never seen", async () => {
+    const { io, fs } = makeHarness({ "note.md": "" });
+    const converged: string[] = [];
+    const merged: string[] = [];
+    const store = new VaultDocStore({
+      io,
+      resolvePath: () => "note.md",
+      onConverged: (id) => converged.push(id),
+      onExternalMerge: (id) => merged.push(id),
+    });
+
+    await store.applyUpdate("d1", updateSetting("server line"));
+    converged.length = 0;
+    // An AI edits the file while no bridge is alive for it.
+    fs.externalWrite("note.md", "server line\nlocal line");
+
+    await store.applyUpdate("d1", updateSetting("ignored — the doc already has state"));
+
+    expect(merged).toEqual(["d1"]);
+    // Mutually exclusive: those merged ops are local-only, so claiming the server
+    // has this doc would strand exactly the bytes nobody else holds.
+    expect(converged).toEqual([]);
+    expect(fs.get("note.md")).toContain("local line");
+  });
+
+  it("does NOT report converged for a doc that already held local CRDT ops", async () => {
+    const { io, fs } = makeHarness({ "note.md": "" });
+    const converged: string[] = [];
+    const store = new VaultDocStore({
+      io,
+      resolvePath: () => "note.md",
+      onConverged: (id) => converged.push(id),
+    });
+
+    // First delivery lands on an empty placeholder → converged (the join case).
+    await store.applyUpdate("d1", updateSetting("first"));
+    expect(converged).toEqual(["d1"]);
+    converged.length = 0;
+
+    // A later delivery onto a doc with prior local state: the store cannot know
+    // whether those local ops ever reached the server (typed offline, never
+    // flushed), so it must not declare the doc pushed.
+    await store.applyUpdate("d1", updateSetting("second"));
+    expect(converged).toEqual([]);
+    expect(fs.get("note.md")).toContain("second");
+  });
+});
+
 describe("VaultDocStore", () => {
   it("cold-applies an update: writes the .md, persists, caches the state vector", async () => {
     const { io, fs, persistence } = makeHarness({ "note.md": "" });

--- a/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   decodeVoiceFrame,
   encodeVoiceFrame,
+  parseServerControl,
   VOICE_FRAME,
   type VoiceFrame,
 } from "../sync/vaultProtocol";
@@ -667,5 +668,148 @@ describe("VaultSyncEngine voice", () => {
     expect(decoded).toBeNull(); // outbound frames carry no `u` — the server stamps it
     // ...but the raw framing is intact and the server will accept it.
     expect((binary[0] as Uint8Array)[0]).toBe(VOICE_FRAME);
+  });
+});
+
+// ── `ready.empty`: the server's list of docs it holds NO content for ────────
+// The client's own `pushed` checkpoint cannot see a note the server lost (a
+// crashed run, a wiped `.context/`, a restored backup), which is how 613 notes
+// ended up registered with zero content. This frame is the authority, so parsing
+// it has to be defensive: a bogus entry would sit at the HEAD of the upload queue.
+
+describe("parseServerControl — ready", () => {
+  it("reads the empty list and the truncation flag", () => {
+    expect(parseServerControl(JSON.stringify({ t: "ready", empty: ["a", "b"] }))).toEqual({
+      t: "ready",
+      empty: ["a", "b"],
+    });
+    expect(
+      parseServerControl(JSON.stringify({ t: "ready", empty: ["a"], emptyTruncated: true })),
+    ).toEqual({ t: "ready", empty: ["a"], emptyTruncated: true });
+  });
+
+  it("tolerates an older server that omits both fields", () => {
+    expect(parseServerControl(JSON.stringify({ t: "ready" }))).toEqual({ t: "ready" });
+  });
+
+  it("keeps only string ids, and omits the field when nothing survives", () => {
+    expect(
+      parseServerControl(JSON.stringify({ t: "ready", empty: ["a", 7, null, "", "b"] })),
+    ).toEqual({ t: "ready", empty: ["a", "b"] });
+    // A `ready` is still a `ready` — never dropped over a malformed extra.
+    expect(parseServerControl(JSON.stringify({ t: "ready", empty: "a" }))).toEqual({
+      t: "ready",
+    });
+    expect(parseServerControl(JSON.stringify({ t: "ready", empty: [] }))).toEqual({
+      t: "ready",
+    });
+  });
+
+  it("treats anything but `true` as not truncated", () => {
+    expect(
+      parseServerControl(JSON.stringify({ t: "ready", empty: ["a"], emptyTruncated: 1 })),
+    ).toEqual({ t: "ready", empty: ["a"] });
+  });
+});
+
+describe("VaultSyncEngine — server-empty reporting", () => {
+  it("fires onServerEmpty on every ready, before the idle signal", async () => {
+    const sink = new MemSink();
+    let ws: FakeWs | null = null;
+    const events: Array<{ ids: string[]; truncated: boolean }> = [];
+    const order: string[] = [];
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => (ws = new FakeWs()),
+      onServerEmpty: (ids, truncated) => {
+        events.push({ ids, truncated });
+        order.push("empty");
+      },
+      onInboundIdle: () => order.push("idle"),
+    });
+    engine.start();
+    ws!.onopen?.(null);
+    await awaitHello(ws!);
+
+    ws!.onmessage?.({
+      data: JSON.stringify({ t: "ready", empty: ["a", "b"], emptyTruncated: true }),
+    });
+    expect(events).toEqual([{ ids: ["a", "b"], truncated: true }]);
+    // The list must land BEFORE the edge that starts the content run, or the run
+    // works from the previous connect's answer (or none at all).
+    expect(order).toEqual(["empty", "idle"]);
+
+    // Reconnects re-state it — that is what re-arms a paused content run.
+    ws!.onmessage?.({ data: JSON.stringify({ t: "ready" }) });
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ ids: [], truncated: false });
+  });
+
+  it("refresh() sends a fresh hello over the existing backoff", async () => {
+    const sink = new MemSink();
+    const created: FakeWs[] = [];
+    const scheduled: Array<() => void> = [];
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => {
+        const w = new FakeWs();
+        created.push(w);
+        return w;
+      },
+      random: () => 0,
+      setTimeoutImpl: (fn) => {
+        scheduled.push(fn);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeoutImpl: () => {},
+    });
+    engine.start();
+    created[0].onopen?.(null);
+    await awaitHello(created[0]);
+    created[0].onmessage?.({ data: JSON.stringify({ t: "ready", emptyTruncated: true }) });
+
+    // Asking the server the second question: one socket per vault, so the only
+    // way to send another hello is to cycle this one.
+    engine.refresh();
+    expect(created[0].closed).toBe(true);
+    expect(scheduled).toHaveLength(1);
+    scheduled[0]();
+    expect(created).toHaveLength(2);
+    created[1].onopen?.(null);
+    await awaitHello(created[1]);
+    expect(created[1].helloText()).toMatchObject({ t: "hello", token: "vault-tok" });
+  });
+
+  it("a disconnect closes the backfill window, so the download can settle", async () => {
+    // `backfilling` used to survive the socket, and everything that waits for the
+    // download to settle (the content run) waited forever on a flaky link.
+    const sink = new MemSink();
+    const created: FakeWs[] = [];
+    const engine = new VaultSyncEngine({
+      api: tokenApi(),
+      vaultId: "v1",
+      sink,
+      wsFactory: () => {
+        const w = new FakeWs();
+        created.push(w);
+        return w;
+      },
+      random: () => 0,
+      setTimeoutImpl: () => 0 as unknown as ReturnType<typeof setTimeout>,
+      clearTimeoutImpl: () => {},
+    });
+    engine.start();
+    created[0].onopen?.(null);
+    await awaitHello(created[0]);
+    created[0].onmessage?.({ data: updateFrame("a", [1]) });
+    for (let i = 0; i < 40 && !engine.inboundIdle(); i++) await tick();
+    expect(engine.backfillSettled()).toBe(false); // mid-backfill, `ready` pending
+
+    created[0].onclose?.(null);
+    expect(engine.backfillSettled()).toBe(true);
   });
 });

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -451,8 +451,31 @@ export const getVaultEpoch = () => invoke<number>("get_vault_epoch");
 
 // ---- Events ---------------------------------------------------------------
 
+/**
+ * One watcher debounce batch (the Rust `FilesChanged` payload).
+ *
+ * The watcher emits ONE event per batch rather than one per file: a vault import
+ * or an AI writing 200 notes used to cross the IPC boundary 200 times, each
+ * costing a full round of listeners, a registry-pull re-arm and a sidebar
+ * refresh re-arm.
+ */
+export interface FilesChanged {
+  changes: FileChanged[];
+}
+
+/** Subscribe to whole watcher batches — what the sync layer wants, because a
+ *  batch has exactly ONE structural conclusion to draw. */
+export const onFilesChanged = (
+  cb: (changes: FileChanged[]) => void,
+): Promise<UnlistenFn> =>
+  listen<FilesChanged>("files-changed", (event) => cb(event.payload?.changes ?? []));
+
+/** Per-item adapter over {@link onFilesChanged}, for callers that only care that
+ *  *something* changed (the graph, the HTML view, the open note's bridge). */
 export const onFileChanged = (cb: (e: FileChanged) => void): Promise<UnlistenFn> =>
-  listen<FileChanged>("file-changed", (event) => cb(event.payload));
+  onFilesChanged((changes) => {
+    for (const change of changes) cb(change);
+  });
 
 export const onVaultOpened = (cb: (v: VaultInfo) => void): Promise<UnlistenFn> =>
   listen<VaultInfo>("vault-opened", (event) => cb(event.payload));

--- a/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
@@ -131,6 +131,8 @@ interface RigOptions {
   concurrency?: number;
   failureStreakLimit?: number;
   force?: boolean;
+  include?: (docId: string) => boolean;
+  priority?: (docId: string) => boolean;
   ingestFromFile?: boolean;
   mustConnect?: (docId: string) => boolean;
   /** Reuse a previous rig's CRDT store, to model a SECOND run on one device. */
@@ -172,6 +174,8 @@ function rig(opts: RigOptions) {
     },
     skip: opts.skip,
     force: opts.force,
+    include: opts.include,
+    priority: opts.priority,
     ingestFromFile: opts.ingestFromFile,
     mustConnect: opts.mustConnect,
     shouldStop: opts.shouldStop,
@@ -601,5 +605,85 @@ describe("ContentUploader — mustConnect (out-of-band merges)", () => {
     await third.uploader.run();
     expect(third.connects).toEqual(["d1"]);
     expect(third.server.text("d1")).toBe("v1 merged-out-of-band");
+  });
+});
+
+// ── `ready.empty`: the server outranks the local checkpoint ─────────────────
+// `pushed` is a local optimisation. A crashed run, a wiped `.context/` or a
+// restored backup can leave it claiming notes the server never received — 613 of
+// them in prod, registered with zero content and unreachable forever, because
+// every later run skipped them on the strength of that claim.
+
+describe("ContentUploader — include (the server's empty list)", () => {
+  it("pushes a doc the checkpoint claims but the server has no content for", async () => {
+    const r = rig({
+      files: { "Lost.md": "the only copy", "Fine.md": "already there" },
+      notes: [
+        { docId: "lost", relPath: "Lost.md" },
+        { docId: "fine", relPath: "Fine.md" },
+      ],
+      pushed: new Set(["lost", "fine"]),
+      include: (id) => id === "lost",
+    });
+    r.server.seed("fine", "already there");
+
+    const result = await r.uploader.run();
+
+    expect(result.total).toBe(1); // only the doc the server actually lacks
+    expect(r.connects).toEqual(["lost"]);
+    expect(r.server.text("lost")).toBe("the only copy");
+    // …and it is never badged synced on the way in, not even for one emission.
+    expect(r.sink.stateOf("lost")).toEqual(["queued", "syncing", "synced"]);
+    expect(r.sink.stateOf("fine")).toEqual(["synced"]);
+  });
+
+  it("still connects when the file matches the doc (the ingest fast-path must not skip it)", async () => {
+    // The local-change fast-path exists to avoid a socket per watcher echo, and
+    // its whole premise is "the server already has this". For an `include` doc
+    // that premise is false, so the fast-path has to stand down.
+    const r = rig({
+      files: { "Echo.md": "same bytes" },
+      notes: [{ docId: "echo", relPath: "Echo.md" }],
+      pushed: new Set(["echo"]),
+      include: (id) => id === "echo",
+      force: true,
+      ingestFromFile: true,
+    });
+
+    await r.uploader.run();
+
+    expect(r.connects).toEqual(["echo"]);
+    expect(r.server.text("echo")).toBe("same bytes");
+  });
+});
+
+describe("ContentUploader — priority", () => {
+  it("pushes the prioritised docs first, keeping the order within each group", async () => {
+    const notes = ["a", "b", "c", "d", "e"].map((id) => ({
+      docId: id,
+      relPath: `${id.toUpperCase()}.md`,
+    }));
+    const files: Record<string, string> = {};
+    for (const n of notes) files[n.relPath] = `text ${n.docId}`;
+    const r = rig({
+      files,
+      notes,
+      // Serial, so `connects` IS the queue order.
+      concurrency: 1,
+      priority: (id) => id === "d" || id === "b",
+    });
+
+    await r.uploader.run();
+
+    // Stable partition: d/b keep their relative order, and so does the rest.
+    expect(r.connects).toEqual(["b", "d", "a", "c", "e"]);
+  });
+
+  it("leaves the queue untouched when no priority is given", async () => {
+    const notes = ["a", "b", "c"].map((id) => ({ docId: id, relPath: `${id}.md` }));
+    const files: Record<string, string> = { "a.md": "1", "b.md": "2", "c.md": "3" };
+    const r = rig({ files, notes, concurrency: 1 });
+    await r.uploader.run();
+    expect(r.connects).toEqual(["a", "b", "c"]);
   });
 });

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
@@ -357,6 +357,49 @@ describe("SyncManager — ready.empty is the authority", () => {
     await flush();
     expect(progress).toHaveLength(settledAt);
   });
+
+  it("stops claiming 'Syncing…' when the vault channel never connects, and recovers on ready", async () => {
+    vi.useFakeTimers();
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
+    fakeRegistry.pushed.add("a");
+    const sm = new SyncManager();
+    const progress: Array<SyncProgress | null> = [];
+    sm.setSyncProgressListener((p) => progress.push(p));
+    await enable(sm);
+    // The engine is started but its socket never opens: no status, no ready.
+    engineHooks.opts!.onStatus?.("error");
+    await vi.advanceTimersByTimeAsync(31_000);
+    await flush();
+    // The download phase gave up: the pill must not read "Syncing…" forever.
+    expect(progress[progress.length - 1]?.phase).toBe("error");
+
+    // The server comes back: hello → backfill → ready. The stall clears and the
+    // run lands on `done` exactly as it would have without the outage.
+    engineHooks.settled = true;
+    engineHooks.opts!.onStatus?.("synced");
+    engineHooks.opts!.onServerEmpty?.([], false);
+    engineHooks.opts!.onInboundIdle?.();
+    await flush();
+    expect(progress[progress.length - 1]?.phase).toBe("done");
+    vi.useRealTimers();
+  });
+
+  it("does not trip the watchdog once the channel has reached ready", async () => {
+    vi.useFakeTimers();
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
+    fakeRegistry.pushed.add("a");
+    const sm = new SyncManager();
+    const progress: Array<SyncProgress | null> = [];
+    sm.setSyncProgressListener((p) => progress.push(p));
+    await enable(sm);
+    engineHooks.opts!.onStatus?.("synced");
+    engineHooks.opts!.onServerEmpty?.([], false);
+    // A slow backfill is still draining well past the watchdog window.
+    await vi.advanceTimersByTimeAsync(31_000);
+    await flush();
+    expect(progress[progress.length - 1]?.phase).not.toBe("error");
+    vi.useRealTimers();
+  });
 });
 
 describe("SyncManager.handleLocalFilesChanged", () => {

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
@@ -1,0 +1,417 @@
+// The ORDER of a vault's bulk sync, and what the content run is allowed to send.
+//
+// Before this, `enable()` pushed every mapped note over a dedicated per-note
+// provider (a `POST /api/sync-token` + a WebSocket apiece, 3.7 notes/second in
+// prod) WHILE the vault channel was backfilling those same notes over one socket.
+// Every note was therefore delivered twice, and the slow path was the fragile one:
+// a token mint failure timed out, five in a row aborted the run, and nothing ever
+// restarted it — leaving 613 notes registered with zero content on the server.
+//
+// So the contract these tests pin is:
+//   1. download first — no content run until the vault backfill has settled;
+//   2. a doc the backfill delivered cleanly is marked pushed, so the run's queue
+//      is exactly "what the server did not deliver";
+//   3. the server's `ready.empty` outranks the local `pushed` checkpoint, and
+//      those docs go to the FRONT of the queue;
+//   4. every `ready` re-arms a run, which is what makes the uploader's failure
+//      streak a pause rather than a verdict.
+//
+// The registry, the vault channel, the doc store and the per-note provider are
+// faked; the ContentUploader is REAL, so the queue and its order are the ones
+// production computes rather than a restatement of them here.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import type { VaultSyncEngineOptions } from "../vaultSyncEngine";
+import type { VaultDocStoreOptions } from "../vaultDocStore";
+
+const OPEN_DOC = "doc-open";
+
+const fakeRegistry = vi.hoisted(() => {
+  const reg = {
+    vaultId: "collection-1" as string | null,
+    pushed: new Set<string>(),
+    reconcile: vi.fn(async () => ({ seeded: false })),
+    pull: vi.fn(async () => true),
+    reset: vi.fn(),
+    getMapping: vi.fn((_relPath: string): { vaultId: string; docId: string } | null => null),
+    pathForDocId: vi.fn((_docId: string): string | null => null),
+    allDocIds: vi.fn((): string[] => []),
+    setProgressSink: vi.fn(),
+    setMapListener: vi.fn(),
+    setNoteMetaListener: vi.fn(),
+    setColorListener: vi.fn(),
+    setInboundHost: vi.fn(),
+    mappedNotes: vi.fn((): Array<{ docId: string; relPath: string }> => []),
+    isPushed: vi.fn((docId: string) => reg.pushed.has(docId)),
+    markPushed: vi.fn((docId: string) => {
+      reg.pushed.add(docId);
+    }),
+    flushCheckpoint: vi.fn(async () => {}),
+    failures: vi.fn((): unknown[] => []),
+    hasFailures: vi.fn(() => false),
+    limitCode: vi.fn((): string | null => null),
+  };
+  return reg;
+});
+
+vi.mock("../registry", () => ({
+  VaultRegistry: class {
+    constructor() {
+      return fakeRegistry;
+    }
+  },
+}));
+
+/** The vault channel. Captures its options so a test can play server frames. */
+const engineHooks = vi.hoisted(() => {
+  const state = {
+    opts: null as VaultSyncEngineOptions | null,
+    started: 0,
+    refreshes: 0,
+    settled: false,
+  };
+  return state;
+});
+
+vi.mock("../vaultSyncEngine", () => ({
+  VaultSyncEngine: class {
+    constructor(opts: VaultSyncEngineOptions) {
+      engineHooks.opts = opts;
+    }
+    start() {
+      engineHooks.started++;
+    }
+    stop() {}
+    setPresence() {}
+    sendVoice() {
+      return false;
+    }
+    refresh() {
+      engineHooks.refreshes++;
+    }
+    inboundProgress() {
+      return { done: 0, total: 0, queued: 0 };
+    }
+    backfillSettled() {
+      return engineHooks.settled;
+    }
+  },
+}));
+
+/** The bridge-tiering store. `promote` hands back a bridge stub good enough for
+ *  the real ContentUploader: a Y.Doc, non-empty content, no-op disk I/O. */
+const storeHooks = vi.hoisted(() => ({
+  opts: null as VaultDocStoreOptions | null,
+  open: null as string | null,
+  promoted: [] as string[],
+}));
+
+vi.mock("../vaultDocStore", () => ({
+  createIpcManifestStore: () => ({ load: async () => [], save: async () => {} }),
+  VaultDocStore: class {
+    constructor(opts: VaultDocStoreOptions) {
+      storeHooks.opts = opts;
+    }
+    async promote(docId: string) {
+      storeHooks.promoted.push(docId);
+      return {
+        doc: new Y.Doc(),
+        serialize: () => "content",
+        ingestNow: async () => false,
+        seedFromFileIfEmpty: async () => {},
+        flushEgest: async () => {},
+      };
+    }
+    async demote() {}
+    async release() {}
+    peekResident() {
+      return null;
+    }
+    suppressedDoc() {
+      return storeHooks.open;
+    }
+    setSuppressedDoc(docId: string | null) {
+      storeHooks.open = docId;
+    }
+    async flushStateVectors() {}
+    async destroyAll() {}
+  },
+}));
+
+/** The per-note provider. Records the connect ORDER — which, at concurrency 1,
+ *  is the queue the uploader actually built. */
+const connects = vi.hoisted(() => ({ order: [] as string[] }));
+
+vi.mock("../syncManager", () => ({
+  DocSync: class {
+    readonly readOnly = false;
+    isSynced = false;
+    constructor(input: { docId: string }) {
+      connects.order.push(input.docId);
+    }
+    async whenSynced() {
+      this.isSynced = true;
+    }
+    async whenFlushed() {
+      return true;
+    }
+    destroy() {}
+    refreshAccess() {}
+  },
+}));
+
+import type { SessionInfo } from "../../api";
+import { SyncManager } from "../docSession";
+import { vaultScopes, type SyncProgress } from "../vaultScope";
+
+function session(): SessionInfo {
+  return {
+    user: { id: "u1", name: "Ann", email: "ann@example.com" },
+    activeOrganizationId: "org-a",
+  } as unknown as SessionInfo;
+}
+
+async function enable(sm: SyncManager) {
+  return sm.enable(session(), { orgId: "org-a", name: "a", path: "/vaults/a", epoch: 1 });
+}
+
+/** Let the microtask queue (and the uploader's `await tick()`-free path) settle. */
+const flush = async () => {
+  for (let i = 0; i < 20; i++) await Promise.resolve();
+};
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vaultScopes.end();
+  fakeRegistry.pushed = new Set();
+  fakeRegistry.reconcile.mockClear();
+  fakeRegistry.pull.mockClear();
+  fakeRegistry.markPushed.mockClear();
+  fakeRegistry.mappedNotes.mockReturnValue([]);
+  fakeRegistry.getMapping.mockReturnValue(null);
+  engineHooks.opts = null;
+  engineHooks.started = 0;
+  engineHooks.refreshes = 0;
+  engineHooks.settled = false;
+  storeHooks.opts = null;
+  storeHooks.open = null;
+  storeHooks.promoted = [];
+  connects.order = [];
+});
+
+describe("SyncManager — download before upload", () => {
+  it("starts no content run until the vault backfill has settled", async () => {
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
+    const sm = new SyncManager();
+    await enable(sm);
+
+    // The engine is up (one socket, backfilling) and nothing has been pushed over
+    // a per-note provider — that is the whole point of the reorder.
+    expect(engineHooks.started).toBe(1);
+    await flush();
+    expect(connects.order).toEqual([]);
+
+    // The backfill lands: `ready` (with nothing empty), then the queue drains.
+    engineHooks.opts!.onServerEmpty?.([], false);
+    await flush();
+    expect(connects.order).toEqual([]); // still draining
+
+    engineHooks.settled = true;
+    engineHooks.opts!.onInboundIdle?.();
+    await sm.whenBulkSyncSettled();
+    await flush();
+    expect(connects.order).toEqual(["a"]); // the one doc the backfill didn't confirm
+  });
+
+  it("a doc the backfill delivered cleanly is never pushed again", async () => {
+    // `onConverged`: the cold apply wrote the server's state to disk and the file
+    // had nothing of its own to add, so the server has this note BY DEFINITION.
+    // Without this the run re-sent every backfilled note over its own socket.
+    fakeRegistry.mappedNotes.mockReturnValue([
+      { docId: "a", relPath: "A.md" },
+      { docId: "b", relPath: "B.md" },
+    ]);
+    const sm = new SyncManager();
+    await enable(sm);
+
+    storeHooks.opts!.onConverged?.("a");
+    expect(fakeRegistry.markPushed).toHaveBeenCalledWith("a");
+
+    engineHooks.settled = true;
+    engineHooks.opts!.onServerEmpty?.([], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+    expect(connects.order).toEqual(["b"]);
+  });
+
+  it("never marks a diverged doc pushed — its local-only ops are nobody else's", async () => {
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "d", relPath: "D.md" }]);
+    fakeRegistry.pathForDocId.mockReturnValue("D.md");
+    const sm = new SyncManager();
+    await enable(sm);
+
+    // A cold apply merged an external edit into this doc: those ops exist only
+    // here until a provider pushes them.
+    storeHooks.opts!.onExternalMerge?.("d");
+    storeHooks.opts!.onConverged?.("d");
+    expect(fakeRegistry.markPushed).not.toHaveBeenCalled();
+    fakeRegistry.pathForDocId.mockReturnValue(null);
+  });
+});
+
+describe("SyncManager — ready.empty is the authority", () => {
+  it("queues exactly the docs the server lacks, first, ignoring the local checkpoint", async () => {
+    // The prod state: every note is "pushed" locally, and the server holds no
+    // content for two of them.
+    fakeRegistry.mappedNotes.mockReturnValue([
+      { docId: "keep", relPath: "Keep.md" },
+      { docId: "lost-2", relPath: "Lost2.md" },
+      { docId: "fresh", relPath: "Fresh.md" },
+      { docId: "lost-1", relPath: "Lost1.md" },
+      { docId: OPEN_DOC, relPath: "Open.md" },
+    ]);
+    for (const id of ["keep", "lost-1", "lost-2", OPEN_DOC]) fakeRegistry.pushed.add(id);
+    const sm = new SyncManager();
+    await enable(sm);
+    // The note the user has open: its editor session owns that doc's provider.
+    storeHooks.open = OPEN_DOC;
+
+    engineHooks.settled = true;
+    // `unmapped` is a doc id this device knows nothing about (a note it cannot
+    // see, or one deleted locally) — it must not manufacture work.
+    engineHooks.opts!.onServerEmpty?.(["lost-1", "lost-2", "unmapped", OPEN_DOC], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+
+    // Empty-on-the-server first (in the order the vault lists them), then the
+    // genuinely unconfirmed note. The open doc and the unmapped id are absent.
+    expect(connects.order).toEqual(["lost-2", "lost-1", "fresh"]);
+    expect(engineHooks.refreshes).toBe(0); // nothing was truncated
+  });
+
+  it("asks for the next batch when the server truncated its list", async () => {
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
+    const sm = new SyncManager();
+    await enable(sm);
+    engineHooks.settled = true;
+    engineHooks.opts!.onServerEmpty?.(["a"], true);
+    await sm.whenBulkSyncSettled();
+    await flush();
+
+    expect(connects.order).toEqual(["a"]);
+    // One re-hello, not a loop: the flag is consumed, so the next `ready` decides
+    // afresh whether there is more.
+    expect(engineHooks.refreshes).toBe(1);
+  });
+
+  it("does not re-hello after a run that sent nothing (no tight loop)", async () => {
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
+    fakeRegistry.pushed.add("a");
+    const sm = new SyncManager();
+    await enable(sm);
+    engineHooks.settled = true;
+    // Truncated, but every doc it named is one we already confirmed and it named
+    // nothing we can act on — pushing nothing must not earn another handshake.
+    engineHooks.opts!.onServerEmpty?.(["zz-unmapped"], true);
+    await sm.whenBulkSyncSettled();
+    await flush();
+    expect(connects.order).toEqual([]);
+    expect(engineHooks.refreshes).toBe(0);
+  });
+
+  it("a ready during a live run refreshes the list without starting a second run", async () => {
+    fakeRegistry.mappedNotes.mockReturnValue([
+      { docId: "a", relPath: "A.md" },
+      { docId: "b", relPath: "B.md" },
+    ]);
+    const sm = new SyncManager();
+    await enable(sm);
+    engineHooks.settled = true;
+    engineHooks.opts!.onServerEmpty?.([], false);
+    // Two more `ready` frames while the first run is in flight.
+    engineHooks.opts!.onServerEmpty?.([], false);
+    engineHooks.opts!.onServerEmpty?.([], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+    // Each doc connected exactly once: no second run doubled the work.
+    expect(connects.order).toEqual(["a", "b"]);
+  });
+
+  it("reaches a terminal phase with nothing to send, and does not re-stamp it", async () => {
+    fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
+    fakeRegistry.pushed.add("a");
+    const sm = new SyncManager();
+    const progress: Array<SyncProgress | null> = [];
+    sm.setSyncProgressListener((p) => progress.push(p));
+    await enable(sm);
+    engineHooks.settled = true;
+    engineHooks.opts!.onInboundIdle?.();
+    await flush();
+    expect(progress[progress.length - 1]?.phase).toBe("done");
+
+    // A teammate typing keeps draining the inbound queue, which fires this edge
+    // over and over. Re-stamping `done` there is a store write per keystroke.
+    const settledAt = progress.length;
+    for (let i = 0; i < 5; i++) engineHooks.opts!.onInboundIdle?.();
+    await flush();
+    expect(progress).toHaveLength(settledAt);
+  });
+});
+
+describe("SyncManager.handleLocalFilesChanged", () => {
+  it("folds a whole watcher batch into ONE registry pull", async () => {
+    vi.useFakeTimers();
+    const sm = new SyncManager();
+    await enable(sm);
+    fakeRegistry.pull.mockClear();
+
+    // An AI writing a folder full of new notes: 40 unmapped files plus the
+    // directory itself, all in one watcher batch.
+    const changes = [
+      { path: "Imported", kind: "tree" as const },
+      ...Array.from({ length: 40 }, (_, i) => ({
+        path: `Imported/n${i}.md`,
+        kind: "modified" as const,
+      })),
+    ];
+    sm.handleLocalFilesChanged(changes);
+    expect(sm.hasPendingRegistryPull()).toBe(true);
+    await vi.advanceTimersByTimeAsync(300);
+    expect(fakeRegistry.pull).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("queues mapped notes for a content push without pulling the registry", async () => {
+    vi.useFakeTimers();
+    fakeRegistry.getMapping.mockImplementation((relPath: string) =>
+      relPath === "Mapped.md" ? { vaultId: "collection-1", docId: "m1" } : null,
+    );
+    const sm = new SyncManager();
+    await enable(sm);
+    fakeRegistry.pull.mockClear();
+
+    sm.handleLocalFilesChanged([{ path: "Mapped.md", kind: "modified" }]);
+    expect(sm.hasPendingRegistryPull()).toBe(false); // nothing structural happened
+    await vi.advanceTimersByTimeAsync(300);
+    expect(fakeRegistry.pull).not.toHaveBeenCalled();
+
+    // A removal is deliberately inert: propagating disk deletions would let
+    // `git checkout`-style churn delete a team's notes.
+    sm.handleLocalFilesChanged([{ path: "Gone.md", kind: "removed" }]);
+    expect(sm.hasPendingRegistryPull()).toBe(false);
+    fakeRegistry.getMapping.mockReturnValue(null);
+    vi.useRealTimers();
+  });
+
+  it("the single-event form still routes exactly like one batch of one", async () => {
+    vi.useFakeTimers();
+    const sm = new SyncManager();
+    await enable(sm);
+    fakeRegistry.pull.mockClear();
+    sm.handleLocalFileChanged("New.md", "modified");
+    await vi.advanceTimersByTimeAsync(300);
+    expect(fakeRegistry.pull).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/app/apps/desktop/src/lib/sync/__tests__/progressCheckpoint.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/progressCheckpoint.test.ts
@@ -3,7 +3,7 @@
 // single-writer checkpointer (so a kill -9 loses at most one batch).
 
 import { describe, expect, it, vi } from "vitest";
-import { Checkpointer } from "../checkpoint";
+import { Checkpointer, checkpointBatchFor } from "../checkpoint";
 import { SyncProgressReporter } from "../progress";
 import { runPool, withRetry } from "../pool";
 import type { DocSyncState, SyncProgress } from "../vaultScope";
@@ -257,6 +257,80 @@ describe("Checkpointer", () => {
     await cp.flush();
     expect(attempts).toBe(2);
     expect(cp.isDirty).toBe(false);
+  });
+});
+
+// ── config.json write volume ────────────────────────────────────────────────
+// The file is rewritten WHOLE on every flush and carries three entries per note,
+// so on a big vault the batch size decides how many megabytes a backfill writes.
+
+describe("checkpointBatchFor", () => {
+  it("never drops below 25, so a small vault still checkpoints often", () => {
+    expect(checkpointBatchFor(0)).toBe(25);
+    expect(checkpointBatchFor(60)).toBe(25);
+    expect(checkpointBatchFor(1250)).toBe(25);
+  });
+
+  it("scales with the vault, keeping the write COUNT flat as the file grows", () => {
+    // 5,000 notes: ~50 writes of a big file, not ~200.
+    expect(checkpointBatchFor(5_000)).toBe(100);
+    expect(5_000 / checkpointBatchFor(5_000)).toBe(50);
+    expect(20_000 / checkpointBatchFor(20_000)).toBe(50);
+  });
+});
+
+describe("Checkpointer.setEveryItems", () => {
+  it("retunes the batch after the caller learns the vault's size", async () => {
+    const clock = fakeClock();
+    const written: number[] = [];
+    let counter = 0;
+    const cp = new Checkpointer<number>({
+      write: async (v) => {
+        written.push(v);
+      },
+      snapshot: () => counter,
+      everyItems: 25,
+      everyMs: 750,
+      setTimeoutImpl: clock.setTimeoutImpl,
+      clearTimeoutImpl: clock.clearTimeoutImpl,
+    });
+    cp.setEveryItems(checkpointBatchFor(5_000)); // 100
+
+    for (let i = 0; i < 99; i++) {
+      counter++;
+      cp.touch();
+    }
+    await Promise.resolve();
+    expect(written).toHaveLength(0); // the old 25-item batch would have fired 3×
+    counter++;
+    cp.touch();
+    await cp.flush();
+    expect(written).toEqual([100]);
+  });
+
+  it("flushes immediately when the new batch is already full", async () => {
+    const clock = fakeClock();
+    const written: number[] = [];
+    let counter = 0;
+    const cp = new Checkpointer<number>({
+      write: async (v) => {
+        written.push(v);
+      },
+      snapshot: () => counter,
+      everyItems: 100,
+      everyMs: 750,
+      setTimeoutImpl: clock.setTimeoutImpl,
+      clearTimeoutImpl: clock.clearTimeoutImpl,
+    });
+    for (let i = 0; i < 30; i++) {
+      counter++;
+      cp.touch();
+    }
+    // Lowering the batch under what is already pending must not leave the write
+    // owed until the next touch.
+    cp.setEveryItems(10);
+    await cp.flush();
+    expect(written).toEqual([30]);
   });
 });
 

--- a/app/apps/desktop/src/lib/sync/checkpoint.ts
+++ b/app/apps/desktop/src/lib/sync/checkpoint.ts
@@ -18,6 +18,24 @@
 // overlapping flushes can never interleave and write a torn map. Pure — timers
 // injectable — so it is unit-testable without Tauri.
 
+/**
+ * Flush batch for a vault with `mapped` notes in its doc map.
+ *
+ * config.json is not a small file: it carries a `docs` entry, a `baseline` entry
+ * and (once pushed) a `pushed` entry per note, so a 5,000-note vault writes
+ * ~megabytes per flush. A fixed 25-item batch therefore turns a big backfill into
+ * ~200 whole-file rewrites — hundreds of megabytes of disk churn on the very
+ * vaults that are already struggling. Scaling the batch with the map keeps the
+ * number of writes roughly constant (~50 per full run) instead of the SIZE of
+ * each write being the only thing that grows.
+ *
+ * Never below 25: a small vault must still checkpoint often enough that a kill -9
+ * loses under a second of work.
+ */
+export function checkpointBatchFor(mapped: number): number {
+  return Math.max(25, Math.floor(mapped / 50));
+}
+
 export interface CheckpointOptions<T> {
   /** Serialize + persist the value. Must not throw for a normal failure — the
    *  checkpointer logs and keeps the dirty flag so the next window retries. */
@@ -42,7 +60,9 @@ export interface CheckpointOptions<T> {
 export class Checkpointer<T> {
   private readonly writeFn: (value: T) => Promise<void>;
   private readonly snapshotFn: () => T;
-  private readonly everyItems: number;
+  /** Not readonly: {@link Checkpointer.setEveryItems} retunes it once the caller
+   *  knows how big this vault's map actually is. */
+  private everyItems: number;
   private readonly everyMs: number;
   private readonly setT: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
   private readonly clearT: (h: ReturnType<typeof setTimeout>) => void;
@@ -63,6 +83,18 @@ export class Checkpointer<T> {
     this.everyMs = Math.max(0, opts.everyMs ?? 750);
     this.setT = opts.setTimeoutImpl ?? ((fn, ms) => setTimeout(fn, ms));
     this.clearT = opts.clearTimeoutImpl ?? ((h) => clearTimeout(h));
+  }
+
+  /**
+   * Retune the batch size mid-life — the caller only learns the vault's size
+   * after it has read config.json, which is already past construction.
+   *
+   * Flushes immediately if the new (smaller) batch is already full, so lowering
+   * it can't leave a write owed indefinitely.
+   */
+  setEveryItems(n: number): void {
+    this.everyItems = Math.max(1, Math.floor(n));
+    if (!this.disposed && this.pending >= this.everyItems) void this.flush();
   }
 
   /** Note that `n` units of work happened. Flushes when the batch fills, else

--- a/app/apps/desktop/src/lib/sync/contentUpload.ts
+++ b/app/apps/desktop/src/lib/sync/contentUpload.ts
@@ -86,6 +86,25 @@ export interface ContentUploaderOptions {
    *  underneath us, so "pushed" says nothing about the new bytes. */
   force?: boolean;
   /**
+   * Queue this doc even though {@link ContentUploaderOptions.isPushed} says it is
+   * confirmed — a targeted `force`.
+   *
+   * Fed by the vault channel's `ready.empty`: the server is the authority on
+   * whether it holds a note's content, and `pushed` is only a local optimisation
+   * that a crashed run or a wiped `.context/` gets wrong. Without this, a note
+   * the checkpoint claims and the server does not have is unreachable forever.
+   */
+  include?: (docId: string) => boolean;
+  /**
+   * Docs to push FIRST. Order within each group is preserved (a stable
+   * partition), so the queue stays deterministic.
+   *
+   * Used for the same `ready.empty` set: those notes have NO content on the
+   * server, so if a run is cut short (vault switch, quit, failure pause) the
+   * work that mattered most is the work that already happened.
+   */
+  priority?: (docId: string) => boolean;
+  /**
    * Merge each note's current file bytes into its doc (`NoteBridge.ingestNow`)
    * as part of the push — the local-change run's whole reason to exist. Without
    * it this engine only ever *seeds an empty doc*, so an edit to a note that
@@ -111,12 +130,17 @@ export interface ContentUploaderOptions {
   /** How long to wait for the server to ack our push per doc. Default 30s. */
   flushTimeoutMs?: number;
   /**
-   * Consecutive per-doc failures that abort the whole run. Default 5.
+   * Consecutive per-doc failures that PAUSE the run. Default 10.
    *
    * A dead/unreachable server fails EVERY doc, and grinding through 500 × the
-   * sync timeout is exactly the "syncing forever" symptom. Five in a row is
-   * conclusive enough: the run stops, phase goes `error`, and the remaining docs
-   * stay honestly unsynced instead of silently claimed.
+   * sync timeout is exactly the "syncing forever" symptom. So the run stops and
+   * the remaining docs stay honestly unsynced instead of silently claimed.
+   *
+   * This is a pause, not a verdict: a dead server pauses the run, and the next
+   * vault-channel `ready` resumes it (see `SyncManager.handleServerEmpty`). That
+   * is why the limit is 10 rather than the original 5 — with nothing to restart
+   * the run, five transient failures used to strand every remaining note until
+   * the user signed out and back in.
    */
   failureStreakLimit?: number;
 }
@@ -152,7 +176,7 @@ export class ContentUploader {
     this.concurrency = Math.max(1, opts.concurrency ?? UPLOAD_CONCURRENCY);
     this.syncTimeoutMs = opts.syncTimeoutMs ?? 10_000;
     this.flushTimeoutMs = opts.flushTimeoutMs ?? 30_000;
-    this.streakLimit = Math.max(1, opts.failureStreakLimit ?? 5);
+    this.streakLimit = Math.max(1, opts.failureStreakLimit ?? 10);
   }
 
   /** Cancel the run. Called from `SyncManager.teardown` on every vault switch. */
@@ -185,15 +209,26 @@ export class ContentUploader {
     this.streak = 0;
     this.aborted = false;
     try {
-      const queue = this.opts.notes.filter(
-        (n) =>
-          (this.opts.force === true || !this.opts.isPushed(n.docId)) &&
-          !(this.opts.skip?.(n.docId) ?? false),
+      const queue = this.orderQueue(
+        this.opts.notes.filter(
+          (n) =>
+            (this.opts.force === true ||
+              !this.opts.isPushed(n.docId) ||
+              (this.opts.include?.(n.docId) ?? false)) &&
+            !(this.opts.skip?.(n.docId) ?? false),
+        ),
       );
       // Everything already confirmed reads as synced straight away, so the badge
       // for a resumed vault is correct before a single socket opens.
+      const queued = new Set(queue.map((n) => n.docId));
       for (const n of this.opts.notes) {
-        if (this.opts.isPushed(n.docId)) this.progress.doc(n.docId, "synced");
+        // `queued` wins over the checkpoint: a doc named by `ready.empty` is
+        // "pushed" locally and yet has no content on the server, so badging it
+        // synced here — even for the one emission before the `queued` below
+        // overwrites it — would be the exact lie this run exists to fix.
+        if (this.opts.isPushed(n.docId) && !queued.has(n.docId)) {
+          this.progress.doc(n.docId, "synced");
+        }
       }
       this.progress.phase("uploading", queue.length);
       for (const n of queue) this.progress.doc(n.docId, "queued");
@@ -223,6 +258,21 @@ export class ContentUploader {
     } finally {
       this.running = false;
     }
+  }
+
+  /**
+   * Stable partition: `priority` docs first, everything else in its original
+   * order. A sort() would be shorter and wrong — `Array.prototype.sort` is only
+   * guaranteed stable per spec for the comparator's ties, and reordering the
+   * queue arbitrarily makes a resumed run's progress unrepeatable.
+   */
+  private orderQueue<T extends { docId: string }>(queue: T[]): T[] {
+    const isFirst = this.opts.priority;
+    if (!isFirst) return queue;
+    const first: T[] = [];
+    const rest: T[] = [];
+    for (const n of queue) (isFirst(n.docId) ? first : rest).push(n);
+    return [...first, ...rest];
   }
 
   /** Push one note. Returns true when the server has acked its content. */
@@ -262,7 +312,9 @@ export class ContentUploader {
       // update (which we egest to disk, which fires the watcher) from costing a
       // provider connect apiece.
       const changed = await bridge.ingestNow();
-      if (!changed && this.opts.isPushed(docId) && !(this.opts.mustConnect?.(docId) ?? false)) {
+      const serverHasIt =
+        this.opts.isPushed(docId) && !(this.opts.include?.(docId) ?? false);
+      if (!changed && serverHasIt && !(this.opts.mustConnect?.(docId) ?? false)) {
         await this.releaseQuietly(docId);
         this.streak = 0;
         this.progress.doc(docId, "synced");

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -67,6 +67,14 @@ const REGISTRY_MAP_PUBLISH_MS = 100;
 const LOCAL_CHANGE_DEBOUNCE_MS = 800;
 /** Re-check interval while a bulk run holds the uploader slot. */
 const LOCAL_CHANGE_RETRY_MS = 2_000;
+/**
+ * How long the download phase may wait for the vault channel's `ready` before
+ * the run stops reporting "Syncing…" and admits the channel is unreachable.
+ * Generous: a cold 5k-note backfill legitimately takes a while, but its frames
+ * flip the engine to `synced`-in-progress long before this elapses; only a
+ * socket that never opens gets here.
+ */
+const CHANNEL_WATCHDOG_MS = 30_000;
 
 export interface OpenedDoc {
   awareness: Awareness;
@@ -209,6 +217,15 @@ export class SyncManager implements InboundHost {
   private serverEmptyTruncated = false;
   /** True while the run is reporting the vault channel's inbound queue. */
   private downloadPhase = false;
+  /**
+   * The channel watchdog. The content run waits for the vault channel's `ready`
+   * (download before upload), so a channel that never connects — WS blocked by a
+   * proxy, server down — would otherwise leave the pill on "Syncing…" forever.
+   * When this fires with no `ready` in sight, the run is stamped `error` so the
+   * pill reads "Retrying…"; the next `ready` clears the stall and resumes.
+   */
+  private channelWatchdog: ReturnType<typeof setTimeout> | null = null;
+  private channelStalled = false;
   private lastInboundDone = 0;
   private lastInboundTotal = 0;
   /** Resolves when the current bulk run finishes (tests). */
@@ -737,7 +754,9 @@ export class SyncManager implements InboundHost {
       // fires again on every drained inbound frame (a teammate typing), and
       // re-stamping `done` there would be a store write per keystroke.
       const phase = this.progress?.snapshot().phase;
-      if (phase !== "done" && phase !== "error") this.completeRun(scope);
+      const stalled = this.channelStalled;
+      this.channelStalled = false;
+      if (phase !== "done" && (phase !== "error" || stalled)) this.completeRun(scope);
       return;
     }
     this.bulkRun = this.runBulkSync(scope).catch((e) => {
@@ -778,6 +797,7 @@ export class SyncManager implements InboundHost {
    */
   private handleServerEmpty(docIds: string[], truncated: boolean, scope: VaultScope): void {
     if (!scope.isCurrent()) return;
+    this.clearChannelWatchdog(); // `ready` arrived — the channel is alive
     this.serverEmpty = new Set(docIds);
     this.serverEmptyTruncated = truncated;
     // A live run keeps its queue and picks this set up on its next pass; only
@@ -1026,12 +1046,38 @@ export class SyncManager implements InboundHost {
     this.lastInboundDone = done;
     this.lastInboundTotal = total;
     this.downloadPhase = true;
+    this.armChannelWatchdog(scope);
     // Opens at 0/0 ("Syncing…"), because this now runs the moment the engine is
     // started — before its socket is even open, let alone `hello`ed. There is
     // deliberately no `backfillSettled()` short-circuit here any more: an engine
     // that has not connected yet reports settled (nothing is queued and no window
     // is open), so checking it here would end the phase before it began.
     progress.phase("downloading", total - done);
+  }
+
+  private armChannelWatchdog(scope: VaultScope): void {
+    this.clearChannelWatchdog();
+    this.channelWatchdog = setTimeout(() => {
+      this.channelWatchdog = null;
+      if (!scope.isCurrent() || !this.downloadPhase) return;
+      if (this.vaultStatus === "synced") return; // `ready` landed; the idle edge owns it
+      const progress = this.progress;
+      if (!progress) return;
+      // Stop claiming progress that isn't happening. `channelStalled` lets the
+      // next `ready` re-stamp a terminal phase (completion normally refuses to
+      // overwrite `error`, because a real failure must not be papered over).
+      this.downloadPhase = false;
+      this.channelStalled = true;
+      progress.phase("error");
+      progress.flush();
+    }, CHANNEL_WATCHDOG_MS);
+  }
+
+  private clearChannelWatchdog(): void {
+    if (this.channelWatchdog) {
+      clearTimeout(this.channelWatchdog);
+      this.channelWatchdog = null;
+    }
   }
 
   /** One backfilled document applied by the vault channel. */
@@ -1075,6 +1121,8 @@ export class SyncManager implements InboundHost {
     const progress = this.progress;
     if (!progress) return;
     this.downloadPhase = false;
+    this.channelStalled = false;
+    this.clearChannelWatchdog();
     const uploadFailures = this.uploader?.failedDocs().length ?? 0;
     const clean =
       uploadFailures === 0 &&
@@ -1143,6 +1191,8 @@ export class SyncManager implements InboundHost {
     this.uploader = null;
     this.bulkRun = null;
     this.downloadPhase = false;
+    this.clearChannelWatchdog();
+    this.channelStalled = false;
     this.lastInboundDone = 0;
     this.lastInboundTotal = 0;
     this.attachments?.stop();

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -194,6 +194,19 @@ export class SyncManager implements InboundHost {
    *  NOT mean "nothing to send", so the push must connect regardless. Cleared
    *  per doc when a push confirms it, wholesale on teardown. */
   private divergedDocs = new Set<string>();
+  /**
+   * docIds the SERVER says it holds no CRDT state for (`ready.empty`), replaced
+   * on every vault-channel `ready`.
+   *
+   * The authority on what still needs uploading. `registry.isPushed` is a local
+   * optimisation and can be wrong in the one direction that matters — claiming a
+   * note the server never received (613 of them in prod) — so the run's work list
+   * is "not confirmed locally OR named here", and these go first.
+   */
+  private serverEmpty = new Set<string>();
+  /** The server truncated `ready.empty`: more empty docs exist than one frame
+   *  names, so another `hello` is owed once this run drains them. */
+  private serverEmptyTruncated = false;
   /** True while the run is reporting the vault channel's inbound queue. */
   private downloadPhase = false;
   private lastInboundDone = 0;
@@ -492,8 +505,8 @@ export class SyncManager implements InboundHost {
   }
 
   /**
-   * A watcher `file-changed` event for something OTHER than the open note (App
-   * routes the open note's events into its bridge, whose own provider pushes).
+   * One watcher `files-changed` BATCH, minus the open note (App routes the open
+   * note's events into its bridge, whose own provider pushes).
    *
    * This is what makes an external writer a first-class editor: people open the
    * vault folder in an AI tool (Claude, Cursor, a script) that creates and edits
@@ -512,38 +525,54 @@ export class SyncManager implements InboundHost {
    *    MCP): auto-propagating disk deletions would let `git checkout`-style tree
    *    churn delete a team's notes.
    */
-  handleLocalFileChanged(relPath: string, kind: "modified" | "removed" | "tree"): void {
+  handleLocalFilesChanged(
+    changes: ReadonlyArray<{ path: string; kind: "modified" | "removed" | "tree" }>,
+  ): void {
     const scope = this.scope;
     if (!this.enabled || !scope || !scope.isCurrent()) return;
-    if (kind === "removed") return;
-    if (kind === "tree") {
-      this.handleRegistryChanged();
-      return;
+    // ONE registry pull for the whole batch, however many items ask for it. The
+    // watcher already debounces into batches, and an AI writing 200 new files
+    // used to re-enter `handleRegistryChanged` 200 times per batch — 200 timer
+    // teardowns for the single pull that was always going to happen.
+    let pullRegistry = false;
+    for (const { path: relPath, kind } of changes) {
+      if (kind === "removed") continue;
+      if (kind === "tree") {
+        pullRegistry = true;
+        continue;
+      }
+      const mapping = this.registry.getMapping(relPath);
+      if (!mapping) {
+        pullRegistry = true;
+        continue;
+      }
+      // Belt and braces with the uploader's own `skip`: the open note's editor
+      // session owns its provider, and its bridge already ingests watcher events.
+      if (this.docStore?.suppressedDoc() === mapping.docId) continue;
+      this.localChanges.set(mapping.docId, relPath);
+      this.armLocalChangeDrain(scope, LOCAL_CHANGE_DEBOUNCE_MS);
+      // A doc resident in the hot tier has a LIVE bridge, and its next egest (a
+      // remote update landing) would overwrite the file's new bytes before the
+      // drain runs — merge them into the doc NOW. A genuine merge goes into the
+      // diverged set: the drain's own ingest will then find file == doc, and only
+      // this marker tells it the doc still holds unsent ops.
+      const resident = this.docStore?.peekResident(mapping.docId);
+      if (resident) {
+        void resident
+          .ingestNow()
+          .then((changed) => {
+            if (changed && scope.isCurrent()) this.divergedDocs.add(mapping.docId);
+          })
+          .catch((e) => console.warn("[sync] resident ingest failed", e));
+      }
     }
-    const mapping = this.registry.getMapping(relPath);
-    if (!mapping) {
-      this.handleRegistryChanged();
-      return;
-    }
-    // Belt and braces with the uploader's own `skip`: the open note's editor
-    // session owns its provider, and its bridge already ingests watcher events.
-    if (this.docStore?.suppressedDoc() === mapping.docId) return;
-    this.localChanges.set(mapping.docId, relPath);
-    this.armLocalChangeDrain(scope, LOCAL_CHANGE_DEBOUNCE_MS);
-    // A doc resident in the hot tier has a LIVE bridge, and its next egest (a
-    // remote update landing) would overwrite the file's new bytes before the
-    // drain runs — merge them into the doc NOW. A genuine merge goes into the
-    // diverged set: the drain's own ingest will then find file == doc, and only
-    // this marker tells it the doc still holds unsent ops.
-    const resident = this.docStore?.peekResident(mapping.docId);
-    if (resident) {
-      void resident
-        .ingestNow()
-        .then((changed) => {
-          if (changed && scope.isCurrent()) this.divergedDocs.add(mapping.docId);
-        })
-        .catch((e) => console.warn("[sync] resident ingest failed", e));
-    }
+    if (pullRegistry) this.handleRegistryChanged();
+  }
+
+  /** Single-event form of {@link handleLocalFilesChanged}, for call sites that
+   *  see one change at a time. */
+  handleLocalFileChanged(relPath: string, kind: "modified" | "removed" | "tree"): void {
+    this.handleLocalFilesChanged([{ path: relPath, kind }]);
   }
 
   private armLocalChangeDrain(scope: VaultScope, delayMs: number): void {
@@ -658,23 +687,6 @@ export class SyncManager implements InboundHost {
   }
 
   /**
-   * Notes this device has NOT confirmed the content of. Excludes the open note,
-   * whose own editor session owns its provider.
-   *
-   * A freshly materialized note is an EMPTY `.md` on disk (the registry writes a
-   * placeholder and hydrates lazily), so "not confirmed" is literally "this
-   * device does not have the content" — not a bookkeeping detail.
-   */
-  private unconfirmedNotes(): number {
-    const open = this.docStore?.suppressedDoc() ?? null;
-    let n = 0;
-    for (const note of this.registry.mappedNotes()) {
-      if (note.docId !== open && !this.registry.isPushed(note.docId)) n++;
-    }
-    return n;
-  }
-
-  /**
    * Land the vault on a coherent state after a registry pull.
    *
    * A pull re-enters the `registering` phase (it may create rows for a teammate's
@@ -685,8 +697,10 @@ export class SyncManager implements InboundHost {
    * row plus an empty placeholder file. Stamping `done` there would claim the
    * vault is fully synced while that note has no content on this device, and the
    * sidebar would (correctly, and contradictorily) badge its row as not synced.
-   * So: if anything is unconfirmed, run the content pass that confirms it, and let
-   * THAT run stamp the terminal phase. Otherwise stamp it here.
+   * So: if anything is still unconfirmed (or the server told us it holds no
+   * content for it), run the content pass that confirms it and let THAT run stamp
+   * the terminal phase — `startContentRunIfNeeded` decides which, and defers to
+   * the vault channel's backfill if one is still arriving.
    */
   private settleAfterPull(scope: VaultScope): void {
     // A live run will reach its own terminal phase and will pick up whatever the
@@ -694,13 +708,81 @@ export class SyncManager implements InboundHost {
     // pushed set. Restarting it here instead would let a busy team's structural
     // churn abandon the initial backfill over and over.
     if (this.uploader?.isRunning()) return;
-    if (this.unconfirmedNotes() === 0) {
-      this.completeRun(scope);
+    this.startContentRunIfNeeded(scope);
+  }
+
+  /**
+   * Start the content run, or stamp the terminal phase when there is nothing to
+   * send. The ONE entry point for starting a run, called from every edge that can
+   * change the answer: the download phase settling, a `ready` frame, a registry
+   * pull, and the user's manual retry.
+   *
+   * Two gates, both load-bearing:
+   *
+   *  - a run already in flight is left alone. Its queue is rebuilt from
+   *    `mappedNotes()` minus the pushed set, so it picks up whatever arrived
+   *    while it was running; restarting it would let a busy team's structural
+   *    churn abandon the initial backfill over and over.
+   *  - the vault channel's backfill must have settled. Uploading a doc the
+   *    channel is about to hand us is the double delivery this exists to remove,
+   *    and the settle edge re-enters here anyway.
+   */
+  private startContentRunIfNeeded(scope: VaultScope): void {
+    if (!this.enabled || !scope.isCurrent()) return;
+    if (this.uploader?.isRunning()) return;
+    const engine = this.vaultEngine;
+    if (engine && !engine.backfillSettled()) return;
+    if (this.contentWorkList().length === 0) {
+      // Nothing to send. Stamp a terminal phase once, and only once: this edge
+      // fires again on every drained inbound frame (a teammate typing), and
+      // re-stamping `done` there would be a store write per keystroke.
+      const phase = this.progress?.snapshot().phase;
+      if (phase !== "done" && phase !== "error") this.completeRun(scope);
       return;
     }
     this.bulkRun = this.runBulkSync(scope).catch((e) => {
-      console.warn("[sync] follow-up content sync failed", e);
+      console.warn("[sync] content sync failed", e);
     });
+  }
+
+  /**
+   * The docs a content run would push: not confirmed by this device, OR named by
+   * the server's `ready.empty` (which outranks our checkpoint). The open note is
+   * excluded — its editor session owns that doc's provider.
+   *
+   * Replaces the old `unconfirmedNotes()` count, which asked the narrower
+   * (device-local) question and could therefore never see a note the server had
+   * lost. A freshly materialized note is an EMPTY `.md` on disk (the registry
+   * writes a placeholder and hydrates lazily), so "in this list" is literally
+   * "somebody does not have the content" — not a bookkeeping detail.
+   */
+  private contentWorkList(): Array<{ docId: string; relPath: string }> {
+    const open = this.docStore?.suppressedDoc() ?? null;
+    return this.registry
+      .mappedNotes()
+      .filter(
+        (n) =>
+          n.docId !== open &&
+          (!this.registry.isPushed(n.docId) || this.serverEmpty.has(n.docId)),
+      );
+  }
+
+  /**
+   * A `ready` frame told us which readable docs the server holds no content for.
+   *
+   * Every `ready` re-arms the run, which is what makes the uploader's failure
+   * streak a PAUSE rather than a verdict: a server that was dead when the run
+   * gave up will, when it comes back, send a `hello`→`ready` round that starts a
+   * fresh one. Nothing else restarted it before — a five-failure streak stranded
+   * every remaining note until sign-out.
+   */
+  private handleServerEmpty(docIds: string[], truncated: boolean, scope: VaultScope): void {
+    if (!scope.isCurrent()) return;
+    this.serverEmpty = new Set(docIds);
+    this.serverEmptyTruncated = truncated;
+    // A live run keeps its queue and picks this set up on its next pass; only
+    // the set is refreshed here.
+    this.startContentRunIfNeeded(scope);
   }
 
   isEnabled(): boolean {
@@ -796,12 +878,19 @@ export class SyncManager implements InboundHost {
         ?.reconcile()
         .catch((e) => console.warn("[attachments] initial reconcile failed", e));
       this.startVaultEngine(scope);
-      // Bulk content sync runs in the BACKGROUND: `enable` must return as soon as
-      // the vault is usable, or "Turn on sync" would block the UI for the whole
-      // backfill. Progress + per-doc state are reported as it advances.
-      this.bulkRun = this.runBulkSync(scope).catch((e) => {
-        console.warn("[sync] bulk run failed", e);
-      });
+      // DOWNLOAD FIRST, then push what is left. This order is the whole point of
+      // the change: the vault channel backfills every readable doc over ONE
+      // socket, and a doc it delivers needs no upload at all (see the
+      // `onConverged` wiring in `startVaultEngine`). Running the content pass
+      // first meant every note was delivered twice — once over the vault channel
+      // and once over a dedicated per-note provider at 3.7 notes/second.
+      //
+      // The content run is now started by whichever of these lands first: the
+      // download phase settling (`handleInboundIdle`), or a `ready` frame that
+      // names docs the server has no content for (`handleServerEmpty`). Both run
+      // in the BACKGROUND — `enable` must return as soon as the vault is usable,
+      // or "Turn on sync" would block the UI for the whole backfill.
+      this.beginDownloadPhase(scope);
       return { ok: true, seeded, scope };
     } catch (e) {
       if (scope.isCurrent()) this.disable();
@@ -843,13 +932,18 @@ export class SyncManager implements InboundHost {
   }
 
   /**
-   * Push every registered note's CONTENT to the server, then wait out the inbound
-   * backfill, then report a terminal phase.
+   * Push the CONTENT of every note the server does not already have, then report
+   * a terminal phase.
    *
    * This is the half of "turn on sync" that did not exist: reconcile created a
    * `notes` row (and an EMPTY server Y.Doc) per file, and a note's markdown only
    * ever reached the server when a human opened that note. See `contentUpload.ts`
    * for why re-running it cannot duplicate content.
+   *
+   * It runs AFTER the vault channel's backfill now (`startContentRunIfNeeded`),
+   * so its queue is the remainder rather than the whole vault: every doc the
+   * channel delivered is already marked pushed, and every doc the server has no
+   * content for is named in `serverEmpty` and pushed first.
    */
   private async runBulkSync(scope: VaultScope): Promise<void> {
     const vaultId = this.registry.vaultId;
@@ -875,9 +969,17 @@ export class SyncManager implements InboundHost {
           new DocSync({ api, doc, docId, vaultId: collectionId }),
       },
       isPushed: (docId) => this.registry.isPushed(docId),
+      // The server's word beats our checkpoint: a doc it holds no content for is
+      // queued even when `pushed` claims it, which is the only way a note
+      // stranded by a crashed run (or a restored `.context/`) is ever recovered.
+      include: (docId) => this.serverEmpty.has(docId),
+      // …and it goes FIRST. Those notes have nothing at all on the server, so if
+      // the run is cut short they are the work that had to happen.
+      priority: (docId) => this.serverEmpty.has(docId),
       markPushed: (docId) => {
         this.registry.markPushed(docId);
         this.divergedDocs.delete(docId); // a confirmed push carries any merged ops
+        this.serverEmpty.delete(docId); // the server has its content now
       },
       // Never touch the open note: its editor session owns a provider for that doc.
       skip: (docId) => store.suppressedDoc() === docId,
@@ -893,7 +995,15 @@ export class SyncManager implements InboundHost {
     await this.registry.flushCheckpoint();
     if (!scope.isCurrent() || this.uploader !== uploader) return;
     if (result.cancelled) return;
-    this.beginDownloadPhase(scope);
+    this.completeRun(scope);
+    // The server had more empty docs than one `ready` frame names. Ask again —
+    // but only after a run that actually SENT something and failed nothing,
+    // otherwise a server that keeps naming docs we cannot push would spin the
+    // socket in a tight hello/ready loop.
+    if (this.serverEmptyTruncated && result.pushed > 0 && result.failed === 0) {
+      this.serverEmptyTruncated = false;
+      this.vaultEngine?.refresh();
+    }
   }
 
   /**
@@ -911,17 +1021,16 @@ export class SyncManager implements InboundHost {
     const engine = this.vaultEngine;
     const progress = this.progress;
     if (!engine || !progress) return;
+    if (!scope.isCurrent()) return;
     const { done, total } = engine.inboundProgress();
-    // `backfillSettled`, not `inboundIdle`: an idle queue mid-backfill just means
-    // the next document hasn't arrived yet, and stopping there would claim a
-    // still-arriving vault is fully synced.
-    if (engine.backfillSettled()) {
-      this.completeRun(scope);
-      return;
-    }
     this.lastInboundDone = done;
     this.lastInboundTotal = total;
     this.downloadPhase = true;
+    // Opens at 0/0 ("Syncing…"), because this now runs the moment the engine is
+    // started — before its socket is even open, let alone `hello`ed. There is
+    // deliberately no `backfillSettled()` short-circuit here any more: an engine
+    // that has not connected yet reports settled (nothing is queued and no window
+    // is open), so checking it here would end the phase before it began.
     progress.phase("downloading", total - done);
   }
 
@@ -941,10 +1050,18 @@ export class SyncManager implements InboundHost {
     // engine signals the real edge through `handleInboundIdle`.
   }
 
-  /** The backfill finished and everything it sent has been applied. */
+  /**
+   * The backfill finished and everything it sent has been applied — the edge that
+   * ends the download phase and hands over to the content run.
+   *
+   * Fires again on every later drain (a teammate typing keeps the queue moving),
+   * so it must stay cheap when there is nothing to do: `startContentRunIfNeeded`
+   * no-ops unless the work list is non-empty and no run is live.
+   */
   private handleInboundIdle(scope: VaultScope): void {
-    if (!this.downloadPhase || !scope.isCurrent()) return;
-    this.completeRun(scope);
+    if (!scope.isCurrent()) return;
+    this.downloadPhase = false;
+    this.startContentRunIfNeeded(scope);
   }
 
   /**
@@ -1015,6 +1132,10 @@ export class SyncManager implements InboundHost {
     }
     this.localChanges.clear();
     this.divergedDocs.clear();
+    // Scoped to the vault like everything else here: another vault's empty-doc
+    // list would put ITS doc ids at the head of this vault's upload queue.
+    this.serverEmpty.clear();
+    this.serverEmptyTruncated = false;
     // The bulk run before the engine it borrows from: `stop()` makes every pool
     // lane drop at its next checkpoint, so nothing is still promoting a bridge
     // when `stopVaultEngine` destroys the store underneath it.
@@ -1212,6 +1333,21 @@ export class SyncManager implements InboundHost {
           this.armLocalChangeDrain(scope, LOCAL_CHANGE_DEBOUNCE_MS);
         }
       },
+      // The counterpart: a cold apply landed the server's state and the file had
+      // nothing of its own to add, so this doc is on the server BY DEFINITION —
+      // record the push. This is what stops the content run from re-sending every
+      // note the vault channel just delivered, over a socket apiece.
+      //
+      // Never for a diverged doc: those hold local-only ops from an out-of-band
+      // merge, and marking them pushed would strand exactly the bytes nobody else
+      // has. (`divergedDocs` is the only local-only state this layer can see; a
+      // doc edited offline in the editor and never flushed is not in it, which is
+      // why `pushed` stays an optimisation and `ready.empty` stays the authority.)
+      onConverged: (docId) => {
+        if (!scope.isCurrent() || this.divergedDocs.has(docId)) return;
+        this.registry.markPushed(docId);
+        this.serverEmpty.delete(docId);
+      },
     });
     this.docStore = store;
     this.vaultEngine = new VaultSyncEngine({
@@ -1262,8 +1398,12 @@ export class SyncManager implements InboundHost {
       onVoice: (frame) => this.handleVoice(frame),
       // Inbound backfill progress — the `downloading` half of the run's progress.
       onInboundProgress: (done, total) => this.handleInboundProgress(done, total, scope),
-      // …and the edge that ends it.
+      // …and the edge that ends it (and starts the content run).
       onInboundIdle: () => this.handleInboundIdle(scope),
+      // Which readable docs the server has NO content for. Arrives on every
+      // `ready`, so it also re-arms a run the uploader's failure streak paused.
+      onServerEmpty: (docIds, truncated) =>
+        this.handleServerEmpty(docIds, truncated, scope),
     });
     this.vaultEngine.start();
     // Seed our own presence into the fresh engine (it flushes on `ready`).

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -35,7 +35,7 @@ import {
 import * as ipc from "../ipc";
 import type { TreeNode } from "../ipc";
 import { seedWelcomeContent } from "../vault/seed";
-import { Checkpointer } from "./checkpoint";
+import { Checkpointer, checkpointBatchFor } from "./checkpoint";
 import { planInbound } from "./inbound";
 import { REGISTRY_CONCURRENCY, runPool, withRetry } from "./pool";
 import { nullProgressSink, type SyncProgressSink } from "./progress";
@@ -65,11 +65,14 @@ interface VaultSyncConfig {
    * docIds whose CONTENT this device has confirmed on the server (the bulk
    * upload's resume point — see `ContentUploader`).
    *
-   * Purely an optimization: it lets a relaunch skip re-connecting every note in
-   * the vault. Correctness never depends on it, because the upload path is
-   * idempotent by construction (pull-before-seed; it only ever transmits CRDT
-   * state that already exists locally, never re-inserts text). A missing or
-   * stale entry therefore costs a round trip, never duplicated content.
+   * Purely an optimization ("nothing local left to send"), NEVER a correctness
+   * gate — the vault channel's `ready.empty` is the authority on what the server
+   * actually holds. Correctness never depends on this list, because the upload
+   * path is idempotent by construction (pull-before-seed; it only ever transmits
+   * CRDT state that already exists locally, never re-inserts text). A missing
+   * entry costs a round trip; a WRONG one (a crashed run, a wiped `.context/`,
+   * a restored backup) would strand a note forever if anything treated it as
+   * proof — which is why the server re-states the truth on every connect.
    */
   pushed?: string[];
   /**
@@ -856,7 +859,11 @@ export class VaultRegistry {
     // Never write another vault's doc map into this folder's config.
     if (this.stale()) return;
     if (!cfg.serverVaultId) return; // nothing meaningful to persist yet
-    await ipc.setVaultConfig(JSON.stringify(cfg, null, 2), this.epoch());
+    // Compact, not pretty-printed. This file is rewritten whole on every
+    // checkpoint and holds three entries per note; two-space indentation added
+    // ~35% to every one of those writes for the benefit of nobody — it is derived
+    // state, not something a person edits.
+    await ipc.setVaultConfig(JSON.stringify(cfg), this.epoch());
   }
 
   private newCheckpointer(): Checkpointer<VaultSyncConfig> {
@@ -864,9 +871,19 @@ export class VaultRegistry {
     const cp = new Checkpointer<VaultSyncConfig>({
       write: (cfg) => this.writeConfig(cfg),
       snapshot: () => this.configSnapshot(),
+      // Starts at the default and is retuned by `tuneCheckpointBatch` the moment
+      // we know how many notes this vault has (see `checkpointBatchFor`).
+      everyItems: checkpointBatchFor(this.byPath.size),
     });
     this.checkpoint = cp;
     return cp;
+  }
+
+  /** Size the config.json flush batch to this vault: one write per
+   *  `checkpointBatchFor(n)` notes, so the write COUNT stays flat as the file
+   *  itself grows. */
+  private tuneCheckpointBatch(mapped: number): void {
+    this.checkpoint?.setEveryItems(checkpointBatchFor(mapped));
   }
 
   private setMapping(relPath: string, docId: string, vaultId: string): void {
@@ -910,6 +927,7 @@ export class VaultRegistry {
     if (this.stale()) return { seeded: false };
     const cfg = await this.loadConfig();
     if (this.stale()) return { seeded: false };
+    this.tuneCheckpointBatch(Object.keys(cfg.docs ?? {}).length);
 
     // 1. Ensure a server note collection (the `vaults` table row, 1:1 with this
     //    vault in practice) — resolved by ID, never by name (names collide and
@@ -1114,6 +1132,10 @@ export class VaultRegistry {
     let serverNotes = noteRegistry.notes;
     let { folders, notes } = flattenTree(workingTree);
     const checkpoint = this.checkpoint ?? this.newCheckpointer();
+    // A pull can be the first thing to touch a big vault's map (a reconnect
+    // catch-up), so retune here too rather than trusting the construction-time
+    // guess.
+    this.tuneCheckpointBatch(this.byPath.size);
 
     // The local index's docId per note path, read BEFORE any decision so inbound
     // can match by docId rather than by path (a rename changes the path, which is

--- a/app/apps/desktop/src/lib/sync/vaultDocStore.ts
+++ b/app/apps/desktop/src/lib/sync/vaultDocStore.ts
@@ -77,6 +77,17 @@ export interface VaultDocStoreOptions {
    *  session must schedule a content push for this doc (its own local-change
    *  drain would otherwise see file == doc and skip the network). */
   onExternalMerge?: (docId: string) => void;
+  /**
+   * A cold apply landed the server's state for this doc and found NOTHING local
+   * to merge into it — the file on disk now equals the doc, and the doc equals
+   * what the server sent.
+   *
+   * This is the signal that removes the double-delivery: the session marks such
+   * a doc as pushed, so the content run's queue shrinks to exactly "the docs the
+   * server did not deliver" instead of re-pushing every note the vault channel
+   * had already handed us over one socket apiece.
+   */
+  onConverged?: (docId: string) => void;
   /** Durable manifest. Defaults to {@link nullManifestStore}. */
   manifest?: ManifestStore;
   /** Injected in tests. */
@@ -96,6 +107,7 @@ export class VaultDocStore implements DocUpdateSink {
   private readonly io: BridgeIO;
   private readonly resolvePath: (docId: string) => string | null;
   private readonly onExternalMerge?: (docId: string) => void;
+  private readonly onConverged?: (docId: string) => void;
   private readonly hotCap: number;
   private readonly manifest: ManifestStore;
   private readonly setT: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
@@ -130,6 +142,7 @@ export class VaultDocStore implements DocUpdateSink {
     this.io = opts.io ?? createTauriBridgeIO();
     this.resolvePath = opts.resolvePath;
     this.onExternalMerge = opts.onExternalMerge;
+    this.onConverged = opts.onConverged;
     this.hotCap = opts.hotCap ?? HOT_DOC_CAP;
     this.manifest = opts.manifest ?? nullManifestStore;
     this.setT = opts.setTimeoutImpl ?? ((fn, ms) => setTimeout(fn, ms));
@@ -417,12 +430,29 @@ export class VaultDocStore implements DocUpdateSink {
       // unhydrated placeholder on the pull-before-seed path (never a pre-sync
       // seed); converged content makes this a no-op read. A genuine merge is
       // reported up so the session pushes it (see `onExternalMerge`).
+      // Whether this doc held ANY local CRDT ops before the remote state landed.
+      // Only a doc that had none — the empty placeholder a fresh join
+      // materializes — can be declared converged below: a doc with prior local
+      // ops may hold edits the server has never seen (typed offline, app closed
+      // before the flush; NOT in `divergedDocs`, which only tracks out-of-band
+      // file merges), and marking it pushed would strand exactly those bytes.
+      const hadLocalState = bridge.doc.store.clients.size > 0;
+      let merged = false;
       if (bridge.serialize().length > 0 && (await bridge.ingestNow())) {
+        merged = true;
         this.onExternalMerge?.(docId);
       }
       bridge.applyRemote(update);
       await bridge.flushEgest();
       this.rememberSv(docId, Y.encodeStateVector(bridge.doc));
+      // Converged: the server's state is on disk and the file had nothing of its
+      // own to contribute. A merge is the opposite case — those ops are
+      // local-only until a provider pushes them, which is `onExternalMerge`'s
+      // job — so the two are mutually exclusive by construction. And only for a
+      // doc that started empty (see `hadLocalState`): that is the join case the
+      // signal exists for, and the only one where "the server's state is all
+      // there is" holds by construction.
+      if (!merged && !hadLocalState) this.onConverged?.(docId);
     } finally {
       bridge.destroy();
     }

--- a/app/apps/desktop/src/lib/sync/vaultProtocol.ts
+++ b/app/apps/desktop/src/lib/sync/vaultProtocol.ts
@@ -42,7 +42,23 @@ export interface PresenceState {
 }
 
 export type ServerControl =
-  | { t: "ready" }
+  | {
+      t: "ready";
+      /**
+       * Readable docIds the server holds NO CRDT state for — it has a `notes`
+       * row but not one byte of content. Sent on every connect/reconnect, and
+       * the AUTHORITY on what still needs uploading: the client's own `pushed`
+       * checkpoint is a local optimisation that a crashed run, a fresh device or
+       * a wiped `.context/` can silently get wrong (613 notes registered with
+       * zero content in prod).
+       *
+       * Absent when there are none.
+       */
+      empty?: string[];
+      /** The server had more empty docs than it would name in one frame (cap
+       *  2000), so another `hello` is needed to fetch the next batch. */
+      emptyTruncated?: boolean;
+    }
   | { t: "drop"; docId: string }
   | { t: "reauth" }
   | { t: "registry" }
@@ -75,7 +91,21 @@ export function parseServerControl(text: string): ServerControl | null {
   }
   if (!v || typeof v !== "object") return null;
   const t = (v as { t?: unknown }).t;
-  if (t === "ready") return { t: "ready" };
+  if (t === "ready") {
+    const o = v as Record<string, unknown>;
+    // Defensive on purpose: `empty` is new, so an older server omits it and a
+    // future one may widen it. Anything that isn't an array of non-empty strings
+    // is dropped rather than trusted — a bad entry here would put a bogus docId
+    // at the FRONT of the upload queue.
+    const empty = Array.isArray(o.empty)
+      ? o.empty.filter((d): d is string => typeof d === "string" && d.length > 0)
+      : null;
+    return {
+      t: "ready",
+      ...(empty && empty.length > 0 ? { empty } : {}),
+      ...(o.emptyTruncated === true ? { emptyTruncated: true } : {}),
+    };
+  }
   if (t === "reauth") return { t: "reauth" };
   if (t === "registry") return { t: "registry" };
   if (t === "member" && typeof (v as { name?: unknown }).name === "string") {

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -137,6 +137,15 @@ export interface VaultSyncEngineOptions {
    * download phase used to end that way, i.e. never.
    */
   onInboundIdle?: () => void;
+  /**
+   * The server named the readable docs it holds NO CRDT state for (`ready.empty`).
+   *
+   * Fired on EVERY `ready`, i.e. every connect and reconnect, with `truncated`
+   * set when the server had more than it would name in one frame. This is the
+   * authority the content run keys off: a doc listed here needs its markdown
+   * pushed no matter what the local `pushed` checkpoint claims.
+   */
+  onServerEmpty?: (docIds: string[], truncated: boolean) => void;
   /** Injected in tests. Defaults to the global WebSocket. */
   wsFactory?: WsFactory;
   /** Backoff bounds (ms). */
@@ -192,6 +201,7 @@ export class VaultSyncEngine {
   private readonly onVoice?: (frame: VoiceFrame) => void;
   private readonly onInboundProgress?: (done: number, total: number) => void;
   private readonly onInboundIdle?: () => void;
+  private readonly onServerEmpty?: (docIds: string[], truncated: boolean) => void;
   private readonly wsFactory: WsFactory;
   private readonly inboundMaxBytes: number;
   private readonly baseMs: number;
@@ -258,6 +268,7 @@ export class VaultSyncEngine {
     this.onVoice = opts.onVoice;
     this.onInboundProgress = opts.onInboundProgress;
     this.onInboundIdle = opts.onInboundIdle;
+    this.onServerEmpty = opts.onServerEmpty;
     this.inboundMaxBytes = opts.inboundQueueMaxBytes ?? INBOUND_QUEUE_MAX_BYTES;
     this.wsFactory =
       opts.wsFactory ?? ((url) => new WebSocket(url) as unknown as WebSocketLike);
@@ -305,6 +316,25 @@ export class VaultSyncEngine {
   start(): void {
     if (this.stopped || this.ws) return;
     this.connect();
+  }
+
+  /**
+   * Force a fresh `hello` — drop the socket and let the normal backoff bring it
+   * back up.
+   *
+   * The only way to ask the server a second question: `ready.empty` is capped, so
+   * a vault with more empty docs than one frame will name (`emptyTruncated`) needs
+   * another handshake to learn the next batch. Reuses the reconnect machinery
+   * rather than opening a second socket — one WS per vault is the invariant.
+   */
+  refresh(): void {
+    if (this.stopped) return;
+    this.ready = false;
+    this.helloSent = false;
+    this.backfilling = false; // this window is over; the next hello opens a new one
+    this.closeSocket();
+    this.setStatus("connecting");
+    this.scheduleReconnect();
   }
 
   /** Tear down permanently; no further reconnects. */
@@ -457,6 +487,10 @@ export class VaultSyncEngine {
         this.attempt = 0; // a clean sync resets backoff
         this.ready = true;
         this.backfilling = false;
+        // BEFORE the idle signal: `maybeSignalIdle` is what starts the content
+        // run, and a run that starts without this frame's `empty` list would
+        // work from the stale one (or none at all on a first connect).
+        this.onServerEmpty?.(control.empty ?? [], control.emptyTruncated === true);
         // `ready` routinely arrives AFTER the last backfill frame has already been
         // applied, so this is the edge that settles the download phase. Checking
         // only on drain would strand it: no further frame is coming to trigger one.
@@ -608,6 +642,11 @@ export class VaultSyncEngine {
     if (this.stopped) return;
     this.ready = false; // must re-announce presence after we reconnect
     this.helloSent = false;
+    // The backfill window closed with the socket: no further frame of it is
+    // coming until the next `hello` opens a new one. Leaving it open would make
+    // `backfillSettled()` permanently false on a flaky link, and everything that
+    // waits for the download to settle (the content run) would wait forever.
+    this.backfilling = false;
     this.closeSocket();
     this.setStatus("error");
     this.scheduleReconnect();

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -3,6 +3,12 @@
 # Postgres. docker-compose maps host 5439 -> container 5432.
 DATABASE_URL=postgres://context:context@localhost:5439/context
 
+# Max Postgres connections this instance keeps in its pool. Default 20.
+# Raise it for a busy instance; keep the total across ALL instances under the
+# server's max_connections. A vault reconnect alone spends BACKFILL_CONCURRENCY
+# of these, so a pool much smaller than that starves the HTTP routes.
+# PG_POOL_MAX=20
+
 # Shared signing secret: Better Auth crypto + HS256 sync/vault JWTs.
 # REQUIRED. Generate a real one — do NOT ship this placeholder:
 #   openssl rand -base64 32

--- a/app/apps/server/src/db/pool.ts
+++ b/app/apps/server/src/db/pool.ts
@@ -4,9 +4,42 @@ import { config } from "../config.js";
 // Yjs updates are stored as BYTEA. node-postgres returns BYTEA as Buffer by
 // default (type 17 = bytea), which is what we want — no parser override needed.
 
+/**
+ * Connection ceiling. Was a hardcoded 10, which a single vault reconnect can
+ * saturate on its own: backfill runs `BACKFILL_CONCURRENCY` doc reads at a time
+ * per connection, so two clients coming back at once left nothing for the HTTP
+ * routes and requests queued behind `pool.connect()` with no timeout.
+ * Override per deployment with `PG_POOL_MAX` (keep it under the Postgres
+ * `max_connections` budget shared with every other instance).
+ */
+function poolMax(): number {
+  const raw = process.env.PG_POOL_MAX;
+  const n = raw ? Number(raw) : NaN;
+  // Guards "" and garbage: Number("") is 0, and a max of 0 is a pool that never
+  // hands out a connection — i.e. a server that silently serves nothing.
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 20;
+}
+
 export const pool = new pg.Pool({
   connectionString: config.databaseUrl,
-  max: 10,
+  max: poolMax(),
+  // Hand idle connections back rather than pinning `max` sockets forever.
+  idleTimeoutMillis: 30_000,
+  // Fail fast instead of hanging a request forever when the pool is exhausted or
+  // Postgres is unreachable. Unbounded waiting is how a slow DB turns into a
+  // server that accepts connections and answers nothing.
+  connectionTimeoutMillis: 5_000,
+  // Shows up in pg_stat_activity, so a runaway query is attributable.
+  application_name: "baalda-server",
+  // Per-connection statement ceiling. Deliberately set here and NOT in the
+  // migration path: `runMigrations` opens its own `pg.Client`, so DDL (an index
+  // build over a big table) is never subject to this.
+  //
+  // Sent as a startup option, which a direct Postgres connection (and our
+  // deploys) accept. A connection pooler in front of the DB in *transaction*
+  // mode can reject startup options — if a deployment ever puts one there, move
+  // this to a `pool.on("connect")` `SET statement_timeout` instead.
+  options: "-c statement_timeout=15000",
 });
 
 export type Pool = pg.Pool;

--- a/app/apps/server/src/http/app.ts
+++ b/app/apps/server/src/http/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { compress } from "hono/compress";
 import { cors } from "hono/cors";
 import { oAuthDiscoveryMetadata, oAuthProtectedResourceMetadata } from "better-auth/plugins";
 import { config } from "../config.js";
@@ -117,6 +118,27 @@ export function createApp(deps: AppDeps): Hono {
       exposeHeaders: ["set-auth-token"],
     }),
   );
+
+  // Response compression for the JSON API. The registry listings are what make
+  // this worth having: GET /api/notes for a several-hundred-note vault is a few
+  // hundred KB of highly repetitive JSON, and it is on the critical path of every
+  // client start-up and every `registry` broadcast.
+  //
+  // After CORS (so preflights are answered plain) and scoped to /api/*, which
+  // also keeps it off the WS upgrade paths — those are handled by the Node
+  // server, not by Hono, but /health and /p/:token stay uncompressed too.
+  //
+  // Hono's compress already limits itself to compressible content types (its
+  // default regex covers JSON/text and never image/*, application/octet-stream
+  // or text/event-stream). Blob DOWNLOAD is nonetheless excluded by path rather
+  // than trusted to that: a stored mime of text/markdown would otherwise put a
+  // re-encode on a route whose only job is handing back exact bytes. The blob
+  // LIST route (/api/vaults/:id/blobs) is JSON and stays compressed.
+  const compressor = compress();
+  app.use("/api/*", async (c, next) => {
+    if (c.req.path.startsWith("/api/blobs/")) return next();
+    return compressor(c, next);
+  });
 
   app.get("/health", (c) => c.json({ ok: true }));
 

--- a/app/apps/server/src/permissions/http-gates.ts
+++ b/app/apps/server/src/permissions/http-gates.ts
@@ -138,6 +138,12 @@ export async function canReadAttachment(
  * Filter a vault's blob list to the ones `userId` may read (see
  * {@link canReadAttachment}). Vault-wide readers get everything; a scoped
  * member gets only blobs referenced by a note they can read.
+ *
+ * The reference test runs in Postgres, one `LIKE` per (path, readable note),
+ * the same shape {@link canReadAttachment} already uses. It used to `SELECT
+ * content` for every readable doc and concatenate the lot into one JS string —
+ * i.e. pull an entire vault's markdown into the heap of a list request, on a
+ * path a scoped member hits on every attachment sync.
  */
 export async function filterReadableBlobs<T extends { rel_path: string | null }>(
   userId: string,
@@ -151,10 +157,23 @@ export async function filterReadableBlobs<T extends { rel_path: string | null }>
 
   const readable = await listReadableDocsInVault(userId, vaultId, db);
   if (readable.size === 0) return [];
-  const { rows } = await db.query<{ content: string | null }>(
-    `SELECT content FROM note_index WHERE vault_id = $1 AND doc_id = ANY($2::text[])`,
-    [vaultId, [...readable]],
+  // A falsy rel_path can never match (it has no needle to search for), so it is
+  // dropped here exactly as the old `!!b.rel_path` guard dropped it.
+  const paths = [...new Set(blobs.map((b) => b.rel_path).filter((p): p is string => !!p))];
+  if (paths.length === 0) return [];
+
+  // Two parallel arrays, not one: the escaped form is what LIKE matches, the raw
+  // form is what maps the answer back onto the blob rows.
+  const { rows } = await db.query<{ rel_path: string }>(
+    `SELECT p.rel_path
+       FROM unnest($3::text[], $4::text[]) AS p(rel_path, needle)
+      WHERE EXISTS (
+        SELECT 1 FROM note_index ni
+         WHERE ni.vault_id = $1 AND ni.doc_id = ANY($2::text[])
+           AND ni.content LIKE '%' || p.needle || '%' ESCAPE '\\'
+      )`,
+    [vaultId, [...readable], paths, paths.map(likeEscape)],
   );
-  const haystack = rows.map((r) => r.content ?? "").join("\n");
-  return blobs.filter((b) => !!b.rel_path && haystack.includes(b.rel_path));
+  const referenced = new Set(rows.map((r) => r.rel_path));
+  return blobs.filter((b) => !!b.rel_path && referenced.has(b.rel_path));
 }

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -5,7 +5,7 @@ import { config } from "../config.js";
 import { type PubSub, vaultTopic } from "./pubsub.js";
 import { verifyVaultToken } from "../tokens/vault-token.js";
 import { listReadableDocsInVault } from "../permissions/vault-docs.js";
-import { loadDocDiff } from "../yjs/persistence.js";
+import { listEmptyDocs, loadDocDiff } from "../yjs/persistence.js";
 import {
   parseHello,
   parsePresence,
@@ -59,6 +59,8 @@ export interface VaultChannelDeps {
   pubsub: PubSub;
   listReadableDocs?: typeof listReadableDocsInVault;
   loadDiff?: typeof loadDocDiff;
+  /** Which readable docs hold no server content — reported on `ready`. */
+  listEmpty?: typeof listEmptyDocs;
   verifyToken?: typeof verifyVaultToken;
   backfillConcurrency?: number;
   /** Per-connection outbound cap in bytes (default `config.vaultSendCapBytes`). */
@@ -83,6 +85,7 @@ export class VaultChannel {
   private readonly pubsub: PubSub;
   private readonly listReadableDocs: typeof listReadableDocsInVault;
   private readonly loadDiff: typeof loadDocDiff;
+  private readonly listEmpty: typeof listEmptyDocs;
   private readonly verifyToken: typeof verifyVaultToken;
   private readonly concurrency: number;
   private readonly sendCapBytes: number;
@@ -105,6 +108,7 @@ export class VaultChannel {
     this.pubsub = deps.pubsub;
     this.listReadableDocs = deps.listReadableDocs ?? listReadableDocsInVault;
     this.loadDiff = deps.loadDiff ?? loadDocDiff;
+    this.listEmpty = deps.listEmpty ?? listEmptyDocs;
     this.verifyToken = deps.verifyToken ?? verifyVaultToken;
     this.concurrency = deps.backfillConcurrency ?? config.backfillConcurrency;
     this.sendCapBytes = deps.sendCapBytes ?? config.vaultSendCapBytes;
@@ -255,6 +259,7 @@ export class VaultChannel {
     const conn = new VaultConnection(ws, this.pubsub, {
       listReadableDocs: this.listReadableDocs,
       loadDiff: this.loadDiff,
+      listEmpty: this.listEmpty,
       verifyToken: this.verifyToken,
       concurrency: this.concurrency,
       sendCapBytes: this.sendCapBytes,
@@ -269,6 +274,7 @@ export class VaultChannel {
 interface ConnDeps {
   listReadableDocs: typeof listReadableDocsInVault;
   loadDiff: typeof loadDocDiff;
+  listEmpty: typeof listEmptyDocs;
   verifyToken: typeof verifyVaultToken;
   concurrency: number;
   sendCapBytes: number;
@@ -444,7 +450,34 @@ class VaultConnection {
     }
 
     await this.backfill(hello.manifest, hello.priority ?? []);
-    this.send({ t: "ready" });
+
+    // Backfill sends nothing for a doc with no server state, so the client would
+    // otherwise sit on a blank note it can't tell apart from one still in flight
+    // (the 2026-08 bulk-register incident left 613 such notes in prod). Naming
+    // them on `ready` is the client's cue to seed them from disk. One query for
+    // the whole readable set, and a failure only costs the hint — `ready` still
+    // ships, because withholding it would leave the client stuck "connecting".
+    // Gone mid-backfill (a reconnect storm makes this common, and it is exactly
+    // the load this probe must not add to): `send` would no-op anyway, so skip
+    // the query rather than pay for an answer nobody receives.
+    if (this.closed || this.ws.readyState !== this.ws.OPEN) return;
+
+    let empty: string[] = [];
+    let emptyTruncated = false;
+    try {
+      const probe = await this.deps.listEmpty([...this.readable]);
+      empty = probe.empty;
+      emptyTruncated = probe.truncated;
+    } catch (err) {
+      console.error("Vault channel empty-doc probe failed:", err);
+    }
+    this.send({
+      t: "ready",
+      // Omitted when nothing is empty, so the common frame is byte-identical to
+      // what every shipped client already parses.
+      ...(empty.length > 0 ? { empty } : {}),
+      ...(empty.length > 0 && emptyTruncated ? { emptyTruncated: true as const } : {}),
+    });
   }
 
   /** Binary from the client. Only voice frames are defined; the leading type

--- a/app/apps/server/src/sync/vault-protocol.ts
+++ b/app/apps/server/src/sync/vault-protocol.ts
@@ -64,7 +64,24 @@ export interface PresenceState {
 }
 
 export type ServerControl =
-  | { t: "ready" } // initial backfill drained
+  /**
+   * Initial backfill drained.
+   *
+   * `empty` names the readable docs that hold NOTHING on the server — no
+   * snapshot, no logged update. Backfill sends no frame for those, so without
+   * this the client cannot distinguish "the server has nothing" from "my
+   * backfill hasn't reached it yet", and a note registered but never uploaded
+   * (the 2026-08 bulk-register incident) stays blank forever. Named docs are the
+   * client's cue to seed from its own disk. `emptyTruncated` means the list hit
+   * the server's cap and another pass is needed.
+   *
+   * Both fields are OMITTED when nothing is empty, so the overwhelmingly common
+   * frame stays byte-identical to `{"t":"ready"}`. Old clients ignore unknown
+   * keys (`parseServerControl` switches on `t` and reads only what it knows),
+   * which is why this could be added without a capability flag — unlike a new
+   * *binary* frame, see {@link HelloFrame.caps}.
+   */
+  | { t: "ready"; empty?: string[]; emptyTruncated?: true }
   | { t: "drop"; docId: string } // access lost / doc removed -> client evicts
   | { t: "reauth" } // ACL changed in this vault -> client re-mints its open doc's token
   | { t: "registry" } // folders/notes structure changed -> client re-pulls the registry

--- a/app/apps/server/src/yjs/persistence.ts
+++ b/app/apps/server/src/yjs/persistence.ts
@@ -13,11 +13,23 @@ import { config } from "../config.js";
  * doc = apply the snapshot, then replay the update log, in order.
  */
 
-type Queryable = Pick<pg.Pool, "query">;
+/** Anything that can run a query — the pool, or a test double counting calls. */
+export type Queryable = Pick<pg.Pool, "query">;
 
 /**
  * Build a single merged update for a doc: snapshot (if any) + all logged
  * updates, in insertion order. Returns null if the doc has no state yet.
+ *
+ * Merges with `Y.mergeUpdates` rather than replaying into a throwaway `Y.Doc`.
+ * Same bytes-in/state-out, minus the doc: building one costs the full struct
+ * graph of the note in heap, and this runs per doc — the whole point of the
+ * relay is that server memory tracks docs being *edited*, not docs that exist.
+ *
+ * One deliberate difference: a `Y.Doc` (gc on) drops deleted content as it
+ * applies, so the old path returned a GC'd update while `mergeUpdates` keeps
+ * tombstoned content. Bounded and small in practice — `compact()` still writes
+ * a GC'd snapshot, so the un-GC'd part is only the tail of the update log
+ * (≤ `COMPACTION_THRESHOLD` updates).
  */
 export async function loadDocState(
   docId: string,
@@ -35,26 +47,45 @@ export async function loadDocState(
   const snapshotBuf = snap.rows[0]?.snapshot ?? null;
   if (!snapshotBuf && updates.rows.length === 0) return null;
 
-  const doc = new Y.Doc();
-  try {
-    if (snapshotBuf) Y.applyUpdate(doc, new Uint8Array(snapshotBuf));
-    for (const row of updates.rows) {
-      Y.applyUpdate(doc, new Uint8Array(row.update));
-    }
-    return Y.encodeStateAsUpdate(doc);
-  } finally {
-    doc.destroy();
-  }
+  return mergeParts(snapshotBuf, updates.rows);
 }
 
 /**
- * Backfill diff for the vault channel (spec 05 §3.1). Rebuilds the doc, then
- * returns only the ops the client is missing relative to `clientStateVector`
- * (via `Y.encodeStateAsUpdate(doc, sv)`) plus the server's current state vector.
- * When the client's vector already equals the server's, `upToDate` is true and
- * the caller sends nothing — this is what makes an idle reconnect ~free.
+ * Merge a snapshot + update log into one V1 update. V1 only, everywhere:
+ * yjs#687 (open) reports corruption in the V2 merge functions, and mixing
+ * encodings across the snapshot/log boundary would be unrecoverable.
+ */
+function mergeParts(
+  snapshotBuf: Buffer | null,
+  updateRows: Array<{ update: Buffer }>,
+): Uint8Array {
+  const parts: Uint8Array[] = [];
+  if (snapshotBuf) parts.push(new Uint8Array(snapshotBuf));
+  for (const row of updateRows) parts.push(new Uint8Array(row.update));
+  // A lone part is already a complete update; merging it would just re-encode.
+  return parts.length === 1 ? parts[0] : Y.mergeUpdates(parts);
+}
+
+/**
+ * Backfill diff for the vault channel (spec 05 §3.1). Returns only the ops the
+ * client is missing relative to `clientStateVector`, plus the server's current
+ * state vector. When the client's vector already equals the server's,
+ * `upToDate` is true and the caller sends nothing — this is what makes an idle
+ * reconnect ~free.
  *
  * Returns null when the doc has no state at all (nothing to send).
+ *
+ * Two layers keep a reconnect from paying for content nobody needs — the whole
+ * cost of `/vault-sync` used to be one full doc rebuild per readable doc, on
+ * every reconnect, whether or not the client was already current:
+ *
+ *  1. **The probe.** `compact()` has always written `doc_snapshots.state_vector`
+ *     and nothing ever read it. One narrow row (no BYTEA) now answers the common
+ *     case — compacted doc, empty update log, client already current — so the
+ *     up-to-date reconnect never touches the snapshot blob at all.
+ *  2. **No Y.Doc on the slow path.** `mergeUpdates` + `encodeStateVectorFromUpdate`
+ *     + `diffUpdate` compute the same three values off the raw bytes. See
+ *     `loadDocState` for why the doc is worth avoiding.
  */
 export interface DocDiff {
   update: Uint8Array;
@@ -67,6 +98,35 @@ export async function loadDocDiff(
   clientStateVector: Uint8Array | null,
   db: Queryable = defaultPool,
 ): Promise<DocDiff | null> {
+  // Probe: does a snapshot exist, is its stored state vector usable, and is
+  // anything sitting in the log on top of it? Deliberately selects no BYTEA.
+  const probe = await db.query<{ state_vector: Buffer | null; pending: boolean }>(
+    `SELECT s.state_vector,
+            EXISTS (SELECT 1 FROM doc_updates u WHERE u.doc_id = $1) AS pending
+       FROM doc_snapshots s
+      WHERE s.doc_id = $1`,
+    [docId],
+  );
+  const row = probe.rows[0];
+  if (!row) {
+    // No snapshot row, so the probe learned nothing about the log — ask.
+    // Cheap, and it short-circuits the never-written doc, which is the shape
+    // most of a vault's registry is right after a bulk register.
+    const { rows } = await db.query<{ pending: boolean }>(
+      "SELECT EXISTS (SELECT 1 FROM doc_updates WHERE doc_id = $1) AS pending",
+      [docId],
+    );
+    if (!rows[0]?.pending) return null;
+  } else if (row.state_vector && !row.pending && clientStateVector) {
+    const serverStateVector = new Uint8Array(row.state_vector);
+    if (bytesEqual(clientStateVector, serverStateVector)) {
+      return { update: new Uint8Array(0), serverStateVector, upToDate: true };
+    }
+  }
+  // Fall through: uncompacted doc, a pre-`state_vector` snapshot row (the column
+  // is nullable and older rows have it NULL), a client with no vector, or a
+  // client that is genuinely behind.
+
   const snap = await db.query<{ snapshot: Buffer | null }>(
     "SELECT snapshot FROM doc_snapshots WHERE doc_id = $1",
     [docId],
@@ -78,22 +138,64 @@ export async function loadDocDiff(
   const snapshotBuf = snap.rows[0]?.snapshot ?? null;
   if (!snapshotBuf && updates.rows.length === 0) return null;
 
-  const doc = new Y.Doc();
-  try {
-    if (snapshotBuf) Y.applyUpdate(doc, new Uint8Array(snapshotBuf));
-    for (const row of updates.rows) {
-      Y.applyUpdate(doc, new Uint8Array(row.update));
-    }
-    const serverStateVector = Y.encodeStateVector(doc);
-    const upToDate =
-      clientStateVector != null && bytesEqual(clientStateVector, serverStateVector);
-    const update = upToDate
-      ? new Uint8Array(0)
-      : Y.encodeStateAsUpdate(doc, clientStateVector ?? undefined);
-    return { update, serverStateVector, upToDate };
-  } finally {
-    doc.destroy();
+  const merged = mergeParts(snapshotBuf, updates.rows);
+  const serverStateVector = Y.encodeStateVectorFromUpdate(merged);
+  const upToDate =
+    clientStateVector != null && bytesEqual(clientStateVector, serverStateVector);
+  const update = upToDate
+    ? new Uint8Array(0)
+    : clientStateVector
+      ? Y.diffUpdate(merged, clientStateVector)
+      : merged;
+  return { update, serverStateVector, upToDate };
+}
+
+/**
+ * Which of `docIds` have NO server-side content at all — no snapshot, no logged
+ * update? One query for the whole set, so the vault channel can answer it once
+ * per connect instead of probing per doc.
+ *
+ * Exists because of the 2026-08 bulk-register incident: a client can register
+ * hundreds of notes and then fail to upload their bodies, leaving rows that look
+ * like notes and hold nothing. Backfill has nothing to send for those, so the
+ * client cannot tell "empty on the server" from "not backfilled yet" and waits
+ * forever. Naming them on the `ready` frame lets the client seed them from disk.
+ *
+ * `cap` bounds the answer so one enormous vault can't make the frame unbounded;
+ * `truncated` tells the client the list is partial and another pass is needed.
+ */
+export async function listEmptyDocs(
+  docIds: string[],
+  db: Queryable = defaultPool,
+  cap = 2000,
+): Promise<{ empty: string[]; truncated: boolean }> {
+  if (docIds.length === 0) return { empty: [], truncated: false };
+
+  // Postgres takes a large text[] fine, but a single param holding every doc id
+  // in a 100k-note vault is a needlessly big bind — chunk it.
+  const CHUNK = 20_000;
+  const found: string[] = [];
+  for (let i = 0; i < docIds.length; i += CHUNK) {
+    const { rows } = await db.query<{ id: string }>(
+      `SELECT d.id
+         FROM unnest($1::text[]) AS d(id)
+        WHERE NOT EXISTS (SELECT 1 FROM doc_updates u WHERE u.doc_id = d.id)
+          AND NOT EXISTS (SELECT 1 FROM doc_snapshots s WHERE s.doc_id = d.id)
+        ORDER BY d.id
+        LIMIT $2`,
+      [docIds.slice(i, i + CHUNK), cap + 1],
+    );
+    for (const r of rows) found.push(r.id);
+    // Already over the cap — the rest of the chunks can only add to a list we
+    // are about to truncate anyway.
+    if (found.length > cap) break;
   }
+
+  // Sort across chunks: each query orders within its own slice only, and a
+  // stable answer keeps the frame deterministic for tests and for the client.
+  found.sort();
+  if (found.length > cap) return { empty: found.slice(0, cap), truncated: true };
+  return { empty: found, truncated: false };
 }
 
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
@@ -130,6 +232,18 @@ export async function appendUpdate(
  * Merge snapshot + update log into one snapshot row and truncate the log.
  * Captures the current max update id first, then deletes only rows up to that
  * id so concurrently-appended updates are never lost.
+ *
+ * NOTE: this one deliberately still builds a Y.Doc — `encodeStateAsUpdate` on a
+ * gc'd doc is what makes a *compacted* snapshot smaller than the sum of its
+ * updates, which is the whole point of compacting. The read paths avoid the doc;
+ * this write path wants it.
+ *
+ * It runs under the pool-wide `statement_timeout` (see `db/pool.ts`) and NOT a
+ * tighter per-transaction one: `Queryable` is `Pick<Pool, "query">`, so
+ * consecutive calls may land on different pooled connections and a
+ * `BEGIN`/`SET LOCAL`/`COMMIT` sequence issued through it would set the timeout
+ * on an arbitrary connection. Doing it properly means threading a checked-out
+ * client through this signature — worth doing, not worth doing here.
  */
 export async function compact(
   docId: string,

--- a/app/apps/server/tests/blob-visibility.test.ts
+++ b/app/apps/server/tests/blob-visibility.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { filterReadableBlobs } from "../src/permissions/http-gates.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { seedMember, seedNote, seedOrg, seedUser, seedVault } from "./helpers/seed.js";
+
+/**
+ * `filterReadableBlobs` decides which attachments a SCOPED member (no vault-wide
+ * grant) may see: only those referenced by a note they can read. It used to pull
+ * every readable note's body into one JS string and substring-search it; the
+ * reference test now runs in Postgres. These tests pin the semantics that swap
+ * had to preserve — including the LIKE-escaping the SQL form newly needs, since
+ * a rel_path is user-controlled and `%`/`_` are wildcards there but were literal
+ * characters to `String.includes`.
+ */
+
+/** A derived index row — what the reference check actually reads. */
+async function seedIndex(vaultId: string, docId: string, content: string): Promise<void> {
+  await pool.query(
+    "INSERT INTO note_index (doc_id, vault_id, title, content) VALUES ($1, $2, $3, $4)",
+    [docId, vaultId, docId, content],
+  );
+}
+
+/** The shape the blobs route hands in (only `rel_path` is load-bearing). */
+const blob = (rel_path: string | null) => ({ id: `blob:${rel_path}`, rel_path });
+
+describe("filterReadableBlobs (attachment visibility)", () => {
+  let org: string;
+  let owner: string;
+  let member: string;
+  let vault: string;
+  let ownerNote: string;
+  let memberNote: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    org = await seedOrg("Blobs Co", "blobs-co");
+    owner = await seedUser("owner@blobvis.test");
+    await seedMember(org, owner, "owner");
+    // A plain member with no shares: the vault is private by default, so their
+    // readable set is exactly the notes they created.
+    member = await seedUser("member@blobvis.test");
+    await seedMember(org, member, "member");
+    vault = await seedVault(org);
+    ownerNote = await seedNote(vault, null, "Owner.md", owner);
+    memberNote = await seedNote(vault, null, "Member.md", member);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("shows a blob referenced by a note the member can read", async () => {
+    await seedIndex(vault, memberNote, "![](attachments/pic.png)\n");
+    const out = await filterReadableBlobs(member, vault, [blob("attachments/pic.png")]);
+    expect(out.map((b) => b.rel_path)).toEqual(["attachments/pic.png"]);
+  });
+
+  it("hides a blob no readable note references", async () => {
+    await seedIndex(vault, memberNote, "no attachments here");
+    const out = await filterReadableBlobs(member, vault, [blob("attachments/orphan.png")]);
+    expect(out).toEqual([]);
+  });
+
+  it("hides a blob referenced only by a note the member cannot read", async () => {
+    await seedIndex(vault, ownerNote, "![](attachments/secret.png)");
+    await seedIndex(vault, memberNote, "nothing of interest");
+    const out = await filterReadableBlobs(member, vault, [blob("attachments/secret.png")]);
+    expect(out).toEqual([]);
+  });
+
+  it("filters a mixed batch in one pass", async () => {
+    await seedIndex(vault, memberNote, "![](attachments/mine.png) and ![](attachments/also.pdf)");
+    await seedIndex(vault, ownerNote, "![](attachments/theirs.png)");
+    const out = await filterReadableBlobs(member, vault, [
+      blob("attachments/mine.png"),
+      blob("attachments/theirs.png"),
+      blob("attachments/also.pdf"),
+      blob("attachments/orphan.png"),
+      blob(null), // legacy blob with no path — never matchable
+    ]);
+    expect(out.map((b) => b.rel_path).sort()).toEqual([
+      "attachments/also.pdf",
+      "attachments/mine.png",
+    ]);
+  });
+
+  it("treats % and _ in a rel_path as literal characters, not LIKE wildcards", async () => {
+    await seedIndex(
+      vault,
+      memberNote,
+      // The literal path with the metacharacters, plus two decoys that a
+      // WILDCARD interpretation of the other two paths would match.
+      "![](attachments/50%_off.png)\n![](attachments/aXYZb.png)\n![](attachments/aXb.png)\n",
+    );
+    const out = await filterReadableBlobs(member, vault, [
+      blob("attachments/50%_off.png"), // literally present -> visible
+      blob("attachments/a%b.png"), // only matches if % is a wildcard -> hidden
+      blob("attachments/a_b.png"), // only matches if _ is a wildcard -> hidden
+    ]);
+    expect(out.map((b) => b.rel_path)).toEqual(["attachments/50%_off.png"]);
+  });
+
+  it("treats a backslash in a rel_path literally", async () => {
+    // `\` is the ESCAPE character in the LIKE, so an unescaped one would eat the
+    // next character and silently change what is matched.
+    await seedIndex(vault, memberNote, "![](attachments/a\\%b.png)");
+    const out = await filterReadableBlobs(member, vault, [
+      blob("attachments/a\\%b.png"),
+      blob("attachments/ab.png"),
+    ]);
+    expect(out.map((b) => b.rel_path)).toEqual(["attachments/a\\%b.png"]);
+  });
+
+  it("gives a vault-wide reader every blob, referenced or not", async () => {
+    const all = [blob("attachments/pic.png"), blob("attachments/orphan.png"), blob(null)];
+    // Owner: no note_index rows at all, and still sees everything.
+    expect(await filterReadableBlobs(owner, vault, all)).toEqual(all);
+  });
+
+  it("gives a non-member nothing", async () => {
+    const outsider = await seedUser("outsider@blobvis.test");
+    await seedIndex(vault, memberNote, "![](attachments/pic.png)");
+    expect(await filterReadableBlobs(outsider, vault, [blob("attachments/pic.png")])).toEqual([]);
+  });
+
+  it("gives a member with an empty readable set nothing", async () => {
+    // A member who created nothing has no readable docs, so no blob can be
+    // justified — short-circuited before any query.
+    const bystander = await seedUser("bystander@blobvis.test");
+    await seedMember(org, bystander, "member");
+    await seedIndex(vault, memberNote, "![](attachments/pic.png)");
+    expect(await filterReadableBlobs(bystander, vault, [blob("attachments/pic.png")])).toEqual([]);
+  });
+});

--- a/app/apps/server/tests/compression.test.ts
+++ b/app/apps/server/tests/compression.test.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { testAppDeps } from "./helpers/app.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { seedNote, seedVault } from "./helpers/seed.js";
+
+/**
+ * Response compression on the JSON API. The registry listings are why it exists:
+ * `GET /api/notes` for a several-hundred-note vault is a few hundred KB of very
+ * repetitive JSON, on the critical path of every client start-up and every
+ * `registry` broadcast.
+ *
+ * Blob DOWNLOAD is excluded by PATH rather than left to the content-type filter,
+ * because an attachment's stored mime is whatever the uploader sent — a
+ * text/markdown attachment would otherwise get re-encoded on a route whose only
+ * job is handing back exact bytes. The tests below pin both halves.
+ */
+
+const app = createApp(testAppDeps());
+
+async function get(user: TestUser, path: string, acceptEncoding?: string): Promise<Response> {
+  const headers: Record<string, string> = { ...authHeaders(user) };
+  if (acceptEncoding) headers["accept-encoding"] = acceptEncoding;
+  return app.fetch(new Request(`http://local${path}`, { headers }));
+}
+
+/** Read a gzipped Response body as text (a hand-built Response is not
+ *  transparently decoded the way a network fetch would be). */
+async function gunzipText(res: Response): Promise<string> {
+  return gunzipSync(Buffer.from(await res.arrayBuffer())).toString("utf8");
+}
+
+describe("HTTP response compression", () => {
+  let owner: TestUser;
+  let vault: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    owner = await signUp("owner@compress.test");
+    const org = (await createOrg(owner, "Compress Co", "compress-co")).id;
+    vault = await seedVault(org);
+    // Enough rows that the payload is worth compressing at all.
+    for (let i = 0; i < 40; i++) {
+      await seedNote(vault, null, `Note-${String(i).padStart(3, "0")}.md`, owner.userId);
+    }
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("gzips GET /api/notes when the client accepts it", async () => {
+    const res = await get(owner, `/api/notes?vaultId=${vault}`, "gzip");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBe("gzip");
+
+    // And the bytes are real gzip carrying the same JSON.
+    const body = JSON.parse(await gunzipText(res)) as { notes: unknown[] };
+    expect(body.notes.length).toBe(40);
+  });
+
+  it("leaves the response uncompressed when the client doesn't accept it", async () => {
+    const res = await get(owner, `/api/notes?vaultId=${vault}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBeNull();
+    const body = (await res.json()) as { notes: unknown[] };
+    expect(body.notes.length).toBe(40);
+  });
+
+  it("compresses the other registry listings too", async () => {
+    for (const path of [`/api/folders?vaultId=${vault}`, "/api/vaults"]) {
+      const res = await get(owner, path, "gzip");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-encoding")).toBe("gzip");
+    }
+  });
+
+  it("never touches a blob download, even one with a compressible mime", async () => {
+    // text/markdown matches hono's compressible-type regex, so ONLY the path
+    // exclusion can keep this response verbatim.
+    const id = randomUUID();
+    const bytes = Buffer.from("# attachment\n".repeat(200), "utf8");
+    await pool.query(
+      `INSERT INTO blobs (id, vault_id, sha256, size, mime, data, rel_path, filename)
+       VALUES ($1, $2, $3, $4, 'text/markdown', $5, 'attachments/a.md', 'a.md')`,
+      [id, vault, "sha-compress-test", bytes.length, bytes],
+    );
+
+    const res = await get(owner, `/api/blobs/${id}`, "gzip");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBeNull();
+    // Byte-for-byte what was stored.
+    expect(Buffer.from(await res.arrayBuffer()).equals(bytes)).toBe(true);
+  });
+
+  it("still compresses the blob LIST route (JSON, not bytes)", async () => {
+    const res = await get(owner, `/api/vaults/${vault}/blobs`, "gzip");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBe("gzip");
+  });
+
+  it("leaves /health alone (outside /api)", async () => {
+    const res = await app.fetch(
+      new Request("http://local/health", { headers: { "accept-encoding": "gzip" } }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBeNull();
+  });
+});

--- a/app/apps/server/tests/persistence.test.ts
+++ b/app/apps/server/tests/persistence.test.ts
@@ -4,19 +4,25 @@ import {
   appendUpdate,
   compact,
   countUpdates,
+  listEmptyDocs,
+  loadDocDiff,
   loadDocState,
+  type Queryable,
 } from "../src/yjs/persistence.js";
 import { pool } from "../src/db/pool.js";
 import { resetDb } from "./helpers/db.js";
 
 const DOC = "doc-persist-1";
 
+// File-scoped: this used to live in the first describe's afterAll, which closed
+// the pool before any later describe ran.
+afterAll(async () => {
+  await pool.end();
+});
+
 describe("binary Yjs persistence + compaction (spec 02 §5A / 03 §3)", () => {
   beforeEach(async () => {
     await resetDb();
-  });
-  afterAll(async () => {
-    await pool.end();
   });
 
   it("round-trips: appended updates rebuild the exact text", async () => {
@@ -91,5 +97,287 @@ describe("binary Yjs persistence + compaction (spec 02 §5A / 03 §3)", () => {
     const rebuilt = new Y.Doc();
     Y.applyUpdate(rebuilt, state!);
     expect(rebuilt.getText("content").toString()).toBe("abcdef");
+  });
+});
+
+
+// ── Y-level equivalence: the merge path must equal the old rebuild path ──────
+//
+// `loadDocState`/`loadDocDiff` stopped replaying the snapshot + log into a
+// throwaway Y.Doc and now compute over the raw bytes. That swap is only safe if
+// three things are byte-identical to what the doc produced, so prove it directly
+// against real multi-client histories rather than trusting the docs:
+//
+//   encodeStateVectorFromUpdate(mergeUpdates(parts)) == encodeStateVector(doc)
+//   diffUpdate(merged, clientSv)                     == encodeStateAsUpdate(doc, clientSv)
+//
+// V1 throughout, deliberately: yjs#687 (open) reports corruption in the V2 merge
+// functions, so nothing here may drift to a *V2 variant.
+
+/** Build a realistic history: N clients, a shared base, concurrent inserts and
+ *  deletes, everything exchanged. Returns every update in emission order. */
+function multiClientHistory(clientIds: number[]): Uint8Array[] {
+  const docs = clientIds.map((id) => {
+    const d = new Y.Doc();
+    d.clientID = id;
+    return d;
+  });
+  const updates: Uint8Array[] = [];
+  for (const d of docs) d.on("update", (u: Uint8Array) => updates.push(u));
+
+  docs[0].getText("content").insert(0, "# Title\n");
+  const seed = Y.encodeStateAsUpdate(docs[0]);
+  for (const d of docs.slice(1)) Y.applyUpdate(d, seed);
+
+  // Concurrent inserts, then a full exchange.
+  docs.forEach((d, i) => {
+    const t = d.getText("content");
+    t.insert(t.length, `line ${i}\n`);
+  });
+  for (const u of updates.slice()) for (const d of docs) Y.applyUpdate(d, u);
+
+  // Deletes matter: a Y.Doc with gc on drops deleted content while
+  // `mergeUpdates` keeps the tombstones, so this is where the two paths are most
+  // likely to diverge.
+  docs[0].getText("content").delete(0, 2);
+  if (docs[2]) docs[2].getText("content").delete(3, 4);
+  for (const u of updates.slice()) for (const d of docs) Y.applyUpdate(d, u);
+
+  for (const d of docs) d.destroy();
+  return updates;
+}
+
+describe("merge-path equivalence (no Y.Doc on the read path)", () => {
+  // Client-id order is the specific hazard: `encodeStateVector(doc)` sorts its
+  // entries, while `encodeStateVectorFromUpdate` writes them in the order the
+  // merged update happens to carry. Shuffled ids prove the two agree anyway.
+  for (const ids of [
+    [10, 20, 30],
+    [30, 20, 10],
+    [20, 30, 10],
+    [7, 999_999, 42],
+  ]) {
+    it(`state vector from a merged update matches the rebuilt doc (clients ${ids.join()})`, () => {
+      const updates = multiClientHistory(ids);
+
+      const rebuilt = new Y.Doc();
+      for (const u of updates) Y.applyUpdate(rebuilt, u);
+
+      const merged = Y.mergeUpdates(updates);
+      expect(Y.encodeStateVectorFromUpdate(merged)).toEqual(Y.encodeStateVector(rebuilt));
+
+      // ...and the merged bytes still reconstruct the same text.
+      const fromMerged = new Y.Doc();
+      Y.applyUpdate(fromMerged, merged);
+      expect(fromMerged.getText("content").toString()).toBe(
+        rebuilt.getText("content").toString(),
+      );
+    });
+  }
+
+  it("diffUpdate equals encodeStateAsUpdate(doc, sv) and converges the client", () => {
+    const updates = multiClientHistory([101, 202, 303]);
+    const rebuilt = new Y.Doc();
+    for (const u of updates) Y.applyUpdate(rebuilt, u);
+
+    // A client that saw only the first two updates — i.e. genuinely behind.
+    const client = new Y.Doc();
+    for (const u of updates.slice(0, 2)) Y.applyUpdate(client, u);
+    const clientSv = Y.encodeStateVector(client);
+
+    const merged = Y.mergeUpdates(updates);
+    const oldDiff = Y.encodeStateAsUpdate(rebuilt, clientSv);
+    const newDiff = Y.diffUpdate(merged, clientSv);
+    expect(newDiff).toEqual(oldDiff);
+
+    Y.applyUpdate(client, newDiff);
+    expect(client.getText("content").toString()).toBe(rebuilt.getText("content").toString());
+  });
+});
+
+// ── loadDocDiff: the state-vector probe ─────────────────────────────────────
+
+/** A Queryable that records the SQL it runs, so a test can assert what was NOT
+ *  read. The point of the probe is skipping the snapshot BYTEA, and only the
+ *  query log can show that. */
+function countingDb(): { db: Queryable; sql: string[] } {
+  const sql: string[] = [];
+  const db = {
+    query: (text: unknown, params?: unknown) => {
+      sql.push(String(text));
+      return (pool.query as (t: unknown, p?: unknown) => Promise<unknown>)(text, params);
+    },
+  };
+  return { db: db as unknown as Queryable, sql };
+}
+
+const SNAPSHOT_READ = "SELECT snapshot FROM doc_snapshots";
+
+/** Seed DOC from a fresh single-client history; returns the authoritative doc. */
+async function seedDoc(text: string, docId = DOC): Promise<Y.Doc> {
+  const doc = new Y.Doc();
+  const updates: Uint8Array[] = [];
+  doc.on("update", (u: Uint8Array) => updates.push(u));
+  doc.getText("content").insert(0, text);
+  for (const u of updates) await appendUpdate(docId, u, pool, 1000);
+  return doc;
+}
+
+describe("loadDocDiff (vault-channel backfill)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("returns null for a doc with no snapshot and no updates", async () => {
+    expect(await loadDocDiff(DOC, null)).toBeNull();
+    expect(await loadDocDiff(DOC, new Uint8Array([0]))).toBeNull();
+  });
+
+  it("probe answers an up-to-date client WITHOUT reading the snapshot", async () => {
+    const doc = await seedDoc("hello probe");
+    await compact(DOC, pool); // writes state_vector, empties the log
+    const sv = Y.encodeStateVector(doc);
+
+    const { db, sql } = countingDb();
+    const diff = await loadDocDiff(DOC, sv, db);
+
+    expect(diff).not.toBeNull();
+    expect(diff!.upToDate).toBe(true);
+    expect(diff!.update.length).toBe(0);
+    expect(diff!.serverStateVector).toEqual(sv);
+    // The whole point: the snapshot BYTEA was never fetched.
+    expect(sql.some((q) => q.includes(SNAPSHOT_READ))).toBe(false);
+  });
+
+  it("a NULL state_vector falls through to the merge path", async () => {
+    const doc = await seedDoc("null sv");
+    await compact(DOC, pool);
+    // Snapshot rows written before the column existed have it NULL; the probe
+    // must not treat that as "no state" or as a match.
+    await pool.query("UPDATE doc_snapshots SET state_vector = NULL WHERE doc_id = $1", [DOC]);
+
+    const { db, sql } = countingDb();
+    const diff = await loadDocDiff(DOC, Y.encodeStateVector(doc), db);
+
+    expect(diff!.upToDate).toBe(true); // same answer, computed the slow way
+    expect(sql.some((q) => q.includes(SNAPSHOT_READ))).toBe(true);
+  });
+
+  it("a pending logged update defeats the probe and ships the diff", async () => {
+    const doc = await seedDoc("base");
+    await compact(DOC, pool);
+
+    // A client that was fully caught up as of the compaction.
+    const client = new Y.Doc();
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(doc));
+    const staleSv = Y.encodeStateVector(client);
+
+    // One more edit lands after compaction, so the log is non-empty. The stored
+    // state_vector is now stale, which is exactly what `pending` guards against.
+    const later: Uint8Array[] = [];
+    doc.on("update", (u: Uint8Array) => later.push(u));
+    doc.getText("content").insert(4, " + more");
+    for (const u of later) await appendUpdate(DOC, u, pool, 1000);
+
+    const { db, sql } = countingDb();
+    const diff = await loadDocDiff(DOC, staleSv, db);
+
+    expect(diff!.upToDate).toBe(false);
+    expect(sql.some((q) => q.includes(SNAPSHOT_READ))).toBe(true);
+
+    Y.applyUpdate(client, diff!.update);
+    expect(client.getText("content").toString()).toBe("base + more");
+    expect(diff!.serverStateVector).toEqual(Y.encodeStateVector(doc));
+  });
+
+  it("a client with no state vector gets the full state", async () => {
+    const doc = await seedDoc("# Full\nbody");
+    const diff = await loadDocDiff(DOC, null);
+    expect(diff!.upToDate).toBe(false);
+
+    const client = new Y.Doc();
+    Y.applyUpdate(client, diff!.update);
+    expect(client.getText("content").toString()).toBe(doc.getText("content").toString());
+    expect(diff!.serverStateVector).toEqual(Y.encodeStateVector(doc));
+  });
+
+  it("a partially-caught-up client converges on the diff alone", async () => {
+    // Two clients, so the diff has to carry ops from a client the receiver has
+    // never heard from.
+    const a = new Y.Doc();
+    a.clientID = 501;
+    const b = new Y.Doc();
+    b.clientID = 502;
+    const updates: Uint8Array[] = [];
+    a.on("update", (u: Uint8Array) => updates.push(u));
+    b.on("update", (u: Uint8Array) => updates.push(u));
+
+    a.getText("content").insert(0, "shared base\n");
+    Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+    const clientSv = Y.encodeStateVector(b); // the client stops listening here
+    a.getText("content").insert(12, "from a\n");
+    b.getText("content").insert(0, "from b\n");
+    Y.applyUpdate(a, Y.encodeStateAsUpdate(b));
+    Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+
+    for (const u of updates) await appendUpdate(DOC, u, pool, 1000);
+
+    // The client's own doc, frozen at clientSv.
+    const client = new Y.Doc();
+    for (const u of updates.slice(0, 2)) Y.applyUpdate(client, u);
+
+    const diff = await loadDocDiff(DOC, Y.encodeStateVector(client));
+    expect(diff!.upToDate).toBe(false);
+    Y.applyUpdate(client, diff!.update);
+
+    const server = new Y.Doc();
+    Y.applyUpdate(server, (await loadDocState(DOC))!);
+    expect(client.getText("content").toString()).toBe(server.getText("content").toString());
+    // Sanity: the client really was behind, so the diff did the work.
+    expect(clientSv).not.toEqual(diff!.serverStateVector);
+  });
+});
+
+// ── listEmptyDocs: the `ready.empty` hint ───────────────────────────────────
+
+describe("listEmptyDocs", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("names docs with no updates and no snapshot, and only those", async () => {
+    await seedDoc("has content", "doc-with-updates");
+
+    const compacted = await seedDoc("compacted", "doc-compacted");
+    await compact("doc-compacted", pool); // snapshot only, log empty
+    compacted.destroy();
+
+    const res = await listEmptyDocs([
+      "doc-with-updates",
+      "doc-compacted",
+      "doc-empty-1",
+      "doc-empty-2",
+    ]);
+    expect(res).toEqual({ empty: ["doc-empty-1", "doc-empty-2"], truncated: false });
+  });
+
+  it("never names a doc that wasn't asked about", async () => {
+    // "doc-unasked" is empty too, but it is outside the caller's readable set.
+    const res = await listEmptyDocs(["doc-empty-1"]);
+    expect(res.empty).toEqual(["doc-empty-1"]);
+    expect(res.empty).not.toContain("doc-unasked");
+  });
+
+  it("caps the list and reports truncation", async () => {
+    const ids = Array.from({ length: 10 }, (_, i) => `empty-${i}`);
+    const res = await listEmptyDocs(ids, pool, 4);
+    expect(res.truncated).toBe(true);
+    expect(res.empty.length).toBe(4);
+    // Sorted, so the answer is deterministic across chunks and runs.
+    expect(res.empty).toEqual([...res.empty].sort());
+  });
+
+  it("is a no-op on an empty input", async () => {
+    expect(await listEmptyDocs([])).toEqual({ empty: [], truncated: false });
   });
 });

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it } from "vitest";
-import { VaultChannel } from "../src/sync/vault-channel.js";
+import { VaultChannel, type VaultChannelDeps } from "../src/sync/vault-channel.js";
 import { InMemoryPubSub } from "../src/sync/pubsub.js";
 import {
   decodeWsUpdate,
@@ -82,7 +82,16 @@ async function waitFor(fn: () => boolean, ms = 1000): Promise<void> {
 }
 
 const pubsubs: InMemoryPubSub[] = [];
-function channelWith(readable: () => Set<string>): { channel: VaultChannel; pubsub: InMemoryPubSub } {
+
+/** No-op empty-doc probe. Stubbed by default because the real one queries
+ *  Postgres and these are socket-free unit tests; the `ready.empty` suite below
+ *  injects its own. */
+const noEmpty = async () => ({ empty: [] as string[], truncated: false });
+
+function channelWith(
+  readable: () => Set<string>,
+  listEmpty: VaultChannelDeps["listEmpty"] = noEmpty,
+): { channel: VaultChannel; pubsub: InMemoryPubSub } {
   const pubsub = new InMemoryPubSub();
   pubsubs.push(pubsub);
   const channel = new VaultChannel({
@@ -93,6 +102,7 @@ function channelWith(readable: () => Set<string>): { channel: VaultChannel; pubs
     },
     listReadableDocs: async () => readable(),
     loadDiff: async (docId: string) => diffFor(docId),
+    listEmpty,
     backfillConcurrency: 4,
   });
   return { channel, pubsub };
@@ -285,6 +295,7 @@ describe("VaultChannel relay (spec 05 §3.1)", () => {
         return new Set(["A"]);
       },
       loadDiff: async (docId: string) => diffFor(docId),
+      listEmpty: noEmpty,
       backfillConcurrency: 4,
     });
 
@@ -317,6 +328,7 @@ function voiceChannel(): { channel: VaultChannel; pubsub: InMemoryPubSub } {
     verifyToken: async (token: string) => ({ userId: token, vaultId: "v1" }),
     listReadableDocs: async () => new Set<string>(),
     loadDiff: async () => null,
+    listEmpty: noEmpty,
     backfillConcurrency: 4,
   });
   return { channel, pubsub };
@@ -450,5 +462,98 @@ describe("VaultChannel voice broadcast", () => {
 
     await new Promise((r) => setTimeout(r, 30));
     expect(grace.voices()).toHaveLength(0);
+  });
+});
+
+// ---- `ready.empty`: notes that hold nothing on the server -----------------
+//
+// The 2026-08 bulk-register incident left 613 notes registered with no content.
+// Backfill sends no frame for such a doc, so the client cannot tell "the server
+// has nothing" from "not backfilled yet" and the note stays blank forever. The
+// `ready` frame now names them so the client seeds from its own disk.
+
+/** The `ready` control frame this connection received. */
+function readyFrame(ws: FakeWs): Record<string, unknown> | undefined {
+  return ws.controls().find((c) => c.t === "ready");
+}
+
+async function connectAndWait(channel: VaultChannel): Promise<FakeWs> {
+  const ws = new FakeWs();
+  channel.handleConnection(ws as never);
+  ws.hello("good");
+  await waitFor(() => ws.controls().some((c) => c.t === "ready"));
+  return ws;
+}
+
+describe("ready.empty (server-side-empty notes)", () => {
+  it("names a readable doc that has no updates and no snapshot", async () => {
+    // The probe is handed the readable set and answers from it; "B" is the doc
+    // with nothing behind it.
+    const { channel } = channelWith(
+      () => new Set(["A", "B"]),
+      async (docIds) => ({ empty: docIds.filter((d) => d === "B"), truncated: false }),
+    );
+    const ws = await connectAndWait(channel);
+    expect(readyFrame(ws)).toEqual({ t: "ready", empty: ["B"] });
+  });
+
+  it("omits `empty` entirely when every readable doc has content", async () => {
+    const { channel } = channelWith(() => new Set(["A", "B"]));
+    const ws = await connectAndWait(channel);
+    // Byte-identical to what every shipped client already parses — no new keys.
+    const frame = readyFrame(ws)!;
+    expect(frame).toEqual({ t: "ready" });
+    expect("empty" in frame).toBe(false);
+    expect("emptyTruncated" in frame).toBe(false);
+  });
+
+  it("is asked about exactly the readable set, so a doc outside it can't appear", async () => {
+    let asked: string[] = [];
+    const { channel } = channelWith(
+      () => new Set(["A", "B"]),
+      async (docIds) => {
+        asked = [...docIds];
+        // A hostile/buggy probe naming an unreadable doc still can't leak it,
+        // because the probe is only ever given the readable set.
+        return { empty: docIds, truncated: false };
+      },
+    );
+    const ws = await connectAndWait(channel);
+    expect(asked.sort()).toEqual(["A", "B"]);
+    expect(readyFrame(ws)!.empty).toEqual(["A", "B"]);
+    expect(readyFrame(ws)!.empty).not.toContain("C");
+  });
+
+  it("flags a truncated list", async () => {
+    const { channel } = channelWith(
+      () => new Set(["A", "B", "C"]),
+      async () => ({ empty: ["A", "B"], truncated: true }),
+    );
+    const ws = await connectAndWait(channel);
+    expect(readyFrame(ws)).toEqual({ t: "ready", empty: ["A", "B"], emptyTruncated: true });
+  });
+
+  it("still sends `ready` when the probe throws", async () => {
+    // Withholding `ready` would leave the client stuck "connecting" forever, so
+    // a failed hint must cost only the hint.
+    const { channel } = channelWith(
+      () => new Set(["A"]),
+      async () => {
+        throw new Error("probe exploded");
+      },
+    );
+    const ws = await connectAndWait(channel);
+    expect(readyFrame(ws)).toEqual({ t: "ready" });
+  });
+
+  it("sends `ready` after the backfill frames, never before", async () => {
+    const { channel } = channelWith(
+      () => new Set(["A", "B"]),
+      async (docIds) => ({ empty: [...docIds], truncated: false }),
+    );
+    const ws = await connectAndWait(channel);
+    const readyAt = ws.sent.findIndex((x) => x.kind === "text" && (x.value as { t: string }).t === "ready");
+    const lastBinary = ws.sent.reduce((acc, x, i) => (x.kind === "binary" ? i : acc), -1);
+    expect(readyAt).toBeGreaterThan(lastBinary);
   });
 });

--- a/app/apps/server/tests/vault-fanout-load.test.ts
+++ b/app/apps/server/tests/vault-fanout-load.test.ts
@@ -60,6 +60,8 @@ describe("vault fanout isolation / load (spec 05 §5)", () => {
       listReadableDocs: async (_userId: string, vaultId: string) =>
         new Set([`doc:${vaultId}`]),
       loadDiff: async () => null, // no backfill; we only measure live fanout
+      // Stubbed: pure in-memory fanout test, no DB.
+      listEmpty: async () => ({ empty: [], truncated: false }),
     });
 
     const sockets: FakeWs[] = [];

--- a/app/apps/server/tests/vault-fanout-stress.test.ts
+++ b/app/apps/server/tests/vault-fanout-stress.test.ts
@@ -59,6 +59,8 @@ function makeChannel(): VaultChannel {
     listReadableDocs: async (_userId: string, vaultId: string) =>
       new Set(Array.from({ length: DOCS_PER_VAULT }, (_, i) => `${vaultId}/doc${i}`)),
     loadDiff: async () => null, // no backfill; we measure live fanout only
+    // Stubbed: pure in-memory fanout test, no DB.
+    listEmpty: async () => ({ empty: [], truncated: false }),
   });
 }
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -202,6 +202,7 @@ curl -sL https://railway.com/deploy/baalda-server | grep -o '<title>[^<]*</title
 | Variable | Required | Default | Notes |
 |---|---|---|---|
 | `DATABASE_URL` | yes | `postgres://context:context@localhost:5439/context` | Postgres connection string. |
+| `PG_POOL_MAX` | no | `20` | Postgres connections this instance pools. Keep the total across all instances under the server's `max_connections`; a pool below `BACKFILL_CONCURRENCY` lets one vault reconnect starve the HTTP routes. |
 | `JWT_SECRET` | yes | dev-only insecure default | Better Auth crypto **and** sync JWT signing. Generate with `openssl rand -base64 32`. Rotating it invalidates all sessions and sync tokens. |
 | `BETTER_AUTH_URL` | yes | `http://localhost:3010` | Public base URL used for auth links (email verification, invitations). Must match the URL clients actually use. |
 | `PORT` | no | `3010` | HTTP API port. Serves the sync WebSocket at `/sync` too. This is the only port a deployment needs to expose. |


### PR DESCRIPTION
## Why
Initial sync of large vaults was slow (~3.7 notes/s measured in prod) and left 613 notes registered on the server with no content: on a fresh join the per-note socket path re-pushed every note the vault channel had already delivered, and a token-mint blip tripped a 5-failure streak abort that nothing restarted.

## What
- Server `ready.empty`: every `/vault-sync` connect names the readable docs the server holds no content for; the client pushes exactly those, first, on every reconnect (self-healing).
- Download before upload: the content run starts after the vault backfill settles; a converged cold apply of an empty placeholder marks the doc pushed, so the per-note path runs only over the remainder. Streak abort becomes a pause; a 30 s channel watchdog stops the pill from claiming "Syncing…" when the channel never connects ("Retrying…").
- Server: `loadDocDiff` no longer builds a Y.Doc per doc (state-vector probe → up-to-date with zero bytea; `Y.mergeUpdates`/`diffUpdate` otherwise, byte-equality proven in tests); `filterReadableBlobs` moved into SQL; pool 20 with connect/statement timeouts; gzip on `/api/*`.
- Rust: `index_notes` batches whole-vault link resolution once per batch (1,000-file drop into a 2k vault: ~25 s → ~0.14 s); watcher emits one `files-changed` batch with a 1 s max window; atomic + fsync'd `config.json`; `synchronous=NORMAL`.
- Version 0.1.41.

Tests: server 354, desktop 678, Rust 91 — all green.