### PR TITLE
Sync fixes (self-host uploads, empty-note resync loop), error surfacing, large-vault perf, MCP revisions + edit_note, tab menu, drive-root vault

### DIFF
--- a/.claude/skills/baalda-guide/SKILL.md
+++ b/.claude/skills/baalda-guide/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: baalda-guide
+description: Answer any question about Baalda (the team second-brain app at baalda.com) in plain, non-technical language — what it is, what it can and cannot do, which file formats it supports (Markdown, images, PDF, DOCX, XLSX, code files), how sync, offline, sharing, permissions, version history, AI/MCP, pricing, platforms and self-hosting work. Use this whenever someone asks "does Baalda…", "can Baalda…", "how does Baalda…", compares it with Obsidian/Notion/Logseq, or asks what happens to a file type in a vault, even if they do not say the word Baalda but are clearly asking about this product's features.
+---
+
+# Baalda guide
+
+You are the friendly product expert for Baalda. People asking are often not developers: a team
+lead deciding whether to adopt it, a teammate who was just invited, a writer wondering if their
+Word documents will work. Give them a correct, short, plain answer.
+
+## How to answer
+
+1. **Find the fact, do not guess.** Read `references/sources.md` once; it routes every kind of
+   question to the right place in this order:
+   - the bundled references (`file-formats.md`, `features.md`, `faq.md`) — usually enough. They
+     were checked line by line against the code, so do not re-verify them in the code unless the
+     question hinges on a detail they do not state;
+   - the product docs in the repo (`docs/`, `README.md`), assumed up to date; read only the one
+     or two files the routing table names. If you are not inside the repository, fetch the same
+     paths from `https://raw.githubusercontent.com/naveedharri/baalda/main/`;
+   - the website for downloads and positioning. For price and plans, `features.md` ("Hosting
+     options") is the source: the managed Pro plan is live and self-serve in the app, and the
+     public pricing page can lag behind it;
+   - a single targeted code file only when the docs are silent on a precise behaviour.
+   Never sweep the whole repository for a question; it is slow and the docs already answer it.
+
+2. **Answer first, then stop early.** Open with the direct answer (yes / no / partly / it
+   depends on X). Follow with the two to five facts that decide the question. Then stop. The
+   budget is about **150 words for a single question and 250 for a multi-part one**; a reader
+   who wants more will ask. Each part of a multi-part question gets one to three sentences, not
+   its own section. Include at most one caveat, and only the one that would change the reader's
+   decision. Do not add "worth knowing before you switch" lists, migration walkthroughs, or
+   hosting comparisons unless asked. Length is the failure mode to watch: in testing, correct
+   answers came out at 400–500 words and read as a brochure, not an answer.
+
+3. **Plain words.** Say "notes are ordinary text files", not "Markdown is the durable source of
+   truth". Say "changes merge automatically", not "CRDT operations". If a technical term is
+   unavoidable (MCP, self-host, Markdown), add a four-word gloss the first time.
+
+4. **Be honest about limits.** Say plainly what Baalda does *not* do, and label roadmap items as
+   "planned", never "available". Overpromising a feature to someone choosing a tool is worse than
+   a blunt no. If the docs and website disagree, the repo is newer; say so if it matters.
+
+5. **Point to where it is.** When relevant, end with where the person finds the thing in the app
+   ("right-click the note → Share", "Vault Settings → MCP") or a single link (a docs file or a
+   baalda.com page). One pointer, not a bibliography.
+
+6. **Match the depth asked.** A yes/no question gets a paragraph. "Explain how Baalda works" gets
+   a few short sections. A developer asking about internals can be sent to `CLAUDE.md` and
+   `docs/specs/` instead of a rewrite here.
+
+## Answer shape
+
+```
+<Direct answer in one sentence.>
+
+<2–5 sentences or bullets: what works, what does not, the one caveat that matters.>
+
+<Optional: where to find it in the app, or one link.>
+```
+
+Multi-part question: one short paragraph or bullet per part, same total budget. Bold a lead-in
+word per part if it helps scanning; no headers.
+
+## Example
+
+Question: "Can it hold, load and sync other formats like DOCX, XLSX, PNG, PY and JS files?"
+
+Answer:
+
+> Partly. Baalda is built around Markdown notes; other files fall into three groups.
+>
+> - **Images and PDFs** (PNG, JPG, GIF, SVG, PDF) show in the sidebar, preview in the app, and
+>   sync to your team when you paste or drag them into a note.
+> - **Office and other files** (DOCX, XLSX, CSV, ZIP) can be dragged onto a note; they sync as a
+>   download link, but Baalda cannot open or edit them. Convert to Markdown to get the content in.
+> - **Code files** (PY, JS) are ignored on purpose so a project folder does not flood your vault.
+>   Paste code into a note as a code block instead.
+>
+> Only text notes get live co-editing, search and AI access. Attachments cap at 25 MB each.
+
+That is about 110 words. It names every format asked about, says what does not work, and stops.
+
+## Things people ask that trip up a naive answer
+
+- "Is it encrypted?" The server holds binary sync records, not files, but it *can* reconstruct
+  note text; it is not end-to-end encrypted. See `faq.md`.
+- "Does it sync my images?" Only through the note (the `attachments/` folder). An image copied
+  into a sub-folder stays local. See `file-formats.md`.
+- "How much does it cost? Can my team start now?" Yes, now. Free locally and self-hosted with no
+  limits; the managed service is free up to 3 vaults per user and 10 members per vault, then Pro
+  at $10 per vault per month or $97 per year, bought in-app under Vault Settings → Billing. Do not
+  say "early access" or "contact us for pricing"; that wording on the website is out of date.
+- "Is there a mobile / web app?" No. iOS is planned; public links open read-only in a browser.
+- "Does it have AI built in?" It has an AI *connection point* (MCP) and works with any local
+  agent; it ships no model and no chat panel.
+- "Are notes private by default?" New vaults are shared with the team by default; the README
+  still says the opposite. Any folder or note can be made private. See `sources.md`, "Known
+  stale spots".
+- "How many people / notes can it handle?" Give the engineering numbers from `features.md`
+  (hundreds of concurrent users per server instance, teams under ~50 editing live), not the
+  marketing ones, when the person is deciding whether to adopt it.
+
+## Keeping this skill correct
+
+The reference files were written from the repo and website on 2026-09-03. Features change with
+every release. If you notice a reference file contradicting `docs/STATUS.md`,
+`docs/RELEASE_NOTES.md` or the code, trust the repo and, if you are in the repo, update the
+reference file so the next answer is right.

--- a/.claude/skills/baalda-guide/evals/evals.json
+++ b/.claude/skills/baalda-guide/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "baalda-guide",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "by the way how does it or can it hold and load and sync other formats like DOCX, XLSX, PNG, PY, and JS files?",
+      "expected_output": "Plain-language answer: images/PDF preview and sync via attachments; DOCX/XLSX attach-only as links, not opened or converted; PY/JS ignored on purpose; only text notes get live editing/search/AI; 25 MB attachment limit.",
+      "files": [],
+      "assertions": [
+        "Leads with a direct answer (yes/no/partly) in the first sentence",
+        "States that PY and JS (code files) are ignored / not shown in the vault",
+        "States that DOCX and XLSX cannot be opened or edited in Baalda but can be attached to a note",
+        "States that PNG (images) preview in the app and sync when embedded in a note",
+        "Does not use the words CRDT, Yjs, or Hocuspocus",
+        "Under 250 words"
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "My team of 6 uses Obsidian with a shared Dropbox folder and it keeps making conflicted copies. Would Baalda fix that? Do we all need to pay, and can we keep our existing vault?",
+      "expected_output": "Yes: live merge, no conflicted copies; existing Obsidian vault opens as-is (plugins don't carry over); free locally/self-hosted; managed service free up to 3 vaults/10 members, then Pro $10/vault/month or $97/year bought in-app; team can start today.",
+      "files": [],
+      "assertions": [
+        "Says conflicted copies do not happen because edits merge automatically",
+        "Says the existing Obsidian vault folder can be opened directly without conversion",
+        "Mentions that Obsidian plugins do not carry over",
+        "States the managed plan is live and self-serve now (upgrade in-app), with Pro at $10 per vault per month or $97 per year; does not say 'early access' or 'contact us for pricing'",
+        "Distinguishes free (local/self-host) from the paid managed Team plan",
+        "Does not use the words CRDT, Yjs, or Hocuspocus"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I'm not technical. If I invite my assistant to my Baalda vault, can I stop her from seeing my personal folder? And can I let ChatGPT or Claude read my notes, and would it also see her stuff?",
+      "expected_output": "Yes: make the folder private / share per person with view or edit; AI via MCP token is bound to the token creator's permissions, or a local agent edits files on disk; no built-in chat; mention where in the app.",
+      "files": [],
+      "assertions": [
+        "Says a folder or note can be made private or shared with specific people",
+        "Says the AI connects through a token created in Vault Settings (MCP) or via a local tool editing files",
+        "Says the AI sees exactly what the person who made the token can see (same permissions)",
+        "Explains MCP in a short gloss rather than assuming the reader knows it",
+        "Gives at least one concrete in-app location (e.g. right-click → Share, Vault Settings → MCP)",
+        "Under 300 words"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/baalda-guide/references/faq.md
+++ b/.claude/skills/baalda-guide/references/faq.md
@@ -1,0 +1,102 @@
+# Ready answers to common questions
+
+Each answer is written for a non-technical reader. Reuse the wording; trim to fit.
+
+## What is Baalda, in one breath?
+A notes app for teams where every note is a plain Markdown file on your own computer, your
+teammates can edit the same note with you live, and an AI assistant can read and edit those
+notes too. Think "Obsidian, but multiplayer and AI-friendly".
+
+## Is it free?
+The desktop app and the server are open source (Apache 2.0). Using it on your own computer is
+free forever, and you can run your own server for free with no limits. The managed backend
+(hosted by Baalda, the app's default) also starts free: 3 vaults per user and 10 members per
+vault. Past that, upgrade a vault to Pro from inside the app.
+
+## What does the paid plan cost, and can my team start today?
+Yes, today. Sign up in the app, turn on sync, invite the team. The free tier already covers a
+team of up to 10 in one vault. When you need more members or more vaults, go to Vault Settings →
+Billing → Upgrade to Pro: $10 per vault per month or $97 per vault per year, priced per vault,
+not per person, with unlimited members. Only the vault owner or an admin pays; everyone else just
+needs a free account. baalda.com/pricing is the place to ask questions or talk to the team, but
+nobody has to wait for a call to get started.
+
+## Do I need an account?
+No. You can open a folder and start writing with no account and no internet. An account is only
+needed for sync between devices, team collaboration, and the hosted AI endpoint.
+
+## Does it work offline?
+Yes. Everything local (editing, search, backlinks, graph) works with no connection. When you
+reconnect, your changes merge with everyone else's; there are no conflict dialogs.
+
+## What happens if two people edit the same note at once?
+Both edits are kept and merged character by character, live, with visible cursors. The same is
+true when an AI edits a note while a person is typing in it.
+
+## Where are my notes stored?
+In a folder you choose on your disk (default `~/Documents/Baalda Vaults/<vault name>`). They are ordinary `.md`
+files you can open in any editor, back up, or put in Git. A hidden `.context/` folder inside the
+vault holds the search index and sync state; you can delete it and Baalda rebuilds it.
+
+## What does the server store? Can Baalda read my notes?
+The server stores the sync history as binary change records, not `.md` files, and each device
+rebuilds its own files from that. Be honest here: the server *can* reconstruct note text; that
+is how server-side search, public links and the MCP endpoint work. Notes are not end-to-end
+encrypted today (at-rest encryption is on the roadmap). If that matters, self-host.
+
+## Can I use it with my Obsidian vault?
+Yes. Open the folder. Markdown, folders, `[[wikilinks]]` and `#tags` carry over. Obsidian
+plugins do not. See `file-formats.md` for what happens to non-Markdown files.
+
+## Which platforms?
+macOS (Apple Silicon and Intel), Windows 10/11, Linux (AppImage, .deb, .rpm). iOS is planned,
+not available. The macOS build is signed and notarized; Windows and Linux builds are unsigned,
+so a fresh Windows download shows a SmartScreen warning (More info → Run anyway). The app
+updates itself with a signed updater after the first install.
+
+## How do I share notes with my team?
+Sign in, turn on sync for your vault, invite people by email or share a join code. New vaults
+are shared with the whole team by default; you can make any folder or note private, share it
+with specific people, and choose view or edit for each. Roles are owner, admin, member.
+
+## Can I share a note with someone who does not use Baalda?
+Yes. "Copy link" on a note offers a public link: a read-only web page anyone with the link can
+open. Revoke it any time. There is also a private link that only works for teammates with access.
+
+## How does the AI part work?
+Two ways. (1) Local: because notes are plain files, any tool on your computer, for example
+Claude Code, can edit them directly; Baalda notices the change and syncs it. (2) Remote: Baalda
+has a built-in MCP endpoint (Model Context Protocol, the standard way AI assistants connect to
+tools). Create a token in Vault Settings → MCP, give it to your AI client, and the AI can list,
+search, read, create, update, move and delete notes, limited by the same permissions as a person.
+There is no built-in chat panel or bundled AI model; you bring your own AI.
+
+## Is there version history?
+Yes. Each note keeps versions (captured automatically after a pause in editing, and before any
+revert) that you can preview and restore. Owners and admins can also take a checkpoint of the
+whole vault and revert to it.
+
+## Can I lock a note?
+Yes. Lock a note or folder so it becomes read-only for everyone, including admins, until unlocked.
+
+## What is the voice button?
+Push-to-talk. Hold it to speak to teammates who are in the same vault. Nothing is recorded or
+stored; if someone was offline they simply did not hear it.
+
+## Does it have a graph view, backlinks, tags, search?
+Yes to all. Full-text search runs locally and instantly. When a vault is synced there is also a
+server-side semantic search. Backlinks survive renames and moves because notes are tracked by a
+stable id, not by filename.
+
+## Is there a mobile app or web app?
+Not yet. Desktop only; iOS is on the roadmap. Public note links open in any browser, read-only.
+
+## Can I self-host?
+Yes. The server is Node + Postgres. One-click deploy to Railway, a Docker Compose bundle, or
+plain Docker; see `docs/DEPLOY.md`. Then paste your server URL into the app's settings.
+Self-hosted servers have no plan limits.
+
+## What is NOT there (so you do not overpromise)?
+Rich WYSIWYG block editing, in-app AI chat, comments and @mentions, end-to-end encryption,
+a mobile app, Office file conversion, plugins, two-factor authentication, SSO, audit logs. Several are on the Phase 4 roadmap in
+`docs/STATUS.md`; say "planned", never "available".

--- a/.claude/skills/baalda-guide/references/features.md
+++ b/.claude/skills/baalda-guide/references/features.md
@@ -1,0 +1,177 @@
+# Baalda features, in plain words
+
+Everything below is shipped unless marked **Planned**. Last verified against the repo on
+2026-09-03 (desktop v0.1.42). When in doubt about a detail, check `docs/STATUS.md`.
+
+## The idea
+
+Baalda is a "team second brain". Three things that normally do not go together:
+
+1. **Your notes are plain Markdown files on your disk.** No database lock-in. Open them in any
+   editor, back them up, put them in Git. If Baalda vanished tomorrow you would still have
+   everything.
+2. **Teammates edit the same notes live**, with visible cursors, like a shared Google Doc.
+3. **An AI can read and write the notes as a teammate**, either directly on disk or through a
+   built-in connection point (MCP), and its edits merge with yours instead of overwriting.
+
+Why nobody else does this: file-based note apps (Obsidian, Logseq) are single-player, and
+collaborative apps (Notion, Confluence) keep your data in their database. Baalda bridges the two.
+
+## Vaults
+
+- A **vault** is a folder of notes. It can be **Local** (just a folder, no account), **Synced**
+  (your folder, backed up and shared through a server) or **Remote** (a team vault you joined
+  that Baalda downloads to your machine).
+- Create a new vault, open any existing folder, or type a path (even a whole drive) on the
+  welcome screen. Recent vaults are listed for quick switching.
+- Default location for new vaults: `~/Documents/Baalda Vaults/<vault name>` (under Documents so it
+  shows in the Finder/Explorer sidebar). Change the root in settings; existing vaults stay put.
+  A `current` shortcut inside that root always points at the vault you have open, handy for
+  scripts and AI tools.
+- Importing an existing folder (for example an Obsidian vault) is a plain "open folder".
+  Import files or folders into a vault, and export a note, a folder or the whole vault as files.
+- Very large vaults load lazily (folders are read when you expand them), so size is not a
+  problem. Marketing says "millions of notes" and "thousands of teammates"; the engineering
+  docs are more measured: one server instance handles hundreds of concurrent users, thousands
+  need several instances behind a load balancer with Redis, and a vault's live fan-out is sized
+  for teams under about 50 people editing at once. Quote the measured numbers to a buyer.
+- **Freeze vault root**: a setting that stops anyone, including owners, from adding new items at
+  the top level once the structure is settled.
+
+## Writing
+
+- Markdown editor with live preview (headings, lists, links, images, tables, code blocks render
+  in place while you type). Inline HTML is rendered but sanitized.
+- `[[Wikilinks]]` between notes, with a backlinks panel. Links survive renames and moves.
+- `#tags` inline or in frontmatter.
+- Tabs for open notes, with a right-click menu (close, close others, close to the right, close
+  all).
+- Autosave. Undo/redo is shared correctly even during live collaboration.
+- Paste or drag images and PDFs into a note; they embed in place (see `file-formats.md`).
+- `.html` files open as a sandboxed, read-only rendered page (scripts never run) with a
+  Preview/Source toggle; they do not get live co-editing. `.txt` and `.canvas` open as text.
+- Light and dark themes. Colour-tag notes and folders in the sidebar; colours sync to the team.
+- Right-click any note or folder: rename, delete, move, share, lock, colour, reveal in
+  Finder/Explorer, export.
+
+## Finding things
+
+- **Full-text search** runs locally and instantly, with highlighted snippets.
+- **Semantic search** (meaning-based) is available for synced vaults, served by the server. It
+  works offline-capable with a built-in lightweight embedder; a self-hoster can plug in OpenAI
+  embeddings for better results. A stronger vector search is planned.
+- **Backlinks** panel per note.
+- **Graph view** of how notes link to each other.
+
+## Sync (your own devices)
+
+- Sign in, turn on sync for a vault, and open the same vault on another machine. Changes
+  converge in milliseconds when online; offline edits merge when you reconnect.
+- Sync is always on in the background for the whole vault, not just the open note, so notes are
+  already up to date before you click them.
+- What travels: binary change records, never whole files. Each device rebuilds its own `.md`.
+- Deleting a file on disk does not delete it for the team (deliberate safety rule). Delete inside
+  the app to remove it everywhere.
+- Renames and moves are tracked by a stable note id, so nothing forks or loses its history.
+- Multiple vaults per account. Switch between them from the account menu.
+
+## Team collaboration
+
+- **Invite** teammates by email, or hand out a **join code**. Invitations expire after 48 hours.
+- **Roles**: owner, admin, member.
+- **Live presence**: coloured cursors and selections in the note, "who is viewing" avatars,
+  and small presence dots in the sidebar showing who is in which note or folder. Ping a
+  teammate to get their attention.
+- **Sharing model**: new vaults are shared with the whole team by default (vaults created before
+  mid-2026 stayed private until their owner flips them in Access). Any folder or note
+  can be made **private** (visible only to people you name), **shared with the team**, or shared
+  with specific people, each as **view** or **edit**. A person can also be blocked from an item.
+  Permissions cascade down folders; the most permissive grant wins, except that "denied" and
+  "locked" override. **Private really means nobody**: not the owner, not an admin, not even the
+  person who wrote the note, until they are named on the item's list. So when you make your own
+  folder private, add yourself. Owners and admins can always change the setting back.
+- The MCP screen in the app puts the AI rule in one line: "It gets the same access you do."
+  Deleting a token cuts the AI off immediately.
+- **Locks**: lock a note or folder so it is read-only for everyone, admins included, until
+  unlocked.
+- **Losing access** removes the note from the ex-reader's other devices (moved to trash, never
+  destroyed); regaining access brings it back.
+- Not built (deferred): comments and @mentions, activity feed, audit log, sub-teams or custom
+  roles, SSO/SAML, two-factor authentication, email verification at sign-up.
+- **Public links**: turn a note into a read-only web page anyone with the link can read. Revoke
+  any time. **Private links** (`baalda://note/...`) open a note for teammates who already have
+  access; they carry no access themselves.
+- **Push-to-talk voice**: hold a button to talk to everyone in the vault. Nothing is recorded.
+- **Access panel** (owners/admins): a tree of every folder and note in the vault with its sharing
+  state, independent of what is on your own disk.
+
+## History and recovery
+
+- **Note versions**: captured automatically after roughly ten minutes of quiet following an edit,
+  and always before a revert. Preview any version and restore it.
+- **Vault checkpoints**: owners and admins can snapshot the whole vault and revert it later.
+- A local recovery snapshot is taken before a large external rewrite (for example an AI replacing
+  most of a note).
+
+## AI
+
+- **Local agents** (Claude Code, Codex, any script): nothing to configure. They edit the `.md`
+  files; Baalda notices and syncs. A human typing and an AI rewriting the same note merge.
+- **Remote / cloud agents** use the built-in **MCP endpoint** (`<server>/api/mcp`). Create a
+  token in Vault Settings → MCP. Tools: list vaults, list/create/move/delete folders,
+  list/read/search/create/update/append/move/delete notes. The AI is bound by the exact same
+  permissions as the person who created the token. If a note is open, you watch the AI type.
+- Bring your own model. Baalda ships no AI model, no API key requirement, and no chat panel.
+- **Planned**: in-app AI panel, AI as a live collaboration peer, richer vector search.
+
+## Accounts and security
+
+- Email + password accounts (argon2id hashing). Google sign-in is available when the server has
+  it configured (the managed service does). There is no email verification step yet and no
+  two-factor authentication.
+- Session token lives in the operating system keychain, never in a file.
+- Server stores binary sync records, not `.md` files; but it can reconstruct note text for
+  search, public links and MCP, so it is **not end-to-end encrypted**. At-rest encryption is
+  **Planned**.
+- The macOS app is Developer-ID signed and notarized. Auto-updates on every platform are
+  verified with Baalda's own signing key.
+- No analytics or tracking in the app or on the site.
+
+## Platforms and install
+
+- macOS (Apple Silicon + Intel, `.dmg`), Windows 10/11 (`.exe`, `.msi`), Linux x64 (`.AppImage`,
+  `.deb`, `.rpm`). Windows/Linux builds are unsigned, so first launch may warn.
+- In-app updater, signed. Releases at github.com/naveedharri/baalda/releases.
+- **Planned**: iOS app. No web app for editing (public links are read-only pages).
+
+## Hosting options
+
+- **Local only**: no server, no account, free.
+- **Self-hosted server**: Node + Postgres. Railway one-click, Docker Compose, or plain Docker.
+  Set the server URL in the app's settings. No plan limits, and Google sign-in / billing are
+  optional switches.
+- **Managed server** at `https://api.baalda.com` (the default in the app). Same code as the
+  self-hosted server. It is live and self-serve today: a team can sign up, sync and collaborate
+  right away on the free tier, and upgrade from inside the app when they hit a cap.
+  - **Free tier**: up to 3 vaults per user and 10 members per vault (members plus pending invites).
+  - **Pro**: $10 per vault per month, or $97 per vault per year. Priced per vault, not per
+    person. Unlocks unlimited members, notes, devices and AI edits; a Pro vault does not count
+    toward the owner's free vaults. Two subscriptions exist today: monthly and yearly.
+  - **How to buy**: Vault Settings → Billing → Upgrade to Pro (owners and admins). Checkout opens
+    in the browser; the app flips to Pro as soon as payment lands. "Manage subscription" opens the
+    billing portal for invoices, plan changes and cancellation.
+  - The public pricing page (baalda.com/pricing) may still describe the Team plan as early access
+    or "talk to us". The app is ahead of the page: tell people they can upgrade in-app now, and
+    to use the pricing page as the contact route if they want to talk first.
+
+## Licensing
+
+Apache 2.0 for the whole app and core server. The `ee/` folder is reserved for future
+commercial-only features under a separate licence. The Baalda name is a trademark; forks must
+use their own name.
+
+## Roadmap (Planned, not shipped)
+
+From `docs/STATUS.md` Phase 4: rich WYSIWYG editing, vector/hybrid search, AI as a live CRDT
+peer, at-rest encryption, OAuth beyond Google, iOS. Also not built: comments and mentions,
+plugins, Office file import.

--- a/.claude/skills/baalda-guide/references/file-formats.md
+++ b/.claude/skills/baalda-guide/references/file-formats.md
@@ -1,0 +1,91 @@
+# What file types Baalda supports
+
+The single most common question. Answer it precisely, because "supports" means
+four different things in Baalda and people usually mean one of them:
+
+| Level | What it means | File types |
+|---|---|---|
+| **Note** | Opens in the editor, edited live with teammates and AI, searchable, backlinks, version history, synced to the server | `.md` `.markdown` `.mdx` `.txt` `.html` `.htm` `.canvas` |
+| **Viewable file** | Shows in the sidebar, opens in a built-in viewer, cannot be edited inside Baalda | Images: `.png` `.jpg` `.jpeg` `.gif` `.webp` `.svg` `.avif` · Documents: `.pdf` |
+| **Attachment** | Any file dragged onto an open note. Copied into the vault's hidden `attachments/` folder, linked from the note, synced to teammates | Anything: `.docx` `.xlsx` `.pptx` `.csv` `.zip` `.mp4`, code files, and so on |
+| **Ignored** | Not shown, not indexed, not synced | Everything else, plus `node_modules`, `dist`, `build`, `target`, `vendor`, `venv`, `__pycache__`, and any dot-folder like `.git` |
+
+Source: `app/apps/desktop/src-tauri/src/vault.rs` (`ALLOWED_EXTS`, `DENIED_DIRS`),
+`app/apps/desktop/src/lib/sync/registry.ts` (`NOTE_EXTS`), `app/apps/desktop/src/lib/preview.ts`,
+`app/apps/desktop/src/lib/attachments.ts`.
+
+## The details that matter
+
+**Markdown is the real format.** Everything else is secondary. A note is a plain text file
+on disk. Only text notes go through the live-collaboration engine and the AI path.
+
+**Text-like formats open as text.** `.txt`, `.html`, `.canvas` (Obsidian canvas files, which
+are JSON) are treated as notes: you can open and edit them as text and they sync like notes.
+Two wrinkles: full-text search and backlinks only index `.md` files, and the Import command
+converts `.txt` and `.markdown` files to `.md` on the way in so they get the full treatment.
+`.html` files render as a sandboxed read-only page (with a Source toggle); they are not
+co-edited live. There is no rich rendering of `.canvas`.
+
+**Images and PDFs are view-only.** Baalda previews them in place (images inline, PDFs as a
+block) and lets you embed them in notes with `![name](/attachments/...)`. It does not edit them.
+
+**How images and PDFs get into a note.** Paste a screenshot or drag a file onto an open note.
+Baalda copies it into `attachments/` at the vault root, names it by content hash (so the same
+file dropped twice is stored once), and inserts the embed for you. HEIC and TIFF photos are
+converted to PNG on import so they display on every platform. That `attachments/` folder is
+hidden from the sidebar on purpose; it is the sync store for binary files.
+
+**Only the `attachments/` folder syncs binary files.** An image or PDF you put elsewhere in the
+vault (say `Projects/diagram.png`) shows up in your sidebar and previews locally, but it is not
+sent to the server or to teammates. The registry only registers text notes; binary sync only
+mirrors `attachments/`. If someone asks "why don't my teammates see my image", this is why:
+drop it onto a note instead of copying it into a folder.
+
+**Office files (DOCX, XLSX, PPTX) are attachments, not notes.** Baalda does not open, convert,
+render, or edit them. You can attach one to a note and it will sync to the team as a download
+link, but that is all. To open the file itself, use "Reveal in Finder/Explorer" and open it
+from the `attachments/` folder with Word or Excel; clicking the link inside the note does not
+launch an external app. To get the *content* into Baalda, convert it to Markdown first (Pandoc,
+"Save as Markdown", or ask your AI to convert it) or export a PDF and attach that.
+
+**Spreadsheets have no special treatment.** A `.csv` is an attachment. Tables inside notes are
+ordinary Markdown tables.
+
+**Code files (`.py`, `.js`, `.ts`, `.rs`, etc.) are deliberately ignored.** Baalda is a notes
+app, not a code editor. The exclusion exists so you can point Baalda at a real project folder
+(or even a whole drive) and see only your notes, never source files or dependency folders.
+If you want code in your second brain, paste it into a note inside a fenced code block, or
+attach the file to a note. Do not expect syntax highlighting of a standalone `.py` file.
+
+**Size limits (managed and self-hosted servers).**
+
+| Thing | Limit | Where set |
+|---|---|---|
+| One note's text | 10 MB | `MAX_NOTE_MB` on the server |
+| One attachment | 25 MB | `MAX_BLOB_BYTES` on the server |
+
+Local-only vaults have no such limits; these apply when syncing.
+
+**Attachments are never AI-edited or searched.** The MCP tools and the search index only see
+note text. An AI connected over MCP cannot read a PDF or DOCX you attached.
+
+## Ready answers
+
+Q: *Can it hold and sync DOCX, XLSX, PNG, PY and JS files?*
+
+> Partly. PNG (and other common images plus PDF) show in the sidebar and preview in the app.
+> Anything you drag onto a note, including DOCX and XLSX, is stored as an attachment and syncs
+> to your team as a link, but Baalda cannot open or edit Office files; convert them to Markdown
+> if you want the content inside a note. PY and JS files are ignored on purpose so a project
+> folder does not flood your vault with code; paste code into a note instead. Only Markdown and
+> other text notes get the live editing, search and AI features.
+
+Q: *Can I use my existing Obsidian vault?*
+
+> Yes. Point Baalda at the folder. Your `.md` files, folders, `[[wikilinks]]` and tags work as-is.
+> Obsidian-specific plugins and their data do not carry over, and `.canvas` files open as text.
+
+Q: *Where do pasted images go?*
+
+> Into a hidden `attachments/` folder at the top of your vault, named by a content hash.
+> The note gets an embed line pointing at it. Teammates receive the file through sync.

--- a/.claude/skills/baalda-guide/references/sources.md
+++ b/.claude/skills/baalda-guide/references/sources.md
@@ -1,0 +1,87 @@
+# Where the truth lives
+
+Use these sources in this order. Stop as soon as the question is answered; do not crawl the
+whole repository for a simple question.
+
+## 1. This skill's reference files (fastest)
+
+| Question is about | Read |
+|---|---|
+| File types, formats, DOCX/XLSX/images/code, attachments, size limits | `references/file-formats.md` |
+| What Baalda does, feature by feature, in plain words | `references/features.md` |
+| Common questions with ready-to-give answers | `references/faq.md` |
+
+## 2. The product docs (assumed up to date)
+
+Locate them: if the current directory (or a parent) contains `docs/Baalda.md`, read local files.
+Otherwise fetch the same paths from GitHub:
+`https://raw.githubusercontent.com/naveedharri/baalda/main/<path>`.
+
+| Topic | File |
+|---|---|
+| Product pitch, the core idea, stack, principles | `README.md`, `docs/Baalda.md` |
+| What is built, what is planned (phases, Phase 4 list) | `docs/STATUS.md` |
+| The 12 requirements the product is measured against | `docs/specs/REQUIREMENTS.md` |
+| Latest shipped changes | `docs/RELEASE_NOTES.md`, then GitHub Releases. (The root `CHANGELOG.md` is not maintained; its "Unreleased" section lists things that shipped long ago.) |
+| Self-hosting, deployment, environment variables | `docs/DEPLOY.md` |
+| How releases, installers, signing and auto-update work | `docs/RELEASE.md` |
+| Every button in the app and what it does | `docs/INTERACTIONS.md` |
+| Desktop app design (editor, tree, commands) | `docs/specs/01-desktop-app.md` |
+| Sync, offline behaviour, conflict merging | `docs/specs/03-sync-engine.md`, `docs/specs/05-vault-sync-engine.md` |
+| Teams, roles, sharing, permissions, presence | `docs/specs/04-team-collaboration.md` |
+| Storage layout, index, server tables | `docs/specs/02-database-architecture.md` |
+| Brand vs codename ("context"), rebrand rules | `docs/BRANDING.md` |
+| Developer orientation, conventions | `CLAUDE.md` at the repo root |
+
+## 3. The website (pricing, downloads, positioning)
+
+For price and plans, trust `references/features.md` ("Hosting options"), which mirrors the
+server's billing code and the app's Upgrade to Pro dialog. The public pricing page may still say
+the Team plan is in early access; the in-app purchase is live.
+
+| Page | URL |
+|---|---|
+| Home | https://baalda.com |
+| Pricing | https://baalda.com/pricing |
+| Download (current version, per-platform installers) | https://baalda.com/download |
+| Compare with Obsidian, Notion, Tana, Reflect, Logseq, Anytype, Confluence | https://baalda.com/compare and `/compare/<product>` |
+| Security and privacy statements | https://baalda.com/security · https://baalda.com/privacy |
+| Open source and licensing | https://baalda.com/open-source |
+| Blog (team second brain, MCP, Obsidian for teams) | https://baalda.com/blog |
+| Docs landing (points back to GitHub) | https://baalda.com/docs |
+| Source, releases, issues | https://github.com/naveedharri/baalda |
+
+## 4. Code (only for a precise behaviour the docs do not state)
+
+Do a targeted read of one file, never a sweep. Good entry points:
+
+| Behaviour | File |
+|---|---|
+| Which extensions show in the sidebar / are ignored | `app/apps/desktop/src-tauri/src/vault.rs` |
+| Which files become synced notes | `app/apps/desktop/src/lib/sync/registry.ts` (`NOTE_EXTS`) |
+| Image/PDF preview kinds | `app/apps/desktop/src/lib/preview.ts` |
+| Drag-drop / paste attachment behaviour | `app/apps/desktop/src/lib/attachments.ts` |
+| Server limits and free-tier caps | `app/apps/server/src/config.ts`, `app/apps/server/.env.example` |
+| Paid plan prices and checkout | `app/apps/server/src/http/routes/billing.ts`, `app/apps/desktop/src/components/UpgradeDialog.tsx` |
+| Attachment size limit | `app/apps/server/src/http/routes/blobs.ts` |
+| Permission rules | `app/apps/server/src/permissions/resolver.ts` |
+| MCP tools list | `app/apps/server/src/mcp/` |
+| Version history and vault checkpoints | `app/apps/server/src/http/routes/versions.ts` |
+| Installer platforms and signing | `.github/workflows/release.yml`, `docs/RELEASE.md` |
+
+## Known stale spots (trust the code / CLAUDE.md over these)
+
+- `README.md` and `docs/specs/04-team-collaboration.md` say notes are *private by default*. The
+  current behaviour is *shared with the team by default* for new vaults (see `CLAUDE.md`,
+  "permissions/resolver"); older vaults stayed private.
+- `docs/specs/REQUIREMENTS.md` lists graph view, semantic search and version history as
+  deferred. All three shipped.
+- `CHANGELOG.md` at the repo root is abandoned; use `docs/RELEASE_NOTES.md`.
+- baalda.com/pricing describes the Team plan as "early access, talk to us". The managed Pro plan is
+  live and self-serve in the app (Vault Settings → Billing); see `features.md`. Code:
+  `app/apps/server/src/http/routes/billing.ts` (plans) and `config.ts` (free caps).
+
+## Recency check
+
+The repo's `app/apps/desktop/src-tauri/tauri.conf.json` holds the current version. The
+website's download page may lag one release behind. If they differ, the repo is newer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,10 @@ Pure TS with dependency-injected I/O so it runs under vitest in Node. `adapter.t
 - `docSession.ts` (`syncManager`) — owns the registry, current `DocSync`, presence, attachments.
 - `syncManager.ts` (`DocSync`) — `HocuspocusProvider` over the bridge's `Y.Doc`; doc name
   `vault:<vaultId>/note:<docId>`. Token is a **function** re-minted per (re)connect via `POST /api/sync-token`;
-  403 → `no-access`. WS URL derived from the server URL (`deriveWsUrl`): explicit port 3010 →
-  legacy dedicated port 3011; any other/no port → same-origin `ws(s)://…/sync` (single-port topology).
+  403 → `no-access`. WS URL derived from the server URL (`deriveWsUrl`): ALWAYS same-origin
+  `ws(s)://<server>/sync`, like the vault channel's `/vault-sync`. (It used to bump an explicit
+  `:3010` to the dedicated `:3011`, which broke every single-port self-host — the Compose bundle
+  publishes only 3010 — so content never uploaded while structure synced fine, #79.)
 - `startup.ts` (`decideSeed`) — **split-brain rule**: when signed in, pull from server FIRST, then seed a
   local orphan only if the doc is still empty. Reversing this causes permanent divergence.
 - `registry.ts` — reconciles local vault ↔ server vault/folders/notes, persists the doc-id map to
@@ -147,6 +149,12 @@ Pure TS with dependency-injected I/O so it runs under vitest in Node. `adapter.t
   echoes; the `divergedDocs` set forces a connect for out-of-band merges by resident bridges / cold applies).
   `NoteBridge.hydrate` also ingests the file on reopen when it moved on while the doc was closed. Disk
   deletions are deliberately NOT propagated to the server.
+- **`ready.empty` is filtered against disk** (`SyncManager.settleServerEmpty`): the server names every
+  readable doc it holds no CRDT for on each connect, but a doc whose LOCAL file is empty too has nothing
+  to push — it is marked pushed + badged synced and never queued (a vault with 307 zero-byte `_Index.md`
+  stubs used to "re-sync 307 notes" on every reload). Files over `MAX_NOTE_BYTES` (10 MB, the server's
+  `MAX_NOTE_MB`) fail once, permanently, without a socket (`permanentFailures`) instead of being rejected
+  by the server on every reconnect.
 
 ### Desktop — React (`src/`)
 `store.ts` is a Zustand **UI view-state mirror only** (vault, tree, open note, auth/session, org members,
@@ -187,7 +195,12 @@ flow through the same sync server via `createDocWriter` so AI edits persist/broa
   registry listings).
 - `tokens/sync-token.ts` — HS256 per-doc JWT (`jose`), TTL `SYNC_TOKEN_TTL_SECONDS` (default 600).
 - `mcp/` — JSON-RPC 2.0 over Streamable HTTP at `POST /api/mcp` (no SSE; GET/DELETE → 405). Tools:
-  `list_vaults/list_folders/create_folder/move_folder/delete_folder/list_notes/read_note/search_notes/create_note/update_note/append_note/move_note/delete_note`.
+  `list_vaults/list_folders/create_folder/move_folder/delete_folder/list_notes/read_note/search_notes/create_note/update_note/append_note/edit_note/move_note/delete_note`.
+  `read_note` returns a `revision` (sha256 of the body); `update_note`/`append_note`/`edit_note` take an
+  optional `expectedRevision` and refuse a stale write (the check runs under the doc writer's per-doc
+  lock, so check + apply are atomic). `edit_note` applies exact-anchor replace/insert/delete ops (an
+  anchor must match exactly once unless `all`), `update_note` sends only the changed span, and
+  `append_note` accepts an `idempotencyKey` so a retried call cannot append twice.
   Structural tools (create/move/delete of folders and notes) broadcast `registry-changed` with a
   `null` origin, and content writes fan out through `createDocWriter`, so an AI edit lands live on
   every open app exactly like a teammate's. `delete_folder` refuses a non-empty folder unless

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cd apps/server
 cp .env.example .env      # adjust JWT_SECRET for anything real
 pnpm run db:up            # start Postgres in Docker (host port 5439)
 pnpm run migrate          # create the database schema
-pnpm run dev              # HTTP API :3010 · sync WS :3011 (also served at :3010/sync)
+pnpm run dev              # HTTP API :3010 · sync WS at :3010/sync (a legacy dedicated :3011 also listens)
 ```
 
 ### 3. Start the desktop app
@@ -206,7 +206,7 @@ claude mcp add --transport http context http://localhost:3010/api/mcp \
 (On the managed service the endpoint is `https://api.baalda.com/api/mcp`; for a
 self-hosted server, use your server URL plus `/api/mcp`.)
 
-The AI can now `read_note`, `search_notes`, `create_note`, `update_note`, and more. Its writes flow through the same sync engine, so if the note is open you'll watch the AI type in real time.
+The AI can now `read_note`, `search_notes`, `create_note`, `edit_note` (targeted replace/insert/delete at exact anchors), `update_note`, and more. `read_note` returns a `revision`; pass it back as `expectedRevision` and a write against a note that changed in between is refused instead of merged. Its writes flow through the same sync engine, so if the note is open you'll watch the AI type in real time.
 
 ---
 

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.41"
+version = "0.1.42"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -146,14 +146,30 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+/// Label for a path with no `file_name` (a filesystem/drive root): the path
+/// itself minus trailing separators, so `D:\\` reads "D:" — except a bare `/`,
+/// which has nothing left after the trim and stays as it is.
+fn root_label(path: &str) -> String {
+    let trimmed = path.trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() {
+        path.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 fn vault_info(path: &Path, epoch: u64) -> VaultInfo {
+    // A filesystem/drive root (`/`, `D:\`) has no `file_name`, but it is a
+    // legal vault root (opened by path — the native picker can't select one).
+    // Label it by the path itself, trimmed of trailing separators, rather than
+    // the old anonymous "vault".
+    let name = match path.file_name().and_then(|s| s.to_str()) {
+        Some(n) => n.to_string(),
+        None => root_label(&path.to_string_lossy()),
+    };
     VaultInfo {
         path: path.to_string_lossy().to_string(),
-        name: path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("vault")
-            .to_string(),
+        name,
         epoch,
     }
 }
@@ -1079,6 +1095,22 @@ pub async fn read_external_file(path: String) -> AppResult<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A vault opened at a filesystem/drive root has no `file_name`; its label
+    /// must fall back to the path itself, never the anonymous "vault".
+    #[test]
+    fn vault_info_names_filesystem_roots() {
+        // Ordinary folder: the folder's own name.
+        let v = vault_info(Path::new("/home/me/Notes"), 1);
+        assert_eq!(v.name, "Notes");
+        // Unix root: nothing to trim — keep the path.
+        let v = vault_info(Path::new("/"), 1);
+        assert_eq!(v.name, "/");
+        // Windows drive root (verbatim string, host-independent): trailing
+        // separator trimmed so the label reads "D:".
+        assert_eq!(root_label("D:\\"), "D:");
+        assert_eq!(root_label("/"), "/");
+    }
 
     /// The rediscovery probe must identify a vault folder without opening it,
     /// and must answer None (never an error) for everything that isn't one —

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -174,6 +174,17 @@ fn vault_info(path: &Path, epoch: u64) -> VaultInfo {
     }
 }
 
+/// Payload of the `index-ready` event: the background index rebuild that
+/// `open_vault` starts has committed. `epoch` lets the UI drop a stale one.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexReady {
+    pub path: String,
+    pub epoch: u64,
+    pub ok: bool,
+    pub ms: u64,
+}
+
 /// The epoch of the currently-open vault (0 when none has been opened). The TS
 /// layer reads this when it starts a VaultScope for a vault it didn't just open.
 #[tauri::command]
@@ -199,21 +210,68 @@ fn open_vault_inner(app: &AppHandle, state: &State<AppState>, path: PathBuf) -> 
     // stream vault files (e.g. `<img src>` in notes) via convertFileSrc.
     let _ = app.asset_protocol_scope().allow_directory(&path, true);
 
-    let index = Index::open(&path)?;
-    index.rebuild(&path)?;
-    let index = Arc::new(Mutex::new(index));
+    let index = Arc::new(Mutex::new(Index::open(&path)?));
 
+    // The watcher first, so nothing that changes during the rebuild below is
+    // missed: its drain thread queues behind the same index lock and re-indexes
+    // any file the rebuild may have seen too (idempotent).
     let watcher = watcher::start(path.clone(), index.clone(), app.clone())?;
 
     let epoch = {
         let mut inner = state.inner.lock().unwrap();
+        // Every open invalidates the previous vault's epoch, so any command still
+        // in flight for it is rejected rather than applied to this one.
+        let epoch = inner.vault_epoch + 1;
+
+        // Reconcile the index with disk in the BACKGROUND (#84). This used to run
+        // inline, so opening a large vault returned nothing to the UI until every
+        // changed/new `.md` had been re-parsed — a multi-second blank on first
+        // open, read as "the app hangs". The sidebar listing needs no index (it
+        // walks the disk), so the vault is usable at once; anything that does
+        // need the index (titles, search, backlinks, the sync reconcile) simply
+        // waits on its lock and gets the rebuilt answer.
+        //
+        // The rebuild thread takes the index lock BEFORE this open publishes the
+        // index into the state (the `ready` handshake below), so no command can
+        // read a stale index in between: the first reader blocks until the
+        // rebuild commits, exactly as if it had been inline. Correctness of every
+        // index reader is unchanged; only who waits for the rebuild is.
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+        let (bg_index, bg_path, bg_app) = (index.clone(), path.clone(), app.clone());
+        std::thread::spawn(move || {
+            let guard = bg_index.lock().unwrap();
+            let _ = ready_tx.send(());
+            let started = std::time::Instant::now();
+            let result = guard.rebuild(&bg_path);
+            drop(guard);
+            let ok = match result {
+                Ok(()) => true,
+                Err(e) => {
+                    eprintln!("[index] rebuild failed for {}: {e}", bg_path.display());
+                    false
+                }
+            };
+            // Tells the UI the index is current: titles/backlinks/graph refresh.
+            let _ = bg_app.emit(
+                "index-ready",
+                IndexReady {
+                    path: bg_path.to_string_lossy().to_string(),
+                    epoch,
+                    ok,
+                    ms: started.elapsed().as_millis() as u64,
+                },
+            );
+        });
+        // Wait until the rebuild thread HOLDS the index lock (sub-millisecond),
+        // then publish. A `recv` error means the thread died before locking, in
+        // which case the index is simply stale-but-consistent, as before.
+        let _ = ready_rx.recv();
+
         inner.vault = Some(path.clone());
         inner.index = Some(index);
         inner.watcher = Some(watcher); // replaces & drops any previous watcher
-        // Every open invalidates the previous vault's epoch, so any command still
-        // in flight for it is rejected rather than applied to this one.
-        inner.vault_epoch += 1;
-        inner.vault_epoch
+        inner.vault_epoch = epoch;
+        epoch
     };
 
     let info = vault_info(&path, epoch);
@@ -942,6 +1000,18 @@ pub async fn graph_edges(state: State<'_, AppState>) -> AppResult<Vec<GraphEdge>
     let (_, index) = require_vault(&state)?;
     let guard = index.lock().unwrap();
     guard.graph_edges()
+}
+
+/// The edges touching the given notes only — the Graph view's per-change delta
+/// (#83), so an edit to one note no longer re-reads the whole edge set.
+#[tauri::command]
+pub async fn graph_edges_for(
+    state: State<'_, AppState>,
+    note_ids: Vec<String>,
+) -> AppResult<Vec<GraphEdge>> {
+    let (_, index) = require_vault(&state)?;
+    let guard = index.lock().unwrap();
+    guard.graph_edges_for(&note_ids)
 }
 
 #[tauri::command]

--- a/app/apps/desktop/src-tauri/src/index.rs
+++ b/app/apps/desktop/src-tauri/src/index.rs
@@ -752,6 +752,38 @@ impl Index {
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
+    /// The edges touching any of `note_ids` (as source OR target) — the delta the
+    /// Graph view applies when a few notes change, instead of re-reading every
+    /// edge in the vault on every `files-changed` (#83). Deduplicated across the
+    /// ids so an edge between two changed notes is reported once.
+    pub fn graph_edges_for(&self, note_ids: &[String]) -> AppResult<Vec<GraphEdge>> {
+        let mut out: Vec<GraphEdge> = Vec::new();
+        if note_ids.is_empty() {
+            return Ok(out);
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT src_note_id, dst_note_id
+             FROM links
+             WHERE dst_note_id IS NOT NULL AND (src_note_id = ?1 OR dst_note_id = ?1)",
+        )?;
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        for id in note_ids {
+            let rows = stmt.query_map(params![id], |r| {
+                Ok(GraphEdge {
+                    source: r.get(0)?,
+                    target: r.get(1)?,
+                })
+            })?;
+            for edge in rows {
+                let edge = edge?;
+                if seen.insert((edge.source.clone(), edge.target.clone())) {
+                    out.push(edge);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     pub fn get_note_meta(&self, rel: &str) -> AppResult<Option<NoteMeta>> {
         let base = self
             .conn

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -85,6 +85,7 @@ pub fn run() {
             commands::search_notes,
             commands::get_backlinks,
             commands::graph_edges,
+            commands::graph_edges_for,
             commands::get_note_meta,
             commands::resolve_wikilink,
             commands::list_note_titles,

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -456,6 +456,21 @@ button.primary.hero:hover:not(:disabled) {
   outline: none;
   border-color: var(--accent);
 }
+/* "Open by path" — the picker's escape hatch for what the native folder dialog
+   can't select (a drive root as the vault). Sits under the hint that reveals it. */
+.open-by-path {
+  display: flex;
+  gap: var(--sp-2);
+  align-items: stretch;
+  justify-content: center;
+  width: min(420px, 84vw);
+  margin: var(--sp-2) auto 0;
+}
+.open-by-path-input {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--fs-sm);
+}
 .new-vault-loc {
   font-size: var(--fs-sm);
   color: var(--text-tertiary);

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -21,6 +21,7 @@ import { VersionPanel } from "./components/VersionPanel";
 import { bridgeManager } from "./lib/bridge";
 import { BRAND_NAME } from "./lib/brand";
 import * as ipc from "./lib/ipc";
+import { implicatedFolders } from "./lib/tree/lazyTree";
 import { syncManager } from "./lib/sync/docSession";
 import {
   backgroundUpdateCheck,
@@ -616,7 +617,11 @@ export default function App() {
           // (`get_last_vault` reports the epoch from before it opened anything).
           useStore.getState().setVault(opened ?? last);
           await useStore.getState().refreshTree();
-          await useStore.getState().refreshTitles();
+          // Not awaited: the index rebuild runs in the background now (#84), and
+          // this call parks on its lock until it commits. The tree above needs
+          // no index, so the vault is on screen while the rebuild runs; titles
+          // land when it finishes (and `index-ready` refreshes them again).
+          void useStore.getState().refreshTitles();
         }
       } catch (e) {
         console.error("auto-reopen failed", e);
@@ -644,15 +649,27 @@ export default function App() {
   useEffect(() => {
     let unlistenFile: (() => void) | undefined;
     let unlistenVault: (() => void) | undefined;
+    let unlistenIndex: (() => void) | undefined;
     // Coalesce sidebar refreshes: a bulk change (e.g. importing a folder) emits
     // many `file-changed` batches in quick succession; refreshing the tree on
     // each one re-renders the whole sidebar repeatedly and flickers hover state.
     // Debounce so a burst settles into a single refresh.
     let refreshTimer: ReturnType<typeof setTimeout> | null = null;
-    const scheduleRefresh = () => {
+    // Folders whose listings the pending batches can have changed; null once any
+    // batch in the window carried a structural change (then the whole tree is
+    // re-listed, as before).
+    let pendingFolders: Set<string> | null = new Set();
+    const scheduleRefresh = (changes: ipc.FileChanged[]) => {
+      if (pendingFolders) {
+        const dirs = implicatedFolders(changes);
+        if (dirs) for (const d of dirs) pendingFolders.add(d);
+        else pendingFolders = null;
+      }
       if (refreshTimer) clearTimeout(refreshTimer);
       refreshTimer = setTimeout(() => {
-        void useStore.getState().refreshTree();
+        const folders = pendingFolders;
+        pendingFolders = new Set();
+        void useStore.getState().refreshTree(folders ?? undefined);
         void useStore.getState().refreshTitles();
         void useStore.getState().refreshBacklinks();
       }, 120);
@@ -692,16 +709,28 @@ export default function App() {
         }
         if (forSync.length > 0) syncManager.handleLocalFilesChanged(forSync);
 
-        // Refresh tree + titles + backlinks (coalesced for bursts).
-        scheduleRefresh();
+        // Refresh tree + titles + backlinks (coalesced for bursts; the tree
+        // refresh is targeted at the folders this batch touched — #82).
+        scheduleRefresh(changes);
       });
       unlistenVault = await ipc.onVaultOpened((v) => {
         useStore.getState().setVault(v);
+      });
+      // The background index rebuild committed: everything derived from the
+      // index catches up. Stale epochs (a vault switched during a long rebuild)
+      // are dropped — the open that replaced it gets its own event.
+      unlistenIndex = await ipc.onIndexReady((e) => {
+        const vault = useStore.getState().vault;
+        if (!vault || vault.epoch !== e.epoch) return;
+        if (!e.ok) toast("Couldn't finish indexing this vault — search and backlinks may be incomplete.", "error");
+        void useStore.getState().refreshTitles();
+        void useStore.getState().refreshBacklinks();
       });
     })();
     return () => {
       unlistenFile?.();
       unlistenVault?.();
+      unlistenIndex?.();
       if (refreshTimer) clearTimeout(refreshTimer);
     };
   }, []);

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1375,7 +1375,14 @@ function GeneralTab({
     } catch (e) {
       const kind = classifyLimitError(e);
       if (kind) setLimitNudge({ kind, limit: limitFromError(e) });
-      else setError(e instanceof Error ? e.message : String(e));
+      else {
+        const message = e instanceof Error ? e.message : String(e);
+        setError(message);
+        // The inline line can be scrolled out of view, and the button simply
+        // returns to idle — which reads as "nothing happened". A sticky toast is
+        // always visible (#85).
+        toast(`Couldn't turn on sync — ${message}`, "error");
+      }
     } finally {
       setBusy(false);
     }
@@ -1678,7 +1685,10 @@ function VaultsTab() {
       setBound(readOrgVaults());
       setConfirmDelete(null);
     } catch (e) {
-      setActionError(e instanceof Error ? e.message : String(e));
+      const message = e instanceof Error ? e.message : String(e);
+      setActionError(message);
+      // Destructive path: a failure here must never look like a success (#85).
+      toast(`Couldn't delete the vault — ${message}`, "error");
     } finally {
       setBusy(false);
     }
@@ -2678,7 +2688,11 @@ function McpTab() {
       setTokens((prev) => [row, ...prev]);
       setName("");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      // Otherwise the button just returns to idle and the user clicks again,
+      // minting duplicate tokens on a server that is actually failing (#85).
+      toast(`Couldn't create the MCP token — ${message}`, "error");
     } finally {
       setBusy(false);
     }

--- a/app/apps/desktop/src/components/TabBar.tsx
+++ b/app/apps/desktop/src/components/TabBar.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { placeMenu, type Placement } from "../lib/menuPlacement";
 import { useStore } from "../store";
 
 /** Tab label: the note's indexed title when we have one, else the filename.
@@ -11,10 +12,18 @@ function tabLabel(path: string, titleByPath: Map<string, string>): string {
   return base.replace(/\.(md|html?)$/i, "");
 }
 
+/** Right-click menu state: the tab it was opened on plus the cursor anchor. */
+interface TabMenu {
+  x: number;
+  y: number;
+  path: string;
+}
+
 /**
  * The open-files strip under the main header. Every `openNoteByPath` keeps its
  * file as a tab (store `openTabs`), so moving between notes no longer loses
- * where you were — click to switch back, × or middle-click to close.
+ * where you were — click to switch back, × or middle-click to close, and
+ * right-click for the bulk close actions (others / to the right / all).
  *
  * The ACTIVE tab is derived from `openNote.path`, never tracked separately, so
  * the strip can't disagree with the editor about what's on screen.
@@ -46,7 +55,46 @@ export function TabBar() {
     activeRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [activePath]);
 
+  // Context menu, same placement dance as the file tree's row menu: render
+  // hidden at the anchor, measure, then let `placeMenu` flip/clamp it on-screen.
+  const [menu, setMenu] = useState<TabMenu | null>(null);
+  const menuRef = useRef<HTMLUListElement | null>(null);
+  const [menuPos, setMenuPos] = useState<Placement | null>(null);
+
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    // Any click lands somewhere else (menu items close themselves first), and a
+    // second right-click elsewhere replaces the menu via onContextMenu below.
+    window.addEventListener("click", close);
+    window.addEventListener("blur", close);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("blur", close);
+    };
+  }, [menu]);
+
+  useLayoutEffect(() => {
+    if (!menu) {
+      setMenuPos(null);
+      return;
+    }
+    const el = menuRef.current;
+    if (!el) return;
+    const box = el.getBoundingClientRect();
+    setMenuPos(
+      placeMenu(
+        { x: menu.x, y: menu.y },
+        { width: box.width, height: box.height },
+        { width: window.innerWidth, height: window.innerHeight },
+      ),
+    );
+  }, [menu]);
+
   if (tabs.length === 0) return null;
+
+  const menuIdx = menu ? tabs.indexOf(menu.path) : -1;
+  const menuLabel = menu ? tabLabel(menu.path, titleByPath) : "";
 
   return (
     <div className="tab-strip" role="tablist" aria-label="Open files">
@@ -66,6 +114,11 @@ export function TabBar() {
             // Middle-click closes, the platform-wide tab convention.
             onAuxClick={(e) => {
               if (e.button === 1) useStore.getState().closeTab(path);
+            }}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setMenu({ x: e.clientX, y: e.clientY, path });
             }}
           >
             <button
@@ -101,6 +154,66 @@ export function TabBar() {
           </div>
         );
       })}
+
+      {menu && (
+        <ul
+          className="context-menu"
+          role="menu"
+          aria-label={`Tab actions for ${menuLabel}`}
+          ref={menuRef}
+          style={
+            menuPos
+              ? { left: menuPos.left, top: menuPos.top, maxHeight: menuPos.maxHeight }
+              : // Rendered off the anchor for the measuring pass only, and hidden
+                // so that pass can't flash on screen at the wrong place.
+                { left: menu.x, top: menu.y, visibility: "hidden" }
+          }
+        >
+          <li
+            role="menuitem"
+            onClick={() => {
+              useStore.getState().closeTab(menu.path);
+              setMenu(null);
+            }}
+          >
+            Close
+          </li>
+          <li
+            role="menuitem"
+            className={tabs.length < 2 ? "disabled" : undefined}
+            onClick={() => {
+              if (tabs.length < 2) return;
+              useStore.getState().closeOtherTabs(menu.path);
+              setMenu(null);
+            }}
+          >
+            Close others
+          </li>
+          <li
+            role="menuitem"
+            // Last tab (or the phantom active-only tab, which renders last) has
+            // nothing to its right.
+            className={menuIdx === -1 || menuIdx === tabs.length - 1 ? "disabled" : undefined}
+            onClick={() => {
+              if (menuIdx === -1 || menuIdx === tabs.length - 1) return;
+              useStore.getState().closeTabsToRight(menu.path);
+              setMenu(null);
+            }}
+          >
+            Close tabs to the right
+          </li>
+          <li
+            role="menuitem"
+            className="menu-sep-item"
+            onClick={() => {
+              useStore.getState().closeAllTabs();
+              setMenu(null);
+            }}
+          >
+            Close all
+          </li>
+        </ul>
+      )}
     </div>
   );
 }

--- a/app/apps/desktop/src/components/VaultPicker.tsx
+++ b/app/apps/desktop/src/components/VaultPicker.tsx
@@ -198,6 +198,28 @@ export function VaultPicker() {
     await useStore.getState().adoptOpenedVault(vault, opts);
   }
 
+  // "Open by path": a typed/pasted absolute path, for what the native picker
+  // cannot select — notably a drive root (a bare `D:\` or a mounted volume).
+  // The OS folder dialog only offers folders *inside* a drive, so the only way
+  // to make the drive itself the vault is to say so in text (#75).
+  const [pathOpen, setPathOpen] = useState(false);
+  const [manualPath, setManualPath] = useState("");
+  async function openByPath() {
+    const path = manualPath.trim();
+    if (!path) return;
+    setBusy(true);
+    setError(null);
+    try {
+      // `openLocalVault`, not `adoptOpenedVault`: WE control this open, so the
+      // store can tear down any active vault sync before Rust swaps the slot.
+      await useStore.getState().openLocalVault(path);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   // "Open existing": native folder picker → open the chosen vault.
   async function pickExisting() {
     setBusy(true);
@@ -774,8 +796,54 @@ export function VaultPicker() {
               reduceMotion ? undefined : revealTransition(REVEAL_DELAY + 0.3)
             }
           >
-            A vault is any folder of <code>.md</code> files.
+            A vault is any folder of <code>.md</code> files.{" "}
+            <button
+              type="button"
+              className="linkish"
+              disabled={busy}
+              aria-expanded={pathOpen}
+              onClick={() => setPathOpen((v) => !v)}
+            >
+              Open by path
+            </button>
           </motion.p>
+        )}
+
+        {/* The escape hatch itself. Plain conditional (no enter animation): it
+            appears in direct response to the link above, and motion between a
+            question and its answer reads as lag. */}
+        {!inFlow && pathOpen && (
+          <form
+            className="open-by-path"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void openByPath();
+            }}
+          >
+            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+            <input
+              className="new-vault-input open-by-path-input"
+              autoFocus
+              value={manualPath}
+              disabled={busy}
+              onChange={(e) => setManualPath(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setPathOpen(false);
+              }}
+              placeholder={"Full folder or drive path, e.g. D:\\ or /Volumes/Notes"}
+              spellCheck={false}
+              autoComplete="off"
+            />
+            <button
+              type="submit"
+              className={`primary sm${busy ? " is-busy" : ""}`}
+              disabled={busy || !manualPath.trim()}
+              aria-busy={busy || undefined}
+            >
+              <span className="async-btn-label">{busy ? "Opening…" : "Open"}</span>
+              {busy && <Spinner size="xs" tone="on-accent" />}
+            </button>
+          </form>
         )}
 
         {/*

--- a/app/apps/desktop/src/lib/bridge/__tests__/egest-failure.test.ts
+++ b/app/apps/desktop/src/lib/bridge/__tests__/egest-failure.test.ts
@@ -1,0 +1,125 @@
+// A failed egest (CRDT → disk) must never be silent, and must never move the
+// echo guard onto bytes that are not on disk (#81). The .md is the durable
+// source of truth, so a lost write is a data-safety event: the bridge keeps the
+// text in the CRDT, tells the UI, and retries with backoff until it lands.
+
+import { describe, expect, it, vi } from "vitest";
+import { NoteBridge } from "../noteBridge";
+import { makeHarness, sha256Hex } from "./helpers";
+
+const PATH = "note.md";
+const SEED = "# Title\n\nhello world\n";
+
+function failingIo(seed: Record<string, string>) {
+  const h = makeHarness(seed);
+  let failing = false;
+  const failed: Array<{ path: string; attempt: number }> = [];
+  const recovered: string[] = [];
+  const io = {
+    ...h.io,
+    writeFileAtomic: async (p: string, c: string) => {
+      if (failing) throw new Error("ENOSPC: no space left on device");
+      return h.io.writeFileAtomic(p, c);
+    },
+    onWriteFailed: (path: string, _err: unknown, attempt: number) => {
+      failed.push({ path, attempt });
+    },
+    onWriteRecovered: (path: string) => {
+      recovered.push(path);
+    },
+  };
+  return { ...h, io, failed, recovered, setFailing: (v: boolean) => (failing = v) };
+}
+
+describe("egest write failure", () => {
+  it("keeps the echo guard on the bytes actually on disk, reports, and retries until it lands", async () => {
+    vi.useFakeTimers();
+    try {
+      const r = failingIo({ [PATH]: SEED });
+      const bridge = await NoteBridge.open(r.io, { docId: "doc-1", path: PATH });
+      r.setFailing(true);
+
+      bridge.edit((t) => t.insert(t.toString().length, "!!!"));
+      await vi.advanceTimersByTimeAsync(300); // the egest fires and FAILS
+
+      // Nothing landed, and the guard still describes the file as it is — not
+      // the bytes that never made it.
+      expect(r.fs.get(PATH)).toBe(SEED);
+      expect(bridge.lastHash).toBe(sha256Hex(SEED));
+      expect(bridge.pendingWriteFailures).toBe(1);
+      expect(r.failed).toEqual([{ path: PATH, attempt: 1 }]);
+      expect(r.recovered).toEqual([]);
+
+      // A watcher read of the (unchanged) file in the meantime is a no-op: the
+      // file matches the guard, so no bogus "external edit" is diffed back into
+      // the doc and the user's text survives.
+      const opsBefore = bridge.updatesObserved;
+      bridge.ingest();
+      await vi.advanceTimersByTimeAsync(150);
+      expect(bridge.updatesObserved).toBe(opsBefore);
+      expect(bridge.serialize()).toBe(SEED + "!!!");
+
+      // Retry #1 at 1s — still failing. Backoff doubles.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(r.failed).toHaveLength(2);
+      expect(bridge.pendingWriteFailures).toBe(2);
+      await vi.advanceTimersByTimeAsync(1_000); // 1s into the 2s wait: nothing yet
+      expect(r.failed).toHaveLength(2);
+
+      // The disk comes back. The next retry lands, the guard moves to the new
+      // bytes, and the UI is told the note is safe again.
+      r.setFailing(false);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(r.fs.get(PATH)).toBe(SEED + "!!!");
+      expect(bridge.lastHash).toBe(sha256Hex(SEED + "!!!"));
+      expect(bridge.pendingWriteFailures).toBe(0);
+      expect(r.recovered).toEqual([PATH]);
+
+      // And the echo of that write is dropped as usual.
+      const ops = bridge.updatesObserved;
+      bridge.ingest();
+      await vi.advanceTimersByTimeAsync(150);
+      expect(bridge.updatesObserved).toBe(ops);
+      bridge.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushEgest on close forces an immediate retry instead of waiting out the backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const r = failingIo({ [PATH]: SEED });
+      const bridge = await NoteBridge.open(r.io, { docId: "doc-2", path: PATH });
+      r.setFailing(true);
+      bridge.edit((t) => t.insert(0, "x"));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(r.fs.get(PATH)).toBe(SEED);
+
+      r.setFailing(false);
+      await bridge.flushEgest(); // close/save path
+      expect(r.fs.get(PATH)).toBe("x" + SEED);
+      expect(r.recovered).toEqual([PATH]);
+      bridge.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a successful write still sets the guard exactly once, after the bytes land", async () => {
+    vi.useFakeTimers();
+    try {
+      const r = failingIo({ [PATH]: SEED });
+      const bridge = await NoteBridge.open(r.io, { docId: "doc-3", path: PATH });
+      bridge.edit((t) => t.insert(0, "y"));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(r.fs.get(PATH)).toBe("y" + SEED);
+      expect(bridge.lastHash).toBe(sha256Hex("y" + SEED));
+      expect(r.failed).toEqual([]);
+      expect(r.recovered).toEqual([]); // no failure, so no recovery cue either
+      bridge.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/app/apps/desktop/src/lib/bridge/adapter.ts
+++ b/app/apps/desktop/src/lib/bridge/adapter.ts
@@ -4,8 +4,46 @@
 
 import * as ipc from "../ipc";
 import { currentVaultEpoch } from "../sync/vaultScope";
+import { dismissToast, toast } from "../toast";
 import { NoteBridge } from "./noteBridge";
 import type { BridgeIO } from "./types";
+
+/**
+ * One sticky "couldn't save" toast per note with a failing egest, dismissed the
+ * moment a write lands. Module-level so every bridge (the open note's and the
+ * background store's) shares the same de-duplication.
+ */
+const saveFailureToasts = new Map<string, number>();
+
+function baseName(relPath: string): string {
+  const i = relPath.lastIndexOf("/");
+  return i === -1 ? relPath : relPath.slice(i + 1);
+}
+
+function errorText(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw.length > 160 ? `${raw.slice(0, 157)}…` : raw;
+}
+
+/** An egest write failed. Surface it once (sticky), keep it until it recovers. */
+export function reportSaveFailure(relPath: string, err: unknown, attempt: number): void {
+  if (saveFailureToasts.has(relPath)) return;
+  const id = toast(
+    `Couldn't save "${baseName(relPath)}" to disk — ${errorText(err)}. Your text is kept and the save will be retried.`,
+    "error",
+  );
+  saveFailureToasts.set(relPath, id);
+  if (attempt > 1) console.warn(`[bridge] save still failing for ${relPath} (attempt ${attempt})`);
+}
+
+/** A write landed after failures: clear the warning. */
+export function reportSaveRecovered(relPath: string): void {
+  const id = saveFailureToasts.get(relPath);
+  if (id == null) return;
+  saveFailureToasts.delete(relPath);
+  dismissToast(id);
+  toast(`Saved "${baseName(relPath)}"`, "success");
+}
 
 /** SHA-256 hex via the Web Crypto API (available in the Tauri webview). */
 export async function sha256Hex(text: string): Promise<string> {
@@ -34,6 +72,10 @@ export function createTauriBridgeIO(epoch?: ipc.VaultEpoch): BridgeIO {
     // so egest gets FTS/backlink refresh for free — no separate reindex hook.
     writeFileAtomic: (path, content) => ipc.writeNote(path, content, epoch),
     sha256: sha256Hex,
+    // A failed write is the one bridge error a person must see (#81): the .md is
+    // the durable copy, and "nothing happened" is how it would otherwise read.
+    onWriteFailed: reportSaveFailure,
+    onWriteRecovered: reportSaveRecovered,
     persistence: {
       loadState: async (docId) => {
         const s = await ipc.loadYjsState(docId, epoch);

--- a/app/apps/desktop/src/lib/bridge/noteBridge.ts
+++ b/app/apps/desktop/src/lib/bridge/noteBridge.ts
@@ -49,6 +49,9 @@ export class NoteBridge {
   private egestTimer: number | null = null;
   private ingestDirty = false;
   private destroyed = false;
+  /** Consecutive failed egest writes (0 once one lands). Drives the retry
+   *  backoff and the `onWriteFailed`/`onWriteRecovered` UI cues. */
+  private egestFailures = 0;
 
   private readonly setT: (fn: () => void, ms: number) => number;
   private readonly clearT: (id: number) => void;
@@ -338,15 +341,68 @@ export class NoteBridge {
         return;
       }
     }
-    // Set the echo guard BEFORE writing so the watcher's ingest sees our bytes
-    // and drops them (this is what closes the loop — spec 03 §5).
-    this.lastWrittenHash = await this.hash(content);
+    // Hash first, assign only once the bytes are CONFIRMED on disk. The guard
+    // used to be primed before the write; a failed write (disk full, permission
+    // lost, path gone) then left it pointing at bytes that never landed, so the
+    // next watcher read of the still-stale file was judged against the wrong
+    // baseline. Assigning after is still in time for the echo: the watcher's
+    // event is debounced ~150ms in Rust and ~150ms more here, while this
+    // assignment runs the moment the IPC resolves (spec 03 §5).
+    const hash = await this.hash(content);
     try {
       await this.io.writeFileAtomic(this._path, content);
-      if (this.io.reindex) await this.io.reindex(this._path);
     } catch (e) {
+      // The .md on disk is the durable source of truth, so a lost write is a
+      // data-safety event, not a log line: tell the UI, and retry with backoff
+      // until it lands (the CRDT still holds the text; nothing is dropped).
+      this.egestFailures++;
       this.reportError(e, "egest:write");
+      try {
+        this.io.onWriteFailed?.(this._path, e, this.egestFailures);
+      } catch (hookErr) {
+        this.reportError(hookErr, "egest:onWriteFailed");
+      }
+      this.scheduleEgestRetry();
+      return;
     }
+    this.lastWrittenHash = hash;
+    if (this.egestFailures > 0) {
+      this.egestFailures = 0;
+      try {
+        this.io.onWriteRecovered?.(this._path);
+      } catch (hookErr) {
+        this.reportError(hookErr, "egest:onWriteRecovered");
+      }
+    }
+    // Indexing is derived state: a failure here is worth a log, not a re-write.
+    if (this.io.reindex) {
+      try {
+        await this.io.reindex(this._path);
+      } catch (e) {
+        this.reportError(e, "egest:reindex");
+      }
+    }
+  }
+
+  /** Re-arm the egest after a failed write: 1s, 2s, 4s… capped (`egestRetryMaxMs`).
+   *  Reuses `egestTimer`, so `flushEgest` (close/save) still forces an attempt
+   *  and `destroy` still cancels it. */
+  private scheduleEgestRetry(): void {
+    if (this.destroyed) return;
+    const delay = Math.min(
+      this.cfg.egestRetryMaxMs,
+      this.cfg.egestRetryBaseMs * 2 ** Math.max(0, this.egestFailures - 1),
+    );
+    if (this.egestTimer != null) this.clearT(this.egestTimer);
+    this.egestTimer = this.setT(() => {
+      this.egestTimer = null;
+      void this.drainEgest();
+    }, delay);
+  }
+
+  /** Consecutive failed disk writes for this note (tests / observability). */
+  get pendingWriteFailures(): number {
+    return this.egestFailures;
   }
 
   /**

--- a/app/apps/desktop/src/lib/bridge/types.ts
+++ b/app/apps/desktop/src/lib/bridge/types.ts
@@ -47,6 +47,14 @@ export interface BridgeIO {
   reindex?(path: string): Promise<void> | void;
   /** Optional error sink (defaults to console.error). */
   onError?(err: unknown, context: string): void;
+  /**
+   * Optional: an egest (CRDT → disk) write FAILED. `attempt` counts consecutive
+   * failures for this note; the bridge retries with backoff on its own, so this
+   * is the UI's cue to say "couldn't save" — never a place to retry from.
+   */
+  onWriteFailed?(path: string, err: unknown, attempt: number): void;
+  /** Optional: an egest write succeeded after one or more failures. */
+  onWriteRecovered?(path: string): void;
   /** Optional timer injection; defaults to global setTimeout/clearTimeout. */
   setTimeout?(fn: () => void, ms: number): number;
   clearTimeout?(id: number): void;
@@ -62,6 +70,10 @@ export interface BridgeConfig {
   compactThreshold: number;
   /** Take a recovery snapshot before a diff that churns this fraction of the doc. */
   largeDiffRatio: number;
+  /** First retry delay after a failed egest write; doubles per consecutive
+   *  failure up to `egestRetryMaxMs`. */
+  egestRetryBaseMs: number;
+  egestRetryMaxMs: number;
   /**
    * Undo grouping window: local edits landing within this many ms of each other
    * merge into ONE undo step (Yjs `UndoManager.captureTimeout`). This is what
@@ -83,6 +95,8 @@ export const DEFAULT_CONFIG: BridgeConfig = {
   egestDebounceMs: 300,
   compactThreshold: 64,
   largeDiffRatio: 0.6,
+  egestRetryBaseMs: 1_000,
+  egestRetryMaxMs: 30_000,
   // 500ms matches Yjs' own default and CodeMirror's `newGroupDelay`, so undo
   // granularity feels the same as the non-collab editor.
   undoCaptureTimeoutMs: 500,

--- a/app/apps/desktop/src/lib/graph/buildGraph.test.ts
+++ b/app/apps/desktop/src/lib/graph/buildGraph.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assembleGraph } from "./buildGraph";
+import { assembleGraph, applyGraphDelta } from "./buildGraph";
 import type { NoteTitle } from "../ipc";
 
 function title(id: string, path: string, titleText: string): NoteTitle {
@@ -61,5 +61,67 @@ describe("assembleGraph", () => {
   it("returns an empty graph for an empty vault", () => {
     const graph = assembleGraph([], []);
     expect(graph).toEqual({ nodes: [], edges: [] });
+  });
+});
+
+describe("applyGraphDelta (#83)", () => {
+  const titles = [
+    { id: "a", path: "A.md", title: "A" },
+    { id: "b", path: "B.md", title: "B" },
+    { id: "c", path: "C.md", title: "C" },
+  ];
+  const base = () =>
+    assembleGraph(titles, [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+    ]);
+
+  it("replaces a changed note's edges and refreshes its title without touching the rest", () => {
+    // A's edit dropped its link to B and added one to C; its title changed too.
+    const next = applyGraphDelta(base(), {
+      nodes: [{ id: "a", path: "A.md", title: "Alpha" }],
+      edges: [{ source: "a", target: "c" }],
+    });
+    expect(next).not.toBeNull();
+    expect(next!.edges).toEqual([
+      { source: "b", target: "c" }, // untouched: neither end changed
+      { source: "a", target: "c" },
+    ]);
+    const byId = new Map(next!.nodes.map((n) => [n.id, n]));
+    expect(byId.get("a")).toMatchObject({ title: "Alpha", linkCount: 1 });
+    expect(byId.get("b")).toMatchObject({ title: "B", linkCount: 1 }); // lost a→b
+    expect(byId.get("c")).toMatchObject({ linkCount: 2 });
+  });
+
+  it("keeps edges INTO a changed note only if the delta still reports them", () => {
+    // B changed; the delta says a→b still exists but b→c is gone.
+    const next = applyGraphDelta(base(), {
+      nodes: [{ id: "b", path: "B.md", title: "B" }],
+      edges: [{ source: "a", target: "b" }],
+    });
+    expect(next!.edges).toEqual([{ source: "a", target: "b" }]);
+  });
+
+  it("refuses a delta naming a note the graph does not have (caller rebuilds)", () => {
+    expect(
+      applyGraphDelta(base(), {
+        nodes: [{ id: "new", path: "New.md", title: "New" }],
+        edges: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("is a no-op for a delta that changes nothing", () => {
+    const g = base();
+    const next = applyGraphDelta(g, {
+      nodes: [{ id: "a", path: "A.md", title: "A" }],
+      edges: [{ source: "a", target: "b" }],
+    });
+    // Same nodes and counts; edge ORDER may differ (kept edges first), which the
+    // renderer does not depend on.
+    expect(next!.nodes).toEqual(g.nodes);
+    expect(new Set(next!.edges.map((e) => `${e.source}->${e.target}`))).toEqual(
+      new Set(g.edges.map((e) => `${e.source}->${e.target}`)),
+    );
   });
 });

--- a/app/apps/desktop/src/lib/graph/buildGraph.ts
+++ b/app/apps/desktop/src/lib/graph/buildGraph.ts
@@ -10,7 +10,13 @@
 // transformation (dedupe, self-link/dangling-link filtering, linkCount
 // aggregation) can be unit-tested without Tauri.
 
-import { getGraphEdges, listNoteTitles, type NoteTitle } from "../ipc";
+import {
+  getGraphEdges,
+  getGraphEdgesFor,
+  getNoteMeta,
+  listNoteTitles,
+  type NoteTitle,
+} from "../ipc";
 
 export interface GraphNode {
   id: string;
@@ -70,4 +76,57 @@ export function assembleGraph(titles: NoteTitle[], rawEdges: GraphEdge[]): Graph
 export async function buildGraph(): Promise<Graph> {
   const [titles, edges] = await Promise.all([listNoteTitles(), getGraphEdges()]);
   return assembleGraph(titles, edges);
+}
+
+/** What changed for a handful of notes: their current title rows and EVERY
+ *  edge touching them (as source or target), fresh from the index. */
+export interface GraphDelta {
+  nodes: NoteTitle[];
+  edges: GraphEdge[];
+}
+
+/**
+ * Patch `graph` with a delta for the notes in `delta.nodes` (#83): their
+ * titles/paths are refreshed, every edge touching them is replaced by the
+ * delta's edges, and link counts are recomputed. Pure.
+ *
+ * Returns null when the delta names a note the graph does not have — a NEW note
+ * (or one the graph predates). A new note can also resolve OTHER notes' dangling
+ * `[[links]]`, which no per-note query would report, so the caller falls back to
+ * a full rebuild there rather than guess.
+ */
+export function applyGraphDelta(graph: Graph, delta: GraphDelta): Graph | null {
+  const changed = new Set(delta.nodes.map((n) => n.id));
+  const known = new Set(graph.nodes.map((n) => n.id));
+  for (const id of changed) if (!known.has(id)) return null;
+
+  // Refresh the changed rows in place; everything else is carried over as-is.
+  const fresh = new Map(delta.nodes.map((n) => [n.id, n] as const));
+  const titles: NoteTitle[] = graph.nodes.map((n) => {
+    const f = fresh.get(n.id);
+    return f ?? { id: n.id, path: n.path, title: n.title };
+  });
+
+  // Every edge touching a changed note is stale (a removed [[link]] would
+  // otherwise survive); the delta carries the current set for those notes.
+  const kept: GraphEdge[] = graph.edges.filter(
+    (e) => !changed.has(e.source) && !changed.has(e.target),
+  );
+  return assembleGraph(titles, [...kept, ...delta.edges]);
+}
+
+/**
+ * Fetch a delta for `paths` (modified notes) — two round trips bounded by the
+ * number of changed notes, not the vault. Returns null when any path no longer
+ * resolves to an indexed note (deleted/renamed under us): full rebuild.
+ */
+export async function fetchGraphDelta(paths: string[]): Promise<GraphDelta | null> {
+  const metas = await Promise.all(paths.map((p) => getNoteMeta(p)));
+  const nodes: NoteTitle[] = [];
+  for (const m of metas) {
+    if (!m) return null;
+    nodes.push({ id: m.id, path: m.path, title: m.title });
+  }
+  const edges = await getGraphEdgesFor(nodes.map((n) => n.id));
+  return { nodes, edges };
 }

--- a/app/apps/desktop/src/lib/graph/useGraphData.ts
+++ b/app/apps/desktop/src/lib/graph/useGraphData.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { UnlistenFn } from "@tauri-apps/api/event";
-import { buildGraph, type Graph } from "./buildGraph";
-import { onFileChanged } from "../ipc";
+import { applyGraphDelta, buildGraph, fetchGraphDelta, type Graph } from "./buildGraph";
+import { onFilesChanged, type FileChanged } from "../ipc";
 import { useStore } from "../../store";
 
 /** Delay before rebuilding after a file-changed event, so bursts of edits
@@ -22,12 +22,19 @@ export interface GraphDataState {
  *     the current vault even if this hook mounted before the index was ready
  *     (e.g. right after a vault switch or an app reload; otherwise the first,
  *     empty build would stick, since a view-only session fires no edits), and
- *  3. `file-changed` from the Rust watcher, debounced, for live edits.
+ *  3. `file-changed` from the Rust watcher, debounced, for live edits — as a
+ *     DELTA when the batch only modified notes the graph already has (#83):
+ *     re-query those notes' titles + edges and patch them in, instead of
+ *     re-reading every title and every edge in the vault per keystroke egest.
+ *     Removals, structural changes and unknown notes still take the full build.
  */
 export function useGraphData(): GraphDataState {
   const [graph, setGraph] = useState<Graph | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // The latest graph, readable from the debounce callback without re-subscribing.
+  const graphRef = useRef<Graph | null>(null);
+  graphRef.current = graph;
 
   // Guards async callbacks that outlive the component.
   const isMountedRef = useRef(true);
@@ -45,6 +52,9 @@ export function useGraphData(): GraphDataState {
   // Readiness signals: which vault is open, and how many notes it has indexed.
   const vaultPath = useStore((s) => s.vault?.path ?? null);
   const noteCount = useStore((s) => s.titles.length);
+  // Changed note paths accumulated across the debounce window; `null` once any
+  // change in the window ruled the delta path out (then it's a full rebuild).
+  const pendingPathsRef = useRef<Set<string> | null>(new Set());
 
   const applyBuild = useCallback((showLoading: boolean) => {
     const id = ++buildIdRef.current;
@@ -82,18 +92,67 @@ export function useGraphData(): GraphDataState {
     applyBuild(true);
   }, [applyBuild, vaultPath, noteCount]);
 
-  // Live updates: debounce file-changed events into one silent rebuild (no
-  // loading flash, so the view updates in place).
+  // Live updates: debounce file-changed events into one silent update (no
+  // loading flash, so the view updates in place) — a delta where possible.
   useEffect(() => {
     const rebuildSilently = () => applyBuild(false);
+
+    const applyDelta = (paths: string[]) => {
+      const id = ++buildIdRef.current;
+      const isLatest = () => isMountedRef.current && buildIdRef.current === id;
+      fetchGraphDelta(paths)
+        .then((delta) => {
+          if (!isLatest()) return;
+          if (!delta) {
+            rebuildSilently(); // a path stopped resolving — the index moved on
+            return;
+          }
+          let fellBack = false;
+          setGraph((prev) => {
+            if (!prev) return prev;
+            const next = applyGraphDelta(prev, delta);
+            if (next) return next;
+            fellBack = true; // a note the graph doesn't have yet
+            return prev;
+          });
+          if (fellBack) rebuildSilently();
+        })
+        .catch(() => {
+          if (isLatest()) rebuildSilently();
+        });
+    };
+
+    const flush = () => {
+      const paths = pendingPathsRef.current;
+      pendingPathsRef.current = new Set();
+      if (paths && paths.size > 0 && graphRef.current) applyDelta([...paths]);
+      else rebuildSilently();
+    };
+
+    const collect = (changes: FileChanged[]) => {
+      const pending = pendingPathsRef.current;
+      if (pending) {
+        for (const c of changes) {
+          // Only an in-place edit to a markdown note is a delta. A removal or a
+          // structural change (folder, rename, non-note file) can move or drop
+          // nodes the delta cannot see.
+          if (c.kind !== "modified" || !c.path.toLowerCase().endsWith(".md")) {
+            pendingPathsRef.current = null;
+            break;
+          }
+          pending.add(c.path);
+        }
+      }
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(flush, REBUILD_DEBOUNCE_MS);
+    };
 
     // Effect body can't be async; capture the unlisten fn when it resolves,
     // and tear down immediately if we already unmounted before it did.
     let unlisten: UnlistenFn | undefined;
     let cancelled = false;
-    onFileChanged(() => {
-      clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(rebuildSilently, REBUILD_DEBOUNCE_MS);
+    onFilesChanged((changes) => {
+      if (changes.length > 0) collect(changes);
     }).then((fn) => {
       if (cancelled) fn();
       else unlisten = fn;

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -311,6 +311,9 @@ export const getBacklinks = (noteId: string) =>
  *  Graph view instead of one getBacklinks per note. */
 export const getGraphEdges = () =>
   invoke<{ source: string; target: string }[]>("graph_edges");
+/** Only the edges touching `noteIds` — the Graph view's per-change delta (#83). */
+export const getGraphEdgesFor = (noteIds: string[]) =>
+  invoke<{ source: string; target: string }[]>("graph_edges_for", { noteIds });
 export const getNoteMeta = (path: string) =>
   invoke<NoteMeta | null>("get_note_meta", { path });
 export const resolveWikilink = (name: string) =>
@@ -479,3 +482,13 @@ export const onFileChanged = (cb: (e: FileChanged) => void): Promise<UnlistenFn>
 
 export const onVaultOpened = (cb: (v: VaultInfo) => void): Promise<UnlistenFn> =>
   listen<VaultInfo>("vault-opened", (event) => cb(event.payload));
+
+/** The background index rebuild `open_vault` starts has committed (#84). */
+export interface IndexReady {
+  path: string;
+  epoch: number;
+  ok: boolean;
+  ms: number;
+}
+export const onIndexReady = (cb: (e: IndexReady) => void): Promise<UnlistenFn> =>
+  listen<IndexReady>("index-ready", (event) => cb(event.payload));

--- a/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
@@ -14,7 +14,7 @@
 import { describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { makeHarness } from "../../bridge/__tests__/helpers";
-import { ContentUploader, type DocPush } from "../contentUpload";
+import { ContentUploader, MAX_NOTE_BYTES, type DocPush } from "../contentUpload";
 import { UPLOAD_CONCURRENCY } from "../pool";
 import type { SyncProgressSink } from "../progress";
 import { VaultDocStore } from "../vaultDocStore";
@@ -138,6 +138,8 @@ interface RigOptions {
   /** Reuse a previous rig's CRDT store, to model a SECOND run on one device. */
   harness?: ReturnType<typeof makeHarness>;
   onAcquire?: (docId: string, store: VaultDocStore) => void;
+  /** Wire the production `readFile` dep (the pre-network checks need it). */
+  readFile?: boolean;
 }
 
 function rig(opts: RigOptions) {
@@ -166,6 +168,7 @@ function rig(opts: RigOptions) {
       },
       release: (docId) => store.demote(docId),
       connect,
+      ...(opts.readFile ? { readFile: (relPath: string) => harness.io.readFile(relPath) } : {}),
     },
     isPushed: (id) => pushedSet.has(id),
     markPushed: (id) => {
@@ -187,6 +190,73 @@ function rig(opts: RigOptions) {
   });
   return { uploader, store, server, harness, connects, marked, sink, pushedSet };
 }
+
+describe("ContentUploader — pre-network checks (readFile)", () => {
+  it("settles a note the server lacks whose file is empty too, without a socket", async () => {
+    // The prod loop: 307 zero-byte .md files, all "pushed" locally, all named by
+    // `ready.empty` on every connect. Seeding an empty file inserts nothing, so
+    // the server kept holding nothing and named them again next time — a token
+    // mint and a WebSocket apiece, forever.
+    const r = rig({
+      files: { "Empty.md": "" },
+      notes: [{ docId: "e", relPath: "Empty.md" }],
+      pushed: new Set(["e"]),
+      include: () => true, // the server says it has nothing for this doc
+      readFile: true,
+    });
+    const result = await r.uploader.run();
+    expect(result).toMatchObject({ total: 1, pushed: 1, failed: 0 });
+    expect(r.connects).toEqual([]);
+    expect(r.marked).toEqual(["e"]);
+    const states = r.sink.stateOf("e");
+    expect(states[states.length - 1]).toBe("synced");
+    expect(r.store.hotSize()).toBe(0);
+  });
+
+  it("still PULLS for an empty placeholder when the server has not said it is empty", async () => {
+    // Same local shape (empty file, empty doc) but the server holds content the
+    // backfill never delivered here. Skipping the network would strand the note
+    // blank until the next reconnect — the socket is the recovery path.
+    const server = new FakeServer();
+    server.seed("p", "content from a teammate");
+    const r = rig({
+      files: { "Placeholder.md": "" },
+      notes: [{ docId: "p", relPath: "Placeholder.md" }],
+      server,
+      readFile: true,
+    });
+    await r.uploader.run();
+    expect(r.connects).toEqual(["p"]);
+    expect(r.harness.fs.get("Placeholder.md")).toBe("content from a teammate");
+  });
+
+  it("fails a note over the size ceiling permanently, without a socket or a streak hit", async () => {
+    const huge = "x".repeat(MAX_NOTE_BYTES + 1);
+    const r = rig({
+      files: { "Huge.md": huge, "Small.md": "fine" },
+      notes: [
+        { docId: "huge", relPath: "Huge.md" },
+        { docId: "small", relPath: "Small.md" },
+      ],
+      readFile: true,
+      concurrency: 1,
+      failureStreakLimit: 1, // a single COUNTED failure would abort the run
+    });
+    const result = await r.uploader.run();
+    // The oversized note failed once, for a reason a person can act on...
+    expect(r.uploader.failedDocs()).toEqual([
+      expect.objectContaining({
+        docId: "huge",
+        permanent: true,
+        reason: expect.stringContaining("10 MB"),
+      }),
+    ]);
+    expect(r.connects).toEqual(["small"]); // ...never dialled the server...
+    // ...and did not count toward the streak: the run carried on and pushed the rest.
+    expect(result).toMatchObject({ total: 2, pushed: 1, failed: 1, aborted: false });
+    expect(r.server.text("small")).toBe("fine");
+  });
+});
 
 describe("ContentUploader — pushing local content", () => {
   it("seeds an empty server doc from the local markdown", async () => {

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
@@ -36,6 +36,9 @@ const fakeRegistry = vi.hoisted(() => {
     reset: vi.fn(),
     getMapping: vi.fn((_relPath: string): { vaultId: string; docId: string } | null => null),
     pathForDocId: vi.fn((_docId: string): string | null => null),
+    /** relPaths the fake disk holds as EMPTY files. */
+    emptyOnDisk: new Set<string>(),
+    isNoteEmptyOnDisk: vi.fn(async (relPath: string) => reg.emptyOnDisk.has(relPath)),
     allDocIds: vi.fn((): string[] => []),
     setProgressSink: vi.fn(),
     setMapListener: vi.fn(),
@@ -190,6 +193,9 @@ beforeEach(() => {
   fakeRegistry.markPushed.mockClear();
   fakeRegistry.mappedNotes.mockReturnValue([]);
   fakeRegistry.getMapping.mockReturnValue(null);
+  fakeRegistry.pathForDocId.mockReturnValue(null);
+  fakeRegistry.emptyOnDisk = new Set();
+  fakeRegistry.isNoteEmptyOnDisk.mockClear();
   engineHooks.opts = null;
   engineHooks.started = 0;
   engineHooks.refreshes = 0;
@@ -288,6 +294,51 @@ describe("SyncManager — ready.empty is the authority", () => {
     // genuinely unconfirmed note. The open doc and the unmapped id are absent.
     expect(connects.order).toEqual(["lost-2", "lost-1", "fresh"]);
     expect(engineHooks.refreshes).toBe(0); // nothing was truncated
+  });
+
+  it("settles a server-empty doc whose local file is empty too - no push, ever", async () => {
+    // The production loop behind "310 files re-syncing on every reload": the
+    // vault holds hundreds of zero-byte placeholder notes. The server has no
+    // content for them (there is none), names them on every `ready`, and the run
+    // pushed each one over its own socket - seeding nothing - every connect.
+    const notes = [
+      { docId: "stub-1", relPath: "Daily/_Index.md" },
+      { docId: "stub-2", relPath: "Departments/_Index.md" },
+      { docId: "real", relPath: "Real.md" },
+    ];
+    fakeRegistry.mappedNotes.mockReturnValue(notes);
+    fakeRegistry.pathForDocId.mockImplementation(
+      (docId: string) => notes.find((n) => n.docId === docId)?.relPath ?? null,
+    );
+    fakeRegistry.emptyOnDisk = new Set(["Daily/_Index.md", "Departments/_Index.md"]);
+    for (const n of notes) fakeRegistry.pushed.add(n.docId);
+    const sm = new SyncManager();
+    const badges: Record<string, string> = {};
+    sm.setDocStateListener((patch) => {
+      for (const [id, state] of Object.entries(patch)) if (state) badges[id] = state;
+    });
+    await enable(sm);
+    engineHooks.settled = true;
+
+    engineHooks.opts!.onServerEmpty?.(["stub-1", "stub-2", "real"], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+
+    // Only the note with bytes to give dialled the server; the stubs were settled
+    // from disk, badged synced, and recorded as confirmed.
+    expect(connects.order).toEqual(["real"]);
+    expect(badges["stub-1"]).toBe("synced");
+    expect(badges["stub-2"]).toBe("synced");
+    expect(fakeRegistry.isNoteEmptyOnDisk).toHaveBeenCalledTimes(3);
+
+    // The next connect names them again (the server still has nothing, which is
+    // correct). This time not even the disk is consulted: nothing re-queues.
+    fakeRegistry.isNoteEmptyOnDisk.mockClear();
+    engineHooks.opts!.onServerEmpty?.(["stub-1", "stub-2"], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+    expect(connects.order).toEqual(["real"]);
+    expect(fakeRegistry.isNoteEmptyOnDisk).not.toHaveBeenCalled();
   });
 
   it("asks for the next batch when the server truncated its list", async () => {

--- a/app/apps/desktop/src/lib/sync/__tests__/syncManager.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/syncManager.test.ts
@@ -22,11 +22,14 @@ describe("deriveWsUrl", () => {
     expect(deriveWsUrl("https://api.baalda.com/")).toBe("wss://api.baalda.com/sync");
   });
 
-  it("swaps legacy dev port 3010 to the dedicated 3011, no path change", () => {
-    expect(deriveWsUrl("http://localhost:3010")).toBe("ws://localhost:3011");
+  it("keeps an explicit :3010 on the SAME port and appends /sync (single-port self-host, #79)", () => {
+    // The Compose bundle publishes only 3010; bumping to a dedicated 3011 here
+    // sent every content upload to a port nothing listened on.
+    expect(deriveWsUrl("http://localhost:3010")).toBe("ws://localhost:3010/sync");
+    expect(deriveWsUrl("http://127.0.0.1:3010")).toBe("ws://127.0.0.1:3010/sync");
   });
 
-  it("falls back to the local default for unparseable input", () => {
-    expect(deriveWsUrl("not a url")).toBe("ws://localhost:3011");
+  it("falls back to the local default on the HTTP port for unparseable input", () => {
+    expect(deriveWsUrl("not a url")).toBe("ws://localhost:3010/sync");
   });
 });

--- a/app/apps/desktop/src/lib/sync/contentUpload.ts
+++ b/app/apps/desktop/src/lib/sync/contentUpload.ts
@@ -59,13 +59,42 @@ export interface ContentUploadDeps {
   release(docId: string): Promise<void>;
   /** Attach a network provider to the bridge's Y.Doc (`new DocSync(...)`). */
   connect(input: { docId: string; vaultId: string; doc: Y.Doc }): DocPush;
+  /**
+   * Read a note's current file text (`ipc.readNote`, epoch-pinned). Optional so
+   * the older harnesses need not provide it; when present it powers the two
+   * pre-network checks in {@link ContentUploader.pushOne}: the empty-everywhere
+   * short-circuit and the size ceiling.
+   */
+  readFile?(relPath: string): Promise<string>;
 }
+
+/**
+ * The note-size ceiling, mirroring the server's `MAX_NOTE_MB` default (10 MB;
+ * `sync/hocuspocus.ts` refuses any sync message above it and closes the socket).
+ *
+ * Checked BEFORE a provider is opened. Without it a file over the cap was pushed
+ * on every connect: the server closed the connection, the push read as "server
+ * did not acknowledge", and — because the server still held nothing for the doc —
+ * the next `ready.empty` queued it again. Two such files in one production vault
+ * cost a rejected socket apiece on every reconnect of every member, forever.
+ * Here the doc fails ONCE, permanently, with a reason a person can act on.
+ */
+export const MAX_NOTE_BYTES = 10 * 1024 * 1024;
+
+const utf8 = new TextEncoder();
 
 /** A doc whose content could not be pushed, after retries. */
 export interface UploadFailure {
   docId: string;
   relPath: string;
   reason: string;
+  /**
+   * The failure is a property of the FILE, not of the network: retrying on the
+   * next `ready` cannot fix it (today: the note is over {@link MAX_NOTE_BYTES}).
+   * The session remembers these so they are not re-queued every connect, and
+   * they never count toward the failure streak that pauses a run.
+   */
+  permanent?: boolean;
 }
 
 export interface ContentUploaderOptions {
@@ -301,6 +330,61 @@ export class ContentUploader {
       return false;
     }
 
+    // Two checks that need no socket, both driven by the file's current bytes.
+    if (this.opts.deps.readFile) {
+      let fileText: string | null = null;
+      try {
+        fileText = await this.opts.deps.readFile(relPath);
+      } catch {
+        fileText = null; // unreadable — let the normal path decide (and report)
+      }
+      if (this.shouldStop()) {
+        await this.releaseQuietly(docId);
+        return false;
+      }
+      if (fileText != null) {
+        // (a) Over the server's size ceiling: the server would refuse the sync
+        //     message and close the socket, so don't open one. Permanent — the
+        //     bytes on disk have to change for this to ever succeed.
+        const bytes = utf8.encode(fileText).byteLength;
+        if (bytes > MAX_NOTE_BYTES) {
+          await this.releaseQuietly(docId);
+          const mb = (bytes / (1024 * 1024)).toFixed(1);
+          const cap = Math.round(MAX_NOTE_BYTES / (1024 * 1024));
+          this.fail(docId, relPath, `too large to sync (${mb} MB; the limit is ${cap} MB)`, {
+            permanent: true,
+          });
+          return false;
+        }
+        // (b) Nothing anywhere: the SERVER said it holds nothing for this doc
+        //     (`include`, fed by `ready.empty`), the file is empty AND the local
+        //     doc is empty. There is no text to seed and nothing to pull, so a
+        //     socket would only cost a token mint to learn that — and on a vault
+        //     with hundreds of empty placeholder files, `ready.empty` names every
+        //     one of them on EVERY connect, which is exactly how "310 files
+        //     re-syncing on each reload" happened. Record it as confirmed.
+        //
+        //     Gated on the server's word on purpose. Without `include`, an empty
+        //     file + empty doc can still mean "a placeholder whose backfill
+        //     frame this device missed" — the pull is what fills it in — or, on
+        //     a local-change run, "someone truncated the file", which the
+        //     post-sync ingest must propagate as a deletion. Both keep the
+        //     network path.
+        if (
+          fileText.length === 0 &&
+          bridge.serialize().length === 0 &&
+          (this.opts.include?.(docId) ?? false)
+        ) {
+          await this.releaseQuietly(docId);
+          this.streak = 0;
+          this.opts.markPushed(docId);
+          this.progress.doc(docId, "synced");
+          this.progress.item("ok");
+          return true;
+        }
+      }
+    }
+
     let preIngested = false;
     if (this.opts.ingestFromFile && bridge.serialize().length > 0) {
       preIngested = true;
@@ -390,10 +474,18 @@ export class ContentUploader {
     }
   }
 
-  private fail(docId: string, relPath: string, reason: string): void {
-    this.failures.push({ docId, relPath, reason });
+  private fail(
+    docId: string,
+    relPath: string,
+    reason: string,
+    opts: { permanent?: boolean } = {},
+  ): void {
+    this.failures.push({ docId, relPath, reason, ...(opts.permanent ? { permanent: true } : {}) });
     this.progress.doc(docId, "error");
     this.progress.item("failed");
+    // A permanent failure says nothing about the server's health, so it must
+    // not help trip the streak that pauses the run for everyone else.
+    if (opts.permanent) return;
     this.streak++;
     if (this.streak >= this.streakLimit && !this.aborted) {
       this.aborted = true;

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -19,7 +19,8 @@ import { api } from "../auth/authManager";
 import { colorForUser, presenceUser } from "../presence/color";
 import type { ActivityStatus } from "../prefs";
 import { AttachmentSync } from "./attachments";
-import { ContentUploader } from "./contentUpload";
+import { ContentUploader, type UploadFailure } from "./contentUpload";
+import { runPool } from "./pool";
 import { SyncProgressReporter } from "./progress";
 import { decideSeed } from "./startup";
 import { DocSync, type SyncStatus } from "./syncManager";
@@ -215,6 +216,29 @@ export class SyncManager implements InboundHost {
   /** The server truncated `ready.empty`: more empty docs exist than one frame
    *  names, so another `hello` is owed once this run drains them. */
   private serverEmptyTruncated = false;
+  /**
+   * Docs named by `ready.empty` whose LOCAL file is empty too — nothing anywhere.
+   *
+   * `ready.empty` is the authority on what the server lacks, but it cannot know
+   * that this device has nothing to give: a 0-byte `.md` is a legitimate note (an
+   * index stub, a placeholder someone meant to fill in). Pushing one seeds no
+   * text, the server keeps holding nothing, and the NEXT connect names it again —
+   * so a vault with 307 empty files "re-synced 307 notes" on every reload and
+   * every vault switch, a token mint and a WebSocket apiece, for nothing. These
+   * are settled here instead: marked pushed, badged synced, never queued. A
+   * watcher event for the file drops it from this set so real bytes still push.
+   */
+  private emptyEverywhere = new Set<string>();
+  /** The in-flight disk probe behind {@link handleServerEmpty}, if any. The
+   *  content run waits for it, so a run never starts from a half-filtered list. */
+  private emptyProbe: Promise<void> | null = null;
+  /**
+   * Docs the uploader gave up on PERMANENTLY (over the size ceiling): re-queuing
+   * them on every `ready` would only re-fail them. They stay unsynced — and the
+   * run stays `error` — until the file changes, which is when the watcher lets
+   * them back in. Keyed by docId like everything else here.
+   */
+  private permanentFailures = new Map<string, UploadFailure>();
   /** True while the run is reporting the vault channel's inbound queue. */
   private downloadPhase = false;
   /**
@@ -566,6 +590,11 @@ export class SyncManager implements InboundHost {
       // Belt and braces with the uploader's own `skip`: the open note's editor
       // session owns its provider, and its bridge already ingests watcher events.
       if (this.docStore?.suppressedDoc() === mapping.docId) continue;
+      // The file has new bytes, so two verdicts about its OLD bytes are void: an
+      // empty placeholder may now hold text, and an oversized file may have been
+      // trimmed under the ceiling. Both get a fresh push.
+      this.emptyEverywhere.delete(mapping.docId);
+      this.permanentFailures.delete(mapping.docId);
       this.localChanges.set(mapping.docId, relPath);
       this.armLocalChangeDrain(scope, LOCAL_CHANGE_DEBOUNCE_MS);
       // A doc resident in the hot tier has a LIVE bridge, and its next egest (a
@@ -639,6 +668,7 @@ export class SyncManager implements InboundHost {
         release: (docId) => store.demote(docId),
         connect: ({ docId, vaultId: collectionId, doc }) =>
           new DocSync({ api, doc, docId, vaultId: collectionId }),
+        readFile: (relPath) => ipc.readNote(relPath, scope.vaultEpoch),
       },
       isPushed: (docId) => this.registry.isPushed(docId),
       markPushed: (docId) => {
@@ -656,6 +686,7 @@ export class SyncManager implements InboundHost {
 
     const result = await uploader.run();
     if (!scope.isCurrent() || this.uploader !== uploader) return;
+    this.recordPermanentFailures(uploader);
     await this.registry.flushCheckpoint();
     if (!scope.isCurrent() || this.uploader !== uploader) return;
     if (result.cancelled) return;
@@ -747,6 +778,10 @@ export class SyncManager implements InboundHost {
   private startContentRunIfNeeded(scope: VaultScope): void {
     if (!this.enabled || !scope.isCurrent()) return;
     if (this.uploader?.isRunning()) return;
+    // The `ready.empty` list is still being checked against disk. Starting now
+    // would queue every named doc — including the empty placeholders the probe
+    // is about to settle — so the probe's completion re-enters here instead.
+    if (this.emptyProbe) return;
     const engine = this.vaultEngine;
     if (engine && !engine.backfillSettled()) return;
     if (this.contentWorkList().length === 0) {
@@ -782,6 +817,10 @@ export class SyncManager implements InboundHost {
       .filter(
         (n) =>
           n.docId !== open &&
+          // Settled as "nothing anywhere", or failed for a reason a retry can't
+          // fix — neither is work (see the field comments).
+          !this.emptyEverywhere.has(n.docId) &&
+          !this.permanentFailures.has(n.docId) &&
           (!this.registry.isPushed(n.docId) || this.serverEmpty.has(n.docId)),
       );
   }
@@ -798,11 +837,82 @@ export class SyncManager implements InboundHost {
   private handleServerEmpty(docIds: string[], truncated: boolean, scope: VaultScope): void {
     if (!scope.isCurrent()) return;
     this.clearChannelWatchdog(); // `ready` arrived — the channel is alive
-    this.serverEmpty = new Set(docIds);
     this.serverEmptyTruncated = truncated;
     // A live run keeps its queue and picks this set up on its next pass; only
-    // the set is refreshed here.
+    // the set is refreshed here. The refresh itself may need the disk (see
+    // `settleServerEmpty`); when it does, the run start waits for it.
+    const settled = this.settleServerEmpty(docIds, scope);
+    if (settled instanceof Promise) {
+      const probe = settled.then(() => {
+        if (this.emptyProbe === probe) this.emptyProbe = null;
+        if (!scope.isCurrent()) return;
+        this.startContentRunIfNeeded(scope);
+      });
+      this.emptyProbe = probe;
+      return;
+    }
+    this.serverEmpty = settled;
     this.startContentRunIfNeeded(scope);
+  }
+
+  /**
+   * Turn `ready.empty` into the docs that actually need a push, settling the
+   * ones this device has nothing for (see {@link emptyEverywhere}).
+   *
+   * Synchronous when nothing has to be read — a doc whose path is unknown here
+   * stays in the list (the run can't manufacture work for it anyway, but this
+   * layer must not decide that), and one already settled is skipped without a
+   * read. Otherwise the remaining files are read with bounded concurrency and
+   * the result lands in `serverEmpty` when the promise resolves. Every step is
+   * scope-guarded: a vault switch mid-probe leaves the new vault's set alone.
+   */
+  private settleServerEmpty(docIds: string[], scope: VaultScope): Set<string> | Promise<void> {
+    const keep = new Set<string>();
+    const toProbe: Array<{ docId: string; relPath: string }> = [];
+    for (const docId of docIds) {
+      if (this.emptyEverywhere.has(docId) || this.permanentFailures.has(docId)) continue;
+      const relPath = this.registry.pathForDocId(docId);
+      if (!relPath) {
+        keep.add(docId);
+        continue;
+      }
+      toProbe.push({ docId, relPath });
+    }
+    if (toProbe.length === 0) return keep;
+    return runPool(
+      toProbe,
+      async ({ docId, relPath }) => {
+        let empty = false;
+        try {
+          empty = await this.registry.isNoteEmptyOnDisk(relPath);
+        } catch {
+          empty = false; // unreadable ⇒ let the run try (and report) it
+        }
+        if (!scope.isCurrent()) return;
+        if (!empty) {
+          keep.add(docId);
+          return;
+        }
+        // Nothing here, nothing there. Confirmed by definition — there is no
+        // content whose arrival on the server could still be pending.
+        this.emptyEverywhere.add(docId);
+        this.registry.markPushed(docId);
+        this.progress?.doc(docId, "synced");
+      },
+      { concurrency: 8, shouldStop: () => !scope.isCurrent() },
+    ).then(() => {
+      if (!scope.isCurrent()) return;
+      this.serverEmpty = keep;
+      this.progress?.flush();
+    });
+  }
+
+  /** Remember the run's permanent failures so later runs neither re-queue nor
+   *  forget them (each run builds a fresh uploader with an empty failure list). */
+  private recordPermanentFailures(uploader: ContentUploader): void {
+    for (const f of uploader.failedDocs()) {
+      if (f.permanent) this.permanentFailures.set(f.docId, f);
+    }
   }
 
   isEnabled(): boolean {
@@ -919,8 +1029,10 @@ export class SyncManager implements InboundHost {
   }
 
   /** Resolves when the current bulk sync run settles (tests / shutdown). */
-  whenBulkSyncSettled(): Promise<void> {
-    return this.bulkRun ?? Promise.resolve();
+  async whenBulkSyncSettled(): Promise<void> {
+    // The disk probe behind a `ready` runs before the run it may start.
+    while (this.emptyProbe) await this.emptyProbe;
+    await (this.bulkRun ?? Promise.resolve());
   }
 
   /**
@@ -987,6 +1099,7 @@ export class SyncManager implements InboundHost {
         release: (docId) => store.demote(docId),
         connect: ({ docId, vaultId: collectionId, doc }) =>
           new DocSync({ api, doc, docId, vaultId: collectionId }),
+        readFile: (relPath) => ipc.readNote(relPath, scope.vaultEpoch),
       },
       isPushed: (docId) => this.registry.isPushed(docId),
       // The server's word beats our checkpoint: a doc it holds no content for is
@@ -1010,6 +1123,7 @@ export class SyncManager implements InboundHost {
 
     const result = await uploader.run();
     if (!scope.isCurrent() || this.uploader !== uploader) return;
+    this.recordPermanentFailures(uploader);
     // Durably record what we pushed before claiming anything: this is the resume
     // point a kill -9 falls back to.
     await this.registry.flushCheckpoint();
@@ -1126,6 +1240,7 @@ export class SyncManager implements InboundHost {
     const uploadFailures = this.uploader?.failedDocs().length ?? 0;
     const clean =
       uploadFailures === 0 &&
+      this.permanentFailures.size === 0 &&
       !this.registry.hasFailures() &&
       this.registry.limitCode() == null;
     progress.phase(clean ? "done" : "error");
@@ -1138,9 +1253,17 @@ export class SyncManager implements InboundHost {
     content: Array<{ docId: string; relPath: string; reason: string }>;
     limitCode: string | null;
   } {
+    // Permanent failures are remembered across runs (see the field), so they are
+    // reported from there; the live uploader's list covers this run's transient
+    // ones. A doc in both is listed once.
+    const content = [...this.permanentFailures.values()];
+    const seen = new Set(content.map((f) => f.docId));
+    for (const f of this.uploader?.failedDocs() ?? []) {
+      if (!seen.has(f.docId)) content.push(f);
+    }
     return {
       registry: this.registry.failures(),
-      content: this.uploader?.failedDocs() ?? [],
+      content,
       limitCode: this.registry.limitCode(),
     };
   }
@@ -1184,6 +1307,9 @@ export class SyncManager implements InboundHost {
     // list would put ITS doc ids at the head of this vault's upload queue.
     this.serverEmpty.clear();
     this.serverEmptyTruncated = false;
+    this.emptyEverywhere.clear();
+    this.permanentFailures.clear();
+    this.emptyProbe = null; // a probe still in flight sees a stale scope and drops
     // The bulk run before the engine it borrows from: `stop()` makes every pool
     // lane drop at its next checkpoint, so nothing is still promoting a bridge
     // when `stopVaultEngine` destroys the store underneath it.

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -836,6 +836,16 @@ export class VaultRegistry {
     return { changedDisk, suppress: plan.suppress };
   }
 
+  /**
+   * Is this note empty on disk (nothing but whitespace)? Public for the session's
+   * `ready.empty` probe: a doc the server has no content for AND whose file here
+   * is empty has nothing to push, so it must not be queued (see
+   * `SyncManager.settleServerEmpty`). Epoch-pinned like every read here.
+   */
+  isNoteEmptyOnDisk(relPath: string): Promise<boolean> {
+    return this.isEmptyOnDisk(relPath);
+  }
+
   /** Is this note empty on disk? Used to decide whether an unconfirmed note is
    *  safe to remove — an empty file can't be holding the only copy of anything. */
   private async isEmptyOnDisk(relPath: string): Promise<boolean> {

--- a/app/apps/desktop/src/lib/sync/syncManager.ts
+++ b/app/apps/desktop/src/lib/sync/syncManager.ts
@@ -78,35 +78,37 @@ export function ttlFromToken(token: string, nowMs = Date.now()): number {
 }
 
 /**
- * Derive the sync WebSocket URL from the HTTP base.
+ * Derive the per-note sync WebSocket URL from the HTTP base.
  *
- * Two server topologies, two rules:
- *  - Local/self-hosted dev (explicit port 3010, README "Ports" default): the
- *    dedicated Hocuspocus port 3011 is still separate from the HTTP API, so we
- *    just swap scheme http→ws and bump 3010→3011, path untouched. Kept for
- *    back-compat with existing dev setups and older self-hosted servers.
- *  - Everything else — no port (a normal hosted domain) or any other explicit
- *    port (e.g. a PaaS-assigned :8080) — assumes the single-port topology: the
- *    WS upgrade is mounted at `/sync` on the SAME origin/port as the HTTP API.
- *    We swap scheme and append `/sync` after any existing path (preserving a
- *    reverse-proxy sub-path prefix), collapsing double/trailing slashes. This
- *    is what lets the server run behind one domain on PaaS hosts.
+ * ONE rule: the Hocuspocus upgrade is mounted at `/sync` on the SAME origin and
+ * port as the HTTP API (`sync/http-upgrade.ts`), so we swap the scheme and
+ * append `/sync` after any existing path — preserving a reverse-proxy sub-path
+ * prefix and collapsing double/trailing slashes. Identical to how the vault
+ * channel derives its `/vault-sync` URL (`deriveVaultWsUrl`).
  *
- * Unparseable input falls back to the legacy local default.
+ * This used to special-case an explicit `:3010` and bump it to the dedicated
+ * Hocuspocus port `:3011`, "for local dev". That assumption broke every
+ * single-port self-host: the Docker Compose bundle publishes ONLY 3010, so with
+ * a server URL of `http://localhost:3010` the vault channel connected (one TCP
+ * connection to :3010, structure and downloads fine) while every per-note
+ * provider — the path ALL content uploads take — dialled a port nothing was
+ * listening on, timed out, and the run gave up after ten failures. The server
+ * held a `notes` row and no content for every file, forever (#79). The server
+ * has served `/sync` on the HTTP port since single-port deploys existed, so the
+ * dedicated port is never needed by a client; `HOCUSPOCUS_PORT` stays for
+ * anything else that still dials it.
+ *
+ * Unparseable input falls back to the local default, on the HTTP port.
  */
 export function deriveWsUrl(httpBase: string): string {
   try {
     const u = new URL(httpBase);
     u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
-    if (u.port === "3010") {
-      u.port = "3011";
-    } else {
-      const prefix = u.pathname.replace(/\/+$/, "");
-      u.pathname = `${prefix}/sync`;
-    }
+    const prefix = u.pathname.replace(/\/+$/, "");
+    u.pathname = `${prefix}/sync`;
     return u.toString().replace(/\/+$/, "");
   } catch {
-    return "ws://localhost:3011";
+    return "ws://localhost:3010/sync";
   }
 }
 

--- a/app/apps/desktop/src/lib/tree/lazyTree.test.ts
+++ b/app/apps/desktop/src/lib/tree/lazyTree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TreeNode } from "../ipc";
-import { loadedFolderPaths, setChildrenAt } from "./lazyTree";
+import { loadedFolderPaths, setChildrenAt, implicatedFolders, mergeChildren, nodeAt } from "./lazyTree";
 
 // The sidebar folds itself up if a refresh forgets which folders were expanded.
 // `refreshTree` runs on every `file-changed` burst and every sync registry pull
@@ -140,5 +140,70 @@ describe("restoring an expanded tree the way refreshTree does", () => {
     const rebuilt = rootWith([]);
     expect(loadedFolderPaths(expanded)).toEqual(["Gone"]);
     expect(rebuilt.children).toEqual([]);
+  });
+});
+
+describe("targeted refresh helpers (#82)", () => {
+  const dir = (path: string, extra: Partial<TreeNode> = {}): TreeNode => ({
+    id: path,
+    name: path.split("/").pop() ?? path,
+    path,
+    isDir: true,
+    children: [],
+    ...extra,
+  });
+  const file = (path: string): TreeNode => ({
+    id: path,
+    name: path.split("/").pop() ?? path,
+    path,
+    isDir: false,
+  });
+
+  it("implicatedFolders: a file change implicates only its parent; structure means everything", () => {
+    expect(
+      implicatedFolders([
+        { path: "Daily/2026-09-04.md", kind: "modified" },
+        { path: "Root.md", kind: "removed" },
+        { path: "Daily/notes.md", kind: "modified" },
+      ]),
+    ).toEqual(new Set(["Daily", ""]));
+    expect(
+      implicatedFolders([
+        { path: "Daily/x.md", kind: "modified" },
+        { path: "Archive", kind: "tree" },
+      ]),
+    ).toBeNull();
+  });
+
+  it("mergeChildren keeps an expanded sub-folder loaded across a fresh listing", () => {
+    const previous = [
+      dir("A/inner", { childrenLoaded: true, children: [file("A/inner/n.md")] }),
+      dir("A/stale", { childrenLoaded: true, children: [file("A/stale/old.md")] }),
+      file("A/gone.md"),
+    ];
+    // The fresh listing: `inner` (as a placeholder), a new folder, a new file;
+    // `stale` and `gone.md` left the disk.
+    const fresh = [dir("A/inner", { childrenLoaded: false }), dir("A/new"), file("A/new.md")];
+    const merged = mergeChildren(previous, fresh);
+    expect(merged.map((n) => n.path)).toEqual(["A/inner", "A/new", "A/new.md"]);
+    const inner = merged[0];
+    expect(inner.childrenLoaded).toBe(true);
+    expect(inner.children?.map((c) => c.path)).toEqual(["A/inner/n.md"]);
+    expect(merged[1].childrenLoaded).toBeFalsy();
+  });
+
+  it("nodeAt finds a loaded folder by path and returns null for an unloaded one", () => {
+    const root: TreeNode = dir("", {
+      childrenLoaded: true,
+      children: [
+        dir("A", { childrenLoaded: true, children: [dir("A/inner", { childrenLoaded: true })] }),
+        dir("B"),
+      ],
+    });
+    expect(nodeAt(root, "")?.path).toBe("");
+    expect(nodeAt(root, "A/inner")?.path).toBe("A/inner");
+    expect(nodeAt(root, "B")?.path).toBe("B");
+    expect(nodeAt(root, "B/deeper")).toBeNull();
+    expect(nodeAt(root, "Absent")).toBeNull();
   });
 });

--- a/app/apps/desktop/src/lib/tree/lazyTree.ts
+++ b/app/apps/desktop/src/lib/tree/lazyTree.ts
@@ -24,6 +24,55 @@ export function loadedFolderPaths(node: TreeNode | null): string[] {
   return out.sort((a, b) => a.split("/").length - b.split("/").length);
 }
 
+/**
+ * A fresh listing of one folder, with the previously-loaded subtrees carried
+ * over: a sub-folder present in both keeps its old `children`/`childrenLoaded`
+ * (the listing only knows it as an unloaded placeholder), so re-listing a
+ * folder never folds up what the user had expanded beneath it. Sub-folders that
+ * left the listing drop out; new ones arrive as placeholders.
+ */
+export function mergeChildren(previous: TreeNode[] | undefined, fresh: TreeNode[]): TreeNode[] {
+  if (!previous || previous.length === 0) return fresh;
+  const byPath = new Map<string, TreeNode>();
+  for (const p of previous) if (p.isDir && p.childrenLoaded === true) byPath.set(p.path, p);
+  if (byPath.size === 0) return fresh;
+  return fresh.map((node) => {
+    if (!node.isDir || node.childrenLoaded === true) return node;
+    const loaded = byPath.get(node.path);
+    return loaded ? { ...node, children: loaded.children, childrenLoaded: true } : node;
+  });
+}
+
+/** The node at `path` in a lazy-loaded tree, or null if it isn't loaded. */
+export function nodeAt(node: TreeNode, path: string): TreeNode | null {
+  if (node.path === path) return node;
+  if (!node.children) return null;
+  for (const c of node.children) {
+    if (!c.isDir) continue;
+    if (path === c.path || path.startsWith(`${c.path}/`)) return nodeAt(c, path);
+  }
+  return null;
+}
+
+/**
+ * The folders a watcher batch can have changed the LISTING of, for a targeted
+ * sidebar refresh (#82): a modified or removed file changes only its parent
+ * folder's listing. Returns null when the batch has a structural change (`tree`:
+ * a folder created/removed/renamed, a non-note file) — those can move whole
+ * subtrees, and only a full re-list is honest there.
+ */
+export function implicatedFolders(
+  changes: ReadonlyArray<{ path: string; kind: "modified" | "removed" | "tree" }>,
+): Set<string> | null {
+  const dirs = new Set<string>();
+  for (const c of changes) {
+    if (c.kind === "tree") return null;
+    const i = c.path.lastIndexOf("/");
+    dirs.add(i === -1 ? "" : c.path.slice(0, i));
+  }
+  return dirs;
+}
+
 /** Immutably replace one node's `children` (by path) in a lazy-loaded tree. */
 export function setChildrenAt(
   node: TreeNode,

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -293,6 +293,13 @@ interface AppStore {
   pruneTabs: (paths: string[]) => void;
   /** Re-point tabs across a rename/move of a file or a folder subtree. */
   remapTabs: (from: string, to: string) => void;
+  /** Close every tab except the given one, which takes (or keeps) the screen. */
+  closeOtherTabs: (path: string) => void;
+  /** Close every tab after the given one; it takes the screen if the active
+   *  tab was among the closed. */
+  closeTabsToRight: (path: string) => void;
+  /** Close every tab and clear the editor. */
+  closeAllTabs: () => void;
 
   // Auth actions
   initAuth: () => Promise<void>;
@@ -1283,6 +1290,32 @@ export const useStore = create<AppStore>((set, get) => ({
     if (next.length !== tabs.length || next.some((p, i) => p !== tabs[i])) {
       set({ openTabs: next });
     }
+  },
+
+  closeOtherTabs: (path) => {
+    // No membership guard: the strip can offer this on the phantom tab it
+    // renders for an open note that vault machinery dropped from the list —
+    // "close others" then simply makes that note's tab real and only.
+    set({ openTabs: [path] });
+    // The survivor takes the screen; leaving a closed tab's note up would break
+    // the strip's "active = what's on screen" rule.
+    if (get().openNote?.path !== path) void get().openNoteByPath(path);
+  },
+
+  closeTabsToRight: (path) => {
+    const { openTabs, openNote } = get();
+    const idx = openTabs.indexOf(path);
+    if (idx === -1 || idx === openTabs.length - 1) return;
+    const next = openTabs.slice(0, idx + 1);
+    set({ openTabs: next });
+    // The active tab was among the closed: the anchor of the close is the
+    // nearest survivor, so it takes the screen.
+    if (openNote && !next.includes(openNote.path)) void get().openNoteByPath(path);
+  },
+
+  closeAllTabs: () => {
+    set({ openTabs: [] });
+    get().closeNote();
   },
 
   // ---- Auth ----

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -13,7 +13,7 @@ import {
   writeItemColors,
 } from "./lib/appearance";
 import { readItemOrder, writeItemOrder, type ItemOrder } from "./lib/ordering";
-import { loadedFolderPaths, setChildrenAt } from "./lib/tree/lazyTree";
+import { loadedFolderPaths, mergeChildren, nodeAt, setChildrenAt } from "./lib/tree/lazyTree";
 import {
   ApiError,
   type BillingConfig,
@@ -66,6 +66,10 @@ import {
   queueNoteLink,
   takePendingNoteLink,
 } from "./lib/noteLinkFlow";
+
+/** Notes already toasted about a failed sync registration — one sticky
+ *  explanation per note is enough; the retry is automatic. */
+const registerFailureToasted = new Set<string>();
 
 export interface OpenNote {
   path: string;
@@ -267,7 +271,12 @@ interface AppStore {
   setRootFrozen: (frozen: boolean) => Promise<void>;
   setItemOrder: (order: ItemOrder) => void;
   setTreeSort: (sort: TreeSort) => void;
-  refreshTree: () => Promise<void>;
+  /**
+   * Re-list the sidebar. With `folders`, ONLY those folder listings are re-read
+   * (the watcher batch said nothing else changed); without it, the root and
+   * every expanded folder are re-listed.
+   */
+  refreshTree: (folders?: ReadonlySet<string>) => Promise<void>;
   /** Lazily load one folder's immediate children into the sidebar tree. */
   loadChildren: (path: string) => Promise<void>;
   refreshTitles: () => Promise<void>;
@@ -969,12 +978,45 @@ export const useStore = create<AppStore>((set, get) => ({
     set({ treeSort: sort });
   },
 
-  refreshTree: async () => {
+  refreshTree: async (folders) => {
     // Lazy loading: fetch only the vault's top level, not the whole tree.
     // Folders load their children on first expand (see `loadChildren`), so
     // switching a large vault no longer ships/parses the entire node set.
     const vault = get().vault;
     const epoch = vault?.epoch;
+    const current = get().tree;
+    // Targeted refresh (#82): the watcher told us which files changed, so only
+    // their parent folders' listings can differ. Re-list exactly those (and only
+    // if they are on screen — a collapsed folder has no listing to refresh),
+    // patching them into the tree in place. Every file change used to re-list
+    // the root AND every expanded folder, one IPC apiece — a burst of
+    // filesystem work per keystroke egest on a big tree.
+    if (folders && current) {
+      const loaded = new Set(loadedFolderPaths(current));
+      const targets = [...folders].filter((dir) => dir === "" || loaded.has(dir));
+      if (targets.length === 0) return;
+      const listings = await Promise.all(
+        targets.map(async (dir) => {
+          try {
+            return { dir, kids: await ipc.listChildren(dir, epoch) };
+          } catch (e) {
+            if (ipc.isVaultMismatch(e)) return { dir, kids: null };
+            return { dir, kids: null }; // folder gone mid-refresh: leave it, the
+            // structural batch that follows re-lists its parent
+          }
+        }),
+      );
+      if (!sameVault(get, epoch)) return;
+      let next = get().tree; // re-read: another refresh may have landed meanwhile
+      if (!next) return;
+      for (const { dir, kids } of listings) {
+        if (!kids) continue;
+        const merged = mergeChildren(nodeAt(next, dir)?.children, kids);
+        next = setChildrenAt(next, dir, merged);
+      }
+      set({ tree: next });
+      return;
+    }
     // Which folders were already expanded/listed. This refresh runs on every
     // `file-changed` burst and every sync registry pull — i.e. constantly while
     // you work — and rebuilding from the top level alone would drop each of
@@ -1108,6 +1150,27 @@ export const useStore = create<AppStore>((set, get) => ({
           await syncManager.registry.registerNote(path, title, meta?.id);
         } catch (e) {
           console.warn("[sync] registerNote failed", e);
+          if (!sameVault(get, epoch)) return;
+          // The note opens regardless (local-first: the text is safe on disk),
+          // but it opens UNREGISTERED — no docId, so no provider connects and
+          // nothing it says reaches the server. Two things keep that from being
+          // silent (#80): the row stays badged unsynced (it has no mapping, and
+          // the sidebar counts unmapped notes as unsynced), and the same
+          // debounced registry pull a teammate's change triggers is armed here,
+          // which registers the note and uploads its content when it runs.
+          syncManager.handleRegistryChanged();
+          // Say so once per note. Skipped while the vault channel itself is down:
+          // the connection indicator already reads "Retrying…", and a toast per
+          // opened note while offline would only bury it.
+          if (get().syncStatus === "synced" && !registerFailureToasted.has(path)) {
+            registerFailureToasted.add(path);
+            toast(
+              `"${title}" couldn't be registered for sync — ${
+                e instanceof Error ? e.message : String(e)
+              }. It's saved on this device and will be retried.`,
+              "error",
+            );
+          }
         }
         if (!sameVault(get, epoch)) return;
       }

--- a/app/apps/server/README.md
+++ b/app/apps/server/README.md
@@ -88,7 +88,7 @@ npm run build && npm run start
 ```
 
 - HTTP API → `http://localhost:3010`
-- Hocuspocus sync → `ws://localhost:3011`
+- Hocuspocus sync → `ws://localhost:3010/sync` (the desktop app always uses the HTTP port + `/sync`; the dedicated `ws://localhost:3011` still listens)
 - Health check → `GET /health`
 
 ## Ports & env (`.env`)

--- a/app/apps/server/src/db/text.ts
+++ b/app/apps/server/src/db/text.ts
@@ -1,0 +1,11 @@
+/**
+ * Postgres `text` cannot hold U+0000 — every INSERT of a note body carrying one
+ * fails with `invalid byte sequence for encoding "UTF8": 0x00`, which took a
+ * whole vault's daily checkpoint down with it in production (one note in
+ * `Archive/…` held a NUL). Yjs text is fine with it; only the DERIVED copies
+ * (search index, versions, checkpoints) live in Postgres, so strip it there.
+ * The CRDT — the note itself — is untouched.
+ */
+export function pgText(s: string): string {
+  return s.includes("\u0000") ? s.replace(/\u0000/g, "") : s;
+}

--- a/app/apps/server/src/index/indexer.ts
+++ b/app/apps/server/src/index/indexer.ts
@@ -1,4 +1,5 @@
 import * as Y from "yjs";
+import { pgText } from "../db/text.js";
 import type pg from "pg";
 import { pool as defaultPool } from "../db/pool.js";
 import { loadDocState } from "../yjs/persistence.js";
@@ -94,8 +95,10 @@ export async function indexDoc(
     return false;
   }
 
-  const content = await extractDocText(docId, db);
-  const title = note.title ?? relPathStem(note.rel_path);
+  // Postgres rejects NUL in `text`; a single such byte in one note used to fail
+  // that note's indexing forever (see `pgText`).
+  const content = pgText(await extractDocText(docId, db));
+  const title = pgText(note.title ?? relPathStem(note.rel_path));
   const links = parseWikilinks(content);
   // Embed title + body so a query matching the title still ranks the note.
   const vector = embed(`${title ?? ""}\n${content}`);

--- a/app/apps/server/src/mcp/doc-writer.ts
+++ b/app/apps/server/src/mcp/doc-writer.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as Y from "yjs";
 import type { LocalTransactionOrigin, Server } from "@hocuspocus/server";
 import { formatDocName } from "../sync/doc-name.js";
@@ -33,7 +34,53 @@ export interface DocActor {
   userId?: string | null;
 }
 
+/**
+ * One targeted change to a note body: delete `deleteLength` chars at `index`,
+ * then insert `insert` there. Applied IN ORDER, each index relative to the text
+ * as left by the previous op — the natural shape of "edit, then edit again".
+ */
+export interface TextOp {
+  index: number;
+  deleteLength: number;
+  insert: string;
+}
+
+/**
+ * The revision of a note body: sha256 of its current text. What `read_note`
+ * hands out and what a mutation may be preconditioned on (#78) — a stable,
+ * cheap identity for "the text I read", with no server-side revision counter to
+ * keep (the CRDT has no single version number; the content hash is the honest
+ * equivalent).
+ */
+export function revisionOf(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/** A mutation's precondition failed: the note is not the text the caller read. */
+export class StaleRevisionError extends Error {
+  constructor(
+    readonly expected: string,
+    readonly actual: string,
+  ) {
+    super(
+      `Stale write: the note changed since it was read (revision ${actual.slice(0, 12)}…, expected ${expected.slice(0, 12)}…). Read it again and retry.`,
+    );
+  }
+}
+
 export interface DocWriter {
+  /**
+   * Apply targeted ops (#78). `plan` runs under the doc's write lock with the
+   * CURRENT text and returns the ops to apply, or throws to abort with nothing
+   * written — that is where a revision precondition is checked, so the check and
+   * the write are one atomic step. Returns the resulting text's revision.
+   */
+  editContent(
+    vaultId: string,
+    docId: string,
+    plan: (current: string) => TextOp[],
+    actor?: DocActor,
+  ): Promise<{ revision: string; content: string }>;
   /** Replace the whole note body. */
   setContent(
     vaultId: string,
@@ -101,7 +148,41 @@ export function createDocWriter(
   publishUpdate?: DocUpdatePublisher,
   onDocWritten?: DocWrittenHook,
 ): DocWriter {
-  async function mutate(
+  /**
+   * Per-doc write serialisation. The detached path awaits between reading the
+   * stored state and appending its update, so two concurrent MCP writes to one
+   * note used to each hydrate the SAME state and each apply a whole-body
+   * delete+insert — Yjs merged both inserts and the note held the text twice
+   * (#78's "duplicated" outcome). Chaining per docId makes the second write see
+   * the first's result, which is also what makes a revision precondition mean
+   * anything. Self-cleaning: an entry is removed once its chain settles.
+   */
+  const locks = new Map<string, Promise<unknown>>();
+  async function withDocLock<T>(docId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = locks.get(docId) ?? Promise.resolve();
+    const run = prev.then(fn, fn);
+    const chain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    locks.set(docId, chain);
+    try {
+      return await run;
+    } finally {
+      if (locks.get(docId) === chain) locks.delete(docId);
+    }
+  }
+
+  function mutate(
+    vaultId: string,
+    docId: string,
+    fn: (text: Y.Text) => void,
+    actor?: DocActor,
+  ): Promise<void> {
+    return withDocLock(docId, () => mutateLocked(vaultId, docId, fn, actor));
+  }
+
+  async function mutateLocked(
     vaultId: string,
     docId: string,
     fn: (text: Y.Text) => void,
@@ -134,8 +215,11 @@ export function createDocWriter(
       if (state) Y.applyUpdate(doc, state);
       // Register AFTER hydration so we capture only our own edit.
       doc.on("update", capture);
-      doc.transact(() => fn(doc.getText(CONTENT_FIELD)), MCP_ORIGIN);
-      doc.off("update", capture);
+      try {
+        doc.transact(() => fn(doc.getText(CONTENT_FIELD)), MCP_ORIGIN);
+      } finally {
+        doc.off("update", capture);
+      }
       if (updates.length > 0) {
         const merged = Y.mergeUpdates(updates);
         await appendUpdate(docId, merged);
@@ -201,7 +285,43 @@ export function createDocWriter(
     }
   };
 
+  /** Apply a plan's ops to a Y.Text, validating each against the live length. */
+  const applyOps = (text: Y.Text, ops: TextOp[]): void => {
+    for (const op of ops) {
+      const len = text.length;
+      if (
+        !Number.isInteger(op.index) ||
+        !Number.isInteger(op.deleteLength) ||
+        op.index < 0 ||
+        op.deleteLength < 0 ||
+        op.index + op.deleteLength > len
+      ) {
+        throw new Error(`edit out of range: index ${op.index}, delete ${op.deleteLength}, length ${len}`);
+      }
+      requireUnderCap(len - op.deleteLength + op.insert.length);
+      if (op.deleteLength > 0) text.delete(op.index, op.deleteLength);
+      if (op.insert) text.insert(op.index, op.insert);
+    }
+  };
+
   return {
+    editContent: async (vaultId, docId, plan, actor) => {
+      let result = "";
+      await mutate(
+        vaultId,
+        docId,
+        (text) => {
+          // The plan sees the text under the lock; a throw here (stale revision,
+          // missing anchor) leaves the transaction empty — nothing is written.
+          const ops = plan(text.toString());
+          applyOps(text, ops);
+          result = text.toString();
+        },
+        actor,
+      );
+      return { revision: revisionOf(result), content: result };
+    },
+
     setContent: (vaultId, docId, content, actor) =>
       mutate(
         vaultId,

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -19,7 +19,7 @@ import {
 } from "../registry/tree-ops.js";
 import { purgeNoteIndex, searchNoteIndex } from "../index/indexer.js";
 import type { McpAuth } from "./tokens.js";
-import type { DocWriter } from "./doc-writer.js";
+import { StaleRevisionError, revisionOf, type DocWriter, type TextOp } from "./doc-writer.js";
 
 /**
  * The CRUD operations the MCP exposes, each one gated by the SAME ACL the rest
@@ -453,6 +453,9 @@ export async function readNote(ctx: McpContext, docId: string) {
     relPath: note.rel_path,
     permission: perm,
     content,
+    // Hand back with `expectedRevision` on update/append/edit to refuse a write
+    // against text that has since changed (#78).
+    revision: revisionOf(content),
   };
 }
 
@@ -575,20 +578,249 @@ async function requireEditableNote(auth: McpAuth, docId: string) {
  * doc-scoped frame (`{t:"touched", docId, updatedAt}`) the client applies to one
  * row — not a whole-tree re-pull.
  */
-export async function updateNote(ctx: McpContext, docId: string, content: string) {
+/**
+ * Refuse a write whose caller read a different text (#78). Runs inside the
+ * doc's write lock (see `DocWriter.editContent`), so "checked" and "applied"
+ * cannot straddle a concurrent edit.
+ */
+function requireRevision(current: string, expected: string | undefined): void {
+  if (expected === undefined) return;
+  const actual = revisionOf(current);
+  if (actual !== expected) throw new StaleRevisionError(expected, actual);
+}
+
+/** Map the doc writer's failures onto user-facing tool errors. */
+async function writeOrToolError<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof StaleRevisionError || err instanceof EditError) {
+      throw new McpToolError(err.message);
+    }
+    throw err;
+  }
+}
+
+/**
+ * The smallest single replacement that turns `current` into `next`: the shared
+ * prefix and suffix are left alone. So `update_note` on a 20 KB note where one
+ * paragraph changed touches one paragraph's worth of CRDT — a concurrent edit
+ * elsewhere in the note merges instead of being clobbered by a delete-all —
+ * while remaining, by construction, a whole-body replacement in effect.
+ */
+export function replacementOp(current: string, next: string): TextOp[] {
+  if (current === next) return [];
+  let prefix = 0;
+  const max = Math.min(current.length, next.length);
+  while (prefix < max && current.charCodeAt(prefix) === next.charCodeAt(prefix)) prefix++;
+  let suffix = 0;
+  while (
+    suffix < max - prefix &&
+    current.charCodeAt(current.length - 1 - suffix) === next.charCodeAt(next.length - 1 - suffix)
+  ) {
+    suffix++;
+  }
+  return [
+    {
+      index: prefix,
+      deleteLength: current.length - prefix - suffix,
+      insert: next.slice(prefix, next.length - suffix),
+    },
+  ];
+}
+
+export async function updateNote(
+  ctx: McpContext,
+  docId: string,
+  content: string,
+  expectedRevision?: string,
+) {
   const note = await requireEditableNote(ctx.auth, docId);
   // The actor rides along so the edit is attributed to the MCP token's user —
   // an AI write shows up as "edited by <that user>" like any teammate's.
-  await ctx.docWriter.setContent(note.vault_id, docId, content, { userId: ctx.auth.userId });
+  const { revision } = await writeOrToolError(() =>
+    ctx.docWriter.editContent(
+      note.vault_id,
+      docId,
+      (current) => {
+        requireRevision(current, expectedRevision);
+        return replacementOp(current, content);
+      },
+      { userId: ctx.auth.userId },
+    ),
+  );
   await pool.query("UPDATE notes SET updated_at = now() WHERE id = $1", [docId]);
-  return { docId, bytes: content.length };
+  return { docId, bytes: content.length, revision };
 }
 
-export async function appendNote(ctx: McpContext, docId: string, text: string) {
+/**
+ * Appends already seen, keyed by (docId, idempotencyKey) → the result returned
+ * the first time. An agent that retries a timed-out `append_note` with the same
+ * key gets that result back instead of a second copy of the text (#78).
+ * In-memory and bounded: a key is remembered for {@link APPEND_KEY_TTL_MS} or
+ * until the map fills, whichever comes first — a best-effort dedupe window for
+ * retries, not a durable ledger (a restart forgets it).
+ */
+const APPEND_KEY_TTL_MS = 24 * 60 * 60 * 1000;
+const APPEND_KEY_CAP = 10_000;
+const seenAppends = new Map<string, { at: number; result: { revision: string } }>();
+
+function rememberAppend(key: string, result: { revision: string }): void {
+  if (seenAppends.size >= APPEND_KEY_CAP) {
+    // Map iteration is insertion-ordered: the first key is the oldest.
+    const oldest = seenAppends.keys().next().value;
+    if (oldest !== undefined) seenAppends.delete(oldest);
+  }
+  seenAppends.set(key, { at: Date.now(), result });
+}
+
+function recallAppend(key: string): { revision: string } | null {
+  const hit = seenAppends.get(key);
+  if (!hit) return null;
+  if (Date.now() - hit.at > APPEND_KEY_TTL_MS) {
+    seenAppends.delete(key);
+    return null;
+  }
+  return hit.result;
+}
+
+/** Test hook: forget every idempotency key. */
+export function resetAppendKeys(): void {
+  seenAppends.clear();
+}
+
+export async function appendNote(
+  ctx: McpContext,
+  docId: string,
+  text: string,
+  opts: { expectedRevision?: string; idempotencyKey?: string } = {},
+) {
   const note = await requireEditableNote(ctx.auth, docId);
-  await ctx.docWriter.appendContent(note.vault_id, docId, text, { userId: ctx.auth.userId });
+  const key = opts.idempotencyKey ? `${docId}\n${opts.idempotencyKey}` : null;
+  if (key) {
+    const prior = recallAppend(key);
+    if (prior) return { docId, appended: 0, duplicate: true, revision: prior.revision };
+  }
+  const { revision } = await writeOrToolError(() =>
+    ctx.docWriter.editContent(
+      note.vault_id,
+      docId,
+      (current) => {
+        requireRevision(current, opts.expectedRevision);
+        return [{ index: current.length, deleteLength: 0, insert: text }];
+      },
+      { userId: ctx.auth.userId },
+    ),
+  );
+  if (key) rememberAppend(key, { revision });
   await pool.query("UPDATE notes SET updated_at = now() WHERE id = $1", [docId]);
-  return { docId, appended: text.length };
+  return { docId, appended: text.length, duplicate: false, revision };
+}
+
+// ── targeted edits (#78) ────────────────────────────────────────────────────
+
+/** One `edit_note` instruction. Anchors are matched EXACTLY (no regex). */
+export type NoteEdit =
+  | { type: "replace"; find: string; replace: string; all?: boolean }
+  | { type: "insert_before"; anchor: string; text: string }
+  | { type: "insert_after"; anchor: string; text: string }
+  | { type: "delete"; find: string; all?: boolean };
+
+/** An edit's anchor was missing or ambiguous — nothing was written. */
+export class EditError extends Error {}
+
+function occurrences(haystack: string, needle: string): number[] {
+  const out: number[] = [];
+  let from = 0;
+  for (;;) {
+    const i = haystack.indexOf(needle, from);
+    if (i === -1) return out;
+    out.push(i);
+    from = i + needle.length;
+  }
+}
+
+function anchorOf(edit: NoteEdit): string {
+  return edit.type === "replace" || edit.type === "delete" ? edit.find : edit.anchor;
+}
+
+/**
+ * Turn `edits` into ops against `current`, in order — each edit is matched in
+ * the text as left by the previous ones, and its ops are emitted with indices
+ * relative to that text (which is exactly how `TextOp`s are applied).
+ *
+ * Strict on purpose: an anchor must occur EXACTLY once unless the edit says
+ * `all`. "Not found" and "ambiguous" are both refused with the count, so an
+ * agent gets a conflict it can reason about instead of a change in the wrong
+ * place — the failure mode this tool exists to remove.
+ */
+export function planEdits(current: string, edits: NoteEdit[]): TextOp[] {
+  if (edits.length === 0) throw new EditError("edit_note needs at least one edit");
+  const ops: TextOp[] = [];
+  let text = current;
+  edits.forEach((edit, n) => {
+    const anchor = anchorOf(edit);
+    if (typeof anchor !== "string" || anchor.length === 0) {
+      throw new EditError(`edit ${n + 1}: the anchor text must be a non-empty string`);
+    }
+    const hits = occurrences(text, anchor);
+    const all = (edit.type === "replace" || edit.type === "delete") && edit.all === true;
+    if (hits.length === 0) {
+      throw new EditError(
+        `edit ${n + 1} (${edit.type}): anchor not found — the note may have changed; read it again`,
+      );
+    }
+    if (hits.length > 1 && !all) {
+      throw new EditError(
+        `edit ${n + 1} (${edit.type}): anchor matches ${hits.length} times — include more surrounding text to make it unique` +
+          (edit.type === "replace" || edit.type === "delete" ? ", or set all: true" : ""),
+      );
+    }
+    const targets = all ? hits : [hits[0]];
+    // Apply right-to-left so earlier indices stay valid within this one edit.
+    for (const at of [...targets].reverse()) {
+      let op: TextOp;
+      switch (edit.type) {
+        case "replace":
+          op = { index: at, deleteLength: anchor.length, insert: edit.replace };
+          break;
+        case "delete":
+          op = { index: at, deleteLength: anchor.length, insert: "" };
+          break;
+        case "insert_before":
+          op = { index: at, deleteLength: 0, insert: edit.text };
+          break;
+        case "insert_after":
+          op = { index: at + anchor.length, deleteLength: 0, insert: edit.text };
+          break;
+      }
+      ops.push(op);
+      text = text.slice(0, op.index) + op.insert + text.slice(op.index + op.deleteLength);
+    }
+  });
+  return ops;
+}
+
+export async function editNote(
+  ctx: McpContext,
+  docId: string,
+  edits: NoteEdit[],
+  expectedRevision?: string,
+) {
+  const note = await requireEditableNote(ctx.auth, docId);
+  const { revision, content } = await writeOrToolError(() =>
+    ctx.docWriter.editContent(
+      note.vault_id,
+      docId,
+      (current) => {
+        requireRevision(current, expectedRevision);
+        return planEdits(current, edits);
+      },
+      { userId: ctx.auth.userId },
+    ),
+  );
+  await pool.query("UPDATE notes SET updated_at = now() WHERE id = $1", [docId]);
+  return { docId, applied: edits.length, bytes: content.length, revision };
 }
 
 /** Soft-delete a note (matches the app: sets deleted_at, keeps CRDT history). */

--- a/app/apps/server/src/mcp/tools.ts
+++ b/app/apps/server/src/mcp/tools.ts
@@ -5,6 +5,7 @@ import {
   createNote,
   deleteFolder,
   deleteNote,
+  editNote,
   listFolders,
   listNotes,
   listVaults,
@@ -14,6 +15,7 @@ import {
   searchNotes,
   updateNote,
   type McpContext,
+  type NoteEdit,
 } from "./service.js";
 
 /**
@@ -87,6 +89,37 @@ function optStrOrNull(args: Args, key: string): string | null | undefined {
 
 const S = (description: string) => ({ type: "string", description });
 
+/** Validate `edit_note`'s `edits` argument into typed edits (McpToolError on a bad shape). */
+function parseEdits(raw: unknown): NoteEdit[] {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new McpToolError("edit_note requires a non-empty `edits` array");
+  }
+  return raw.map((e, i): NoteEdit => {
+    if (!e || typeof e !== "object") throw new McpToolError(`edits[${i}] must be an object`);
+    const o = e as Args;
+    const str = (key: string): string => {
+      const v = o[key];
+      if (typeof v !== "string") throw new McpToolError(`edits[${i}].${key} must be a string`);
+      return v;
+    };
+    const all = optBool(o, "all");
+    switch (o.type) {
+      case "replace":
+        return { type: "replace", find: str("find"), replace: str("replace"), ...(all !== undefined ? { all } : {}) };
+      case "delete":
+        return { type: "delete", find: str("find"), ...(all !== undefined ? { all } : {}) };
+      case "insert_before":
+        return { type: "insert_before", anchor: str("anchor"), text: str("text") };
+      case "insert_after":
+        return { type: "insert_after", anchor: str("anchor"), text: str("text") };
+      default:
+        throw new McpToolError(
+          `edits[${i}].type must be one of replace, insert_before, insert_after, delete`,
+        );
+    }
+  });
+}
+
 export const TOOLS: McpTool[] = [
   {
     name: "list_vaults",
@@ -126,7 +159,8 @@ export const TOOLS: McpTool[] = [
   },
   {
     name: "read_note",
-    description: "Read a note's full markdown content by its docId.",
+    description:
+      "Read a note's full markdown content by its docId. Also returns its `revision` — pass it as expectedRevision to update_note / append_note / edit_note so a write is refused if the note changed in between.",
     inputSchema: {
       type: "object",
       properties: { docId: S("Note docId from list_notes or search_notes") },
@@ -182,32 +216,86 @@ export const TOOLS: McpTool[] = [
   {
     name: "update_note",
     description:
-      "Replace a note's entire markdown content. Read it first if you mean to edit rather than overwrite.",
+      "Replace a note's entire markdown content. Prefer edit_note for a change to part of a note. Pass expectedRevision (from read_note) so the write is refused if the note changed since you read it.",
     inputSchema: {
       type: "object",
       properties: {
         docId: S("Note docId"),
         content: S("The new full markdown content"),
+        expectedRevision: S(
+          "The `revision` read_note returned. If the note no longer matches, the write is refused with a conflict — read again and retry.",
+        ),
       },
       required: ["docId", "content"],
       additionalProperties: false,
     },
     annotations: { idempotentHint: true },
-    handler: (ctx, a) => updateNote(ctx, reqStr(a, "docId"), reqStr(a, "content")),
+    handler: (ctx, a) =>
+      updateNote(ctx, reqStr(a, "docId"), reqStr(a, "content"), optStr(a, "expectedRevision")),
   },
   {
     name: "append_note",
-    description: "Append text to the end of a note's markdown content.",
+    description:
+      "Append text to the end of a note's markdown content. Pass an idempotencyKey when you may retry the call, so a retry cannot append the text twice.",
     inputSchema: {
       type: "object",
       properties: {
         docId: S("Note docId"),
         text: S("Markdown to append to the end of the note"),
+        expectedRevision: S("Optional `revision` from read_note; refuses the append if the note changed."),
+        idempotencyKey: S(
+          "Optional caller-chosen key (e.g. a UUID). A repeat with the same key returns the first result instead of appending again.",
+        ),
       },
       required: ["docId", "text"],
       additionalProperties: false,
     },
-    handler: (ctx, a) => appendNote(ctx, reqStr(a, "docId"), reqStr(a, "text")),
+    handler: (ctx, a) =>
+      appendNote(ctx, reqStr(a, "docId"), reqStr(a, "text"), {
+        expectedRevision: optStr(a, "expectedRevision"),
+        idempotencyKey: optStr(a, "idempotencyKey"),
+      }),
+  },
+  {
+    name: "edit_note",
+    description:
+      "Make targeted edits to a note without resending the whole body: replace exact text, insert before/after an anchor, or delete exact text. Each anchor must match exactly once (or set all: true for replace/delete); a missing or ambiguous anchor refuses the whole call with nothing written. Edits apply in order. Pass expectedRevision from read_note to also refuse the call if the note changed since you read it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        docId: S("Note docId"),
+        expectedRevision: S("Optional `revision` from read_note; refuses the edit if the note changed."),
+        edits: {
+          type: "array",
+          minItems: 1,
+          description: "Edits to apply in order, each matched against the text as left by the previous one.",
+          items: {
+            type: "object",
+            properties: {
+              type: {
+                type: "string",
+                enum: ["replace", "insert_before", "insert_after", "delete"],
+                description: "What to do at the anchor.",
+              },
+              find: S("Exact text to replace or delete (replace / delete)"),
+              replace: S("Replacement text (replace)"),
+              anchor: S("Exact text to insert next to (insert_before / insert_after)"),
+              text: S("Text to insert (insert_before / insert_after)"),
+              all: {
+                type: "boolean",
+                description: "replace / delete only: apply to every occurrence instead of requiring exactly one.",
+              },
+            },
+            required: ["type"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["docId", "edits"],
+      additionalProperties: false,
+    },
+    handler: (ctx, a) =>
+      editNote(ctx, reqStr(a, "docId"), parseEdits(a.edits), optStr(a, "expectedRevision")),
   },
   {
     name: "delete_note",

--- a/app/apps/server/src/versions/capture.ts
+++ b/app/apps/server/src/versions/capture.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { pgText } from "../db/text.js";
 import type pg from "pg";
 import { pool as defaultPool } from "../db/pool.js";
 import type { DocWriter } from "../mcp/doc-writer.js";
@@ -56,7 +57,9 @@ export async function recordVersion(
   },
   db: Queryable = defaultPool,
 ): Promise<number | null> {
-  const sha = sha256Hex(input.content);
+  // NUL cannot be stored in Postgres text (see `pgText`); hash what is stored.
+  const content = pgText(input.content);
+  const sha = sha256Hex(content);
   const { rows: latest } = await db.query<{ sha256: string }>(
     "SELECT sha256 FROM note_versions WHERE doc_id = $1 ORDER BY id DESC LIMIT 1",
     [input.docId],
@@ -67,7 +70,7 @@ export async function recordVersion(
     `INSERT INTO note_versions (doc_id, vault_id, content, sha256, cause, author_id)
      VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING id`,
-    [input.docId, input.vaultId, input.content, sha, input.cause, input.authorId],
+    [input.docId, input.vaultId, content, sha, input.cause, input.authorId],
   );
   await pruneVersions(input.docId, db);
   // BIGSERIAL arrives as a string from node-postgres; the API hands out numbers.

--- a/app/apps/server/src/versions/checkpoints.ts
+++ b/app/apps/server/src/versions/checkpoints.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { pgText } from "../db/text.js";
 import type pg from "pg";
 import { pool as defaultPool } from "../db/pool.js";
 import type { DocWriter } from "../mcp/doc-writer.js";
@@ -141,7 +142,9 @@ export async function captureCheckpoint(
 
   let noteCount = 0;
   for (const note of structure.notes) {
-    const content = await opts.docWriter.peekContent(vaultId, note.id);
+    const raw = await opts.docWriter.peekContent(vaultId, note.id);
+    // NUL would abort the whole checkpoint transaction (see `pgText`).
+    const content = raw == null ? null : pgText(raw);
     // `null` = the server has never seen this note's content (registered, but
     // its CRDT is still on its way up from a freshly-synced client). Recording
     // "" for it would make a later revert bulldoze the real text — the exact

--- a/app/apps/server/tests/helpers/app.ts
+++ b/app/apps/server/tests/helpers/app.ts
@@ -1,5 +1,5 @@
 import type { AppDeps } from "../../src/http/app.js";
-import type { DocActor, DocWriter } from "../../src/mcp/doc-writer.js";
+import { revisionOf, type DocActor, type DocWriter, type TextOp } from "../../src/mcp/doc-writer.js";
 
 /** One recorded write, so a test can assert WHO the server said wrote it. */
 export interface RecordedWrite {
@@ -22,6 +22,18 @@ export function memoryDocWriter(): MemoryDocWriter {
   return {
     store,
     writes,
+    async editContent(vaultId, docId, plan: (current: string) => TextOp[], actor) {
+      let text = store.get(docId) ?? "";
+      for (const op of plan(text)) {
+        if (op.index < 0 || op.deleteLength < 0 || op.index + op.deleteLength > text.length) {
+          throw new Error(`edit out of range: index ${op.index}, delete ${op.deleteLength}, length ${text.length}`);
+        }
+        text = text.slice(0, op.index) + op.insert + text.slice(op.index + op.deleteLength);
+      }
+      store.set(docId, text);
+      writes.push({ vaultId, docId, content: text, actor });
+      return { revision: revisionOf(text), content: text };
+    },
     async setContent(vaultId, docId, content, actor) {
       store.set(docId, content);
       writes.push({ vaultId, docId, content, actor });

--- a/app/apps/server/tests/index-engine.test.ts
+++ b/app/apps/server/tests/index-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { parseWikilinks } from "../src/index/indexer.js";
 import {
   EMBED_DIM,
@@ -70,3 +70,38 @@ describe("embedder helpers", () => {
     expect(l2normalize([0, 0, 0])).toEqual([0, 0, 0]);
   });
 });
+
+describe("indexer — NUL bytes", () => {
+  beforeEach(async () => {
+    const { resetDb } = await import("./helpers/db.js");
+    await resetDb();
+  });
+  afterAll(async () => {
+    const { pool } = await import("../src/db/pool.js");
+    await pool.end();
+  });
+
+  it("indexes a note whose body contains U+0000 (Postgres text rejects it)", async () => {
+    // One such note in production failed its own indexing AND every daily
+    // checkpoint of its vault: `invalid byte sequence for encoding "UTF8": 0x00`.
+    const { pool } = await import("../src/db/pool.js");
+    const { indexDoc } = await import("../src/index/indexer.js");
+    const { appendUpdate } = await import("../src/yjs/persistence.js");
+    const { seedOrg, seedVault, seedNote } = await import("./helpers/seed.js");
+    const Y = await import("yjs");
+    const org = await seedOrg("Nul", "nul-org");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "nul.md");
+    const doc = new Y.Doc();
+    doc.getText("content").insert(0, "before\u0000after [[Target]]");
+    await appendUpdate(docId, Y.encodeStateAsUpdate(doc));
+    doc.destroy();
+    await expect(indexDoc(docId)).resolves.toBe(true);
+    const { rows } = await pool.query<{ content: string }>(
+      "SELECT content FROM note_index WHERE doc_id = $1",
+      [docId],
+    );
+    expect(rows[0].content).toBe("beforeafter [[Target]]");
+  });
+});
+

--- a/app/apps/server/tests/mcp-doc-writer.test.ts
+++ b/app/apps/server/tests/mcp-doc-writer.test.ts
@@ -95,6 +95,70 @@ describe("MCP doc writer (no client connected)", () => {
     mirror.destroy();
   });
 
+  it("editContent applies targeted ops to the stored text and reports the revision", async () => {
+    const writer = writerThatRecords();
+    await writer.setContent("vault-1", "doc-e", "# T\n\n- one\n- two\n");
+    const res = await writer.editContent("vault-1", "doc-e", (current) => {
+      expect(current).toBe("# T\n\n- one\n- two\n");
+      return [
+        { index: current.indexOf("- two"), deleteLength: "- two".length, insert: "- 2" },
+        { index: current.length - "- two".length + "- 2".length, deleteLength: 0, insert: "- 3\n" },
+      ];
+    });
+    expect(res.content).toBe("# T\n\n- one\n- 2\n- 3\n");
+    expect(await persistedText("doc-e")).toBe(res.content);
+    // Two updates published (set + edit); replaying them reconstructs the note.
+    const mirror = new Y.Doc();
+    for (const p of published) Y.applyUpdate(mirror, p.update);
+    expect(mirror.getText("content").toString()).toBe(res.content);
+    mirror.destroy();
+  });
+
+  it("a plan that throws writes nothing (the precondition path)", async () => {
+    const writer = writerThatRecords();
+    await writer.setContent("vault-1", "doc-f", "keep");
+    published = [];
+    await expect(
+      writer.editContent("vault-1", "doc-f", () => {
+        throw new Error("stale");
+      }),
+    ).rejects.toThrow("stale");
+    expect(published).toHaveLength(0);
+    expect(await persistedText("doc-f")).toBe("keep");
+  });
+
+  it("serialises concurrent writes to one doc — no doubled text (#78)", async () => {
+    // Before the per-doc lock, two concurrent detached writes each hydrated the
+    // SAME stored state and each applied delete-all + insert; Yjs merged both
+    // inserts and the note held two bodies. Now the second sees the first.
+    const writer = writerThatRecords();
+    await writer.setContent("vault-1", "doc-g", "start");
+    await Promise.all([
+      writer.setContent("vault-1", "doc-g", "AAA"),
+      writer.setContent("vault-1", "doc-g", "BBB"),
+      writer.appendContent("vault-1", "doc-g", "!"),
+    ]);
+    const text = await persistedText("doc-g");
+    // The append lands after whichever replacement ran last; both replacements
+    // are wholesale, so exactly one body survives.
+    expect(["AAA!", "BBB!"]).toContain(text);
+
+    // And the plan of an edit sees the text the previous write left.
+    const seen: string[] = [];
+    await Promise.all([
+      writer.editContent("vault-1", "doc-g", (cur) => {
+        seen.push(cur);
+        return [{ index: cur.length, deleteLength: 0, insert: "1" }];
+      }),
+      writer.editContent("vault-1", "doc-g", (cur) => {
+        seen.push(cur);
+        return [{ index: cur.length, deleteLength: 0, insert: "2" }];
+      }),
+    ]);
+    expect(seen[1]).toBe(`${seen[0]}1`);
+    expect(await persistedText("doc-g")).toBe(`${seen[0]}12`);
+  });
+
   it("announces a rewrite even when the text is unchanged", async () => {
     // `setContent` is a wholesale replace — delete the whole Y.Text, insert the
     // new one — so re-setting identical content is still a real CRDT change and

--- a/app/apps/server/tests/mcp-edits.test.ts
+++ b/app/apps/server/tests/mcp-edits.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { EditError, planEdits, replacementOp } from "../src/mcp/service.js";
+import { revisionOf } from "../src/mcp/doc-writer.js";
+
+/**
+ * The pure half of #78: how `edit_note` turns anchors into ops, and how
+ * `update_note` shrinks a whole-body replacement to the part that changed. No
+ * database — these are the rules an agent's edit lives or dies by.
+ */
+
+function apply(text: string, ops: ReturnType<typeof planEdits>): string {
+  for (const op of ops) {
+    text = text.slice(0, op.index) + op.insert + text.slice(op.index + op.deleteLength);
+  }
+  return text;
+}
+
+describe("planEdits", () => {
+  const note = "# Title\n\n- one\n- two\n- three\n";
+
+  it("replaces, inserts before/after and deletes at unique anchors, in order", () => {
+    const ops = planEdits(note, [
+      { type: "replace", find: "- two", replace: "- 2" },
+      { type: "insert_after", anchor: "- 2", text: "\n- 2.5" },
+      { type: "insert_before", anchor: "- one", text: "- zero\n" },
+      { type: "delete", find: "- three\n" },
+    ]);
+    expect(apply(note, ops)).toBe("# Title\n\n- zero\n- one\n- 2\n- 2.5\n");
+  });
+
+  it("refuses a missing anchor with nothing planned", () => {
+    expect(() => planEdits(note, [{ type: "replace", find: "- four", replace: "x" }])).toThrow(
+      EditError,
+    );
+    expect(() => planEdits(note, [{ type: "replace", find: "- four", replace: "x" }])).toThrow(
+      /not found/,
+    );
+  });
+
+  it("refuses an ambiguous anchor unless the edit says all", () => {
+    expect(() => planEdits(note, [{ type: "delete", find: "- " }])).toThrow(/matches 3 times/);
+    expect(() => planEdits(note, [{ type: "insert_after", anchor: "- ", text: "x" }])).toThrow(
+      /matches 3 times/,
+    );
+    const ops = planEdits(note, [{ type: "replace", find: "- ", replace: "* ", all: true }]);
+    expect(apply(note, ops)).toBe("# Title\n\n* one\n* two\n* three\n");
+  });
+
+  it("a later edit sees the text as left by an earlier one", () => {
+    // "- two" only exists after the first replace; without in-order semantics
+    // the second edit would be refused.
+    const ops = planEdits("- 2\n", [
+      { type: "replace", find: "- 2", replace: "- two" },
+      { type: "insert_after", anchor: "- two", text: "!" },
+    ]);
+    expect(apply("- 2\n", ops)).toBe("- two!\n");
+  });
+
+  it("rejects an empty anchor and an empty edit list", () => {
+    expect(() => planEdits(note, [])).toThrow(EditError);
+    expect(() => planEdits(note, [{ type: "delete", find: "" }])).toThrow(/non-empty/);
+  });
+});
+
+describe("replacementOp", () => {
+  it("touches only the changed span of a whole-body replacement", () => {
+    const before = "intro\n\npara one\n\noutro\n";
+    const after = "intro\n\npara ONE, edited\n\noutro\n";
+    const ops = replacementOp(before, after);
+    expect(ops).toEqual([
+      { index: "intro\n\npara ".length, deleteLength: 3, insert: "ONE, edited" },
+    ]);
+    expect(apply(before, ops)).toBe(after);
+  });
+
+  it("is empty for identical text and handles pure insertions/deletions at either end", () => {
+    expect(replacementOp("same", "same")).toEqual([]);
+    expect(apply("abc", replacementOp("abc", "abcXYZ"))).toBe("abcXYZ");
+    expect(apply("abc", replacementOp("abc", "XYZabc"))).toBe("XYZabc");
+    expect(apply("abcdef", replacementOp("abcdef", "abef"))).toBe("abef");
+    expect(apply("aaa", replacementOp("aaa", "aa"))).toBe("aa");
+    expect(apply("", replacementOp("", "new"))).toBe("new");
+    expect(apply("gone", replacementOp("gone", ""))).toBe("");
+  });
+});
+
+describe("revisionOf", () => {
+  it("is a stable content hash", () => {
+    expect(revisionOf("x")).toBe(revisionOf("x"));
+    expect(revisionOf("x")).not.toBe(revisionOf("y"));
+    expect(revisionOf("")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/app/apps/server/tests/mcp.test.ts
+++ b/app/apps/server/tests/mcp.test.ts
@@ -104,6 +104,7 @@ describe("MCP server", () => {
         "read_note",
         "create_note",
         "update_note",
+        "edit_note",
         "delete_note",
         "search_notes",
       ]),
@@ -142,9 +143,10 @@ describe("MCP server", () => {
     const notes = await call(token, "list_notes", { vaultId: vault });
     expect(notes.data.results.map((n: any) => n.docId)).toContain(docId);
 
-    // update_note replaces content.
-    await call(token, "update_note", { docId, content: "replaced" });
+    // update_note replaces content, and reports the new revision.
+    const updated = await call(token, "update_note", { docId, content: "replaced" });
     expect(mem.store.get(docId)).toBe("replaced");
+    expect(updated.data.revision).toBe((await call(token, "read_note", { docId })).data.revision);
 
     // append_note appends.
     await call(token, "append_note", { docId, text: "!" });
@@ -159,6 +161,130 @@ describe("MCP server", () => {
 
     // read after delete → error.
     expect((await call(token, "read_note", { docId })).isError).toBe(true);
+  });
+
+  // ── stale-write protection + targeted edits (#78) ─────────────────────────
+  describe("revisions and edit_note", () => {
+    let token: string;
+    let docId: string;
+
+    beforeEach(async () => {
+      const owner = await seedUser("owner@mcp-rev.com");
+      const org = await seedOrg("Acme", "acme-mcp-rev");
+      await seedMember(org, owner, "owner");
+      const vault = await seedVault(org);
+      token = await tokenFor(owner, org);
+      const created = await call(token, "create_note", {
+        vaultId: vault,
+        relPath: "plan.md",
+        content: "# Plan\n\n- one\n- two\n",
+      });
+      docId = created.data.docId as string;
+    });
+
+    it("read_note returns a revision that changes with the content", async () => {
+      const a = await call(token, "read_note", { docId });
+      expect(a.data.revision).toMatch(/^[0-9a-f]{64}$/);
+      await call(token, "append_note", { docId, text: "- three\n" });
+      const b = await call(token, "read_note", { docId });
+      expect(b.data.revision).not.toBe(a.data.revision);
+    });
+
+    it("update_note / append_note / edit_note refuse a stale expectedRevision, writing nothing", async () => {
+      const read = await call(token, "read_note", { docId });
+      // Someone else edits in between (here: another MCP call).
+      await call(token, "append_note", { docId, text: "- interloper\n" });
+      const after = mem.store.get(docId);
+
+      const upd = await call(token, "update_note", {
+        docId,
+        content: "clobber",
+        expectedRevision: read.data.revision,
+      });
+      expect(upd.isError).toBe(true);
+      expect(upd.text).toMatch(/Stale write/);
+      const app = await call(token, "append_note", {
+        docId,
+        text: "x",
+        expectedRevision: read.data.revision,
+      });
+      expect(app.isError).toBe(true);
+      const edit = await call(token, "edit_note", {
+        docId,
+        expectedRevision: read.data.revision,
+        edits: [{ type: "replace", find: "- one", replace: "- 1" }],
+      });
+      expect(edit.isError).toBe(true);
+      expect(mem.store.get(docId)).toBe(after); // untouched by all three
+
+      // With the CURRENT revision the same write goes through.
+      const fresh = await call(token, "read_note", { docId });
+      const ok = await call(token, "update_note", {
+        docId,
+        content: "clobber",
+        expectedRevision: fresh.data.revision,
+      });
+      expect(ok.isError).toBe(false);
+      expect(mem.store.get(docId)).toBe("clobber");
+    });
+
+    it("edit_note applies targeted edits and refuses missing/ambiguous anchors as a whole", async () => {
+      const res = await call(token, "edit_note", {
+        docId,
+        edits: [
+          { type: "replace", find: "- two", replace: "- 2" },
+          { type: "insert_after", anchor: "- 2", text: "\n- 3" },
+          { type: "delete", find: "# Plan\n\n" },
+        ],
+      });
+      expect(res.isError).toBe(false);
+      expect(res.data.applied).toBe(3);
+      expect(mem.store.get(docId)).toBe("- one\n- 2\n- 3\n");
+      expect(res.data.revision).toBe((await call(token, "read_note", { docId })).data.revision);
+
+      const before = mem.store.get(docId);
+      const missing = await call(token, "edit_note", {
+        docId,
+        edits: [
+          { type: "replace", find: "- one", replace: "- 1" }, // fine on its own…
+          { type: "replace", find: "- nine", replace: "x" }, // …but this anchor is gone
+        ],
+      });
+      expect(missing.isError).toBe(true);
+      expect(missing.text).toMatch(/edit 2 .*not found/);
+      expect(mem.store.get(docId)).toBe(before); // all-or-nothing
+
+      const ambiguous = await call(token, "edit_note", {
+        docId,
+        edits: [{ type: "insert_before", anchor: "- ", text: "*" }],
+      });
+      expect(ambiguous.isError).toBe(true);
+      expect(ambiguous.text).toMatch(/matches 3 times/);
+      expect(mem.store.get(docId)).toBe(before);
+
+      const bad = await call(token, "edit_note", { docId, edits: [{ type: "explode" }] });
+      expect(bad.isError).toBe(true);
+    });
+
+    it("append_note with an idempotencyKey appends once across retries", async () => {
+      const first = await call(token, "append_note", {
+        docId,
+        text: "- retry-me\n",
+        idempotencyKey: "k-1",
+      });
+      expect(first.data.duplicate).toBe(false);
+      const again = await call(token, "append_note", {
+        docId,
+        text: "- retry-me\n",
+        idempotencyKey: "k-1",
+      });
+      expect(again.data.duplicate).toBe(true);
+      expect(again.data.revision).toBe(first.data.revision);
+      expect(mem.store.get(docId)).toBe("# Plan\n\n- one\n- two\n- retry-me\n");
+      // A different key is a different append.
+      await call(token, "append_note", { docId, text: "- more\n", idempotencyKey: "k-2" });
+      expect(mem.store.get(docId)).toBe("# Plan\n\n- one\n- two\n- retry-me\n- more\n");
+    });
   });
 
   it("create_note adopts the note already at that path instead of duplicating it", async () => {

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -9,12 +9,18 @@ instead of self-hosting: set the server URL in Settings to `https://api.baalda.c
 
 ## Ports
 
-The server binds one HTTP port (`PORT`, default `3010`) that serves both the
-REST/auth API and the sync WebSocket at `/sync`. That is the only port a
-deployment needs to expose. `HOCUSPOCUS_PORT` (default `3011`) still exists for
-local development and for older clients that dial the dedicated Hocuspocus
-port directly, but it does not need to be reachable from outside the container
-in production.
+The server binds one HTTP port (`PORT`, default `3010`) that serves the
+REST/auth API, the per-note sync WebSocket at `/sync` and the vault channel at
+`/vault-sync`. That is the only port a deployment needs to expose, and the only
+one the desktop app (0.1.42+) ever dials — it derives both WebSocket URLs from
+the server URL by appending the path, whatever the port. `HOCUSPOCUS_PORT`
+(default `3011`) still listens for anything else that dials the dedicated
+Hocuspocus port directly, but nothing in this repo needs it reachable.
+
+> Desktop builds before 0.1.42 bumped an explicit `:3010` in the server URL to
+> `:3011` for per-note sync. On a single-port deploy that port is unreachable,
+> so folder structure synced while note content never uploaded (issue #79).
+> Update the app; no server change is needed.
 
 ## Option A: plain Docker
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+- Self-hosted servers on a single port (the Docker Compose bundle) now receive note content: the app no longer dials a separate sync port that isn't exposed, so "structure syncs but notes stay empty" is fixed
+- Reloading or switching vaults no longer "re-syncs" hundreds of empty placeholder notes on every connect
+- Notes over the 10 MB sync limit are reported once as too large instead of being retried on every reconnect
+- If a note can't be written to disk (disk full, permissions), you now see a sticky warning and the save is retried automatically until it lands
+- A note that fails to register for sync when opened now tells you, and registration is retried automatically
+- Turning on sync, creating an MCP token and deleting a vault now show a visible error when they fail
+- Opening a large vault no longer freezes while the index rebuilds — the sidebar appears immediately and search/backlinks fill in when indexing finishes
+- The sidebar refreshes only the folders a change touched, and the graph view patches only the notes that changed, so big vaults stay smooth while editing
+- MCP: `read_note` returns a `revision`, writes accept `expectedRevision` to refuse stale edits, a new `edit_note` tool makes targeted changes, and `append_note` accepts an idempotency key
+- Server: notes containing a NUL character no longer break search indexing or version checkpoints
 - Right-click a tab for quick actions: close, close others, close tabs to the right, or close all
 - You can now open a folder — including a whole drive — as a vault by typing its path on the vault screen
 - A vault at a drive root now shows its drive name instead of a generic label

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-- Notes now open in **tabs** across the top — switch with a click, close with × or a middle-click, and jump back to where you were
-- Tabs follow renames and moves, and close themselves when a note is deleted
-- Teammates now show up in the sidebar the moment they open the app, instead of after their vault finishes syncing
+- Right-click a tab for quick actions: close, close others, close tabs to the right, or close all
+- You can now open a folder — including a whole drive — as a vault by typing its path on the vault screen
+- A vault at a drive root now shows its drive name instead of a generic label


### PR DESCRIPTION
One PR for every open issue plus the "300 files re-sync on every reload" bug seen on the BenAI OS vault.

## Sync (root causes, verified against production data)

**#79 — self-host: content never uploads.** `deriveWsUrl` bumped an explicit `:3010` to a dedicated `:3011` for per-note sync. The Compose bundle only publishes 3010, so the vault channel (`/vault-sync` on 3010) worked — structure synced, server-created notes came down — while every per-note provider, which is the path ALL content uploads take, dialled a port nothing listened on, timed out, and the run paused after ten failures. Fixed: the per-note WS URL is always same-origin `/sync`, like the vault channel. Tests updated.

**"310 files re-syncing" on every reload / vault switch.** The server names every readable doc it holds no CRDT for on each connect (`ready.empty`). The BenAI OS vault has exactly 307 such notes — and all 307 are 0-byte files on disk (`_Index.md` stubs and the like). Seeding an empty file inserts nothing, so the server kept holding nothing and named them again next connect: a token mint + WebSocket per note, forever. Fixed: `ready.empty` is now checked against disk (`settleServerEmpty`); a doc with nothing on either side is marked pushed, badged synced and never queued, and a later watcher event for that file lets it push again. Same short-circuit in the uploader, gated on the server's word so a placeholder whose backfill was missed still pulls.

**Oversized notes hammering the server.** Two notes in another vault are over `MAX_NOTE_MB`; the server rejected the socket on every reconnect, forever. The uploader now fails such a doc once, permanently, with a reason ("too large to sync (12.3 MB; the limit is 10 MB)"), without a socket and without counting toward the failure streak. Remembered for the session, cleared when the file changes.

## Data safety / visibility
- **#81** egest: the echo-guard hash is set only after the write lands; a failed write is retried with backoff (1s→30s), and a sticky toast says "Couldn't save … retrying", dismissed on recovery. Bridge suite + new `egest-failure` tests.
- **#80** a failed `registerNote` on open now schedules the registry pull (which registers + uploads) and toasts once per note (skipped while the vault channel is down — the indicator already says so).
- **#85** turn-on-sync, MCP-token create and permanent vault delete raise sticky error toasts in addition to the inline line.
- **Server:** notes containing NUL no longer fail indexing / version capture / daily checkpoints (`invalid byte sequence for encoding "UTF8": 0x00` in prod logs).

## Large-vault performance
- **#84** vault open no longer blocks on the index rebuild: it runs on a background thread that takes the index lock before the vault is published, so every index reader simply waits for it (no stale reads); the sidebar (disk walk) shows immediately, `index-ready` refreshes titles/backlinks.
- **#82** `refreshTree` re-lists only the folders a watcher batch touched (structural batches still re-list everything); expanded sub-folders are carried over.
- **#83** the graph view applies a per-note delta (`graph_edges_for`) for in-place `.md` edits; removals, structural changes and unknown notes still rebuild.

## MCP (#78)
- `read_note` returns `revision` (sha256 of the body); `update_note` / `append_note` / `edit_note` accept `expectedRevision` and refuse a stale write with a conflict, checked under a new per-doc write lock in the doc writer (which also removes the doubled-body outcome of two concurrent detached writes).
- New `edit_note`: exact-anchor `replace` / `insert_before` / `insert_after` / `delete`, anchors must match exactly once (or `all: true`), all-or-nothing.
- `update_note` now sends only the changed span; `append_note` takes an `idempotencyKey`.

## Earlier in this PR
Tab context menu (#76) and opening a drive root as a vault (#75) — see the first commits.

Closes #75 #76 #78 #79 #80 #81 #82 #83 #84 #85

## Testing
- Desktop vitest: 692 passed (incl. new sync/bridge/tree/graph tests) · `tsc --noEmit` clean · `cargo test` green
- Server vitest on the scratch DB: 383 passed (incl. new MCP revision/edit/idempotency, doc-writer lock, NUL indexing tests) · `tsc --noEmit` clean
- Version stays 0.1.42 (bumped earlier in this PR; main is 0.1.41)
