### PR TITLE
Folder sync badges count the current wave; synced dots without a run; patch titles per change (0.1.43)

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.42",
+  "version": "0.1.43",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.42"
+version = "0.1.43"
 dependencies = [
  "keyring",
  "notify",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.42"
+version = "0.1.43"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -659,19 +659,28 @@ export default function App() {
     // batch in the window carried a structural change (then the whole tree is
     // re-listed, as before).
     let pendingFolders: Set<string> | null = new Set();
+    // The file changes themselves (last kind per path), for the titles patch.
+    let pendingChanges = new Map<string, "modified" | "removed">();
     const scheduleRefresh = (changes: ipc.FileChanged[]) => {
       if (pendingFolders) {
         const dirs = implicatedFolders(changes);
         if (dirs) for (const d of dirs) pendingFolders.add(d);
         else pendingFolders = null;
       }
+      for (const c of changes) if (c.kind !== "tree") pendingChanges.set(c.path, c.kind);
       if (refreshTimer) clearTimeout(refreshTimer);
       refreshTimer = setTimeout(() => {
         const folders = pendingFolders;
+        const fileChanges = [...pendingChanges].map(([path, kind]) => ({ path, kind }));
         pendingFolders = new Set();
-        void useStore.getState().refreshTree(folders ?? undefined);
-        void useStore.getState().refreshTitles();
-        void useStore.getState().refreshBacklinks();
+        pendingChanges = new Map();
+        const store = useStore.getState();
+        void store.refreshTree(folders ?? undefined);
+        // Titles: patch the named rows for a plain file batch; only a structural
+        // change (folder rename/move, which rewrites many paths) re-lists all.
+        if (folders) void store.patchTitles(fileChanges);
+        else void store.refreshTitles();
+        void store.refreshBacklinks();
       }, 120);
     };
     (async () => {

--- a/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/syncRollup.test.ts
@@ -248,6 +248,32 @@ describe("FolderWaveTracker", () => {
     expect(rowSyncMark(dir("A"), next)!.progress).toEqual({ done: 0, total: 1 });
   });
 
+  it("does not pin the wave on notes nobody has reported yet (fresh launch)", () => {
+    // A fresh launch: the registry has mapped every note but the run has not
+    // stamped anything. Every note reads unsynced, yet none of them is WORK —
+    // pinning the wave here is what produced "186/187" for one new note.
+    const waves = new FolderWaveTracker();
+    const launch = buildTreeSyncIndex({
+      docIdByPath: { "A/a.md": "d1", "A/b.md": "d2", "A/c.md": "d3" },
+      docSyncState: {},
+      localNotePaths: ["A/a.md", "A/b.md", "A/c.md"],
+    });
+    waves.apply(launch);
+    expect(launch.folders.get("A")!.unreported).toBe(3);
+    expect(launch.folders.get("A")!.state).toBe("unsynced"); // still honest
+    expect(rowSyncMark(dir("A"), launch)!.progress).toBeNull(); // no "0/3"
+
+    // The run's batch lands: two confirmed, and one NEW file appears queued.
+    const busy = buildTreeSyncIndex({
+      docIdByPath: { "A/a.md": "d1", "A/b.md": "d2", "A/c.md": "d3", "A/new.md": "d4" },
+      docSyncState: { d1: "synced", d2: "synced", d3: "synced", d4: "queued" },
+      localNotePaths: ["A/a.md", "A/b.md", "A/c.md", "A/new.md"],
+    });
+    waves.apply(busy);
+    expect(rowSyncMark(dir("A"), busy)!.progress).toEqual({ done: 0, total: 1 }); // not 3/4
+    expect(folderSyncTitle(busy.folders.get("A")!)).toBe("3 of 4 notes synced");
+  });
+
   it("grows the wave when more work arrives mid-flight", () => {
     const waves = new FolderWaveTracker();
     const one = indexOf({ "A/a.md": "syncing" });

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
@@ -389,6 +389,31 @@ describe("SyncManager — ready.empty is the authority", () => {
     expect(connects.order).toEqual(["a", "b"]);
   });
 
+  it("badges every confirmed note synced even when there is nothing to send", async () => {
+    // Only a run's uploader used to stamp confirmed docs `synced`; a fully
+    // synced vault (empty work list ⇒ no run) sat on unsynced badges until
+    // something happened to start one.
+    fakeRegistry.mappedNotes.mockReturnValue([
+      { docId: "a", relPath: "A.md" },
+      { docId: "b", relPath: "B.md" },
+      { docId: OPEN_DOC, relPath: "Open.md" },
+    ]);
+    for (const id of ["a", "b", OPEN_DOC]) fakeRegistry.pushed.add(id);
+    const sm = new SyncManager();
+    const badges: Record<string, string> = {};
+    sm.setDocStateListener((patch) => {
+      for (const [id, state] of Object.entries(patch)) if (state) badges[id] = state;
+    });
+    await enable(sm);
+    storeHooks.open = OPEN_DOC;
+    engineHooks.settled = true;
+    engineHooks.opts!.onServerEmpty?.([], false);
+    engineHooks.opts!.onInboundIdle?.();
+    await flush();
+    expect(connects.order).toEqual([]);
+    expect(badges).toEqual({ a: "synced", b: "synced" }); // the open note reports itself
+  });
+
   it("reaches a terminal phase with nothing to send, and does not re-stamp it", async () => {
     fakeRegistry.mappedNotes.mockReturnValue([{ docId: "a", relPath: "A.md" }]);
     fakeRegistry.pushed.add("a");

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -23,6 +23,7 @@ const empty = {
   localFolders: new Set<string>(),
   folderTombstones: new Set<string>() as Set<string> | null,
   localFolderIds: new Map<string, string>(),
+  serverFolderIds: new Map<string, string>(),
 };
 
 function plan(over: Partial<typeof empty>) {
@@ -98,6 +99,28 @@ describe("planInbound — folders", () => {
     const p = plan({
       localFolderIds: new Map([["A", "fa"]]),
       folderTombstones: new Set(["fa"]),
+    });
+    expect(p.removeFolders).toEqual([]);
+  });
+
+  it("removes the emptied old directory of a folder the server MOVED", () => {
+    // We recorded id f1 at "Projects/vid"; the server now has f1 at "Archive/vid".
+    const p = plan({
+      localFolders: new Set(["Projects", "Projects/vid"]),
+      localFolderIds: new Map([["Projects", "fp"], ["Projects/vid", "f1"]]),
+      serverFolders: new Set(["Projects", "Archive", "Archive/vid"]),
+      serverFolderIds: new Map([["fp", "Projects"], ["fa", "Archive"], ["f1", "Archive/vid"]]),
+    });
+    expect(p.removeFolders).toEqual(["Projects/vid"]);
+    expect(p.createFolders).toEqual(["Archive", "Archive/vid"]);
+  });
+
+  it("leaves a moved folder's old path alone once the server has re-created it there", () => {
+    const p = plan({
+      localFolders: new Set(["Projects/vid"]),
+      localFolderIds: new Map([["Projects/vid", "f1"]]),
+      serverFolders: new Set(["Projects/vid", "Archive/vid"]),
+      serverFolderIds: new Map([["f1", "Archive/vid"], ["f2", "Projects/vid"]]),
     });
     expect(p.removeFolders).toEqual([]);
   });

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -530,6 +530,35 @@ describe("inbound folder deletion", () => {
     );
   });
 
+  it("removes the emptied old directory after a server-side folder move, and does not re-register it", async () => {
+    const disk = new FakeDisk();
+    disk.folders.add("Projects");
+    disk.folders.add("Projects/vid");
+    disk.notes.set("Projects/vid/a.md", "d1");
+    const { api } = await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Projects/vid/a.md" }],
+        folders: [{ id: "fp", path: "Projects" }, { id: "f1", path: "Projects/vid" }],
+      },
+      then: {
+        notes: [{ id: "d1", rel_path: "Archive/vid/a.md" }],
+        folders: [
+          { id: "fp", path: "Projects" },
+          { id: "fa", path: "Archive" },
+          { id: "f1", path: "Archive/vid" },
+        ],
+      },
+    });
+    // The note followed the move, the emptied old directory is gone, and — the
+    // part that used to bite the whole team — no empty twin was created upstream.
+    expect(disk.notes.has("Archive/vid/a.md")).toBe(true);
+    expect(disk.folders.has("Projects/vid")).toBe(false);
+    expect(vi.mocked(api.createFolder)).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: "Projects/vid" }),
+    );
+  });
+
   it("re-creates a folder at a path the server MOVED away from, so a file left there registers", async () => {
     // Production case ("1 not synced", forever): the server moved
     // `Projects/vid` to `Archive/vid`. The old directory stayed on disk (it held

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -530,6 +530,111 @@ describe("inbound folder deletion", () => {
     );
   });
 
+  it("re-creates a folder at a path the server MOVED away from, so a file left there registers", async () => {
+    // Production case ("1 not synced", forever): the server moved
+    // `Projects/vid` to `Archive/vid`. The old directory stayed on disk (it held
+    // a file the per-note rename never carried), the old path → id entry stayed
+    // in the map, and every later file dropped into the old directory was
+    // registered with the MOVED folder's id — refused as path_folder_mismatch.
+    const disk = new FakeDisk();
+    disk.folders.add("Projects");
+    disk.folders.add("Projects/vid");
+    const first: ServerState = {
+      notes: [],
+      folders: [{ id: "f1", path: "Projects/vid" }],
+    };
+    install(disk);
+    const reg1 = new VaultRegistry(fakeApi(first));
+    await reg1.reconcile({ organizationId: ORG, vaultName: "v" });
+    expect(reg1.getFolderId("Projects/vid")).toBe("f1");
+    const writes = vi.mocked(ipc.setVaultConfig).mock.calls;
+    vi.mocked(ipc.getVaultConfig).mockResolvedValue(writes[writes.length - 1]?.[0] as never);
+
+    // The server moved the folder; a new note appears in the OLD directory.
+    disk.notes.set("Projects/vid/new.md", "d-new");
+    const api = fakeApi({
+      notes: [],
+      folders: [
+        { id: "folder-Projects", path: "Projects" },
+        { id: "fa", path: "Archive" },
+        { id: "f1", path: "Archive/vid" },
+      ],
+    });
+    vi.mocked(api.createFolder).mockClear();
+    vi.mocked(api.createNote).mockClear();
+    const reg = new VaultRegistry(api);
+    reg.setInboundHost(recordingHost().host);
+    await reg.reconcile({ organizationId: ORG, vaultName: "v" });
+
+    // The stale entry is gone, the old path is a NEW folder under its real
+    // parent, and the note registers against it — not against the moved id.
+    expect(vi.mocked(api.createFolder)).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "Projects/vid", parentId: "folder-Projects" }),
+    );
+    expect(reg.getFolderId("Projects/vid")).toBe("folder-Projects/vid");
+    expect(reg.getFolderId("Archive/vid")).toBe("f1");
+    expect(vi.mocked(api.createNote)).toHaveBeenCalledWith(
+      expect.objectContaining({ relPath: "Projects/vid/new.md", folderId: "folder-Projects/vid" }),
+    );
+    expect(reg.getMapping("Projects/vid/new.md")?.docId).toBe("d-new");
+    expect(reg.failures()).toEqual([]);
+  });
+
+  it("trashes an EMPTY leftover of a deleted note that the plan could only suppress", async () => {
+    // The file at the deleted note's path is still on disk, but the local index
+    // keys it under a different id (a re-indexed placeholder). The plan can't
+    // prove it is the same note, so it only suppresses re-registration; for an
+    // empty file that left a zero-byte stub nobody could sync or count.
+    const disk = new FakeDisk();
+    disk.folders.add("Team");
+    disk.notes.set("Team/stub.md", "d1");
+    const { api } = await twoPasses({
+      disk,
+      // Between passes the local index re-keyed the file: swap its id below.
+      first: {
+        notes: [{ id: "d1", rel_path: "Team/stub.md" }],
+        folders: [{ id: "f1", path: "Team" }],
+      },
+      then: { notes: [], tombstones: ["d1"], folders: [{ id: "f1", path: "Team" }] },
+    });
+    // twoPasses already trashed the file under its ORIGINAL id (the plain path,
+    // covered elsewhere). Re-run the deleted state with the file re-keyed and
+    // present again, as the production stubs were.
+    disk.notes.set("Team/stub.md", "local-rekeyed");
+    disk.trashed.length = 0;
+    vi.mocked(api.createNote).mockClear();
+    const reg = new VaultRegistry(api);
+    reg.setInboundHost(recordingHost().host);
+    await reg.reconcile({ organizationId: ORG, vaultName: "v" });
+
+    expect(disk.trashed.map((t) => t.from)).toEqual(["Team/stub.md"]);
+    expect(vi.mocked(api.createNote)).not.toHaveBeenCalled();
+  });
+
+  it("leaves a NON-empty suppressed leftover alone (it may be someone's work)", async () => {
+    const disk = new FakeDisk();
+    disk.folders.add("Team");
+    disk.notes.set("Team/stub.md", "d1");
+    const { api } = await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Team/stub.md" }],
+        folders: [{ id: "f1", path: "Team" }],
+      },
+      then: { notes: [], tombstones: ["d1"], folders: [{ id: "f1", path: "Team" }] },
+    });
+    disk.notes.set("Team/stub.md", "local-rekeyed");
+    disk.bodies.set("Team/stub.md", "typed here after the delete");
+    disk.trashed.length = 0;
+    vi.mocked(api.createNote).mockClear();
+    const reg = new VaultRegistry(api);
+    reg.setInboundHost(recordingHost().host);
+    await reg.reconcile({ organizationId: ORG, vaultName: "v" });
+
+    expect(disk.trashed).toEqual([]);
+    expect(vi.mocked(api.createNote)).not.toHaveBeenCalled(); // still no ghost
+  });
+
   it("does nothing on folder tombstones the server did not answer about (null)", async () => {
     const disk = new FakeDisk();
     disk.folders.add("Team");

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -791,12 +791,32 @@ export class SyncManager implements InboundHost {
       const phase = this.progress?.snapshot().phase;
       const stalled = this.channelStalled;
       this.channelStalled = false;
-      if (phase !== "done" && (phase !== "error" || stalled)) this.completeRun(scope);
+      if (phase !== "done" && (phase !== "error" || stalled)) {
+        // The per-doc badges too. A run's uploader stamps every confirmed note
+        // `synced` before its first socket; with no run there was nobody to do
+        // it, so a fully-synced vault sat on "0/N" folder badges until something
+        // happened to start one. Same guard as the phase: once per settle.
+        this.badgeConfirmedDocs();
+        this.completeRun(scope);
+      }
       return;
     }
     this.bulkRun = this.runBulkSync(scope).catch((e) => {
       console.warn("[sync] content sync failed", e);
     });
+  }
+
+  /** Report every note the server is known to hold as `synced` (one coalesced
+   *  patch). The open note is left to its own provider's reporting. */
+  private badgeConfirmedDocs(): void {
+    const progress = this.progress;
+    if (!progress) return;
+    const open = this.docStore?.suppressedDoc() ?? null;
+    for (const { docId } of this.registry.mappedNotes()) {
+      if (docId !== open && this.registry.isPushed(docId) && !this.serverEmpty.has(docId)) {
+        progress.doc(docId, "synced");
+      }
+    }
   }
 
   /**

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -118,6 +118,15 @@ export interface InboundPlan {
    * it here lets the existing prune drop the mapping instead.
    */
   suppress: Set<string>;
+  /**
+   * Paths of DELETED (tombstoned — the server answered) notes whose file is
+   * still on disk but which the local index keys under some other id, so the
+   * plan could only suppress them (see the `dead && loc === undefined` branch).
+   * The executor may trash such a file if — and only if — it is empty: no work
+   * to lose, and otherwise a zero-byte stub nobody can sync or count, forever.
+   * Never populated for revoked notes or when tombstones were not reported.
+   */
+  stubs: string[];
   rejected: InboundRejection[];
 }
 
@@ -230,6 +239,7 @@ export function planInbound(input: InboundInput): InboundPlan {
     trash: [],
     revoked: new Set(),
     suppress: new Set(),
+    stubs: [],
     rejected: [],
   };
 
@@ -331,7 +341,10 @@ export function planInbound(input: InboundInput): InboundPlan {
         // match we can't prove the file at that path is still this note, and a
         // wrong guess here deletes someone's work. It stays on disk as a purely
         // local note the user can remove themselves.
-        if (prev !== undefined && localPaths.has(prev)) plan.suppress.add(prev);
+        if (prev !== undefined && localPaths.has(prev)) {
+          plan.suppress.add(prev);
+          plan.stubs.push(prev);
+        }
         continue;
       }
       // Belt as well as braces: if the trash step is skipped or fails, this still

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -54,6 +54,15 @@ export interface InboundInput {
    * user re-created at the same path gets a fresh id and never matches.
    */
   localFolderIds?: Map<string, string>;
+  /**
+   * Server folder id → its CURRENT path. Lets the plan see a folder the server
+   * MOVED: the id we recorded at a local path now lives elsewhere. The old
+   * directory (emptied by the per-note renames) is then removed if empty, like a
+   * tombstoned one — otherwise it lingered as a trap: a file dropped into it
+   * later re-registered it as a brand-new server folder, and the folder move
+   * "came back" for the whole team as an empty twin.
+   */
+  serverFolderIds?: Map<string, string>;
 }
 
 export interface InboundRename {
@@ -265,6 +274,23 @@ export function planInbound(input: InboundInput): InboundPlan {
     plan.createFolders.push(path);
   }
   plan.createFolders.sort(byDepth);
+
+  // A local folder whose recorded server id now lives at ANOTHER path was moved
+  // remotely. Its notes move via their own renames; the emptied old directory
+  // is removed (empty-only, like a tombstone) so it can't be re-registered as
+  // a new folder on the next pass. Gated on the id still existing on the server
+  // (a deleted id is the tombstone case below) and on the old path not having
+  // been re-created server-side since.
+  if (input.serverFolderIds && input.localFolderIds) {
+    for (const [path, id] of input.localFolderIds) {
+      const now = input.serverFolderIds.get(id);
+      if (now === undefined || now === path) continue;
+      if (!input.localFolders.has(path)) continue; // already gone locally
+      if (input.serverFolders.has(path)) continue; // re-created server-side
+      if (!isSafeFolderPath(path)) continue;
+      plan.removeFolders.push(path);
+    }
+  }
 
   // A local folder whose recorded server id is tombstoned was deleted remotely.
   // Gated on the id match (a same-path successor has a fresh id and never

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -800,6 +800,35 @@ export class VaultRegistry {
       }
     }
 
+    // Paths the plan suppressed WITHOUT trashing: a tombstoned note whose file
+    // is still on disk under an identity the index no longer ties to the
+    // tombstone (a materialized placeholder whose mapping was pruned). The plan
+    // cannot prove that file IS the deleted note, so it leaves it — rightly, for
+    // a file with text in it. An EMPTY file is different: there is no work in it
+    // to lose, and left alone it sits unmapped, uncounted and unsyncable forever
+    // (21 zero-byte stubs under re-created "… 2/" folders in one vault). So the
+    // empty ones go to the trash like any other tombstoned note.
+    // (`plan.stubs` is only ever filled for notes the server confirmed deleted —
+    // never for revocations or a listing that didn't report tombstones, where
+    // "I don't know" must remove nothing.)
+    for (const path of plan.stubs) {
+      if (this.stopRun()) break;
+      if (!(await this.isEmptyOnDisk(path))) continue;
+      if (this.stale()) return { changedDisk, suppress: plan.suppress };
+      try {
+        await ipc.trashNote(path, stamp, this.epoch());
+        changedDisk = true;
+        // Nothing is at that path any more, so no baseline entry may keep
+        // claiming it (which would suppress a genuinely new file there later).
+        for (const [docId, rp] of [...this.baselineDocs]) {
+          if (rp === path) this.baselineDocs.delete(docId);
+        }
+      } catch (e) {
+        if (ipc.isVaultMismatch(e)) return { changedDisk, suppress: plan.suppress };
+        // Left on disk; it stays suppressed and harmless, as before.
+      }
+    }
+
     // Folders the server has deleted, children before parents, AFTER the trash
     // loop above has moved their notes out. Empty-only removal (`remove_dir`,
     // never recursive): a folder still holding anything stays on disk and — its
@@ -1209,6 +1238,19 @@ export class VaultRegistry {
     }
 
     // 2. Folders: adopt by path, create missing (parents first).
+    //
+    // The path → id map is RE-DERIVED from the server's listing, not merely added
+    // to. A folder the server moved keeps its id under a new path, and the old
+    // path's entry used to survive here forever. This device then believed the
+    // old directory — still on disk, e.g. holding a `.txt` the index doesn't key
+    // and so the per-note rename never carried — was registered, never re-created
+    // it, and registered any note inside it with the MOVED folder's id. The server
+    // rightly refused that as `path_folder_mismatch`, on every pull, forever:
+    // "1 not synced" with nothing the user could do about it.
+    const serverFolderByPath = new Map(serverFolders.map((f) => [f.path, f.id] as const));
+    for (const [rp, id] of [...this.folderByPath]) {
+      if (serverFolderByPath.get(rp) !== id) this.folderByPath.delete(rp);
+    }
     for (const f of serverFolders) this.folderByPath.set(f.path, f.id);
     const missingFolders = folders.filter((f) => !this.folderByPath.has(f.path));
 
@@ -1315,12 +1357,18 @@ export class VaultRegistry {
         // keeps working locally, whereas mapping it would point sync at a doc the
         // user has no grant on, which only yields a permanent 403. Rotating the
         // local doc_id to rejoin such a note to this vault is not implemented.
+        const code = errorCode(out.error) ?? (isConflict(out.error) ? "doc_id_conflict" : null);
+        // The server says the folder id we sent is not the folder at this path:
+        // our mapping for the parent is stale (see step 2). Drop it so the next
+        // pass re-creates the folder and this note registers — belt to step 2's
+        // braces, for a listing that changed between the two reads of one pass.
+        if (code === "path_folder_mismatch") this.folderByPath.delete(parentDir(rp));
         this.recordFailure({
           kind: "note",
           path: rp,
           docId,
           reason: reasonOf(out.error),
-          code: errorCode(out.error) ?? (isConflict(out.error) ? "doc_id_conflict" : null),
+          code,
         });
         this.sink.item("failed");
       },

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -629,7 +629,7 @@ export class VaultRegistry {
       folders: TreeNode[];
       notes: TreeNode[];
       titles: Array<{ path: string; id: string }>;
-      serverFolders: Array<{ path: string }>;
+      serverFolders: Array<{ id: string; path: string }>;
       serverNotes: RegisteredNote[];
       tombstones: string[] | null;
       folderTombstones: string[] | null;
@@ -693,6 +693,7 @@ export class VaultRegistry {
       baseline: this.baselineDocs,
       local,
       serverFolders: new Set(args.serverFolders.map((f) => f.path)),
+      serverFolderIds: new Map(args.serverFolders.map((f) => [f.id, f.path] as const)),
       localFolders: new Set(args.folders.map((f) => f.path)),
       folderTombstones: args.folderTombstones ? new Set(args.folderTombstones) : null,
       // The persisted path → server-folder-id join: an id match against a

--- a/app/apps/desktop/src/lib/syncRollup.ts
+++ b/app/apps/desktop/src/lib/syncRollup.ts
@@ -30,6 +30,15 @@ export interface FolderSyncSummary {
   /** In flight right now (queued or syncing). */
   pending: number;
   failed: number;
+  /**
+   * Mapped notes for which NO state has been reported yet this session. They
+   * read as `unsynced` (honesty: nothing has confirmed them) but they are not
+   * "work": the sync run stamps every confirmed note `synced` in one batch once
+   * the vault channel is ready, and until that batch lands a fresh launch would
+   * otherwise pin every folder's wave at its whole population ("186/187" for
+   * one genuinely new note). See {@link FolderWaveTracker}.
+   */
+  unreported: number;
   /** The folder row's state. See {@link rollupState}. */
   state: DocSyncState;
   /** `synced / total` as a whole percentage, floored (so it reads 99% at 499/500
@@ -79,6 +88,7 @@ interface Counts {
   synced: number;
   pending: number;
   failed: number;
+  unreported: number;
 }
 
 /**
@@ -106,10 +116,14 @@ function summarize(c: Counts): FolderSyncSummary {
 export function buildTreeSyncIndex(input: TreeSyncInput): TreeSyncIndex {
   const { docIdByPath, docSyncState, localNotePaths } = input;
   const notes = new Map<string, DocSyncState>();
+  /** Mapped notes with no reported transition (see `FolderSyncSummary.unreported`). */
+  const unreported = new Set<string>();
 
   // Every note the server knows about, at its reported state.
   for (const [relPath, docId] of Object.entries(docIdByPath)) {
-    notes.set(relPath, docSyncState[docId] ?? "unsynced");
+    const reported = docSyncState[docId];
+    if (reported === undefined) unreported.add(relPath);
+    notes.set(relPath, reported ?? "unsynced");
   }
   // Every note only this device knows about. It has no docId, so it cannot have a
   // state — and "no server row" is exactly what unsynced means.
@@ -123,23 +137,25 @@ export function buildTreeSyncIndex(input: TreeSyncInput): TreeSyncIndex {
   }
 
   const counts = new Map<string, Counts>();
-  const credit = (dir: string, state: DocSyncState): void => {
+  const credit = (dir: string, state: DocSyncState, isUnreported: boolean): void => {
     let c = counts.get(dir);
     if (!c) {
-      c = { total: 0, synced: 0, pending: 0, failed: 0 };
+      c = { total: 0, synced: 0, pending: 0, failed: 0, unreported: 0 };
       counts.set(dir, c);
     }
     c.total++;
     if (state === "synced") c.synced++;
     else if (state === "error") c.failed++;
     else if (state === "queued" || state === "syncing") c.pending++;
+    if (isUnreported) c.unreported++;
   };
 
   // Credit each note to every folder above it, up to and including the root ("").
   for (const [relPath, state] of notes) {
+    const isUnreported = unreported.has(relPath);
     let dir = parentDir(relPath);
     for (;;) {
-      credit(dir, state);
+      credit(dir, state, isUnreported);
       if (dir === "") break;
       dir = parentDir(dir);
     }
@@ -190,7 +206,11 @@ export class FolderWaveTracker {
       if (!s || s.total - s.synced <= 0) this.waves.delete(key);
     }
     const stamp = (path: string, s: FolderSyncSummary): void => {
-      const remaining = s.total - s.synced;
+      // Only notes that have actually been REPORTED as not synced are work. A
+      // mapped note nobody has spoken for yet is not in the wave: before the
+      // run's first batch of `synced` stamps lands, every note looks unsynced,
+      // and pinning the wave then is exactly the "186/187" badge.
+      const remaining = s.total - s.synced - s.unreported;
       if (remaining <= 0) return;
       const wave = Math.max(this.waves.get(path) ?? 0, remaining);
       this.waves.set(path, wave);
@@ -225,6 +245,13 @@ export const DOC_SYNC_TITLES: Record<DocSyncState, string> = {
 
 function plural(n: number, word: string): string {
   return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/** A wave with nothing in it is not progress — draw the dot instead of "0/0". */
+function waveOrNull(
+  wave: { done: number; total: number },
+): { done: number; total: number } | null {
+  return wave.total > 0 ? wave : null;
 }
 
 /** Tooltip for a folder row: always the real counts, never a rounded claim. */
@@ -263,8 +290,14 @@ export function rowSyncMark(
       progress: settled
         ? null
         : // No tracker ran (no `apply` call) ⇒ fall back to the wave a fresh
-          // tracker would report: everything unsynced right now, none done.
-          (summary.wave ?? { done: 0, total: summary.total - summary.synced }),
+          // tracker would report: everything REPORTED unsynced right now, none
+          // done. Nothing reported at all ⇒ no counts to show yet, just the dot.
+          waveOrNull(
+            summary.wave ?? {
+              done: 0,
+              total: summary.total - summary.synced - summary.unreported,
+            },
+          ),
       title: folderSyncTitle(summary),
     };
   }

--- a/app/apps/desktop/src/lib/tree/titles.test.ts
+++ b/app/apps/desktop/src/lib/tree/titles.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { applyTitlePatch } from "./titles";
+
+const t = (path: string, title: string, id = path) => ({ id, path, title });
+
+describe("applyTitlePatch", () => {
+  const base = [t("a.md", "Alpha"), t("b.md", "Beta"), t("c.md", "Gamma")];
+
+  it("replaces changed rows, adds new ones and drops removed paths, keeping title order", () => {
+    const next = applyTitlePatch(base, [t("b.md", "Zeta"), t("d.md", "Delta")], ["c.md"]);
+    expect(next.map((x) => x.title)).toEqual(["Alpha", "Delta", "Zeta"]);
+    expect(next.find((x) => x.path === "b.md")?.title).toBe("Zeta");
+  });
+
+  it("returns the same array when nothing changed (no store write)", () => {
+    expect(applyTitlePatch(base, [t("a.md", "Alpha")], [])).toBe(base);
+    expect(applyTitlePatch(base, [], [])).toBe(base);
+  });
+
+  it("a removal wins over an update for the same path", () => {
+    const next = applyTitlePatch(base, [t("a.md", "Alpha 2")], ["a.md"]);
+    expect(next.map((x) => x.path)).toEqual(["b.md", "c.md"]);
+  });
+
+  it("does not mutate the input", () => {
+    const copy = base.map((x) => ({ ...x }));
+    applyTitlePatch(base, [t("a.md", "Changed")], ["b.md"]);
+    expect(base).toEqual(copy);
+  });
+});

--- a/app/apps/desktop/src/lib/tree/titles.ts
+++ b/app/apps/desktop/src/lib/tree/titles.ts
@@ -1,0 +1,52 @@
+// Pure helper for keeping `store.titles` (the local index's id/path/title rows)
+// current without re-reading all of them.
+//
+// `refreshTitles` marshals EVERY note over IPC (5.9k rows on a large vault) and
+// used to run on every watcher batch — i.e. on every egest a sync run performs.
+// During a bulk sync that was one full-vault round trip every ~150ms, and every
+// one replaced the array, which re-derived the whole sidebar roll-up. A watcher
+// batch names the files that changed, so the rows can be patched instead.
+
+import type { NoteTitle } from "../ipc";
+
+/** Byte-wise title order, as SQLite's default `ORDER BY title` collation. */
+function byTitle(a: NoteTitle, b: NoteTitle): number {
+  return a.title < b.title ? -1 : a.title > b.title ? 1 : a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+}
+
+/**
+ * Apply fresh rows for changed notes and drop removed paths, keeping the array
+ * sorted the way the index lists it. Returns the SAME array when nothing changed
+ * so callers can skip a store write.
+ */
+export function applyTitlePatch(
+  titles: NoteTitle[],
+  updates: NoteTitle[],
+  removedPaths: Iterable<string>,
+): NoteTitle[] {
+  const removed = new Set(removedPaths);
+  const fresh = new Map(updates.map((t) => [t.path, t] as const));
+  let changed = false;
+  const next: NoteTitle[] = [];
+  for (const t of titles) {
+    if (removed.has(t.path)) {
+      changed = true;
+      continue;
+    }
+    const f = fresh.get(t.path);
+    if (f) {
+      fresh.delete(t.path);
+      if (f.id !== t.id || f.title !== t.title) changed = true;
+      next.push(f);
+    } else {
+      next.push(t);
+    }
+  }
+  for (const f of fresh.values()) {
+    if (removed.has(f.path)) continue;
+    next.push(f); // a note the index has that we didn't list yet
+    changed = true;
+  }
+  if (!changed) return titles;
+  return next.sort(byTitle);
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -14,6 +14,7 @@ import {
 } from "./lib/appearance";
 import { readItemOrder, writeItemOrder, type ItemOrder } from "./lib/ordering";
 import { loadedFolderPaths, mergeChildren, nodeAt, setChildrenAt } from "./lib/tree/lazyTree";
+import { applyTitlePatch } from "./lib/tree/titles";
 import {
   ApiError,
   type BillingConfig,
@@ -280,6 +281,12 @@ interface AppStore {
   /** Lazily load one folder's immediate children into the sidebar tree. */
   loadChildren: (path: string) => Promise<void>;
   refreshTitles: () => Promise<void>;
+  /**
+   * Bring `titles` current for just the notes a watcher batch named: re-read
+   * those rows (one `getNoteMeta` each) and drop the removed ones, instead of
+   * re-listing every note in the vault (`refreshTitles`).
+   */
+  patchTitles: (changes: ReadonlyArray<{ path: string; kind: "modified" | "removed" }>) => Promise<void>;
   /** First-run seeding for a local (not-yet-synced) empty vault. */
   seedLocalVaultIfEmpty: () => Promise<void>;
   /** Open the root Welcome note if it exists and nothing else is open. */
@@ -1098,6 +1105,34 @@ export const useStore = create<AppStore>((set, get) => ({
     }
     if (!sameVault(get, epoch)) return;
     set({ titles });
+  },
+
+  patchTitles: async (changes) => {
+    const epoch = get().vault?.epoch;
+    const md = changes.filter((c) => c.path.toLowerCase().endsWith(".md"));
+    if (md.length === 0) return;
+    const removed: string[] = [];
+    const updates: ipc.NoteTitle[] = [];
+    await Promise.all(
+      md.map(async (c) => {
+        if (c.kind === "removed") {
+          removed.push(c.path);
+          return;
+        }
+        try {
+          const meta = await ipc.getNoteMeta(c.path);
+          // Not in the index (yet, or any more): nothing to show for it.
+          if (!meta) removed.push(c.path);
+          else updates.push({ id: meta.id, path: meta.path, title: meta.title });
+        } catch {
+          // Leave that row alone; the next full refresh (a structural batch or a
+          // vault open) reconciles it.
+        }
+      }),
+    );
+    if (!sameVault(get, epoch)) return;
+    const next = applyTitlePatch(get().titles, updates, removed);
+    if (next !== get().titles) set({ titles: next });
   },
 
   seedLocalVaultIfEmpty: async () => {

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
 - Folder badges now count only the notes that actually need syncing (for example "1/2" for two new files), instead of the folder's whole population ("186/187")
 - A fully synced vault shows its synced dots right after connecting, without waiting for a sync run
 - Editing while a sync is running no longer re-reads every note title on each change, so the sidebar stays responsive on large vaults
+- A file added to a folder that a teammate had moved on the server no longer fails to sync forever ("1 not synced"): the folder is re-created at its old path and the file registers normally
+- Empty leftover files of notes deleted on the server are now cleaned up instead of lingering as unsyncable stubs

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,3 +3,4 @@
 - Editing while a sync is running no longer re-reads every note title on each change, so the sidebar stays responsive on large vaults
 - A file added to a folder that a teammate had moved on the server no longer fails to sync forever ("1 not synced"): the folder is re-created at its old path and the file registers normally
 - Empty leftover files of notes deleted on the server are now cleaned up instead of lingering as unsyncable stubs
+- After a teammate moves a folder, the emptied old folder is removed on your device instead of coming back for everyone as an empty duplicate

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,13 +1,3 @@
-- Self-hosted servers on a single port (the Docker Compose bundle) now receive note content: the app no longer dials a separate sync port that isn't exposed, so "structure syncs but notes stay empty" is fixed
-- Reloading or switching vaults no longer "re-syncs" hundreds of empty placeholder notes on every connect
-- Notes over the 10 MB sync limit are reported once as too large instead of being retried on every reconnect
-- If a note can't be written to disk (disk full, permissions), you now see a sticky warning and the save is retried automatically until it lands
-- A note that fails to register for sync when opened now tells you, and registration is retried automatically
-- Turning on sync, creating an MCP token and deleting a vault now show a visible error when they fail
-- Opening a large vault no longer freezes while the index rebuilds — the sidebar appears immediately and search/backlinks fill in when indexing finishes
-- The sidebar refreshes only the folders a change touched, and the graph view patches only the notes that changed, so big vaults stay smooth while editing
-- MCP: `read_note` returns a `revision`, writes accept `expectedRevision` to refuse stale edits, a new `edit_note` tool makes targeted changes, and `append_note` accepts an idempotency key
-- Server: notes containing a NUL character no longer break search indexing or version checkpoints
-- Right-click a tab for quick actions: close, close others, close tabs to the right, or close all
-- You can now open a folder — including a whole drive — as a vault by typing its path on the vault screen
-- A vault at a drive root now shows its drive name instead of a generic label
+- Folder badges now count only the notes that actually need syncing (for example "1/2" for two new files), instead of the folder's whole population ("186/187")
+- A fully synced vault shows its synced dots right after connecting, without waiting for a sync run
+- Editing while a sync is running no longer re-reads every note title on each change, so the sidebar stays responsive on large vaults


### PR DESCRIPTION
Follow-up to #77, from testing the BenAI OS vault after the empty-note resync fix.

## Folder badges count the wave, not the population
The sidebar already had a "wave" tracker meant to show `1/2` (two new notes, one done) rather than `186/187`. It pinned the wave on the first render after launch, when the registry has mapped every note but the sync run has not reported anything yet — so every note read "unsynced" and the wave locked at the folder's whole size. Mapped notes with no reported state are now tracked as `unreported`: they still read unsynced (honesty) but are not counted as work, so the wave pins only on notes actually reported as queued/syncing/unsynced. A folder with nothing reported shows a dot, never `0/N`.

## Synced dots without a run
Only a sync run's uploader stamped confirmed notes `synced`. With #77 the run no longer starts when there is nothing to send (that was the point), which would have left a fully synced vault on unsynced badges until something else started a run. `startContentRunIfNeeded` now badges every confirmed note when it settles with an empty work list — once, under the same guard as the terminal phase.

## Sidebar responsiveness during sync
Every watcher batch re-listed all note titles over IPC (5.9k rows on this vault) and replaced the array, re-deriving the whole roll-up — on every egest a sync run performs. Plain file batches now patch only the named rows (`getNoteMeta` per changed path, `applyTitlePatch` keeps index order); structural batches still re-list everything.

Version 0.1.43 (all four files) + release notes.

## Testing
- Desktop vitest: 698 passed (new: wave-with-unreported, badge-without-run, title patch) · `tsc --noEmit` clean · `cargo check` clean

## "1 not synced", forever (found after installing 0.1.42)
On the BenAI OS vault one file was permanently unsyncable. The server had moved the folder `Projects/Content/youtube/build-claude-skills-video` to `YouTube/videos/…/legacy-projects-content`; the old directory stayed on disk (it held a `.txt`, which the Rust index doesn't key, so the per-note rename never carried it), and the registry's path → folder-id map kept the OLD path pointing at the MOVED folder's id — that map was only ever added to from the server listing, never pruned. Every pull then registered the file with that id and the server refused it as `path_folder_mismatch` (a 4xx, so no retry): one failure, every pull, nothing the user could do.

Fix: the folder map is re-derived from the server listing each pass (an entry whose path no longer carries that id is dropped), so the old path counts as a missing folder, is re-created under its real parent, and the file registers against the new id. A `path_folder_mismatch` response also drops the stale parent entry directly. The server's strict check is correct and unchanged.

Same vault also had 21 zero-byte `.md` stubs under re-created "… 2/" folders: notes the server had deleted whose files the index keyed under a fresh id, so the inbound plan could only suppress re-registration and left them on disk — unmapped, uncounted, unsyncable. The plan now names those (`stubs`, confirmed deletions only — never revocations or an unanswered tombstone list) and the executor trashes the EMPTY ones; a non-empty file is still left alone.

Tests: moved-folder re-creation end to end, empty stub trashed, non-empty stub left alone, the null-tombstones guard still holds. Desktop vitest: 701 passed.

## Emptied directories after a server-side folder move
Root of the trap above: inbound moved a folder's NOTES one by one but never removed the emptied old directory (only tombstoned folders were removed). The old directory lingered, and — now that the folder map is re-derived — would have been re-registered as an empty twin on the next pass, for the whole team. The plan now sees a recorded folder id living at a different server path (`serverFolderIds`) and removes the old directory, empty-only, exactly like a tombstoned one; a directory that still holds something stays and re-registers fresh (content must live somewhere). Plan-level and end-to-end tests.
