### PR TITLE
Fix the CRDT write loop, note doubling, and the sidebar that blinked while syncing

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.43",
+  "version": "0.1.44",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -31,6 +31,7 @@
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-log": "^2.9.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -45,6 +45,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,9 +814,10 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "keyring",
+ "log",
  "notify",
  "once_cell",
  "regex",
@@ -814,6 +832,7 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -1030,6 +1049,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2494,6 +2532,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4212,6 +4259,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e8861142c21636b03ff6eb9682a073814112e35220435670738a8be7b49896"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,7 +4544,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.43"
+version = "0.1.44"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"
@@ -22,6 +22,10 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-process = "2"
 tauri-plugin-clipboard-manager = "2"
+# Frontend logging: `console.log` in a WKWebView never reaches the `tauri dev`
+# terminal, so the UI reports through this plugin's Stdout target instead.
+tauri-plugin-log = "2"
+log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/app/apps/desktop/src-tauri/capabilities/default.json
+++ b/app/apps/desktop/src-tauri/capabilities/default.json
@@ -30,6 +30,10 @@
     "core:window:allow-show",
     "core:window:allow-unminimize",
     {
+      "identifier": "log:default",
+      "comment": "Lets the React layer write to the app log. A `console.log` in a WKWebView reaches only the Web Inspector, so without this the UI cannot report anything to whoever is reading the `tauri dev` terminal. The plugin is registered for debug builds only (src/lib.rs)."
+    },
+    {
       "identifier": "deep-link:default",
       "comment": "Registers the `baalda://` URL scheme and lets the webview subscribe to opens on it. This is how a shared note link gets from a teammate's chat window into this app; the payload is only ever a vault + note id, and the handler resolves it against the signed-in user's own access."
     }

--- a/app/apps/desktop/src-tauri/src/index.rs
+++ b/app/apps/desktop/src-tauri/src/index.rs
@@ -23,9 +23,25 @@ use walkdir::WalkDir;
 /// through the same code and must stay silent.
 const BATCH_LOG_MIN: usize = 50;
 
+/// Files above this are indexed by title only — never parsed for body text or
+/// links. Mirrors the sync layer's `MAX_NOTE_BYTES` (contentUpload.ts): a note
+/// too big to upload is a note too big to fully index. See `index_one`.
+const MAX_INDEX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Which links a resolution pass has to reconsider.
+pub enum LinkScope<'a> {
+    /// Every link in the vault. Correct but O(all links): only for `rebuild`,
+    /// where we are rewriting everything anyway.
+    All,
+    /// Only the links a batch can have changed the answer for (see
+    /// `Index::resolve_links` for why this set is sufficient). These are the
+    /// note ids the batch created, re-parsed, renamed or removed.
+    Touched(&'a [String]),
+}
+
 pub struct Index {
     conn: Connection,
-    /// Test-only: how many times `resolve_all_links` has run. The entire point of
+    /// Test-only: how many times `resolve_links` has run. The entire point of
     /// the batch entry points is ONE link pass per batch instead of one per file,
     /// and that difference is only observable by counting.
     #[cfg(test)]
@@ -317,9 +333,11 @@ impl Index {
             changed = true;
         }
 
-        // Link targets only need re-resolving when the note set changed.
+        // Link targets only need re-resolving when the note set changed. Full
+        // scope: `rebuild` has just rewritten every note, so there is no smaller
+        // set to narrow to.
         if changed {
-            self.resolve_all_links(&tx)?;
+            self.resolve_links(&tx, LinkScope::All)?;
         }
         tx.commit()?;
         log_batch("rebuild", touched, started);
@@ -328,7 +346,7 @@ impl Index {
 
     /// (Re)index a BATCH of notes: ONE transaction, ONE link-resolution pass.
     ///
-    /// Why this exists. `resolve_all_links` reads every row of `notes` and every
+    /// Why this exists. `resolve_links` reads every row of `notes` and every
     /// row of `links` and then rewrites every link row. Running it once *per
     /// file* — which is what `index_note` did, and the watcher called it once per
     /// dirty path — makes indexing N files O(N × links_in_vault), each pass in
@@ -352,19 +370,19 @@ impl Index {
         let started = Instant::now();
         let tx = self.conn.unchecked_transaction()?;
         let mut failures: Vec<(PathBuf, AppError)> = Vec::new();
-        let mut indexed = 0usize;
+        let mut touched: Vec<String> = Vec::with_capacity(abs_paths.len());
         for abs in abs_paths {
             let outcome = rel_from_abs(vault, abs)
                 .and_then(|rel| self.id_for_path(&tx, &rel))
                 .and_then(|reuse_id| self.index_one(&tx, vault, abs, reuse_id));
             match outcome {
-                Ok(()) => indexed += 1,
+                Ok(id) => touched.push(id),
                 Err(e) => failures.push((abs.clone(), e)),
             }
         }
-        // The single pass the whole batch shares.
-        if indexed > 0 {
-            self.resolve_all_links(&tx)?;
+        // The single pass the whole batch shares, narrowed to the notes it wrote.
+        if !touched.is_empty() {
+            self.resolve_links(&tx, LinkScope::Touched(&touched))?;
         }
         tx.commit()?;
         log_batch("index_notes", abs_paths.len(), started);
@@ -394,15 +412,15 @@ impl Index {
         }
         let tx = self.conn.unchecked_transaction()?;
         let mut failures: Vec<(PathBuf, AppError)> = Vec::new();
-        let mut removed = 0usize;
+        let mut gone: Vec<String> = Vec::new();
         for abs in abs_paths {
             match self.remove_one(&tx, vault, abs) {
-                Ok(()) => removed += 1,
+                Ok(mut ids) => gone.append(&mut ids),
                 Err(e) => failures.push((abs.clone(), e)),
             }
         }
-        if removed > 0 {
-            self.resolve_all_links(&tx)?;
+        if !gone.is_empty() {
+            self.resolve_links(&tx, LinkScope::Touched(&gone))?;
         }
         tx.commit()?;
         Ok(failures)
@@ -420,12 +438,16 @@ impl Index {
 
     /// The row-level removal, inside a caller-owned transaction and WITHOUT a
     /// link pass (the batch does that once at the end).
-    fn remove_one(&self, tx: &Connection, vault: &Path, abs: &Path) -> AppResult<()> {
+    /// Returns the ids it deleted, so the batch can scope `resolve_links`: links
+    /// that pointed AT a removed note must go back to dangling.
+    fn remove_one(&self, tx: &Connection, vault: &Path, abs: &Path) -> AppResult<Vec<String>> {
         let rel = rel_from_abs(vault, abs)?;
+        let mut gone: Vec<String> = Vec::new();
 
         // Exact-path note (a file delete).
         if let Some((id, rowid)) = self.row_for_path(tx, &rel)? {
             Self::delete_note_rows(tx, &id, rowid)?;
+            gone.push(id);
         }
 
         // Any notes under a deleted folder (prefix delete).
@@ -439,12 +461,13 @@ impl Index {
         };
         for (id, rowid) in victims {
             Self::delete_note_rows(tx, &id, rowid)?;
+            gone.push(id);
         }
         tx.execute(
             "DELETE FROM folders WHERE id = ?1 OR path LIKE ?2 || '%'",
             params![rel, prefix],
         )?;
-        Ok(())
+        Ok(gone)
     }
 
     fn delete_note_rows(tx: &Connection, id: &str, rowid: i64) -> AppResult<()> {
@@ -490,28 +513,94 @@ impl Index {
             )?;
         }
 
-        // Re-resolve links (a file rename can change the basename used to resolve).
-        self.resolve_all_links(&tx)?;
+        // Re-resolve links (a file rename can change the basename used to
+        // resolve). Full scope: a FOLDER move rewrites a whole subtree's paths,
+        // and the ids are gathered above only for the descendants, so narrowing
+        // here would be easy to get subtly wrong for a rename that changes a
+        // basename other notes link to.
+        self.resolve_links(&tx, LinkScope::All)?;
         tx.commit()?;
         Ok(())
     }
 
+    /// The note row for a file over [`MAX_INDEX_BYTES`]: identity, title and
+    /// mtime, with an EMPTY FTS body and no links or tags. Any body/link/tag rows
+    /// a smaller earlier version left behind are cleared, so a note growing past
+    /// the cap cannot strand millions of link rows in the table.
+    fn index_oversized(
+        &self,
+        tx: &Connection,
+        rel: &str,
+        stem: &str,
+        mtime: i64,
+        reuse_id: Option<String>,
+    ) -> AppResult<String> {
+        let id = reuse_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+        tx.execute(
+            "INSERT INTO notes (id, path, title, mtime, sha256, frontmatter)
+             VALUES (?1, ?2, ?3, ?4, NULL, NULL)
+             ON CONFLICT(id) DO UPDATE SET
+                path=excluded.path, title=excluded.title, mtime=excluded.mtime,
+                sha256=excluded.sha256, frontmatter=excluded.frontmatter",
+            params![id, rel, stem, mtime],
+        )?;
+        let rowid: i64 =
+            tx.query_row("SELECT rowid FROM notes WHERE id = ?1", params![id], |r| {
+                r.get(0)
+            })?;
+        tx.execute("DELETE FROM notes_fts WHERE rowid = ?1", params![rowid])?;
+        tx.execute(
+            "INSERT INTO notes_fts (rowid, title, body) VALUES (?1, ?2, '')",
+            params![rowid, stem],
+        )?;
+        tx.execute("DELETE FROM note_tags WHERE note_id = ?1", params![id])?;
+        tx.execute("DELETE FROM links WHERE src_note_id = ?1", params![id])?;
+        Ok(id)
+    }
+
+    /// Returns the note id it wrote, so a batch can tell `resolve_links` exactly
+    /// which notes it touched (see `LinkScope`).
     fn index_one(
         &self,
         tx: &Connection,
         vault: &Path,
         abs: &Path,
         reuse_id: Option<String>,
-    ) -> AppResult<()> {
+    ) -> AppResult<String> {
         let rel = rel_from_abs(vault, abs)?;
-        let content = std::fs::read_to_string(abs)?;
         let stem = abs
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("untitled");
+        let mtime = file_mtime(abs);
+
+        // Oversized notes are LISTED but not parsed. A note has no business being
+        // this big, and when one gets there anyway (the 2026-09-04 doubling bug
+        // took a daily note to 68 MB) parsing it is what turns one bad file into a
+        // vault-wide outage: `parse_note` found ~86,370 wikilinks in it, `links`
+        // reached 2,025,307 rows for 37,138 distinct targets, the FTS content
+        // table took 503 MB, and index.sqlite hit 1.27 GB. Every index pass then
+        // ran for tens of seconds holding the index mutex, which is the lock the
+        // UI waits on.
+        //
+        // Skipping the parse (not the note row) keeps the file visible in the
+        // sidebar and searchable by title, so the user can find and fix it, while
+        // costing the index nothing. Matches the sync layer's `MAX_NOTE_BYTES`, so
+        // a note too big to upload is also a note too big to fully index.
+        let size = std::fs::metadata(abs).map(|m| m.len()).unwrap_or(0);
+        if size > MAX_INDEX_BYTES {
+            eprintln!(
+                "[index] {} is {:.1} MB (> {} MB cap): indexing title only, skipping body + links",
+                rel,
+                size as f64 / (1024.0 * 1024.0),
+                MAX_INDEX_BYTES / (1024 * 1024)
+            );
+            return self.index_oversized(tx, &rel, stem, mtime, reuse_id);
+        }
+
+        let content = std::fs::read_to_string(abs)?;
         let parsed = parse_note(&content, stem);
         let sha = sha256_hex(&content);
-        let mtime = file_mtime(abs);
 
         let id = reuse_id.unwrap_or_else(|| Uuid::new_v4().to_string());
 
@@ -554,7 +643,7 @@ impl Index {
             )?;
         }
 
-        // Links (dst resolved later in resolve_all_links).
+        // Links (dst resolved later in resolve_links).
         tx.execute("DELETE FROM links WHERE src_note_id = ?1", params![id])?;
         for link in &parsed.links {
             tx.execute(
@@ -564,7 +653,7 @@ impl Index {
             )?;
         }
 
-        Ok(())
+        Ok(id)
     }
 
     fn upsert_folder(&self, tx: &Connection, vault: &Path, abs: &Path) -> AppResult<()> {
@@ -586,10 +675,37 @@ impl Index {
         Ok(())
     }
 
-    /// Recompute `dst_note_id` for every link by matching the raw target against
-    /// note basenames (case-insensitive), then titles. Cheap enough for Phase 0
-    /// and guarantees previously-dangling links resolve once a target appears.
-    fn resolve_all_links(&self, tx: &Connection) -> AppResult<()> {
+    /// Recompute `dst_note_id` for links by matching the raw target against note
+    /// basenames (case-insensitive), then titles.
+    ///
+    /// ## Why this is scoped
+    ///
+    /// This used to be `resolve_all_links`: one pass over EVERY row of `links`,
+    /// per batch. That is O(all links in the vault) work for a change to a
+    /// handful of notes, and it is charged while the watcher's drain thread holds
+    /// the index mutex — the lock every UI command waits on. Measured on a vault
+    /// with a forked note that had ballooned to 68 MB (2,025,307 link rows for
+    /// 37,138 distinct targets): `index_notes: 176 files in 27128 ms`. Opening a
+    /// note, the sidebar's titles and its backlinks all queue behind that, which
+    /// is what "the sidebar blinks and clicks are slow while it syncs" was.
+    ///
+    /// ## Why `Touched` is sufficient
+    ///
+    /// A link's answer is a pure function of (its raw target, the set of note
+    /// basenames/titles). So it can only change when:
+    ///  - its OWN row was just rewritten — `src_note_id` is in the batch
+    ///    (`index_one` deletes and re-inserts a note's links); or
+    ///  - the note it points AT changed path or title, or is gone —
+    ///    `dst_note_id` is in the batch; or
+    ///  - it was dangling and a matching note has now appeared —
+    ///    `dst_note_id IS NULL`.
+    ///
+    /// The one case deliberately NOT re-examined: a new note whose basename
+    /// duplicates an existing note's does not steal links already resolved to
+    /// the older one. That matches the old behaviour, which broke such ties by
+    /// `HashMap::or_insert` over an unordered `SELECT` — i.e. arbitrarily. Making
+    /// it "first writer keeps it" is no less correct and is stable.
+    fn resolve_links(&self, tx: &Connection, scope: LinkScope<'_>) -> AppResult<()> {
         #[cfg(test)]
         self.resolve_calls.set(self.resolve_calls.get() + 1);
         // Build lookup maps from all notes.
@@ -619,22 +735,66 @@ impl Index {
             }
         }
 
-        // Resolve each link.
-        let links: Vec<(i64, String)> = {
-            let mut stmt = tx.prepare("SELECT id, dst_path_raw FROM links")?;
-            let rows = stmt.query_map([], |r| {
-                Ok((
-                    r.get::<_, i64>(0)?,
-                    r.get::<_, Option<String>>(1)?.unwrap_or_default(),
-                ))
-            })?;
-            rows.collect::<Result<Vec<_>, _>>()?
+        // The candidate links. `All` reads the table; `Touched` narrows it to the
+        // three cases that can have changed (see the doc comment) via a temp
+        // table, so the id list is not spliced into SQL and is not capped by
+        // SQLITE_MAX_VARIABLE_NUMBER.
+        let links: Vec<(i64, String)> = match scope {
+            LinkScope::All => {
+                let mut stmt = tx.prepare("SELECT id, dst_path_raw FROM links")?;
+                let rows = stmt.query_map([], |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                    ))
+                })?;
+                rows.collect::<Result<Vec<_>, _>>()?
+            }
+            LinkScope::Touched(ids) => {
+                tx.execute_batch(
+                    "CREATE TEMP TABLE IF NOT EXISTS touched_notes (id TEXT PRIMARY KEY);
+                     DELETE FROM touched_notes;",
+                )?;
+                {
+                    let mut ins =
+                        tx.prepare("INSERT OR IGNORE INTO touched_notes (id) VALUES (?1)")?;
+                    for id in ids {
+                        ins.execute(params![id])?;
+                    }
+                }
+                // Both `idx_links_src` and `idx_links_dst` serve these, and the
+                // NULL arm is an index range scan rather than a table scan.
+                let mut stmt = tx.prepare(
+                    "SELECT id, dst_path_raw FROM links
+                      WHERE dst_note_id IS NULL
+                         OR src_note_id IN (SELECT id FROM touched_notes)
+                         OR dst_note_id IN (SELECT id FROM touched_notes)",
+                )?;
+                let rows = stmt.query_map([], |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                    ))
+                })?;
+                rows.collect::<Result<Vec<_>, _>>()?
+            }
         };
 
         // Hoisted out of the loop: `Connection::execute` re-prepares (and
         // re-parses) the statement on every call, which on a link-dense vault is
         // tens of thousands of needless prepares per pass.
-        let mut update = tx.prepare("UPDATE links SET dst_note_id = ?1 WHERE id = ?2")?;
+        //
+        // `IS NOT ?1` makes the write conditional, and that is the expensive half.
+        // A link's resolution almost never changes — re-indexing a note re-derives
+        // the same target — but this rewrote EVERY row of `links` on EVERY pass,
+        // dirtying a WAL page each time. That fixed cost is what a batch actually
+        // pays for: a 357-file watcher batch on a ~5k-note vault took 10.6s, and
+        // it is paid while `process_batch` holds the index mutex, which is the
+        // lock every UI command queues behind — the "clicks are slow during sync"
+        // report. `IS NOT` (not `<>`) because `dst_note_id` is nullable and an
+        // unresolved link must compare equal to an unresolved link.
+        let mut update =
+            tx.prepare("UPDATE links SET dst_note_id = ?1 WHERE id = ?2 AND dst_note_id IS NOT ?1")?;
         for (link_id, raw) in links {
             // raw may contain alias/heading — strip for matching.
             let target = raw
@@ -828,7 +988,7 @@ impl Index {
     }
 
     /// Resolve a wiki-link target to a note: by full relative path, then by
-    /// basename (case-insensitive), then by title. Mirrors `resolve_all_links`.
+    /// basename (case-insensitive), then by title. Mirrors `resolve_links`.
     pub fn resolve_wikilink(&self, name: &str) -> AppResult<Option<ResolvedLink>> {
         let target = name
             .split('|')
@@ -1371,6 +1531,127 @@ mod tests {
                 .any(|(_, dst, raw)| dst == "-" && raw == "Nowhere"),
             "a dangling link stays dangling: {links:?}"
         );
+    }
+
+    /// A note past `MAX_INDEX_BYTES` must stay LISTED but contribute no links —
+    /// the guard that stops one runaway file (68 MB, ~86k wikilinks) from putting
+    /// 2M rows in `links` and making every later index pass take tens of seconds.
+    #[test]
+    fn an_oversized_note_is_listed_but_not_parsed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        // One link per copy; well past the cap.
+        let huge = "see [[Target]]\n".repeat(800_000);
+        assert!(huge.len() as u64 > MAX_INDEX_BYTES);
+        std::fs::write(v.join("Huge.md"), &huge).unwrap();
+        std::fs::write(v.join("Target.md"), "# Target").unwrap();
+        std::fs::write(v.join("Small.md"), "# Small\n\nsee [[Target]]").unwrap();
+
+        let idx = Index::open(&v).unwrap();
+        idx.index_notes(
+            &v,
+            &[v.join("Huge.md"), v.join("Target.md"), v.join("Small.md")],
+        )
+        .unwrap();
+
+        // Listed, so the user can still find the offender.
+        let listed: i64 = idx
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes WHERE path = 'Huge.md'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(listed, 1, "an oversized note must still be indexed by title");
+
+        // …but it contributes NO links, while the small note's link still works.
+        let from_huge: i64 = idx
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM links l JOIN notes n ON n.id = l.src_note_id
+                  WHERE n.path = 'Huge.md'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(from_huge, 0, "oversized note must not be parsed for links");
+
+        let from_small: i64 = idx
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM links l JOIN notes n ON n.id = l.src_note_id
+                  WHERE n.path = 'Small.md' AND l.dst_note_id IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(from_small, 1, "normal notes are unaffected");
+    }
+
+    /// Scoping the link pass (`LinkScope::Touched`) must not cost correctness.
+    /// The risky case: a link that was DANGLING when written has to resolve once
+    /// its target is indexed by a later, scoped batch — the target's id is in
+    /// that batch, and the dangling row is picked up by the `dst_note_id IS NULL`
+    /// arm.
+    #[test]
+    fn a_dangling_link_still_resolves_when_its_target_arrives_in_a_later_batch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        std::fs::write(v.join("Alpha.md"), "# Alpha\n\nsee [[Beta]]").unwrap();
+        let idx = Index::open(&v).unwrap();
+        idx.index_notes(&v, &[v.join("Alpha.md")]).unwrap();
+
+        // Beta doesn't exist yet, so the link is dangling.
+        let dst: Option<String> = idx
+            .conn
+            .query_row("SELECT dst_note_id FROM links", [], |r| r.get(0))
+            .unwrap();
+        assert!(dst.is_none(), "link to a missing note must be unresolved");
+
+        // Beta arrives in its own batch; Alpha is NOT re-indexed.
+        std::fs::write(v.join("Beta.md"), "# Beta").unwrap();
+        idx.index_notes(&v, &[v.join("Beta.md")]).unwrap();
+
+        let (dst, beta): (Option<String>, String) = (
+            idx.conn
+                .query_row("SELECT dst_note_id FROM links", [], |r| r.get(0))
+                .unwrap(),
+            idx.conn
+                .query_row("SELECT id FROM notes WHERE path = 'Beta.md'", [], |r| {
+                    r.get(0)
+                })
+                .unwrap(),
+        );
+        assert_eq!(dst.as_deref(), Some(beta.as_str()), "must resolve to Beta");
+    }
+
+    /// The other half: removing a note sends links that pointed AT it back to
+    /// dangling. `remove_notes` scopes on the removed ids, so those rows are in
+    /// the `dst_note_id IN (…)` arm.
+    #[test]
+    fn removing_a_note_redangles_links_that_pointed_at_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = tmp.path().to_path_buf();
+        std::fs::write(v.join("Alpha.md"), "# Alpha\n\nsee [[Beta]]").unwrap();
+        std::fs::write(v.join("Beta.md"), "# Beta").unwrap();
+        let idx = Index::open(&v).unwrap();
+        idx.index_notes(&v, &[v.join("Alpha.md"), v.join("Beta.md")])
+            .unwrap();
+        let dst: Option<String> = idx
+            .conn
+            .query_row("SELECT dst_note_id FROM links", [], |r| r.get(0))
+            .unwrap();
+        assert!(dst.is_some(), "precondition: resolved");
+
+        std::fs::remove_file(v.join("Beta.md")).unwrap();
+        idx.remove_notes(&v, &[v.join("Beta.md")]).unwrap();
+
+        let dst: Option<String> = idx
+            .conn
+            .query_row("SELECT dst_note_id FROM links", [], |r| r.get(0))
+            .unwrap();
+        assert!(dst.is_none(), "target gone → link must dangle again");
     }
 
     /// The whole point: ONE link pass for the batch, versus one per file.

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -31,6 +31,23 @@ pub fn run() {
     #[cfg(desktop)]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|_app, _argv, _cwd| {}));
 
+    // The UI's own log, on the dev terminal. A `console.log` inside a WKWebView
+    // goes to the Web Inspector and nowhere else, so anything the React layer
+    // measures about itself is invisible to whoever is reading `tauri dev` —
+    // which is how two wrong diagnoses of "the sidebar blinks while it syncs"
+    // survived as long as they did. The frontend's `@tauri-apps/plugin-log`
+    // calls land on stdout next to the Rust ones, so both halves of a symptom
+    // read as one timeline. Debug builds only; a shipped app logs nothing new.
+    #[cfg(debug_assertions)]
+    let builder = builder.plugin(
+        tauri_plugin_log::Builder::new()
+            .level(log::LevelFilter::Info)
+            .target(tauri_plugin_log::Target::new(
+                tauri_plugin_log::TargetKind::Stdout,
+            ))
+            .build(),
+    );
+
     builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/app/apps/desktop/src-tauri/src/watcher.rs
+++ b/app/apps/desktop/src-tauri/src/watcher.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
@@ -45,10 +46,67 @@ pub struct FilesChanged {
     pub changes: Vec<FileChanged>,
 }
 
-/// Owns the live watcher. Dropping it stops watching and lets the drain thread
-/// exit (its channel disconnects).
+/// How many paths one index transaction may cover.
+///
+/// The batch used to be unbounded: one transaction, one lock acquisition, for
+/// however many paths arrived. A bulk sync writes every note in the vault, so
+/// that became `index_notes: 4940 files in 44778 ms` — 45 seconds during which
+/// the drain thread holds the index mutex and SQLite's single write slot. Every
+/// UI command that touches the index (titles, backlinks, search, opening a note)
+/// queues behind that lock, which is what "clicks are slow while it syncs" was.
+///
+/// Chunking costs one link pass per CHUNK instead of per batch, which is cheap
+/// now that the pass is scoped to the notes a batch actually touched
+/// (`Index::resolve_links` / `LinkScope::Touched`) rather than scanning every
+/// link in the vault. Before that scoping this trade was a bad one, and chunking
+/// made a damaged vault slower rather than faster.
+///
+/// Sized from the real logs of a 1,560-note vault mid-sync: a pass costs about
+/// 88 ms fixed (it rebuilds the basename/title maps from `notes`) plus ~1.4 ms
+/// per file, so 128 files is a ceiling of roughly a quarter second on how long a
+/// click can be stuck behind the indexer — under the ~300 ms where a delay stops
+/// reading as "slow" and starts reading as "broken". Bigger chunks amortise the
+/// fixed cost better (400 measured 1215 ms for 824 files in ONE hold), smaller
+/// ones pay it too often.
+const CHUNK: usize = 128;
+
+/// Breather between chunks. A std mutex is not fair: the drain thread releasing
+/// the guard and immediately re-locking it can hand the lock straight back to
+/// itself while a UI command sits in the queue, which turns per-chunk locking
+/// back into one long hold. Sleeping briefly guarantees the waiters run.
+const CHUNK_GAP: Duration = Duration::from_millis(2);
+
+/// Owns the live watcher and its drain thread.
+///
+/// Dropping it signals the thread to stop and JOINS it. The join is the point:
+/// the thread holds an `Arc<Mutex<Index>>`, and therefore a live SQLite
+/// connection to `.context/index.sqlite`. It used to be spawned detached, so a
+/// vault switch (or, in dev, an HMR remount re-running `open_vault`) opened
+/// connection #2 while the outgoing thread was still inside a multi-second write
+/// transaction on connection #1. Two writers on one SQLite file is
+/// `SQLITE_BUSY`, and past the 5s `busy_timeout` it surfaced as the
+/// `[watcher] index failed …: database is locked` storm — index rows silently
+/// lost, and every reader stalled behind the doomed writer.
+///
+/// `stop` is checked between chunks, so the join waits for at most one chunk
+/// rather than a whole 45-second batch.
 pub struct VaultWatcher {
     _watcher: RecommendedWatcher,
+    stop: Arc<AtomicBool>,
+    drain: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for VaultWatcher {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        // The thread may be parked in `recv_timeout`; it wakes within DEBOUNCE
+        // and sees the flag. Dropping `_watcher` first would also disconnect the
+        // channel, but field drop order is declaration order, so signal
+        // explicitly rather than depending on it.
+        if let Some(h) = self.drain.take() {
+            let _ = h.join();
+        }
+    }
 }
 
 /// Start watching `vault`. Returns a handle that must be kept alive.
@@ -69,10 +127,15 @@ pub fn start(
 
     // Drain thread: collect until quiet (or until the batch has been open for
     // MAX_WINDOW), then process the dirty set as one batch.
-    std::thread::spawn(move || {
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = stop.clone();
+    let drain = std::thread::spawn(move || {
         let mut dirty: HashSet<PathBuf> = HashSet::new();
         let mut opened_at: Option<Instant> = None;
         loop {
+            if thread_stop.load(Ordering::Relaxed) {
+                break;
+            }
             match rx.recv_timeout(DEBOUNCE) {
                 Ok(paths) => {
                     if dirty.is_empty() {
@@ -86,14 +149,14 @@ pub fn start(
                     if stale && !dirty.is_empty() {
                         opened_at = None;
                         let batch = std::mem::take(&mut dirty);
-                        process_batch(&vault, &index, &app, batch);
+                        process_batch(&vault, &index, &app, batch, &thread_stop);
                     }
                 }
                 Err(RecvTimeoutError::Timeout) => {
                     if !dirty.is_empty() {
                         opened_at = None;
                         let batch = std::mem::take(&mut dirty);
-                        process_batch(&vault, &index, &app, batch);
+                        process_batch(&vault, &index, &app, batch, &thread_stop);
                     }
                 }
                 Err(RecvTimeoutError::Disconnected) => break,
@@ -101,7 +164,11 @@ pub fn start(
         }
     });
 
-    Ok(VaultWatcher { _watcher: watcher })
+    Ok(VaultWatcher {
+        _watcher: watcher,
+        stop,
+        drain: Some(drain),
+    })
 }
 
 /// One planned change: what the index must do, and what the UI is told.
@@ -188,23 +255,49 @@ fn process_batch(
     index: &Arc<Mutex<Index>>,
     app: &AppHandle,
     batch: HashSet<PathBuf>,
+    stop: &AtomicBool,
 ) {
     let plan = plan_batch(vault, batch);
     if plan.changes.is_empty() {
         return;
     }
 
-    // ONE lock, ONE transaction each way, ONE link-resolution pass each way.
-    if !plan.modified.is_empty() || !plan.removed.is_empty() {
-        let guard = index.lock().unwrap();
-        if let Ok(failures) = guard.index_notes(vault, &plan.modified) {
-            for (path, err) in failures {
-                eprintln!("[watcher] index failed for {}: {err}", path.display());
+    // One transaction and one link pass per CHUNK, and — the part that matters
+    // for responsiveness — the index mutex is re-acquired per chunk instead of
+    // held for the whole batch. A UI command only ever waits for the chunk in
+    // flight. See `CHUNK`.
+    let mut chunks = 0usize;
+    for slice in plan.modified.chunks(CHUNK) {
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+        if chunks > 0 {
+            std::thread::sleep(CHUNK_GAP);
+        }
+        chunks += 1;
+        {
+            let guard = index.lock().unwrap();
+            if let Ok(failures) = guard.index_notes(vault, slice) {
+                for (path, err) in failures {
+                    eprintln!("[watcher] index failed for {}: {err}", path.display());
+                }
             }
         }
-        if let Ok(failures) = guard.remove_notes(vault, &plan.removed) {
-            for (path, err) in failures {
-                eprintln!("[watcher] remove failed for {}: {err}", path.display());
+    }
+    for slice in plan.removed.chunks(CHUNK) {
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+        if chunks > 0 {
+            std::thread::sleep(CHUNK_GAP);
+        }
+        chunks += 1;
+        {
+            let guard = index.lock().unwrap();
+            if let Ok(failures) = guard.remove_notes(vault, slice) {
+                for (path, err) in failures {
+                    eprintln!("[watcher] remove failed for {}: {err}", path.display());
+                }
             }
         }
     }

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/components/FileTree.tsx
+++ b/app/apps/desktop/src/components/FileTree.tsx
@@ -1,4 +1,6 @@
 import {
+  createContext,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -26,7 +28,7 @@ import {
   removeFromOrder,
   renameInOrder,
 } from "../lib/ordering";
-import { sortTree, TREE_SORTS } from "../lib/tree/sort";
+import { pinModified, sortTree, TREE_SORTS } from "../lib/tree/sort";
 import { LOCK_TITLES, lockScopesByPath, type LockScope } from "../lib/locks";
 import { previewKind } from "../lib/preview";
 import {
@@ -40,12 +42,20 @@ import { toast } from "../lib/toast";
 import { deletePaths } from "../lib/vault/mutatePaths";
 import { AsyncButton } from "./AsyncButton";
 import { Spinner } from "./Spinner";
-import { activeNoteEditable, insertIntoActiveNote } from "../lib/editor/activeView";
+import {
+  activeNoteEditable,
+  insertIntoActiveNote,
+} from "../lib/editor/activeView";
 import { useStore } from "../store";
 import { shareResourceId } from "../lib/api";
 import { syncManager } from "../lib/sync/docSession";
+import { isBulkPhase } from "../lib/sync/vaultScope";
 import type { VaultPeer } from "../lib/sync/vaultSyncEngine";
-import { PRESENCE_OFFLINE, ringShowsColor, statusTone } from "../lib/presence/color";
+import {
+  PRESENCE_OFFLINE,
+  ringShowsColor,
+  statusTone,
+} from "../lib/presence/color";
 import { characterSvg } from "./Identity";
 import { ShareDialog, type ShareTarget } from "./ShareDialog";
 import { placeMenu, type Placement } from "../lib/menuPlacement";
@@ -102,7 +112,13 @@ function dirAtClientPoint(x: number, y: number): string {
  * the pointer is over somewhere nothing may be dropped.
  */
 type DropAt =
-  | { kind: "line"; destDir: string; index: number; top: number; indent: number }
+  | {
+      kind: "line";
+      destDir: string;
+      index: number;
+      top: number;
+      indent: number;
+    }
   | { kind: "into"; destDir: string }
   | null;
 
@@ -225,9 +241,10 @@ export function FileTree() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   // While a bulk delete runs: {done,total} drives a progress bar in the
   // selectbar so a large delete reads as "working", not "frozen".
-  const [bulkProgress, setBulkProgress] = useState<{ done: number; total: number } | null>(
-    null,
-  );
+  const [bulkProgress, setBulkProgress] = useState<{
+    done: number;
+    total: number;
+  } | null>(null);
   // onActivate is captured by arborist; read the live mode through a ref.
   const selectModeRef = useRef(false);
   selectModeRef.current = selectMode;
@@ -263,6 +280,12 @@ export function FileTree() {
   const wavesRef = useRef(new FolderWaveTracker());
   const vaultPath = useStore((s) => s.vault?.path ?? null);
   const lastWaveKeyRef = useRef<string | null>(null);
+  // Split out so a progress emission doesn't rebuild it: `docSyncState` changes
+  // ~10×/second for the length of a bulk run, while `titles` changes only when
+  // the vault does. Re-deriving one string per note (10k+ on a big vault) at
+  // that rate was pure allocation churn on the main thread — the same thread
+  // the sidebar's clicks are queued on.
+  const localNotePaths = useMemo(() => titles.map((t) => t.path), [titles]);
   const syncIndex = useMemo<TreeSyncIndex | null>(() => {
     const waveKey = syncEnabled ? vaultPath : null;
     if (lastWaveKeyRef.current !== waveKey) {
@@ -273,15 +296,42 @@ export function FileTree() {
     const index = buildTreeSyncIndex({
       docIdByPath,
       docSyncState,
-      localNotePaths: titles.map((t) => t.path),
+      localNotePaths,
     });
     wavesRef.current.apply(index);
     return index;
-  }, [syncEnabled, docIdByPath, docSyncState, titles, vaultPath]);
+  }, [syncEnabled, docIdByPath, docSyncState, localNotePaths, vaultPath]);
+
+  // ---- Row-order stability while something is syncing ------------------
+  //
+  // The default sort is "Recently modified", whose key is the `.md` file's
+  // mtime — and a sync run REWRITES files (a bulk wave moved 1,372 of this
+  // vault's 1,560 mtimes inside three minutes). Each write re-sorted its folder
+  // and arborist positions rows absolutely, so the row under the pointer was
+  // swapped for a different one several times a second: the hover highlight
+  // flickers, and a click lands on whatever slid into place. Hence the pin —
+  // rows keep the mtime they were first seen with while either
+  //   • the pointer is inside the sidebar (someone is aiming at a row), or
+  //   • a bulk run is in flight (nothing is stable enough to be worth showing),
+  // and the true order is restored the moment both clear. Only "recent" needs
+  // it; "name" has no live sort key.
+  const [pointerInTree, setPointerInTree] = useState(false);
+  const syncBusy = useStore((s) => isBulkPhase(s.syncProgress?.phase));
+  const orderPinned = treeSort === "recent" && (pointerInTree || syncBusy);
+  const pinnedMtimes = useRef(new Map<string, number>());
+  // Safety net for a pin that never got its `pointerleave` — the window losing
+  // focus with the cursor still over the tree (cmd-tab, a dialog stealing it).
+  // Without this the order could stay frozen with nobody looking at it.
+  useEffect(() => {
+    const thaw = () => setPointerInTree(false);
+    window.addEventListener("blur", thaw);
+    return () => window.removeEventListener("blur", thaw);
+  }, []);
 
   // Resolve lock rows (server resource ids) to tree paths for the badges.
   const lockByPath = useMemo(
-    () => (syncEnabled ? lockScopesByPath(tree, locks, session?.user.id) : new Map()),
+    () =>
+      syncEnabled ? lockScopesByPath(tree, locks, session?.user.id) : new Map(),
     [tree, locks, syncEnabled, session?.user.id],
   );
 
@@ -298,7 +348,9 @@ export function FileTree() {
     if (!syncEnabled) return null;
     if (isDir) {
       const id = syncManager.registry.getFolderId(path);
-      return id ? { resourceType: "folder", resourceId: id, title: name } : null;
+      return id
+        ? { resourceType: "folder", resourceId: id, title: name }
+        : null;
     }
     const mapping = syncManager.registry.getMapping(path);
     return mapping
@@ -316,10 +368,18 @@ export function FileTree() {
   // it received them, so a folder dragged into place keeps its spot while
   // everything untouched — including that folder's own contents — follows the
   // sort. Flipping these two would make every sort change wipe the arrangement.
-  const data = useMemo<TreeNode[]>(
-    () => applyOrder(sortTree(tree?.children ?? [], treeSort), "", itemOrder),
-    [tree, itemOrder, treeSort],
-  );
+  const data = useMemo<TreeNode[]>(() => {
+    const level = tree?.children ?? [];
+    if (!orderPinned) {
+      pinnedMtimes.current.clear();
+      return applyOrder(sortTree(level, treeSort), "", itemOrder);
+    }
+    return applyOrder(
+      sortTree(pinModified(level, pinnedMtimes.current), treeSort),
+      "",
+      itemOrder,
+    );
+  }, [tree, itemOrder, treeSort, orderPinned]);
 
   // Flatten the (arranged) tree so bulk actions can resolve any path — even a
   // collapsed one — to its node, and so "Select all" knows every path.
@@ -402,7 +462,10 @@ export function FileTree() {
     let order = store.itemOrder;
     for (const p of deleted) {
       order = removeFromOrder(order, p);
-      if (openNote && (openNote.path === p || openNote.path.startsWith(p + "/"))) {
+      if (
+        openNote &&
+        (openNote.path === p || openNote.path.startsWith(p + "/"))
+      ) {
         store.closeNote();
       }
     }
@@ -494,7 +557,8 @@ export function FileTree() {
   async function registerImported(summary: ipc.ImportSummary) {
     if (!useStore.getState().syncEnabled) return;
     const roots = summary.imported;
-    const under = (p: string) => roots.some((r) => p === r || p.startsWith(`${r}/`));
+    const under = (p: string) =>
+      roots.some((r) => p === r || p.startsWith(`${r}/`));
     for (const t of useStore.getState().titles) {
       if (!t.path.toLowerCase().endsWith(".md") || !under(t.path)) continue;
       try {
@@ -516,7 +580,9 @@ export function FileTree() {
   /** Announce an import outcome: green on success, neutral if nothing landed. */
   function announceImport(s: ipc.ImportSummary) {
     const files =
-      s.files > 0 ? `Imported ${s.files} file${s.files === 1 ? "" : "s"}` : "Nothing imported";
+      s.files > 0
+        ? `Imported ${s.files} file${s.files === 1 ? "" : "s"}`
+        : "Nothing imported";
     const text = s.skipped > 0 ? `${files} · ${s.skipped} skipped` : files;
     flashStatus(text, s.files > 0 ? "success" : "neutral");
   }
@@ -558,13 +624,17 @@ export function FileTree() {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let cancelled = false;
-    const insideTree = (px: number, py: number): { x: number; y: number } | null => {
+    const insideTree = (
+      px: number,
+      py: number,
+    ): { x: number; y: number } | null => {
       const scale = window.devicePixelRatio || 1;
       const x = px / scale;
       const y = py / scale;
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return null;
-      if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) return null;
+      if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom)
+        return null;
       return { x, y };
     };
     void (async () => {
@@ -588,7 +658,8 @@ export function FileTree() {
           if (!pt && activeNoteEditable()) {
             try {
               const embeds: string[] = [];
-              for (const path of p.paths) embeds.push(await embedDroppedFile(path));
+              for (const path of p.paths)
+                embeds.push(await embedDroppedFile(path));
               insertIntoActiveNote(embeds.join("\n"));
               await refreshAll();
             } catch (e) {
@@ -724,13 +795,24 @@ export function FileTree() {
     if (!node.data.isDir) {
       // Notes/pages render in the editor; images/PDFs open in the file preview.
       // Any other binary is listed but not opened (nothing can render it).
-      if (isOpenablePath(node.data.path) || previewKind(node.data.path) != null) {
+      if (
+        isOpenablePath(node.data.path) ||
+        previewKind(node.data.path) != null
+      ) {
         void useStore.getState().openNoteByPath(node.data.path);
       }
     }
   };
 
-  const onRename = async ({ id, name, node }: { id: string; name: string; node: NodeApi<TreeNode> }) => {
+  const onRename = async ({
+    id,
+    name,
+    node,
+  }: {
+    id: string;
+    name: string;
+    node: NodeApi<TreeNode>;
+  }) => {
     const oldPath = node.data.path;
     const dir = parentDir(oldPath);
     let newName = name.trim();
@@ -760,7 +842,10 @@ export function FileTree() {
       const store = useStore.getState();
       store.setItemOrder(renameInOrder(store.itemOrder, oldPath, newPath));
       store.remapTabs(oldPath, newPath);
-      if (openNote && (openNote.path === oldPath || openNote.path.startsWith(oldPath + "/"))) {
+      if (
+        openNote &&
+        (openNote.path === oldPath || openNote.path.startsWith(oldPath + "/"))
+      ) {
         const updated = openNote.path.replace(oldPath, newPath);
         await useStore.getState().openNoteByPath(updated);
       }
@@ -771,18 +856,21 @@ export function FileTree() {
     void id;
   };
 
-  const applyMove = async (dragIds: string[], destDir: string, index: number) => {
+  const applyMove = async (
+    dragIds: string[],
+    destDir: string,
+    index: number,
+  ) => {
     // dragIds are node ids === current paths. Their paths after the drop only
     // change when the parent folder changes (a reorder keeps the same path).
     const from = dragIds;
     // Dragging something OUT to a frozen root is a root create by another name.
     // Reordering things already at the root is fine — the shape doesn't change.
-    if (
-      destDir === "" &&
-      rootFrozen &&
-      dragIds.some((p) => p.includes("/"))
-    ) {
-      toast("This vault's root is frozen — drop this inside a folder.", "error");
+    if (destDir === "" && rootFrozen && dragIds.some((p) => p.includes("/"))) {
+      toast(
+        "This vault's root is frozen — drop this inside a folder.",
+        "error",
+      );
       return;
     }
     const to = from.map((p) => {
@@ -835,8 +923,13 @@ export function FileTree() {
         }
         movedOnDisk = true;
         useStore.getState().remapTabs(from[i], to[i]);
-        if (openNote && (openNote.path === from[i] || openNote.path.startsWith(from[i] + "/"))) {
-          await useStore.getState().openNoteByPath(openNote.path.replace(from[i], to[i]));
+        if (
+          openNote &&
+          (openNote.path === from[i] || openNote.path.startsWith(from[i] + "/"))
+        ) {
+          await useStore
+            .getState()
+            .openNoteByPath(openNote.path.replace(from[i], to[i]));
         }
       } catch (e) {
         console.error("move failed", e);
@@ -916,7 +1009,9 @@ export function FileTree() {
     //
     // Measuring instead means every pixel of the list belongs to exactly one
     // row, so the target changes once per row and never blinks elsewhere.
-    const rows = Array.from(container.querySelectorAll<HTMLElement>(".tree-row"));
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>(".tree-row"),
+    );
     const rects = rows.map((el) => el.getBoundingClientRect());
     if (!rows.length) {
       return { kind: "line", destDir: "", index: 0, top: 0, indent: 0 };
@@ -974,7 +1069,9 @@ export function FileTree() {
     const holding = held?.kind === "into" && held.destDir === path;
     const lo = holding ? 0.18 : 0.28;
     if (isDir && frac > lo && frac < 1 - lo) {
-      return wouldSwallowItself(moving, path) ? null : { kind: "into", destDir: path };
+      return wouldSwallowItself(moving, path)
+        ? null
+        : { kind: "into", destDir: path };
     }
     const after = frac >= 0.5;
     if (wouldSwallowItself(moving, parent)) return null;
@@ -1000,7 +1097,8 @@ export function FileTree() {
       const p = probe.current;
       if (!p) return;
       if (!dragRef.current) {
-        if (Math.hypot(e.clientX - p.x, e.clientY - p.y) < DRAG_THRESHOLD) return;
+        if (Math.hypot(e.clientX - p.x, e.clientY - p.y) < DRAG_THRESHOLD)
+          return;
         if (!nodeByPath.has(p.path)) return;
         dragRef.current = p.path;
         setDrag({ path: p.path });
@@ -1008,7 +1106,8 @@ export function FileTree() {
       }
       const next = planDrop(p.path, e.clientX, e.clientY);
       if (sameDrop(next, dropAtRef.current)) return;
-      const wasInto = dropAtRef.current?.kind === "into" ? dropAtRef.current.destDir : null;
+      const wasInto =
+        dropAtRef.current?.kind === "into" ? dropAtRef.current.destDir : null;
       dropAtRef.current = next;
       // The line: moved by hand, so it glides between slots (CSS transitions the
       // transform) without React touching a single row.
@@ -1054,7 +1153,10 @@ export function FileTree() {
       window.addEventListener("click", swallow, true);
       setTimeout(() => window.removeEventListener("click", swallow, true), 0);
       if (!p || !plan) return;
-      const index = plan.kind === "into" ? childrenAt(data, plan.destDir).length : plan.index;
+      const index =
+        plan.kind === "into"
+          ? childrenAt(data, plan.destDir).length
+          : plan.index;
       void applyMove([p.path], plan.destDir, index);
     };
     const cancel = (e: KeyboardEvent) => {
@@ -1157,12 +1259,19 @@ export function FileTree() {
       unregister: (p) => syncManager.registry.deletePath(p),
     });
     if (failed.length > 0) {
-      toast(`Couldn't delete "${failed[0].path}" — ${failed[0].reason}`, "error");
+      toast(
+        `Couldn't delete "${failed[0].path}" — ${failed[0].reason}`,
+        "error",
+      );
     }
     if (deleted.length === 0) return;
     store.setItemOrder(removeFromOrder(store.itemOrder, node.data.path));
     store.pruneTabs([node.data.path]);
-    if (openNote && (openNote.path === node.data.path || openNote.path.startsWith(node.data.path + "/"))) {
+    if (
+      openNote &&
+      (openNote.path === node.data.path ||
+        openNote.path.startsWith(node.data.path + "/"))
+    ) {
       store.closeNote();
     }
     await refreshAll();
@@ -1185,7 +1294,9 @@ export function FileTree() {
 
   async function lockFromMenu(target: ShareTarget) {
     try {
-      await useStore.getState().createLock(target.resourceType, target.resourceId, null);
+      await useStore
+        .getState()
+        .createLock(target.resourceType, target.resourceId, null);
     } catch (e) {
       console.error("lock failed", e);
     }
@@ -1202,7 +1313,15 @@ export function FileTree() {
   return (
     // `row-dragging` is added/removed imperatively by the drag listener above,
     // never through React — see the comment there.
-    <div className={`filetree${dropActive ? " drop-active" : ""}`} ref={containerRef}>
+    <div
+      className={`filetree${dropActive ? " drop-active" : ""}`}
+      ref={containerRef}
+      // Pointer in/out drives the row-order pin (see `orderPinned`). On the
+      // whole panel, not the rows: moving between two rows, or up to the
+      // toolbar, must not thaw the order and re-sort mid-aim.
+      onPointerEnter={() => setPointerInTree(true)}
+      onPointerLeave={() => setPointerInTree(false)}
+    >
       <div className="filetree-head">
         <span className="section-label">Notes</span>
         <div className="filetree-actions">
@@ -1233,8 +1352,12 @@ export function FileTree() {
               the shown action and cross-fades to its opposite. */}
           <button
             className={`tree-tool tree-fold-toggle${treeCollapsed ? " collapsed" : ""}`}
-            title={treeCollapsed ? "Expand all folders" : "Collapse all folders"}
-            aria-label={treeCollapsed ? "Expand all folders" : "Collapse all folders"}
+            title={
+              treeCollapsed ? "Expand all folders" : "Collapse all folders"
+            }
+            aria-label={
+              treeCollapsed ? "Expand all folders" : "Collapse all folders"
+            }
             onClick={() => {
               if (treeCollapsed) treeRef.current?.openAll();
               else treeRef.current?.closeAll();
@@ -1379,8 +1502,14 @@ export function FileTree() {
                 onClick={() =>
                   confirmDelete ? void bulkDelete() : setConfirmDelete(true)
                 }
-                title={confirmDelete ? `Delete ${selected.size}? Click to confirm` : "Delete selected"}
-                aria-label={confirmDelete ? "Confirm delete" : "Delete selected"}
+                title={
+                  confirmDelete
+                    ? `Delete ${selected.size}? Click to confirm`
+                    : "Delete selected"
+                }
+                aria-label={
+                  confirmDelete ? "Confirm delete" : "Delete selected"
+                }
               >
                 {ICON_TRASH}
               </button>
@@ -1391,47 +1520,51 @@ export function FileTree() {
       {data.length === 0 ? (
         <div className="filetree-empty">No notes yet</div>
       ) : (
-        <Tree<TreeNode>
-          ref={treeRef}
-          className="filetree-scroll"
-          data={data}
-          idAccessor="id"
-          openByDefault={false}
-          width={dim.width}
-          height={dim.height - 34 - (selectMode ? 36 : 0)}
-          indent={14}
-          rowHeight={32}
-          onToggle={onToggle}
-          onActivate={onActivate}
-          onRename={onRename}
-          // Arborist's own drag is HTML5-based and cannot complete inside this
-          // webview (see the pointer-drag block above), so it is switched off
-          // entirely rather than left to start drags that die silently — which
-          // is also what stopped a refused drag smearing a text selection
-          // across the rows, and what stopped Tauri mistaking a row drag for a
-          // file drop and throwing up the "drop files here" frame.
-          disableDrag
-          disableDrop
-          rowClassName="tree-rowwrap"
+        <RowSharedContext.Provider
+          value={{
+            selectedPath: openNote?.path ?? null,
+            lockByPath,
+            syncIndex,
+            presenceByDoc,
+            itemColors,
+            onMenu: (x, y, node, flipY) => setMenu({ x, y, flipY, node }),
+            selectMode,
+            selected,
+            onToggleCheck: toggleSelect,
+            onDragProbe: beginProbe,
+            dragPath: drag?.path ?? null,
+            dropInto,
+          }}
         >
-          {(props) => (
-            <Node
-              {...props}
-              dropInto={dropInto}
-              dragging={drag?.path === props.node.data.path}
-              onDragProbe={beginProbe}
-              selectedPath={openNote?.path ?? null}
-              lock={lockByPath.get(props.node.data.path) ?? null}
-              syncIndex={syncIndex}
-              presenceByDoc={presenceByDoc}
-              color={itemColors[props.node.data.path]}
-              onMenu={(x, y, node, flipY) => setMenu({ x, y, flipY, node })}
-              selectMode={selectMode}
-              checked={selected.has(props.node.data.path)}
-              onToggleCheck={toggleSelect}
-            />
-          )}
-        </Tree>
+          <Tree<TreeNode>
+            ref={treeRef}
+            className="filetree-scroll"
+            data={data}
+            idAccessor="id"
+            openByDefault={false}
+            width={dim.width}
+            height={dim.height - 34 - (selectMode ? 36 : 0)}
+            indent={14}
+            rowHeight={32}
+            onToggle={onToggle}
+            onActivate={onActivate}
+            onRename={onRename}
+            // Arborist's own drag is HTML5-based and cannot complete inside this
+            // webview (see the pointer-drag block above), so it is switched off
+            // entirely rather than left to start drags that die silently — which
+            // is also what stopped a refused drag smearing a text selection
+            // across the rows, and what stopped Tauri mistaking a row drag for a
+            // file drop and throwing up the "drop files here" frame.
+            disableDrag
+            disableDrop
+            rowClassName="tree-rowwrap"
+          >
+            {/* A module-scope component, NEVER an inline arrow: arborist uses this
+              as the row's element TYPE, so a new identity per render remounts
+              every row. What rows need travels by context — see `RowShared`. */}
+            {TreeRow}
+          </Tree>
+        </RowSharedContext.Provider>
       )}
 
       {/* The insertion line. Mounted for the whole drag and moved by transform
@@ -1446,7 +1579,11 @@ export function FileTree() {
           ref={menuRef}
           style={
             menuPos
-              ? { left: menuPos.left, top: menuPos.top, maxHeight: menuPos.maxHeight }
+              ? {
+                  left: menuPos.left,
+                  top: menuPos.top,
+                  maxHeight: menuPos.maxHeight,
+                }
               : // Rendered off the anchor for the measuring pass only, and hidden
                 // so that pass can't flash on screen at the wrong place.
                 { left: menu.x, top: menu.y, visibility: "hidden" }
@@ -1469,7 +1606,9 @@ export function FileTree() {
             New folder
           </li>
           <li
-            className={menuCreateBlocked ? "menu-sep-item disabled" : "menu-sep-item"}
+            className={
+              menuCreateBlocked ? "menu-sep-item disabled" : "menu-sep-item"
+            }
             title={menuCreateBlocked ? ROOT_FROZEN_HINT : undefined}
             onClick={() => void importFilesInto(menuDir)}
           >
@@ -1482,9 +1621,13 @@ export function FileTree() {
           >
             Import folder…
           </li>
-          {menu.node && <li onClick={() => void exportNode(menu.node!)}>Export…</li>}
           {menu.node && (
-            <li onClick={() => void revealNode(menu.node!)}>{ipc.revealLabel()}</li>
+            <li onClick={() => void exportNode(menu.node!)}>Export…</li>
+          )}
+          {menu.node && (
+            <li onClick={() => void revealNode(menu.node!)}>
+              {ipc.revealLabel()}
+            </li>
           )}
           {menu.node && <li onClick={() => menu.node!.edit()}>Rename</li>}
           {/* The same vault-wide sort as the header button. A per-folder sort
@@ -1518,7 +1661,9 @@ export function FileTree() {
                   : "Forget the drag-and-drop arrangement in this folder"
               }
               onClick={() =>
-                useStore.getState().setItemOrder(clearOrderAt(itemOrder, menuDir))
+                useStore
+                  .getState()
+                  .setItemOrder(clearOrderAt(itemOrder, menuDir))
               }
             >
               Reset manual order
@@ -1527,8 +1672,10 @@ export function FileTree() {
           {menu.node && menuTarget && (
             <li onClick={() => setShareTarget(menuTarget)}>Share…</li>
           )}
-          {menu.node && menuTarget && canManage && (
-            menuLock ? (
+          {menu.node &&
+            menuTarget &&
+            canManage &&
+            (menuLock ? (
               <li onClick={() => void unlockFromMenu(menuLock.id)}>Unlock</li>
             ) : (
               <li
@@ -1537,8 +1684,7 @@ export function FileTree() {
               >
                 Lock for everyone
               </li>
-            )
-          )}
+            ))}
           {menu.node && (
             <li className="menu-swatches" onClick={(e) => e.stopPropagation()}>
               <span
@@ -1556,7 +1702,9 @@ export function FileTree() {
                   style={{ backgroundColor: c.value }}
                   title={c.label}
                   onClick={() => {
-                    useStore.getState().setItemColor(menu.node!.data.path, c.id);
+                    useStore
+                      .getState()
+                      .setItemColor(menu.node!.data.path, c.id);
                     setMenu(null);
                   }}
                 />
@@ -1572,9 +1720,88 @@ export function FileTree() {
       )}
 
       {shareTarget && (
-        <ShareDialog target={shareTarget} onClose={() => setShareTarget(null)} />
+        <ShareDialog
+          target={shareTarget}
+          onClose={() => setShareTarget(null)}
+        />
       )}
     </div>
+  );
+}
+
+/**
+ * Everything a row needs that does not come from arborist, passed by context.
+ *
+ * ## Why this is not just closed over by the render prop
+ *
+ * `<Tree>{...}</Tree>` hands arborist a *component type*: it reads
+ * `renderNode = this.props.children` and renders `<Node …/>` with it. React
+ * treats a new function identity as a new element type, so an inline
+ * `{(props) => <Node …/>}` — a fresh closure on every parent render — made
+ * React UNMOUNT and REMOUNT every visible row each time the sidebar rendered.
+ *
+ * Measured with the log probe while a vault synced: `render=16 rowRender=84
+ * rowUnmount=84 rowMount=84` for six visible rows — every row destroyed and
+ * rebuilt sixteen times a second. A remounted element has no `:hover` until the
+ * pointer moves again, which is the row "blinking" under the cursor, and a
+ * click on an element being torn down mid-gesture goes nowhere. That is the
+ * bug; the sort churn and the index lock were only making it more frequent.
+ *
+ * So {@link TreeRow} is defined ONCE, at module scope, and the values it needs
+ * arrive through this context instead. Context updates propagate through
+ * `React.memo` (arborist memoizes `RowContainer`), so rows still re-render when
+ * a badge or a lock changes — they just never remount.
+ */
+interface RowShared {
+  selectedPath: string | null;
+  lockByPath: Map<string, LockScope>;
+  /** Whole-vault sync roll-up; null when sync is off (no indicators at all). */
+  syncIndex: TreeSyncIndex | null;
+  /** docId -> teammates currently viewing that note (drives presence dots). */
+  presenceByDoc: Map<string, VaultPeer[]>;
+  /** Item color ids (vault-local preference) — tint the type glyph. */
+  itemColors: Record<string, string | undefined>;
+  onMenu: (
+    x: number,
+    y: number,
+    node: NodeApi<TreeNode>,
+    flipY?: number,
+  ) => void;
+  /** Multi-select: when on, rows show a checkbox and hide per-row actions. */
+  selectMode: boolean;
+  selected: Set<string>;
+  onToggleCheck: (path: string) => void;
+  /** Arms a hand-drag on a row; it only starts once the pointer travels. */
+  onDragProbe: (path: string, x: number, y: number) => void;
+  /** The row being dragged, if any (it lifts and dims). */
+  dragPath: string | null;
+  /** The folder a drop would land inside, if the pointer is over one. */
+  dropInto: string | null;
+}
+
+const RowSharedContext = createContext<RowShared | null>(null);
+
+/** The stable row renderer. Its identity must never change — see {@link RowShared}. */
+function TreeRow(props: NodeRendererProps<TreeNode>) {
+  const shared = useContext(RowSharedContext);
+  if (!shared) return null;
+  const path = props.node.data.path;
+  return (
+    <Node
+      {...props}
+      selectedPath={shared.selectedPath}
+      lock={shared.lockByPath.get(path) ?? null}
+      syncIndex={shared.syncIndex}
+      presenceByDoc={shared.presenceByDoc}
+      color={shared.itemColors[path]}
+      onMenu={shared.onMenu}
+      selectMode={shared.selectMode}
+      checked={shared.selected.has(path)}
+      onToggleCheck={shared.onToggleCheck}
+      onDragProbe={shared.onDragProbe}
+      dragging={shared.dragPath === path}
+      dropInto={shared.dropInto}
+    />
   );
 }
 
@@ -1587,7 +1814,12 @@ interface NodeExtra {
   presenceByDoc: Map<string, VaultPeer[]>;
   /** Item color id (vault-local preference) — tints the type glyph. */
   color: string | undefined;
-  onMenu: (x: number, y: number, node: NodeApi<TreeNode>, flipY?: number) => void;
+  onMenu: (
+    x: number,
+    y: number,
+    node: NodeApi<TreeNode>,
+    flipY?: number,
+  ) => void;
   /** Multi-select: when on, rows show a checkbox and hide per-row actions. */
   selectMode: boolean;
   checked: boolean;
@@ -1720,7 +1952,11 @@ function TreeSyncMark({
   const mark = rowSyncMark(node.data, index);
   if (!mark) return null;
   return (
-    <span className={`tree-sync ${mark.state}`} title={mark.title} aria-label={mark.title}>
+    <span
+      className={`tree-sync ${mark.state}`}
+      title={mark.title}
+      aria-label={mark.title}
+    >
       {mark.progress != null ? (
         <span className="tree-sync-pct">
           {mark.progress.done}/{mark.progress.total}
@@ -1744,7 +1980,11 @@ function SidebarAvatar({ peer }: { peer: VaultPeer }) {
   return (
     <span
       className={`tree-presence-avatar tone-${tone}${live ? "" : " offline"}`}
-      style={{ "--user-color": live ? peer.color : PRESENCE_OFFLINE } as CSSProperties}
+      style={
+        {
+          "--user-color": live ? peer.color : PRESENCE_OFFLINE,
+        } as CSSProperties
+      }
       title={peer.name}
       dangerouslySetInnerHTML={{ __html: svg }}
     />
@@ -1755,16 +1995,24 @@ function SidebarAvatar({ peer }: { peer: VaultPeer }) {
 function SidebarPresence({ peers }: { peers: VaultPeer[] }) {
   if (peers.length === 0) return null;
   const shown =
-    peers.length > MAX_ROW_AVATARS ? peers.slice(0, MAX_ROW_AVATARS - 1) : peers;
+    peers.length > MAX_ROW_AVATARS
+      ? peers.slice(0, MAX_ROW_AVATARS - 1)
+      : peers;
   const overflow = peers.length - shown.length;
   const names = peers.map((p) => p.name).join(", ");
   return (
-    <span className="tree-presence" title={names} aria-label={`Viewing: ${names}`}>
+    <span
+      className="tree-presence"
+      title={names}
+      aria-label={`Viewing: ${names}`}
+    >
       {shown.map((p) => (
         <SidebarAvatar key={p.userId} peer={p} />
       ))}
       {overflow > 0 && (
-        <span className="tree-presence-avatar tree-presence-overflow">+{overflow}</span>
+        <span className="tree-presence-avatar tree-presence-overflow">
+          +{overflow}
+        </span>
       )}
     </span>
   );
@@ -1791,7 +2039,9 @@ function Node({
   // also carries `children: []`, and claiming "empty" for it is a flat lie about
   // a folder that may hold hundreds of notes.
   const isEmpty =
-    isDir && node.data.childrenLoaded === true && (node.data.children?.length ?? 0) === 0;
+    isDir &&
+    node.data.childrenLoaded === true &&
+    (node.data.children?.length ?? 0) === 0;
   const isSelected = !isDir && node.data.path === selectedPath;
   // Subscribed as a boolean rather than by pulling the path and comparing, so a
   // note opening elsewhere in the tree doesn't re-render every other row — this
@@ -1836,7 +2086,8 @@ function Node({
         // select checkbox) — those are buttons, not handles. Selection mode
         // is for picking rows, not moving them.
         if (e.button !== 0 || selectMode) return;
-        if ((e.target as HTMLElement).closest("button, input, .tree-check")) return;
+        if ((e.target as HTMLElement).closest("button, input, .tree-check"))
+          return;
         onDragProbe(node.data.path, e.clientX, e.clientY);
       }}
       onClick={() => {
@@ -1909,7 +2160,9 @@ function Node({
         />
       ) : (
         <>
-          <span className="tree-label">{displayName(node.data.name, isDir)}</span>
+          <span className="tree-label">
+            {displayName(node.data.name, isDir)}
+          </span>
           {isEmpty && !lock && <span className="tree-hint">empty</span>}
           {lock && (
             <span
@@ -1923,28 +2176,27 @@ function Node({
           {syncIndex && <TreeSyncMark node={node} index={syncIndex} />}
           <SidebarPresence peers={peers} />
           {!selectMode && (
-          <button
-            className="tree-more"
-            title="More actions"
-            aria-label={`Actions for ${displayName(node.data.name, isDir)}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              const r = e.currentTarget.getBoundingClientRect();
-              // Below the ⋯ button normally; above it when there's no room, so a
-              // flipped menu never lands on top of the button that opened it.
-              onMenu(r.left, r.bottom + 4, node, r.top - 4);
-            }}
-          >
-            <TreeSvg>
-              <circle cx="5" cy="12" r="2.1" />
-              <circle cx="12" cy="12" r="2.1" />
-              <circle cx="19" cy="12" r="2.1" />
-            </TreeSvg>
-          </button>
+            <button
+              className="tree-more"
+              title="More actions"
+              aria-label={`Actions for ${displayName(node.data.name, isDir)}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                const r = e.currentTarget.getBoundingClientRect();
+                // Below the ⋯ button normally; above it when there's no room, so a
+                // flipped menu never lands on top of the button that opened it.
+                onMenu(r.left, r.bottom + 4, node, r.top - 4);
+              }}
+            >
+              <TreeSvg>
+                <circle cx="5" cy="12" r="2.1" />
+                <circle cx="12" cy="12" r="2.1" />
+                <circle cx="19" cy="12" r="2.1" />
+              </TreeSvg>
+            </button>
           )}
         </>
       )}
     </div>
   );
 }
-

--- a/app/apps/desktop/src/lib/bridge/__tests__/doubling.test.ts
+++ b/app/apps/desktop/src/lib/bridge/__tests__/doubling.test.ts
@@ -1,0 +1,112 @@
+// The note-doubling bug (2026-09-04).
+//
+// `seedFromFileIfEmpty` is the orphan-seed hook for the startup-ordering rule:
+// when signed in, the sync layer pulls the server's canonical state FIRST, then
+// asks the bridge to seed from disk only if the doc is still empty. The
+// emptiness test used to run BEFORE the awaited `readFile`, and the insert AFTER
+// it — so a pull landing inside that window seeded a second insert history on
+// top of the server's text.
+//
+// Yjs merges two independent histories by keeping BOTH, so the note came back
+// holding the server's version *and* the file's, and every repeat of the race
+// doubled it again. In the vault that exposed this, a daily note had reached
+// 68 MB — 2,374,523 lines of 35 distinct lines, two interleaved versions at
+// ~43,000 copies each. Downstream, `parse_note` found ~86,370 wikilinks in it,
+// `links` reached 2,025,307 rows, and index.sqlite hit 1.27 GB, which made every
+// index pass hold the index mutex for tens of seconds and froze the sidebar.
+//
+// The fix re-asserts emptiness INSIDE the transaction. These tests pin both
+// halves: the race must not double, and a genuine orphan must still seed.
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { NoteBridge } from "../noteBridge";
+import { makeHarness, sha256Hex } from "./helpers";
+import { ORIGIN_REMOTE, type BridgeIO } from "../types";
+
+const PATH = "Daily/2026-08-10.md";
+const FILE_TEXT = "---\ntype: daily-note\nmeetings: 1\n---\n\n## Busy Monday\n";
+const SERVER_TEXT = "---\ntype: daily-note\nmeetings: 8\n---\n\n## Quiet Monday\n";
+
+describe("note-doubling: seed vs. pull", () => {
+  it("does not seed on top of server state that lands during the file read", async () => {
+    const { io, persistence, fs } = makeHarness({ [PATH]: FILE_TEXT });
+
+    // Open the signed-in way: no seed on open, so the doc waits for the pull.
+    const bridge = await NoteBridge.open(io, {
+      docId: "doc-1",
+      path: PATH,
+      seedFromFile: false,
+    });
+    expect(bridge.serialize()).toBe("");
+
+    // Race the pull into the seed's `await readFile` — exactly the window the
+    // bug lived in. Wrapping the harness's readFile is the only timing control
+    // needed: the remote update is applied while the seed is suspended on it.
+    const racing: BridgeIO = {
+      ...io,
+      readFile: async (p) => {
+        const text = await fs.readFile(p);
+        // The server's canonical state arrives, as a remote update would.
+        const remote = new Y.Doc();
+        remote.getText("content").insert(0, SERVER_TEXT);
+        Y.applyUpdate(bridge.doc, Y.encodeStateAsUpdate(remote), ORIGIN_REMOTE);
+        return text;
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (bridge as any).io = racing;
+
+    const seeded = await bridge.seedFromFileIfEmpty();
+
+    // The pull won: the doc is the server's text, NOT both texts concatenated.
+    expect(seeded).toBe(false);
+    expect(bridge.serialize()).toBe(SERVER_TEXT);
+    expect(bridge.serialize()).not.toContain("Busy Monday");
+    // The clincher — the shape the 68 MB file had:
+    expect(bridge.serialize().length).toBeLessThan(
+      FILE_TEXT.length + SERVER_TEXT.length,
+    );
+    expect(persistence).toBeDefined();
+  });
+
+  it("still seeds a genuine orphan (no server state arrives)", async () => {
+    const { io } = makeHarness({ [PATH]: FILE_TEXT });
+    const bridge = await NoteBridge.open(io, {
+      docId: "doc-2",
+      path: PATH,
+      seedFromFile: false,
+    });
+    expect(bridge.serialize()).toBe("");
+
+    const seeded = await bridge.seedFromFileIfEmpty();
+
+    expect(seeded).toBe(true);
+    expect(bridge.serialize()).toBe(FILE_TEXT);
+    // Seeding must not schedule a write back to disk (ORIGIN_DISK), or the
+    // orphan seed would look like an edit to every other device.
+    expect(bridge.lastHash).toBe(sha256Hex(FILE_TEXT));
+  });
+
+  it("repeating the race cannot accumulate — the doc stays one version", async () => {
+    const { io, fs } = makeHarness({ [PATH]: FILE_TEXT });
+    const bridge = await NoteBridge.open(io, {
+      docId: "doc-3",
+      path: PATH,
+      seedFromFile: false,
+    });
+
+    const remote = new Y.Doc();
+    remote.getText("content").insert(0, SERVER_TEXT);
+    Y.applyUpdate(bridge.doc, Y.encodeStateAsUpdate(remote), ORIGIN_REMOTE);
+
+    // Whatever re-triggers the orphan seed — a reconnect, a relaunch, a retry —
+    // must be a no-op now that the doc holds content. 43,000 of these is what
+    // built the 68 MB file.
+    for (let i = 0; i < 50; i++) {
+      expect(await bridge.seedFromFileIfEmpty()).toBe(false);
+    }
+    expect(bridge.serialize()).toBe(SERVER_TEXT);
+    expect(fs.get(PATH)).toBeDefined();
+  });
+});

--- a/app/apps/desktop/src/lib/bridge/__tests__/noop-egest.test.ts
+++ b/app/apps/desktop/src/lib/bridge/__tests__/noop-egest.test.ts
@@ -1,0 +1,85 @@
+// An egest whose bytes the file ALREADY holds must not write.
+//
+// Where this bites: a sync run rewrote nearly every file in the vault (measured
+// 2026-09-04 — 1,372 of a 1,560-note vault's files inside three minutes), and a
+// write is not free. It costs an atomic write, a watcher event, an index pass,
+// and a fresh mtime — which is the sidebar's "Recently modified" sort key, so
+// every redundant write re-sorted the row the user was pointing at.
+//
+// `lastWrittenHash` already knows what the file holds: egest sets it once a
+// write is confirmed, ingest and the seed paths set it from the file they read.
+
+import { describe, expect, it, vi } from "vitest";
+import { NoteBridge } from "../noteBridge";
+import { makeHarness } from "./helpers";
+
+const PATH = "note.md";
+const SEED = "# Title\n\nhello world\n";
+
+describe("no-op egest", () => {
+  it("does not write when the doc lands back on the bytes already on disk", async () => {
+    vi.useFakeTimers();
+    try {
+      const { io, fs } = makeHarness({ [PATH]: SEED });
+      const bridge = await NoteBridge.open(io, { docId: "doc-1", path: PATH });
+      const writesBefore = fs.writeCount;
+
+      // The doc churns — two ops, a real update appended to the CRDT log — but
+      // it settles on exactly what the file says. This is the shape of a remote
+      // update that agrees with disk.
+      bridge.edit((t) => t.insert(0, "draft "));
+      bridge.edit((t) => t.delete(0, 6));
+      expect(bridge.serialize()).toBe(SEED);
+
+      await vi.advanceTimersByTimeAsync(300);
+      expect(fs.writeCount).toBe(writesBefore);
+      expect(fs.get(PATH)).toBe(SEED);
+
+      // …and the guard is still honest afterwards: a genuine change DOES write.
+      bridge.edit((t) => t.insert(t.toString().length, "more\n"));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(fs.writeCount).toBe(writesBefore + 1);
+      expect(fs.get(PATH)).toBe(SEED + "more\n");
+
+      bridge.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retracts a standing write failure when the disk turns out to be right", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = makeHarness({ [PATH]: SEED });
+      let failing = false;
+      const recovered: string[] = [];
+      const io = {
+        ...h.io,
+        writeFileAtomic: async (p: string, c: string) => {
+          if (failing) throw new Error("EACCES: permission denied");
+          return h.io.writeFileAtomic(p, c);
+        },
+        onWriteRecovered: (path: string) => recovered.push(path),
+      };
+      const bridge = await NoteBridge.open(io, { docId: "doc-1", path: PATH });
+
+      failing = true;
+      bridge.edit((t) => t.insert(t.toString().length, "!!!"));
+      await vi.advanceTimersByTimeAsync(300);
+      expect(bridge.pendingWriteFailures).toBe(1);
+
+      // The edit is undone before the retry lands, so what the failed write was
+      // trying to put on disk is what is already there. Nothing left to retry.
+      failing = false;
+      bridge.edit((t) => t.delete(t.toString().length - 3, 3));
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(bridge.pendingWriteFailures).toBe(0);
+      expect(recovered).toEqual([PATH]);
+      expect(h.fs.get(PATH)).toBe(SEED);
+
+      bridge.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/app/apps/desktop/src/lib/bridge/noteBridge.ts
+++ b/app/apps/desktop/src/lib/bridge/noteBridge.ts
@@ -36,6 +36,10 @@ export class NoteBridge {
   private logLength = 0;
   /** Monotonic count of every update ever observed on this doc (for assertions). */
   private observedUpdates = 0;
+  /** Whether the oversize refusal has already been reported for the current
+   *  run of oversized reads, so one runaway file logs once, not per watcher
+   *  event. Cleared as soon as a normal-sized read comes through. */
+  private oversizeReported = false;
   /** True once a recovery snapshot has been taken for a large diff. */
   private recoverySnapshotTaken = false;
   /** True once this doc has held non-empty text in this session. Guards egest:
@@ -186,6 +190,11 @@ export class NoteBridge {
       }
       if (this.seedOnOpen && fileText.length > 0) {
         this.doc.transact(() => {
+          // Same re-assertion as `seedFromFileIfEmpty`: `subscribe()` is already
+          // live and the file read above was awaited, so a remote update can have
+          // arrived in between. Seeding on top of it would fork the history and
+          // double the text.
+          if (this.text.length > 0) return;
           this.text.insert(0, fileText);
         }, ORIGIN_DISK);
       }
@@ -213,9 +222,22 @@ export class NoteBridge {
       return false;
     }
     if (fileText.length === 0) return false;
+    // Re-assert emptiness INSIDE the transaction. The check above ran before an
+    // `await`, and the server's pull can land during that read — at which point
+    // this doc is no longer an orphan and seeding it is not a no-op, it is a
+    // SECOND insert history. Yjs merges two independent histories by keeping
+    // both, so the note comes back holding the server's text *and* the file's,
+    // and every repeat of the race doubles it again. That is the note-doubling
+    // bug, and it is how a daily note reached 68 MB / 2.37M lines of 35 distinct
+    // lines (two interleaved versions, ~43,000 copies each) in the 2026-09-04
+    // vault: not a diff gone wrong, a seed racing a pull.
+    let seeded = false;
     this.doc.transact(() => {
+      if (this.text.length > 0) return; // the pull won — server state stands
       this.text.insert(0, fileText);
+      seeded = true;
     }, ORIGIN_DISK);
+    if (!seeded) return false;
     this.lastWrittenHash = await this.hash(fileText);
     return true;
   }
@@ -272,6 +294,25 @@ export class NoteBridge {
       this.reportError(e, "ingest:readFile");
       return false;
     }
+
+    // Size ceiling BEFORE the echo guard and the diff: a file this big is damage,
+    // not content, and ingesting it would pull that damage into the CRDT and from
+    // there onto every other device and the server. Reported once per drain so
+    // the user learns which file to fix; the doc keeps whatever it already holds.
+    // See `maxIngestBytes`.
+    if (this.cfg.maxIngestBytes > 0 && fileText.length > this.cfg.maxIngestBytes) {
+      if (!this.oversizeReported) {
+        this.oversizeReported = true;
+        const mb = (fileText.length / (1024 * 1024)).toFixed(1);
+        const cap = Math.round(this.cfg.maxIngestBytes / (1024 * 1024));
+        this.reportError(
+          new Error(`${this._path} is ${mb} MB (> ${cap} MB): refusing to ingest it`),
+          "ingest:oversize",
+        );
+      }
+      return false;
+    }
+    this.oversizeReported = false;
 
     const fileHash = await this.hash(fileText);
     if (fileHash === this.lastWrittenHash) return false; // our own write echoing back → DROP
@@ -349,6 +390,20 @@ export class NoteBridge {
     // event is debounced ~150ms in Rust and ~150ms more here, while this
     // assignment runs the moment the IPC resolves (spec 03 §5).
     const hash = await this.hash(content);
+    // Nothing to write: the file already holds exactly these bytes. That is what
+    // `lastWrittenHash` means on both sides — egest sets it once a write is
+    // CONFIRMED on disk, ingest and the seed paths set it to the hash of the
+    // file they just read. Writing anyway costs a real atomic write, a watcher
+    // event, an index pass and a fresh mtime — and the mtime is the sidebar's
+    // "Recently modified" sort key, so a no-op write reshuffles the rows under
+    // the user's pointer for nothing. A failed write does NOT set the guard, so
+    // a retry still writes.
+    if (hash === this.lastWrittenHash) {
+      // A write that had been failing no longer needs to land: the bytes it was
+      // retrying to put on disk are already there.
+      this.clearWriteFailure();
+      return;
+    }
     try {
       await this.io.writeFileAtomic(this._path, content);
     } catch (e) {
@@ -366,14 +421,7 @@ export class NoteBridge {
       return;
     }
     this.lastWrittenHash = hash;
-    if (this.egestFailures > 0) {
-      this.egestFailures = 0;
-      try {
-        this.io.onWriteRecovered?.(this._path);
-      } catch (hookErr) {
-        this.reportError(hookErr, "egest:onWriteRecovered");
-      }
-    }
+    this.clearWriteFailure();
     // Indexing is derived state: a failure here is worth a log, not a re-write.
     if (this.io.reindex) {
       try {
@@ -381,6 +429,19 @@ export class NoteBridge {
       } catch (e) {
         this.reportError(e, "egest:reindex");
       }
+    }
+  }
+
+  /** Retract a standing write failure: the file on disk now holds what the doc
+   *  says, whether because a retry landed or because the doc came back around to
+   *  the bytes already there. */
+  private clearWriteFailure(): void {
+    if (this.egestFailures === 0) return;
+    this.egestFailures = 0;
+    try {
+      this.io.onWriteRecovered?.(this._path);
+    } catch (hookErr) {
+      this.reportError(hookErr, "egest:onWriteRecovered");
     }
   }
 

--- a/app/apps/desktop/src/lib/bridge/types.ts
+++ b/app/apps/desktop/src/lib/bridge/types.ts
@@ -70,6 +70,18 @@ export interface BridgeConfig {
   compactThreshold: number;
   /** Take a recovery snapshot before a diff that churns this fraction of the doc. */
   largeDiffRatio: number;
+  /**
+   * Refuse to ingest a file larger than this many bytes.
+   *
+   * A note has no business being this big, and a file that gets there is almost
+   * always damage rather than content — on 2026-09-04 a daily note reached
+   * 68 MB (2.37M lines, 35 distinct) from the seed-vs-pull race that used to
+   * double a doc's text. Ingesting such a file pulls the damage INTO the CRDT,
+   * where it then propagates to every device and to the server. Matching the
+   * sync layer's `MAX_NOTE_BYTES` keeps one rule: a note too big to upload is a
+   * note we also refuse to read back in. 0 disables the check.
+   */
+  maxIngestBytes: number;
   /** First retry delay after a failed egest write; doubles per consecutive
    *  failure up to `egestRetryMaxMs`. */
   egestRetryBaseMs: number;
@@ -95,6 +107,7 @@ export const DEFAULT_CONFIG: BridgeConfig = {
   egestDebounceMs: 300,
   compactThreshold: 64,
   largeDiffRatio: 0.6,
+  maxIngestBytes: 10 * 1024 * 1024,
   egestRetryBaseMs: 1_000,
   egestRetryMaxMs: 30_000,
   // 500ms matches Yjs' own default and CodeMirror's `newGroupDelay`, so undo

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -664,6 +664,66 @@ describe("inbound folder deletion", () => {
     expect(vi.mocked(api.createNote)).not.toHaveBeenCalled(); // still no ghost
   });
 
+  it("stops claiming a non-empty leftover, so a LATER pass syncs the user's content", async () => {
+    // The regression behind "dragging a folder in doesn't start syncing, and on
+    // reload it never does". A previously-synced folder was deleted server-side,
+    // leaving tombstones AND baseline entries for its paths. Re-importing the
+    // folder puts files back on those exact paths under fresh local index ids, so
+    // `planInbound` hits `dead && loc === undefined` and suppresses every one of
+    // them — in production, all 176 `Daily/*` notes: `0/174`, nothing queued, no
+    // error shown, and only opening a note synced it (the editor calls
+    // `registerNote` directly, bypassing `suppress`).
+    //
+    // The pass that discovers this still suppresses (no mid-pass ghost), but it
+    // must RELEASE the baseline claim so the next pass can register the file as
+    // the new local note it is.
+    const disk = new FakeDisk();
+    disk.folders.add("Team");
+    disk.notes.set("Team/stub.md", "d1");
+    const { api } = await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Team/stub.md" }],
+        folders: [{ id: "f1", path: "Team" }],
+      },
+      then: { notes: [], tombstones: ["d1"], folders: [{ id: "f1", path: "Team" }] },
+    });
+    // Re-imported: same path, fresh local id, real content.
+    disk.notes.set("Team/stub.md", "local-rekeyed");
+    disk.bodies.set("Team/stub.md", "# a day\n\nreal content the user dropped in");
+    disk.trashed.length = 0;
+
+    // Pass 3 discovers the dead-but-present file: suppressed, not trashed, and
+    // the claim is dropped (surfaced, not silent).
+    vi.mocked(api.createNote).mockClear();
+    const reg = new VaultRegistry(api);
+    reg.setInboundHost(recordingHost().host);
+    await reg.reconcile({ organizationId: ORG, vaultName: "v" });
+    expect(disk.trashed).toEqual([]); // never destroy content we can't identify
+    expect(vi.mocked(api.createNote)).not.toHaveBeenCalled(); // no ghost this pass
+    expect(reg.failures().map((f) => f.reason).join(" ")).toContain(
+      "deleted on the server",
+    );
+
+    // Pass 4 — the reload. THIS is what used to never happen. Feed it the config
+    // pass 3 actually persisted (the harness pins `getVaultConfig` otherwise), so
+    // this is a genuine restart against the released baseline.
+    const writes = vi.mocked(ipc.setVaultConfig).mock.calls;
+    vi.mocked(ipc.getVaultConfig).mockResolvedValue(
+      writes[writes.length - 1]?.[0] as never,
+    );
+    vi.mocked(api.createNote).mockClear();
+    const reg2 = new VaultRegistry(api);
+    reg2.setInboundHost(recordingHost().host);
+    await reg2.reconcile({ organizationId: ORG, vaultName: "v" });
+
+    expect(vi.mocked(api.createNote)).toHaveBeenCalledWith(
+      expect.objectContaining({ relPath: "Team/stub.md" }),
+    );
+    expect(reg2.getMapping("Team/stub.md")).not.toBeNull();
+    expect(disk.trashed).toEqual([]); // still never trashed
+  });
+
   it("does nothing on folder tombstones the server did not answer about (null)", async () => {
     const disk = new FakeDisk();
     disk.folders.add("Team");

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -247,6 +247,9 @@ export class VaultRegistry {
   private byPath = new Map<string, DocMapping>();
   /** Reverse of byPath: docId → relPath, for the vault sync engine (spec 05). */
   private byDocId = new Map<string, string>();
+  /** Lazy case-folded view of `byPath` (lowercased path → the path as mapped).
+   *  Null = not built / invalidated; see `canonicalNotePath`. */
+  private byPathCi: Map<string, string> | null = null;
   private folderByPath = new Map<string, string>();
   /** docIds whose content this device has confirmed on the server. See
    *  `VaultSyncConfig.pushed` for why this is an optimization, not a guarantee. */
@@ -373,7 +376,54 @@ export class VaultRegistry {
   /** Announce a change to the path→docId map. Fired freely (once per adopted or
    *  created note); the listener is responsible for coalescing. */
   private notifyMapChanged(): void {
+    // Every `byPath` mutation funnels through here, which makes it the one place
+    // the case-folded view has to be dropped. See `canonicalNotePath`.
+    this.byPathCi = null;
     this.onMapChanged?.();
+  }
+
+  /**
+   * The path this vault already uses for `relPath`, compared case-insensitively,
+   * or null if nothing is mapped there yet.
+   *
+   * macOS and Windows cannot distinguish `Projects/Community/x.md` from
+   * `Projects/community/x.md` — they are one file. If this device maps its disk
+   * spelling to a second doc_id while the server holds another, the two docs
+   * write over each other through that one file forever (the 2026-09-04 runaway;
+   * `samePath` in the server's tree-ops.ts has the full account). The server now
+   * adopts case-insensitively and answers with its canonical spelling, so this
+   * is the client half: recognise that we already track the file and reuse the
+   * mapping instead of registering a twin.
+   *
+   * Exact hits skip the folded map entirely, so the common path is one Map.get
+   * and nothing is built during a reconcile that finds everything already
+   * mapped. The lazy index is rebuilt at most once per mutation batch.
+   */
+  private canonicalNotePath(relPath: string): string | null {
+    if (this.byPath.has(relPath)) return relPath;
+    if (!this.byPathCi) {
+      this.byPathCi = new Map();
+      // Insertion order = first writer wins, so a vault that still holds
+      // pre-migration-023 twins resolves to one of them consistently rather
+      // than alternating between passes.
+      for (const rp of this.byPath.keys()) {
+        const k = rp.toLowerCase();
+        if (!this.byPathCi.has(k)) this.byPathCi.set(k, rp);
+      }
+    }
+    return this.byPathCi.get(relPath.toLowerCase()) ?? null;
+  }
+
+  /** Folder twin of {@link canonicalNotePath}. Scanned rather than indexed:
+   *  `folderByPath` is a fraction of `byPath` and this runs only when a folder
+   *  is genuinely missing from the map. */
+  private canonicalFolderPath(relPath: string): string | null {
+    if (this.folderByPath.has(relPath)) return relPath;
+    const want = relPath.toLowerCase();
+    for (const rp of this.folderByPath.keys()) {
+      if (rp.toLowerCase() === want) return rp;
+    }
+    return null;
   }
 
   /**
@@ -429,6 +479,7 @@ export class VaultRegistry {
     this.organizationId = null;
     this.byPath.clear();
     this.byDocId.clear();
+    this.byPathCi = null;
     this.folderByPath.clear();
     this.pushed.clear();
     // A surviving baseline is exactly the cross-vault confusion this method
@@ -778,6 +829,19 @@ export class VaultRegistry {
               : "deleted on the server, but this device never confirmed its content — left on disk",
           code: null,
         });
+        // Stop claiming the path, so the file can re-register on a later pass.
+        //
+        // Without this the baseline keeps naming this docId at this path, the
+        // plan suppresses the path on every pass, and the file is stranded:
+        // visible in the sidebar, never counted, never uploaded, while the header
+        // reads "Synced". For a note whose content this device never confirmed
+        // upstream that is the worst possible outcome — the local copy is the ONLY
+        // copy, and we were leaving it unsyncable on purpose. Re-registering it
+        // gets that work onto the server instead.
+        //
+        // NOT for a revocation: there the server still holds the content and the
+        // user has lost write access, so re-registering would only 403 in a loop.
+        if (gone.reason !== "revoked") this.baselineDocs.delete(gone.docId);
         continue;
       }
       await this.host?.releaseDoc(gone.docId);
@@ -814,7 +878,43 @@ export class VaultRegistry {
     // "I don't know" must remove nothing.)
     for (const path of plan.stubs) {
       if (this.stopRun()) break;
-      if (!(await this.isEmptyOnDisk(path))) continue;
+      if (!(await this.isEmptyOnDisk(path))) {
+        // A file WITH content at a path the server says was deleted, and no
+        // docId match to prove it is that note (the `dead && loc === undefined`
+        // branch in `planInbound`). We will not trash it — we cannot prove whose
+        // it is — but we must also stop claiming it, or the baseline suppresses
+        // this path on every pass forever and the user's content becomes
+        // permanently unsyncable while the header still reads "Synced".
+        //
+        // That is exactly what re-dropping a previously-synced folder did: 176
+        // `Daily/*` tombstones still held baseline entries, the re-imported files
+        // landed on those same paths under fresh local index ids, and all 176 were
+        // suppressed — `0/174`, nothing queued, no error, and only opening a note
+        // synced it (the editor calls `registerNote` directly, bypassing
+        // `suppress`). Releasing the claim lets the NEXT pass register it as the
+        // new local note it is.
+        //
+        // The trade this makes, deliberately: a file that really IS the deleted
+        // note — same path, new local identity — re-registers under a fresh docId
+        // instead of staying dead (the resurrect this branch was written to
+        // prevent). That case is visible and re-deletable; silent permanent
+        // divergence is neither, and `.md` on disk is the source of truth. The
+        // device that performed the delete removes its own file, so it never
+        // reaches here. Recorded rather than done silently.
+        for (const [docId, rp] of [...this.baselineDocs]) {
+          if (rp !== path) continue;
+          this.baselineDocs.delete(docId);
+          this.recordFailure({
+            kind: "inbound",
+            path,
+            docId,
+            reason:
+              "deleted on the server but still on disk with content — re-registering it as a new local note",
+            code: "resurrected_local_note",
+          });
+        }
+        continue;
+      }
       if (this.stale()) return { changedDisk, suppress: plan.suppress };
       try {
         await ipc.trashNote(path, stamp, this.epoch());
@@ -1481,8 +1581,11 @@ export class VaultRegistry {
     if (this.stale()) return null;
     const vaultId = this.serverVaultId;
     if (!vaultId) return null;
-    const existing = this.byPath.get(relPath);
-    if (existing) return existing;
+    // Case-insensitive, because on macOS/Windows a case-variant of a path we
+    // already track is the SAME FILE — registering it would map one file to two
+    // doc_ids and start the ping-pong (see `canonicalNotePath`).
+    const mappedAs = this.canonicalNotePath(relPath);
+    if (mappedAs) return this.byPath.get(mappedAs) ?? null;
     try {
       const folderId = this.folderByPath.get(parentDir(relPath)) ?? null;
       const created = await this.api.createNote({
@@ -1496,7 +1599,11 @@ export class VaultRegistry {
       });
       if (this.stale() || this.serverVaultId !== vaultId) return null;
       const mapping = { vaultId, docId: noteDocId(created) };
-      this.setMapping(relPath, mapping.docId, vaultId);
+      // Key by the path the SERVER says this doc lives at. It adopts by path
+      // case-insensitively, so when its spelling differs from ours this is how
+      // the two converge — keying by our own `relPath` instead would leave the
+      // server's spelling unmapped and re-register it on every pass.
+      this.setMapping(noteRelPath(created) ?? relPath, mapping.docId, vaultId);
       this.checkpoint?.touch();
       return mapping;
     } catch (e) {
@@ -1520,8 +1627,10 @@ export class VaultRegistry {
     if (this.stale()) return null;
     const vaultId = this.serverVaultId;
     if (!vaultId) return null;
-    const existing = this.folderByPath.get(relPath);
-    if (existing) return existing;
+    // Case-insensitive for the same reason as `registerNote`: one directory on
+    // disk must not become two folder rows whose subtrees then fork.
+    const mappedAs = this.canonicalFolderPath(relPath);
+    if (mappedAs) return this.folderByPath.get(mappedAs) ?? null;
     try {
       const parentId = this.folderByPath.get(parentDir(relPath)) ?? null;
       const created = await this.api.createFolder({
@@ -1531,7 +1640,8 @@ export class VaultRegistry {
         parentId,
       });
       if (this.stale() || this.serverVaultId !== vaultId) return null;
-      this.folderByPath.set(relPath, created.id);
+      // The server's canonical spelling, as in `registerNote`.
+      this.folderByPath.set(created.path ?? relPath, created.id);
       this.persist();
       return created.id;
     } catch (e) {

--- a/app/apps/desktop/src/lib/sync/vaultScope.ts
+++ b/app/apps/desktop/src/lib/sync/vaultScope.ts
@@ -207,6 +207,13 @@ export type SyncProgressPhase =
   | "done"
   | "error";
 
+/** True while a bulk run is actually moving work — i.e. not idle, finished or
+ *  failed. The UI uses it to hold still: the sidebar pins its row order for the
+ *  length of a wave rather than re-sorting under the pointer as each file lands. */
+export function isBulkPhase(phase: SyncProgressPhase | undefined | null): boolean {
+  return phase === "registering" || phase === "uploading" || phase === "downloading";
+}
+
 /** Counted progress for the current vault's sync run. `null` when none is running. */
 export interface SyncProgress {
   phase: SyncProgressPhase;

--- a/app/apps/desktop/src/lib/tree/__tests__/sort.test.ts
+++ b/app/apps/desktop/src/lib/tree/__tests__/sort.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TreeNode } from "../../ipc";
-import { sortTree } from "../sort";
+import { pinModified, sortTree } from "../sort";
 import { applyOrder } from "../../ordering";
 
 const dir = (name: string, modified: number, children: TreeNode[] = []): TreeNode => ({
@@ -105,5 +105,65 @@ describe("sortTree + applyOrder — the two layers", () => {
     // normally sit below.
     const out = applyOrder(sortTree(build(), "recent"), "", { "": ["loose.md"] });
     expect(names(out)).toEqual(["loose.md", "Alpha", "Beta"]);
+  });
+});
+
+describe("pinModified", () => {
+  it("keeps a row where it was when its mtime moves under the pointer", () => {
+    const pins = new Map<string, number>();
+    const before = [file("a.md", 10), file("b.md", 20), file("c.md", 30)];
+    // First pass records what each row was placed with.
+    expect(names(sortTree(pinModified(before, pins), "recent"))).toEqual([
+      "c.md",
+      "b.md",
+      "a.md",
+    ]);
+
+    // A sync run rewrites a.md, so the disk now says it is the newest file. With
+    // the order pinned, the rows do NOT move — which is the whole point: the row
+    // under the cursor stays the row the user aimed at.
+    const after = [file("a.md", 99), file("b.md", 20), file("c.md", 30)];
+    expect(names(sortTree(pinModified(after, pins), "recent"))).toEqual([
+      "c.md",
+      "b.md",
+      "a.md",
+    ]);
+
+    // Thawing (a fresh, empty memory) reveals the true order.
+    expect(names(sortTree(pinModified(after, new Map()), "recent"))).toEqual([
+      "a.md",
+      "c.md",
+      "b.md",
+    ]);
+  });
+
+  it("still places a file created mid-wave at its real position", () => {
+    const pins = new Map<string, number>();
+    pinModified([file("a.md", 10), file("b.md", 20)], pins);
+    const withNew = [file("a.md", 10), file("b.md", 20), file("new.md", 50)];
+    expect(names(sortTree(pinModified(withNew, pins), "recent"))).toEqual([
+      "new.md",
+      "b.md",
+      "a.md",
+    ]);
+  });
+
+  it("pins inside folders too, and leaves folder order alone", () => {
+    const pins = new Map<string, number>();
+    const level = [dir("Work", 1, [file("Work/x.md", 1), file("Work/y.md", 2)])];
+    pinModified(level, pins);
+    const moved = [dir("Work", 9, [file("Work/x.md", 99), file("Work/y.md", 2)])];
+    const sorted = sortTree(pinModified(moved, pins), "recent");
+    expect(names(sorted)).toEqual(["Work"]);
+    expect(names(sorted[0].children!)).toEqual(["Work/y.md", "Work/x.md"].map((p) =>
+      p.split("/").pop()!,
+    ));
+  });
+
+  it("returns the same arrays when nothing moved, so a memo downstream holds", () => {
+    const pins = new Map<string, number>();
+    const level = [dir("Work", 1, [file("Work/x.md", 1)]), file("a.md", 2)];
+    pinModified(level, pins);
+    expect(pinModified(level, pins)).toBe(level);
   });
 });

--- a/app/apps/desktop/src/lib/tree/sort.ts
+++ b/app/apps/desktop/src/lib/tree/sort.ts
@@ -63,3 +63,48 @@ export function sortTree(nodes: TreeNode[], mode: TreeSort): TreeNode[] {
     n.children ? { ...n, children: sortTree(n.children, mode) } : n,
   );
 }
+
+/**
+ * Freeze the recency sort key of every file node we have already placed.
+ *
+ * `"recent"` sorts files by their `.md` file's mtime, and a sync run rewrites
+ * files: a bulk wave in a 1,560-note vault moved 1,372 mtimes inside three
+ * minutes (measured 2026-09-04). Every one of those writes re-sorted the folder
+ * it was in, and arborist positions rows absolutely — so the row under the
+ * pointer became a *different* row several times a second. That is the sidebar
+ * "blinking on hover" and the clicks that "land on the wrong thing / feel
+ * blocked" while something syncs: the highlight follows the cursor, but the
+ * content beneath it keeps being replaced.
+ *
+ * So while the sidebar is being used (or while a wave is in flight), sort by the
+ * mtime each row was FIRST seen with. `pins` is the caller's memory of that,
+ * keyed by path: a path already in it keeps its remembered key, a new path
+ * records its current one (so a note created mid-wave still appears at the top,
+ * where it belongs). Clearing `pins` thaws it, and the next sort is the true one.
+ *
+ * Folders are untouched — they sort by name in both modes.
+ */
+export function pinModified(nodes: TreeNode[], pins: Map<string, number>): TreeNode[] {
+  let changed = false;
+  const out = nodes.map((n) => {
+    if (n.isDir) {
+      if (!n.children) return n;
+      const kids = pinModified(n.children, pins);
+      if (kids === n.children) return n;
+      changed = true;
+      return { ...n, children: kids };
+    }
+    const live = n.modified ?? 0;
+    const pinned = pins.get(n.path);
+    if (pinned === undefined) {
+      pins.set(n.path, live);
+      return n;
+    }
+    if (pinned === live) return n;
+    changed = true;
+    return { ...n, modified: pinned };
+  });
+  // Identity is load-bearing: an unchanged level returns the SAME array, so a
+  // refresh that moved nothing cannot invalidate a memo downstream.
+  return changed ? out : nodes;
+}

--- a/app/apps/server/migrations/023_case_insensitive_paths.sql
+++ b/app/apps/server/migrations/023_case_insensitive_paths.sql
@@ -1,0 +1,156 @@
+-- A path must name exactly ONE folder and ONE live note per vault, compared
+-- CASE-INSENSITIVELY. Migration 021 (notes) and 022 (folders) established that
+-- rule for exact paths; this extends it to case, which is the version that
+-- actually matters on the platforms we ship.
+--
+-- macOS (APFS default) and Windows are case-insensitive: `Projects/Community`
+-- and `Projects/community` are ONE directory on disk. Postgres TEXT is
+-- case-sensitive, so both were legal distinct rows with distinct doc_ids — and
+-- every desktop then mapped one file to two docs. Doc A egested to disk, the
+-- watcher fired, doc B ingested a file that disagreed with its own CRDT state
+-- and wrote back, forever.
+--
+-- Found in production 2026-09-04 in the BenAI OS vault: a teammate created
+-- `Projects/community` on 2026-08-20 alongside the existing `Projects/Community`
+-- from 2026-08-07, duplicating the whole subtree — 71 folders and 164 note
+-- pairs. The ping-pong ran at **189 MB of updates per hour**; those 328 notes
+-- were 0.5% of the vault's docs and 26% (190 MB of 733 MB) of all its CRDT
+-- bytes, each individual update having grown to 0.6–3.5 MB.
+--
+-- The trade this locks in: a case-sensitive Linux vault can no longer keep
+-- `a.md` and `A.md` as separate notes. That is the same call Git makes with
+-- `core.ignorecase`, and it is the only choice that lets one vault sync between
+-- a Mac and a Linux box at all — the Mac cannot represent both files.
+-- Enforced going forward by `samePath()` in src/registry/tree-ops.ts, which the
+-- HTTP registry and the MCP tools both route through; these indexes are the
+-- backstop for the races those adopt-by-path lookups can still lose.
+
+-- ── 1. Folders: merge case-variant twins ────────────────────────────────────
+-- Same shape as 022's exact-path dedupe: keep the OLDEST row per
+-- (vault_id, lower(path)), re-point everything at it, delete the losers. No
+-- folder_tombstones rows for the losers — a tombstone tells clients to delete
+-- the local folder, and the local folder IS the keeper's (one directory on a
+-- case-insensitive disk, and the same content on a case-sensitive one).
+CREATE TEMP TABLE folder_case_dupes AS
+SELECT f.id AS loser,
+       (SELECT k.id FROM folders k
+         WHERE k.vault_id = f.vault_id AND lower(k.path) = lower(f.path)
+         ORDER BY k.created_at ASC, k.id ASC LIMIT 1) AS keeper
+  FROM folders f;
+DELETE FROM folder_case_dupes WHERE loser = keeper;
+
+UPDATE notes   n  SET folder_id = d.keeper FROM folder_case_dupes d WHERE n.folder_id  = d.loser;
+UPDATE files   fi SET folder_id = d.keeper FROM folder_case_dupes d WHERE fi.folder_id = d.loser;
+UPDATE folders c  SET parent_id = d.keeper FROM folder_case_dupes d WHERE c.parent_id  = d.loser;
+-- Shares pointed at a loser have to follow it, or revoking/attaching access on
+-- the surviving folder would silently ignore a grant that still governs it.
+-- ON CONFLICT: the keeper may already carry the identical grant.
+UPDATE shares s SET resource_id = d.keeper
+  FROM folder_case_dupes d
+ WHERE s.resource_type = 'folder' AND s.resource_id = d.loser
+   AND NOT EXISTS (
+     SELECT 1 FROM shares k
+      WHERE k.resource_type = 'folder' AND k.resource_id = d.keeper
+        AND k.principal_type = s.principal_type AND k.principal_id = s.principal_id);
+DELETE FROM shares s USING folder_case_dupes d
+ WHERE s.resource_type = 'folder' AND s.resource_id = d.loser;
+
+-- Children were re-pointed above, so ON DELETE CASCADE has nothing to cascade.
+DELETE FROM folders f USING folder_case_dupes d WHERE f.id = d.loser;
+DROP TABLE folder_case_dupes;
+
+-- Re-spell every surviving folder onto its parent's actual path, so a subtree
+-- that mixed cases across levels (`Projects/Community/drafts` under a keeper
+-- named `Projects/community`) agrees with `resolveFolderParent` again. Deepest
+-- paths last: a parent must be corrected before its children read it. Bounded
+-- by tree depth, and a no-op on the second pass.
+DO $$
+DECLARE
+  fixed int;
+BEGIN
+  FOR i IN 1..32 LOOP
+    UPDATE folders c
+       SET path = p.path || '/' || c.name
+      FROM folders p
+     WHERE c.parent_id = p.id
+       AND c.path <> p.path || '/' || c.name
+       AND lower(c.path) = lower(p.path || '/' || c.name);
+    GET DIAGNOSTICS fixed = ROW_COUNT;
+    EXIT WHEN fixed = 0;
+  END LOOP;
+END $$;
+
+-- ── 2. Notes: soft-delete case-variant duplicates ───────────────────────────
+-- Same keeper rule as 021: per (vault_id, lower(rel_path)) keep the oldest live
+-- row that actually holds CRDT data (else simply the oldest) and tombstone the
+-- rest. The losers' doc_updates/doc_snapshots are deliberately LEFT IN PLACE —
+-- a soft-deleted note keeps its history recoverable, and the disk file (the
+-- durable source of truth) is untouched and still owned by the keeper.
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY vault_id, lower(rel_path)
+           ORDER BY (EXISTS (SELECT 1 FROM doc_updates u WHERE u.doc_id = notes.id)
+                  OR EXISTS (SELECT 1 FROM doc_snapshots s WHERE s.doc_id = notes.id)) DESC,
+                    created_at ASC,
+                    id ASC
+         ) AS rn
+  FROM notes
+  WHERE deleted_at IS NULL
+)
+UPDATE notes SET deleted_at = now()
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- Re-spell surviving notes onto their folder's path, for the same reason as the
+-- folder pass above (keeps migration 022's `dirname(rel_path) = folder.path`
+-- invariant exact rather than merely case-insensitive). Guarded by the
+-- `lower() = lower()` clause so this only ever fixes CASE — a note whose
+-- rel_path and folder_id genuinely disagree is 022's business, not ours.
+UPDATE notes n
+   SET rel_path = f.path || '/' || substring(n.rel_path FROM '[^/]+$')
+  FROM folders f
+ WHERE n.folder_id = f.id
+   AND n.deleted_at IS NULL
+   AND n.rel_path <> f.path || '/' || substring(n.rel_path FROM '[^/]+$')
+   AND lower(n.rel_path) = lower(f.path || '/' || substring(n.rel_path FROM '[^/]+$'));
+
+-- ── 3. Files: same merge as notes, minus the CRDT tiebreak ──────────────────
+-- `files` has no soft-delete column, so the loser rows go. A file's bytes live
+-- in `blobs` keyed by the doc id, which is why the OLDEST row wins here too:
+-- it is the one clients have been uploading against.
+CREATE TEMP TABLE file_case_dupes AS
+SELECT f.id AS loser,
+       (SELECT k.id FROM files k
+         WHERE k.vault_id = f.vault_id AND lower(k.path) = lower(f.path)
+         ORDER BY k.created_at ASC, k.id ASC LIMIT 1) AS keeper
+  FROM files f;
+DELETE FROM file_case_dupes WHERE loser = keeper;
+
+-- Per-file shares must follow, or the delete below would drop a grant that
+-- still governs the surviving file (`shares.resource_id` has no FK to `files`,
+-- so nothing would flag the orphan).
+UPDATE shares s SET resource_id = d.keeper
+  FROM file_case_dupes d
+ WHERE s.resource_type = 'file' AND s.resource_id = d.loser
+   AND NOT EXISTS (
+     SELECT 1 FROM shares k
+      WHERE k.resource_type = 'file' AND k.resource_id = d.keeper
+        AND k.principal_type = s.principal_type AND k.principal_id = s.principal_id);
+DELETE FROM shares s USING file_case_dupes d
+ WHERE s.resource_type = 'file' AND s.resource_id = d.loser;
+
+DELETE FROM files f USING file_case_dupes d WHERE f.id = d.loser;
+DROP TABLE file_case_dupes;
+
+-- ── 4. The backstops ────────────────────────────────────────────────────────
+-- Both create surfaces adopt case-insensitively by path first; a lost race now
+-- surfaces as 23505, which they catch and adopt (same contract as m021/m022).
+CREATE UNIQUE INDEX IF NOT EXISTS folders_vault_path_ci_uq
+  ON folders (vault_id, lower(path));
+
+CREATE UNIQUE INDEX IF NOT EXISTS notes_live_path_ci_uq
+  ON notes (vault_id, lower(rel_path))
+  WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS files_vault_path_ci_uq
+  ON files (vault_id, lower(path));

--- a/app/apps/server/src/http/routes/registry.ts
+++ b/app/apps/server/src/http/routes/registry.ts
@@ -270,20 +270,34 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
 
     // A given path maps to one folder per vault — adopt an existing row rather
     // than duplicating it (reconcile and on-demand create can race).
-    const existing = await pool.query(
-      "SELECT id FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+    //
+    // Matched case-insensitively, and the response echoes the row's CANONICAL
+    // path/name rather than what was asked for. A Mac and a Windows box see one
+    // directory where Postgres would store two rows, and the desktop that then
+    // maps its file to the twin's doc_id is the 2026-09-04 ping-pong (see
+    // `samePath`). Echoing canonical is what lets the caller converge instead of
+    // re-asking with its own spelling on every pass.
+    const existing = await pool.query<{ id: string; parent_id: string | null; name: string; path: string }>(
+      `SELECT id, parent_id, name, path FROM folders
+        WHERE vault_id = $1 AND lower(path) = lower($2)
+        ORDER BY created_at ASC, id ASC LIMIT 1`,
       [vaultId, path],
     );
     if (existing.rows[0]) {
-      return c.json({ id: existing.rows[0].id, vaultId, parentId: parentId ?? null, name, path }, 200);
+      const e = existing.rows[0];
+      return c.json({ id: e.id, vaultId, parentId: e.parent_id, name: e.name, path: e.path }, 200);
     }
 
     // `path` is authoritative; `parentId` must be the folder at its dirname (or
     // is resolved from it when absent). See `resolveParentFolder` for the
-    // incident this closes.
+    // incident this closes. `storedPath` is `path` rewritten onto the parent's
+    // own spelling, so a subtree never mixes cases across levels.
     let resolvedParent: string | null;
+    let storedPath: string;
     try {
-      resolvedParent = await resolveFolderParent(pool, vaultId, path, parentId ?? null);
+      const loc = await resolveFolderParent(pool, vaultId, path, parentId ?? null);
+      resolvedParent = loc.folderId;
+      storedPath = loc.relPath;
     } catch (err) {
       if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
       throw err;
@@ -303,25 +317,27 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
       await pool.query(
         `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by, color)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-        [id, vaultId, resolvedParent, name, path, body.sort ?? 0, session.userId, color],
+        [id, vaultId, resolvedParent, name, storedPath, body.sort ?? 0, session.userId, color],
       );
     } catch (err) {
       // Lost the race against another device registering the same path: the
-      // unique index `folders_vault_path_uq` (migration 022) refused the twin.
-      // Adopt the winner — before that index, this race produced 2–5 rows per
-      // path and split a folder's notes across them.
+      // unique indexes `folders_vault_path_uq` (m022) / `folders_vault_path_ci_uq`
+      // (m023) refused the twin. Adopt the winner — before those, this race
+      // produced 2–5 rows per path and split a folder's notes across them.
       if ((err as { code?: string }).code === "23505") {
-        const winner = await pool.query<{ id: string; parent_id: string | null; name: string }>(
-          "SELECT id, parent_id, name FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
-          [vaultId, path],
+        const winner = await pool.query<{ id: string; parent_id: string | null; name: string; path: string }>(
+          `SELECT id, parent_id, name, path FROM folders
+            WHERE vault_id = $1 AND lower(path) = lower($2)
+            ORDER BY created_at ASC, id ASC LIMIT 1`,
+          [vaultId, storedPath],
         );
         const w = winner.rows[0];
-        if (w) return c.json({ id: w.id, vaultId, parentId: w.parent_id, name: w.name, path }, 200);
+        if (w) return c.json({ id: w.id, vaultId, parentId: w.parent_id, name: w.name, path: w.path }, 200);
       }
       throw err;
     }
     changed(c, vaultId);
-    return c.json({ id, vaultId, parentId: resolvedParent, name, path, color }, 201);
+    return c.json({ id, vaultId, parentId: resolvedParent, name, path: storedPath, color }, 201);
   });
 
   registryRoutes.get("/folders", async (c) => {
@@ -473,16 +489,29 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // map one file to two docs, and every external write bounces between them,
     // duplicating the content each cycle (the 2026-08-25 runaway-daily-notes
     // incident). The unique index `notes_live_path_uq` backstops the race below.
-    const { rows: samePath } = await pool.query<{
+    // Matched case-insensitively, because a case-variant of a live note's path is
+    // the SAME FILE on macOS and Windows. Storing both forked one file across two
+    // doc_ids and the two docs then wrote over each other through the disk
+    // forever — the 2026-09-04 BenAI OS runaway (`samePath` in tree-ops carries
+    // the full account). `notes_live_path_uq` (m021) could not see it: a
+    // case-only difference satisfies an exact-path unique index.
+    //
+    // The response echoes the row's CANONICAL `rel_path`, not the caller's, so a
+    // desktop whose disk spells it differently adopts this doc_id and stops
+    // re-registering its own spelling on every reconcile pass.
+    const { rows: samePathRows } = await pool.query<{
       id: string;
       folder_id: string | null;
       title: string | null;
+      rel_path: string;
     }>(
-      "SELECT id, folder_id, title FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL",
+      `SELECT id, folder_id, title, rel_path FROM notes
+        WHERE vault_id = $1 AND lower(rel_path) = lower($2) AND deleted_at IS NULL
+        ORDER BY created_at ASC, id ASC LIMIT 1`,
       [vaultId, relPath],
     );
-    if (samePath.length > 0) {
-      const row = samePath[0];
+    if (samePathRows.length > 0) {
+      const row = samePathRows[0];
       return c.json(
         {
           id: row.id,
@@ -490,7 +519,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
           vaultId,
           folderId: row.folder_id,
           title: row.title,
-          relPath,
+          relPath: row.rel_path,
         },
         200,
       );
@@ -502,8 +531,11 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     // inconsistently, otherwise writes a row every client renders in one place
     // and every ACL walk reads in another (2026-08-27 phantom-root-folder).
     let resolvedFolder: string | null;
+    let storedRelPath: string;
     try {
-      resolvedFolder = await resolveParentFolder(pool, vaultId, relPath, folderId ?? null);
+      const loc = await resolveParentFolder(pool, vaultId, relPath, folderId ?? null);
+      resolvedFolder = loc.folderId;
+      storedRelPath = loc.relPath;
     } catch (err) {
       if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
       throw err;
@@ -536,27 +568,39 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
           vaultId,
           resolvedFolder,
           title ?? null,
-          relPath,
+          storedRelPath,
           session.userId,
           normalizeColor(body.color) ?? null,
         ],
       );
     } catch (err) {
       // Lost the race against a concurrent register of the same path
-      // (notes_live_path_uq). The winner's row is this note — adopt it.
+      // (notes_live_path_uq m021, or notes_live_path_ci_uq m023 for a
+      // case-variant). The winner's row is this note — adopt it, canonical path
+      // and all.
       if ((err as { code?: string }).code === "23505") {
         const { rows } = await pool.query<{
           id: string;
           folder_id: string | null;
           title: string | null;
+          rel_path: string;
         }>(
-          "SELECT id, folder_id, title FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL",
-          [vaultId, relPath],
+          `SELECT id, folder_id, title, rel_path FROM notes
+            WHERE vault_id = $1 AND lower(rel_path) = lower($2) AND deleted_at IS NULL
+            ORDER BY created_at ASC, id ASC LIMIT 1`,
+          [vaultId, storedRelPath],
         );
         const row = rows[0];
         if (row) {
           return c.json(
-            { id: row.id, docId: row.id, vaultId, folderId: row.folder_id, title: row.title, relPath },
+            {
+              id: row.id,
+              docId: row.id,
+              vaultId,
+              folderId: row.folder_id,
+              title: row.title,
+              relPath: row.rel_path,
+            },
             200,
           );
         }
@@ -584,7 +628,7 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
     changed(c, vaultId);
     return c.json(
-      { id, docId: id, vaultId, folderId: resolvedFolder, title: title ?? null, relPath },
+      { id, docId: id, vaultId, folderId: resolvedFolder, title: title ?? null, relPath: storedRelPath },
       201,
     );
   });
@@ -751,8 +795,11 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
     const id = typeof body.docId === "string" && body.docId ? body.docId : randomUUID();
     let resolvedFolder: string | null;
+    let storedPath: string;
     try {
-      resolvedFolder = await resolveParentFolder(pool, vaultId, path, folderId ?? null);
+      const loc = await resolveParentFolder(pool, vaultId, path, folderId ?? null);
+      resolvedFolder = loc.folderId;
+      storedPath = loc.relPath;
     } catch (err) {
       if (err instanceof TreeOpError) return c.json(pathFolderMismatch(err), 400);
       throw err;
@@ -766,10 +813,10 @@ export function createRegistryRoutes(deps: RegistryDeps = {}): Hono {
     }
     await pool.query(
       "INSERT INTO files (id, vault_id, folder_id, path) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING",
-      [id, vaultId, resolvedFolder, path],
+      [id, vaultId, resolvedFolder, storedPath],
     );
     changed(c, vaultId);
-    return c.json({ id, docId: id, vaultId, folderId: resolvedFolder, path }, 201);
+    return c.json({ id, docId: id, vaultId, folderId: resolvedFolder, path: storedPath }, 201);
   });
 
   return registryRoutes;

--- a/app/apps/server/src/mcp/service.ts
+++ b/app/apps/server/src/mcp/service.ts
@@ -170,8 +170,11 @@ export async function createFolder(
   // resolved from it. Done before the permission check so the check judges the
   // real parent (see `resolveParentFolder`).
   let parentId: string | null;
+  let storedPath: string;
   try {
-    parentId = await resolveFolderParent(pool, input.vaultId, input.path, input.parentId ?? null);
+    const loc = await resolveFolderParent(pool, input.vaultId, input.path, input.parentId ?? null);
+    parentId = loc.folderId;
+    storedPath = loc.relPath;
   } catch (err) {
     if (err instanceof TreeOpError) throw new McpToolError(err.message);
     throw err;
@@ -180,17 +183,20 @@ export async function createFolder(
     throw new McpToolError("You do not have edit access to create a folder here");
   }
   // Adopt an existing row at this path instead of inserting a duplicate, exactly
-  // as `POST /api/folders` does. There is no UNIQUE constraint behind
-  // (vault_id, path), so without this an assistant asking for "Ideas" twice
-  // creates two rows at one path and the desktop's path→id map picks one at
-  // random. Idempotent is also just the right shape for a tool an LLM retries.
-  const existing = await pool.query<{ id: string; name: string }>(
-    "SELECT id, name FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
-    [input.vaultId, input.path],
+  // as `POST /api/folders` does. Matched case-insensitively and echoing the
+  // stored spelling: `Ideas` and `ideas` are one directory on macOS/Windows, and
+  // an assistant that creates the second one forks the subtree into two rows the
+  // desktop then ping-pongs between (see `samePath`). Idempotent is also just
+  // the right shape for a tool an LLM retries.
+  const existing = await pool.query<{ id: string; name: string; path: string }>(
+    `SELECT id, name, path FROM folders
+      WHERE vault_id = $1 AND lower(path) = lower($2)
+      ORDER BY created_at ASC, id ASC LIMIT 1`,
+    [input.vaultId, storedPath],
   );
   if (existing.rows[0]) {
     const row = existing.rows[0];
-    return { folderId: row.id, parentId, name: row.name, path: input.path, adopted: true };
+    return { folderId: row.id, parentId, name: row.name, path: row.path, adopted: true };
   }
   // After the adopt path: freezing the root must not break re-registering a
   // root folder that already exists.
@@ -205,19 +211,22 @@ export async function createFolder(
       // assistant couldn't see it in their own sidebar or rename it in the app.
       `INSERT INTO folders (id, vault_id, parent_id, name, path, sort, created_by)
        VALUES ($1, $2, $3, $4, $5, 0, $6)`,
-      [id, input.vaultId, parentId, input.name, input.path, ctx.auth.userId],
+      [id, input.vaultId, parentId, input.name, storedPath, ctx.auth.userId],
     );
   } catch (err) {
     // Lost the race against a concurrent create at this path (unique index
-    // `folders_vault_path_uq`): adopt the winner, same as the HTTP route.
+    // `folders_vault_path_uq` m022, or `folders_vault_path_ci_uq` m023 for a
+    // case-variant): adopt the winner, same as the HTTP route.
     if ((err as { code?: string }).code === "23505") {
-      const winner = await pool.query<{ id: string; name: string }>(
-        "SELECT id, name FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
-        [input.vaultId, input.path],
+      const winner = await pool.query<{ id: string; name: string; path: string }>(
+        `SELECT id, name, path FROM folders
+          WHERE vault_id = $1 AND lower(path) = lower($2)
+          ORDER BY created_at ASC, id ASC LIMIT 1`,
+        [input.vaultId, storedPath],
       );
       const w = winner.rows[0];
       if (w) {
-        return { folderId: w.id, parentId, name: w.name, path: input.path, adopted: true };
+        return { folderId: w.id, parentId, name: w.name, path: w.path, adopted: true };
       }
     }
     throw err;
@@ -476,8 +485,11 @@ export async function createNote(
   // `relPath` without the `Team/`) is told so instead of writing a row every
   // client renders at the root while the root-freeze latch sees a parent.
   let folderId: string | null;
+  let storedRelPath: string;
   try {
-    folderId = await resolveParentFolder(pool, input.vaultId, input.relPath, input.folderId ?? null);
+    const loc = await resolveParentFolder(pool, input.vaultId, input.relPath, input.folderId ?? null);
+    folderId = loc.folderId;
+    storedRelPath = loc.relPath;
   } catch (err) {
     if (err instanceof TreeOpError) throw new McpToolError(err.message);
     throw err;
@@ -490,11 +502,16 @@ export async function createNote(
   // nothing in the schema enforces that, and the desktop's path→docId map just
   // picks one of a duplicate pair, so the loser becomes a row no client can see
   // or delete. An LLM retrying a tool call must not be able to create that.
-  const existing = await pool.query<{ id: string; title: string | null; folder_id: string | null }>(
-    `SELECT id, title, folder_id FROM notes
-      WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL
-      ORDER BY created_at ASC LIMIT 1`,
-    [input.vaultId, input.relPath],
+  const existing = await pool.query<{
+    id: string;
+    title: string | null;
+    folder_id: string | null;
+    rel_path: string;
+  }>(
+    `SELECT id, title, folder_id, rel_path FROM notes
+      WHERE vault_id = $1 AND lower(rel_path) = lower($2) AND deleted_at IS NULL
+      ORDER BY created_at ASC, id ASC LIMIT 1`,
+    [input.vaultId, storedRelPath],
   );
   if (existing.rows[0]) {
     const row = existing.rows[0];
@@ -515,8 +532,10 @@ export async function createNote(
       docId: row.id,
       vaultId: input.vaultId,
       folderId: row.folder_id,
-      title: row.title ?? relPathStem(input.relPath),
-      relPath: input.relPath,
+      title: row.title ?? relPathStem(row.rel_path),
+      // The row's OWN spelling: the caller asked for a case-variant of a path
+      // that already exists, and needs to learn which one this vault uses.
+      relPath: row.rel_path,
       adopted: true,
       seeded,
     };
@@ -528,7 +547,7 @@ export async function createNote(
   await pool.query(
     `INSERT INTO notes (id, vault_id, folder_id, title, rel_path, doc_id, created_by)
      VALUES ($1, $2, $3, $4, $5, $1, $6)`,
-    [docId, input.vaultId, folderId, input.title ?? null, input.relPath, ctx.auth.userId],
+    [docId, input.vaultId, folderId, input.title ?? null, storedRelPath, ctx.auth.userId],
   );
   if (input.content) {
     await ctx.docWriter.setContent(input.vaultId, docId, input.content, {
@@ -542,8 +561,8 @@ export async function createNote(
     docId,
     vaultId: input.vaultId,
     folderId,
-    title: input.title ?? relPathStem(input.relPath),
-    relPath: input.relPath,
+    title: input.title ?? relPathStem(storedRelPath),
+    relPath: storedRelPath,
     adopted: false,
     seeded: Boolean(input.content),
   };

--- a/app/apps/server/src/registry/tree-ops.ts
+++ b/app/apps/server/src/registry/tree-ops.ts
@@ -32,6 +32,33 @@ export function dirname(path: string): string {
 }
 
 /**
+ * Do two vault-relative paths name the same item? Compared **case-insensitively**,
+ * because most of our clients cannot tell them apart.
+ *
+ * macOS (APFS default) and Windows are case-INSENSITIVE, so `Projects/Community`
+ * and `Projects/community` are one directory on disk. Postgres `TEXT` compares
+ * case-sensitively, so the server used to store both as distinct rows with
+ * distinct `doc_id`s — and then every desktop mapped ONE file to TWO docs. Each
+ * doc egested to disk, the watcher fired, the other doc ingested a file that
+ * disagreed with its CRDT state and wrote back, forever: the 2026-09-04 BenAI OS
+ * runaway, 189 MB of updates an hour, where 328 notes (0.5% of the vault) were
+ * 26% of all CRDT bytes. Migration 021's `notes_live_path_uq` does not catch it
+ * — the collision is case-only, so both rows satisfy an exact-path unique index.
+ *
+ * A vault that syncs between a Mac and a Linux box therefore cannot safely hold
+ * case-variant siblings: the Mac physically cannot represent both. We treat them
+ * as one item everywhere (the same call Git makes with `core.ignorecase`), which
+ * costs a case-sensitive Linux vault the ability to keep `a.md` and `A.md` apart
+ * and buys every other vault immunity from the fork.
+ *
+ * `toLowerCase()`, not `localeCompare`: it must agree exactly with the
+ * `lower()`-based unique indexes in migration 023 for the backstop to hold.
+ */
+export function samePath(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
  * A vault-relative path the tree can hold: non-empty, no leading/trailing `/`,
  * no empty, `.` or `..` segments. Same shape the desktop's `resolve_in_vault`
  * enforces on disk, so a path the server accepts is one every client can write.
@@ -45,14 +72,27 @@ export function assertValidRelPath(path: string, what = "path"): void {
   if (bad) throw new TreeOpError(`Invalid ${what} "${path}"`);
 }
 
-/** Load the folder at exactly `path` in `vaultId`, or null. */
+/**
+ * Load the folder at `path` in `vaultId`, or null.
+ *
+ * Matched case-insensitively (see {@link samePath}), so a client that walked a
+ * case-insensitive disk and reports `Projects/community` resolves to the
+ * existing `Projects/Community` row instead of being told to create a twin.
+ * The returned row carries the CANONICAL stored path — callers hand that back to
+ * the client so it converges on one spelling.
+ *
+ * Ordered so the result is stable when a pre-migration-023 vault still holds
+ * case-variant twins: oldest wins, matching migration 023's keeper rule.
+ */
 export async function findFolderByPath(
   db: Queryable,
   vaultId: string,
   path: string,
 ): Promise<FolderRow | null> {
   const { rows } = await db.query<FolderRow>(
-    "SELECT id, vault_id, path, parent_id FROM folders WHERE vault_id = $1 AND path = $2 LIMIT 1",
+    `SELECT id, vault_id, path, parent_id FROM folders
+      WHERE vault_id = $1 AND lower(path) = lower($2)
+      ORDER BY created_at ASC, id ASC LIMIT 1`,
     [vaultId, path],
   );
   return rows[0] ?? null;
@@ -81,31 +121,50 @@ export async function findFolderByPath(
  *    the caller (usually an LLM) needs to learn which of its two inputs is wrong.
  *  - `folderId` absent/null → resolve by `dirname(relPath)`: `""` is the root
  *    (null); otherwise the folder at that path must already exist.
- * Returns the resolved parent id (null = vault root).
+ *
+ * The parent is matched case-insensitively ({@link samePath}), and the returned
+ * `relPath` is rewritten onto the parent's OWN spelling. Both matter: a client
+ * reporting `Projects/community/x.md` when the folder row says
+ * `Projects/Community` must resolve to that folder rather than be told to create
+ * a twin, and the stored path must then agree with it exactly, or migration
+ * 022's `dirname(rel_path) === folder.path` invariant would hold only up to case
+ * and the next move would refuse itself.
  */
+export interface ResolvedLocation {
+  /** Resolved parent folder id; `null` = vault root. */
+  folderId: string | null;
+  /** The path to store: the parent's spelling + the caller's basename. */
+  relPath: string;
+}
+
+/** Join a parent path (possibly `""` for the root) and a basename. */
+export function joinPath(dir: string, name: string): string {
+  return dir === "" ? name : `${dir}/${name}`;
+}
+
 export async function resolveParentFolder(
   db: Queryable,
   vaultId: string,
   relPath: string,
   folderId: string | null | undefined,
-): Promise<string | null> {
+): Promise<ResolvedLocation> {
   assertValidRelPath(relPath);
   const dir = dirname(relPath);
   if (folderId != null) {
     const folder = await findFolder(db, folderId);
     if (!folder) throw new TreeOpError("Unknown folder");
     if (folder.vault_id !== vaultId) throw new TreeOpError("Folder is in a different vault");
-    if (folder.path !== dir) {
+    if (!samePath(folder.path, dir)) {
       throw new TreeOpError(
         `"${relPath}" is not inside folder "${folder.path}" — use relPath "${folder.path}/${basename(relPath)}" or the folder whose path is "${dir}"`,
       );
     }
-    return folder.id;
+    return { folderId: folder.id, relPath: joinPath(folder.path, basename(relPath)) };
   }
-  if (dir === "") return null;
+  if (dir === "") return { folderId: null, relPath };
   const byPath = await findFolderByPath(db, vaultId, dir);
   if (!byPath) throw new TreeOpError(`No folder at "${dir}" — create it first`);
-  return byPath.id;
+  return { folderId: byPath.id, relPath: joinPath(byPath.path, basename(relPath)) };
 }
 
 /**
@@ -118,22 +177,22 @@ export async function resolveFolderParent(
   vaultId: string,
   path: string,
   parentId: string | null | undefined,
-): Promise<string | null> {
+): Promise<ResolvedLocation> {
   assertValidRelPath(path, "folder path");
   const dir = dirname(path);
   if (parentId != null) {
     const parent = await findFolder(db, parentId);
     if (!parent) throw new TreeOpError("Unknown parent folder");
     if (parent.vault_id !== vaultId) throw new TreeOpError("Parent folder is in a different vault");
-    if (parent.path !== dir) {
+    if (!samePath(parent.path, dir)) {
       throw new TreeOpError(`Folder path "${path}" is not inside its parent "${parent.path}"`);
     }
-    return parent.id;
+    return { folderId: parent.id, relPath: joinPath(parent.path, basename(path)) };
   }
-  if (dir === "") return null;
+  if (dir === "") return { folderId: null, relPath: path };
   const byPath = await findFolderByPath(db, vaultId, dir);
   if (!byPath) throw new TreeOpError(`No folder at "${dir}" — create it first`);
-  return byPath.id;
+  return { folderId: byPath.id, relPath: joinPath(byPath.path, basename(path)) };
 }
 
 /** Escape SQL LIKE metacharacters (\ % _) so a value is matched literally under
@@ -244,8 +303,10 @@ export async function planFolderMove(
   input: MoveFolderInput,
 ): Promise<{ path: string; parentId: string | null }> {
   if (input.path !== undefined) {
-    const parentId = await resolveFolderParent(db, folder.vault_id, input.path, input.parentId);
-    return { path: input.path, parentId };
+    // `relPath` from the resolver, not `input.path`: it carries the parent's own
+    // spelling, so the subtree keeps one consistent prefix.
+    const resolved = await resolveFolderParent(db, folder.vault_id, input.path, input.parentId);
+    return { path: resolved.relPath, parentId: resolved.folderId };
   }
   if (input.parentId !== undefined) {
     const name = input.name ?? basename(folder.path);
@@ -295,9 +356,14 @@ export async function moveFolder(
     }
   }
 
-  if (newPath !== oldPath) {
+  // `samePath`, not `!==`: a pure case change of the folder's own name (`docs` →
+  // `Docs`) is a legal rename, but landing on a DIFFERENT folder that already
+  // holds this path up to case would fork the subtree across two rows that are
+  // one directory on disk. Surfaced as a refusal so the caller sees why, rather
+  // than as a bare 23505 from `folders_vault_path_ci_uq` (migration 023).
+  if (!samePath(newPath, oldPath)) {
     const clash = await db.query(
-      "SELECT 1 FROM folders WHERE vault_id = $1 AND path = $2 AND id <> $3 LIMIT 1",
+      "SELECT 1 FROM folders WHERE vault_id = $1 AND lower(path) = lower($2) AND id <> $3 LIMIT 1",
       [folder.vault_id, newPath, folderId],
     );
     if ((clash.rowCount ?? 0) > 0) {
@@ -358,8 +424,8 @@ export async function planNoteMove(
   input: MoveNoteInput,
 ): Promise<{ relPath: string; folderId: string | null }> {
   if (input.relPath !== undefined) {
-    const folderId = await resolveParentFolder(db, note.vault_id, input.relPath, input.folderId);
-    return { relPath: input.relPath, folderId };
+    const resolved = await resolveParentFolder(db, note.vault_id, input.relPath, input.folderId);
+    return { relPath: resolved.relPath, folderId: resolved.folderId };
   }
   if (input.folderId !== undefined) {
     const name = basename(note.rel_path);
@@ -386,11 +452,15 @@ export async function moveNote(
   const title = input.title === undefined ? note.title : input.title;
   const { relPath, folderId } = await planNoteMove(db, note, input);
 
-  if (relPath !== note.rel_path) {
+  // Compared up to case (see the folder twin above): renaming `notes.md` →
+  // `Notes.md` is legal, but moving onto a path another live note already holds
+  // case-insensitively is the fork that the 2026-09-04 runaway was made of.
+  if (!samePath(relPath, note.rel_path)) {
     // Surface the collision as a refusal rather than letting the partial unique
-    // index (`notes_live_path_uq`, migration 021) throw a bare 23505.
+    // indexes (`notes_live_path_uq` m021, `notes_live_path_ci_uq` m023) throw a
+    // bare 23505.
     const clash = await db.query(
-      "SELECT 1 FROM notes WHERE vault_id = $1 AND rel_path = $2 AND deleted_at IS NULL AND id <> $3 LIMIT 1",
+      "SELECT 1 FROM notes WHERE vault_id = $1 AND lower(rel_path) = lower($2) AND deleted_at IS NULL AND id <> $3 LIMIT 1",
       [note.vault_id, relPath, docId],
     );
     if ((clash.rowCount ?? 0) > 0) throw new TreeOpError("A note already exists at that path");

--- a/app/apps/server/tests/case-insensitive-paths.test.ts
+++ b/app/apps/server/tests/case-insensitive-paths.test.ts
@@ -1,0 +1,281 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { authHeaders, createOrg, signUp, type TestUser } from "./helpers/auth.js";
+import { seedFolder, seedNote, seedVault } from "./helpers/seed.js";
+import { recordingAppDeps } from "./helpers/app.js";
+import { createMcpToken } from "../src/mcp/tokens.js";
+
+/**
+ * A path names ONE folder and ONE live note per vault, compared
+ * case-insensitively — on every surface that creates or moves one.
+ *
+ * The 2026-09-04 incident: `Projects/Community` (2026-08-07) and
+ * `Projects/community` (a teammate, 2026-08-20) both existed on the server, and
+ * the duplication had spread through the subtree — 71 folders, 164 note pairs.
+ * macOS/Windows cannot tell those paths apart, so every desktop mapped ONE file
+ * to TWO doc_ids: doc A egested to disk, the watcher fired, doc B ingested a
+ * file that disagreed with its CRDT state and wrote back, forever. 189 MB of
+ * updates an hour; individual updates had grown past 3 MB. Migration 021's
+ * exact-path unique index cannot see a case-only collision.
+ */
+
+const rec = recordingAppDeps();
+const app = createApp(rec.deps);
+
+afterAll(async () => {
+  await pool.end();
+});
+
+function req(user: TestUser, method: string, path: string, body?: unknown) {
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers: authHeaders(user),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  );
+}
+
+let rpcId = 0;
+async function call(token: string, name: string, args: Record<string, unknown>) {
+  const res = await app.fetch(
+    new Request("http://local/api/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: ++rpcId,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+  );
+  const body = (await res.json()) as {
+    result?: { structuredContent?: unknown; isError?: boolean; content?: Array<{ text: string }> };
+  };
+  return {
+    isError: body.result?.isError ?? false,
+    data: body.result?.structuredContent as any,
+    text: body.result?.content?.[0]?.text ?? "",
+  };
+}
+
+async function liveNotes(vaultId: string) {
+  const { rows } = await pool.query<{ id: string; rel_path: string }>(
+    "SELECT id, rel_path FROM notes WHERE vault_id = $1 AND deleted_at IS NULL ORDER BY rel_path",
+    [vaultId],
+  );
+  return rows;
+}
+
+describe("case-insensitive path identity", () => {
+  let owner: TestUser;
+  let org: string;
+  let vault: string;
+  let projects: string;
+  let community: string;
+
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+    owner = await signUp("owner@case.test");
+    org = (await createOrg(owner, "Case Co", "case-co")).id;
+    vault = await seedVault(org);
+    projects = await seedFolder(vault, null, "Projects", "Projects");
+    community = await seedFolder(vault, projects, "Community", "Projects/Community");
+  });
+
+  describe("HTTP registry", () => {
+    it("adopts the existing note when a case-variant of its path is registered", async () => {
+      const first = await req(owner, "POST", "/api/notes", {
+        vaultId: vault,
+        relPath: "Projects/Community/spec.md",
+      });
+      expect(first.status).toBe(201);
+      const original = (await first.json()).docId as string;
+
+      // A second device walked the same case-insensitive disk and spells it
+      // differently. This is the exact call that forked the note in production.
+      const second = await req(owner, "POST", "/api/notes", {
+        vaultId: vault,
+        relPath: "projects/community/SPEC.md",
+      });
+      expect(second.status).toBe(200);
+      const body = await second.json();
+      // Same doc_id — one file, one CRDT doc, no ping-pong…
+      expect(body.docId).toBe(original);
+      // …and the caller is told the canonical spelling so it converges.
+      expect(body.relPath).toBe("Projects/Community/spec.md");
+      expect(await liveNotes(vault)).toHaveLength(1);
+    });
+
+    it("adopts the existing folder when a case-variant of its path is registered", async () => {
+      const res = await req(owner, "POST", "/api/folders", {
+        vaultId: vault,
+        name: "community",
+        path: "Projects/community",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.id).toBe(community);
+      expect(body.path).toBe("Projects/Community");
+
+      const { rows } = await pool.query("SELECT 1 FROM folders WHERE vault_id = $1", [vault]);
+      expect(rows).toHaveLength(2); // Projects + Community, no twin
+    });
+
+    it("stores a note under the folder's own spelling, not the caller's", async () => {
+      const res = await req(owner, "POST", "/api/notes", {
+        vaultId: vault,
+        relPath: "Projects/community/notes.md", // lowercase folder segment
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      // Resolved to the real folder, and the stored path agrees with it exactly —
+      // migration 022's dirname(rel_path) === folder.path stays true, not merely
+      // true-up-to-case (a case-only mismatch would refuse the note's next move).
+      expect(body.folderId).toBe(community);
+      expect(body.relPath).toBe("Projects/Community/notes.md");
+    });
+
+    it("refuses a move onto a path another live note holds case-insensitively", async () => {
+      const a = await seedNote(vault, community, "Projects/Community/a.md");
+      await seedNote(vault, community, "Projects/Community/b.md");
+      const res = await req(owner, "PATCH", `/api/notes/${a}`, {
+        relPath: "Projects/Community/B.md",
+      });
+      // 400 is this surface's contract for a TreeOpError (same as an exact-path
+      // collision), not 409.
+      expect(res.status).toBe(400);
+      // Still where it was: the fork was refused, not half-applied.
+      const { rows } = await pool.query("SELECT rel_path FROM notes WHERE id = $1", [a]);
+      expect(rows[0].rel_path).toBe("Projects/Community/a.md");
+    });
+
+    it("still allows a pure case rename of a note (nothing else claims the path)", async () => {
+      const a = await seedNote(vault, community, "Projects/Community/notes.md");
+      const res = await req(owner, "PATCH", `/api/notes/${a}`, {
+        relPath: "Projects/Community/Notes.md",
+      });
+      expect(res.status).toBe(200);
+      const { rows } = await pool.query("SELECT rel_path FROM notes WHERE id = $1", [a]);
+      expect(rows[0].rel_path).toBe("Projects/Community/Notes.md");
+    });
+
+    it("still allows a pure case rename of a folder, rewriting descendants", async () => {
+      await seedNote(vault, community, "Projects/Community/a.md");
+      const res = await req(owner, "PATCH", `/api/folders/${community}`, {
+        path: "Projects/community",
+        name: "community",
+      });
+      expect(res.status).toBe(200);
+      const { rows: f } = await pool.query("SELECT path FROM folders WHERE id = $1", [community]);
+      expect(f[0].path).toBe("Projects/community");
+      // Descendants follow, or the subtree would be split across two spellings.
+      const { rows: n } = await pool.query(
+        "SELECT rel_path FROM notes WHERE vault_id = $1 AND deleted_at IS NULL",
+        [vault],
+      );
+      expect(n[0].rel_path).toBe("Projects/community/a.md");
+    });
+
+    it("refuses a folder move onto a case-variant of another folder's path", async () => {
+      const other = await seedFolder(vault, projects, "Marketing", "Projects/Marketing");
+      const res = await req(owner, "PATCH", `/api/folders/${other}`, {
+        path: "Projects/COMMUNITY",
+      });
+      expect(res.status).toBe(400);
+      const { rows } = await pool.query("SELECT path FROM folders WHERE id = $1", [other]);
+      expect(rows[0].path).toBe("Projects/Marketing");
+    });
+  });
+
+  describe("MCP tools", () => {
+    let token: string;
+
+    beforeEach(async () => {
+      token = (
+        await createMcpToken({ userId: owner.userId, organizationId: org }, "test")
+      ).token;
+    });
+
+    it("adopts rather than forking when an assistant asks for a case-variant path", async () => {
+      const first = await call(token, "create_note", {
+        vaultId: vault,
+        relPath: "Projects/Community/plan.md",
+        content: "# Plan",
+      });
+      expect(first.isError).toBe(false);
+
+      const second = await call(token, "create_note", {
+        vaultId: vault,
+        relPath: "projects/COMMUNITY/Plan.md",
+        content: "# Different",
+      });
+      expect(second.isError).toBe(false);
+      expect(second.data.adopted).toBe(true);
+      expect(second.data.docId).toBe(first.data.docId);
+      expect(second.data.relPath).toBe("Projects/Community/plan.md");
+      // Adopt must never overwrite a note that already says something.
+      expect(second.data.seeded).toBe(false);
+      expect(await liveNotes(vault)).toHaveLength(1);
+    });
+
+    it("adopts an existing folder for a case-variant create_folder", async () => {
+      const res = await call(token, "create_folder", {
+        vaultId: vault,
+        name: "community",
+        path: "PROJECTS/community",
+      });
+      expect(res.isError).toBe(false);
+      expect(res.data.adopted).toBe(true);
+      expect(res.data.folderId).toBe(community);
+      expect(res.data.path).toBe("Projects/Community");
+    });
+
+    it("refuses move_note onto a case-variant of an occupied path", async () => {
+      const a = await seedNote(vault, community, "Projects/Community/a.md", owner.userId);
+      await seedNote(vault, community, "Projects/Community/b.md", owner.userId);
+      const res = await call(token, "move_note", { docId: a, relPath: "Projects/Community/B.MD" });
+      expect(res.isError).toBe(true);
+      expect(res.text).toContain("already exists");
+    });
+  });
+
+  describe("the database backstop (migration 023)", () => {
+    it("rejects a second folder row whose path differs only by case", async () => {
+      await expect(
+        pool.query(
+          "INSERT INTO folders (id, vault_id, parent_id, name, path) VALUES ($1, $2, $3, $4, $5)",
+          [crypto.randomUUID(), vault, projects, "community", "Projects/community"],
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+    });
+
+    it("rejects a second live note row whose path differs only by case", async () => {
+      await seedNote(vault, community, "Projects/Community/a.md");
+      await expect(
+        pool.query(
+          `INSERT INTO notes (id, vault_id, folder_id, rel_path, doc_id)
+           VALUES ($1, $2, $3, $4, $1)`,
+          [crypto.randomUUID(), vault, community, "Projects/Community/A.md"],
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+    });
+
+    it("allows a case-variant path once the twin is soft-deleted", async () => {
+      const a = await seedNote(vault, community, "Projects/Community/a.md");
+      await pool.query("UPDATE notes SET deleted_at = now() WHERE id = $1", [a]);
+      // The partial index only covers live rows, so a tombstone frees the path.
+      await expect(
+        pool.query(
+          `INSERT INTO notes (id, vault_id, folder_id, rel_path, doc_id)
+           VALUES ($1, $2, $3, $4, $1)`,
+          [crypto.randomUUID(), vault, community, "Projects/Community/A.md"],
+        ),
+      ).resolves.toBeTruthy();
+    });
+  });
+});

--- a/app/apps/server/tests/path-folder-consistency.test.ts
+++ b/app/apps/server/tests/path-folder-consistency.test.ts
@@ -232,14 +232,23 @@ describe("rel_path ↔ folder_id consistency", () => {
     const sql = readFileSync(new URL("../migrations/022_note_folder_consistency.sql", import.meta.url), "utf8");
 
     it("collapses duplicate folder rows at one path onto the oldest, re-pointing notes and children", async () => {
-      // The unique index already exists in the test DB (migrations ran), so the
-      // twins are seeded with it dropped and the migration puts it back.
+      // The unique indexes already exist in the test DB (migrations ran), so the
+      // twins are seeded with them dropped and the migration puts them back.
+      // `folders_vault_path_ci_uq` (migration 023, case-insensitive) also refuses
+      // these twins and is NOT restored by 022's SQL, so it is re-created at the
+      // end of this test — dropping it for the whole run would silently disarm
+      // the case-collision backstop for every test after this one.
       await pool.query("DROP INDEX IF EXISTS folders_vault_path_uq");
+      await pool.query("DROP INDEX IF EXISTS folders_vault_path_ci_uq");
       const twin = await seedFolder(vault, team, "Daily", "Team/Daily"); // newer twin of `daily`
       const inTwin = await seedNote(vault, twin, "Team/Daily/twin.md", owner.userId);
       const child = await seedFolder(vault, twin, "Sub", "Team/Daily/Sub");
 
       await pool.query(sql);
+      // 022 has collapsed the twins, so the case-insensitive backstop can go back.
+      await pool.query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS folders_vault_path_ci_uq ON folders (vault_id, lower(path))",
+      );
 
       const { rows } = await pool.query<{ id: string }>(
         "SELECT id FROM folders WHERE vault_id = $1 AND path = 'Team/Daily'",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
+      '@tauri-apps/plugin-log':
+        specifier: ^2.9.1
+        version: 2.9.1
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
@@ -1309,6 +1312,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+
+  '@tauri-apps/plugin-log@2.9.1':
+    resolution: {integrity: sha512-8dYNEQOgZcIEqeFtHAsOIGLoptm+j94270Jf2MrGS/zbsYNd4C8DKyOdeYggAyE3ugwr12mTefIfC8lVVEhdlg==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -3113,6 +3119,10 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-log@2.9.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
Seven fixes from one session's investigation: a CRDT write loop that was burning
189 MB/hour, a note that had doubled itself to 68 MB, a folder that could never
sync again once re-added, and the sidebar that "blinked on hover and swallowed
clicks" while anything synced. Ships as **0.1.44**.

## 1. A path names one note — case-insensitively

`Projects/Community` and `Projects/community` both existed on the server (created
three weeks apart, by two people). Postgres `TEXT` is case-sensitive, so both were
legal rows with distinct `doc_id`s; macOS/APFS is case-insensitive, so they were
**one file**. Every desktop mapped that file to two docs: A egested to disk, the
watcher fired, B ingested a file disagreeing with its own CRDT state and wrote
back — forever. It had spread to 71 folders and 164 note pairs, and those 328
notes (0.5% of docs) owned 26% of all CRDT bytes.

- `registry/tree-ops.ts` — new `samePath()`; `findFolderByPath` and every
  move/clash check compare with `lower(path)`, with `created_at ASC, id ASC`
  ordering so the winner is stable.
- `resolveParentFolder`/`resolveFolderParent` return a `ResolvedLocation`, so a
  note is stored under the **folder's own spelling**, not the caller's — migration
  022's `dirname(rel_path) === folder.path` stays exactly true, not true-up-to-case.
- The HTTP registry and MCP `create_note`/`create_folder` now *adopt* a
  case-variant instead of forking, and echo the canonical spelling back so the
  client converges.
- Migration **023** merges the existing twins (re-pointing notes, files, children
  and shares; preferring the row that holds CRDT data) and adds the
  case-insensitive unique indexes as a backstop.
- 13 new tests in `tests/case-insensitive-paths.test.ts`, covering both surfaces
  plus the DB indexes. Pure case renames are still allowed.

## 2. The seed-vs-pull race that doubled notes

`seedFromFileIfEmpty` checked `text.length > 0`, then `await readFile`, then
inserted — emptiness tested *before* the await, insert *after*. A server pull
landing in that window meant seeding our own insert history on top of the
server's, and **Yjs merges two independent histories by keeping both**. One daily
note reached 68 MB: 2,374,523 lines, **35 distinct** — two versions interleaved
~43,000 times.

Fix: re-assert emptiness *inside* the `doc.transact` (same race in `hydrate`'s
`seedOnOpen`). Regression test `bridge/__tests__/doubling.test.ts` races a remote
update into the read and fails without the fix.

## 3. A re-added folder could never sync again

Dropping a previously-deleted folder back in showed `Daily 0/174` while the header
said "Synced". A server-side delete leaves a tombstone **and** a `baseline` entry,
so `planInbound`'s `dead && loc === undefined && localPaths.has(prev)` suppressed
registration on every pass; only *opening* a note synced it (the editor calls
`registerNote` directly, bypassing suppression). Both affected branches now
release the claim when the file has content, so the next pass registers it as the
new local note it is. Gated on `reason !== "revoked"`, and recorded as a failure
rather than done silently.

## 4–6. Why the sidebar was unusable during a sync

Three separate causes, measured rather than guessed — the log probe was decisive:

```
render=16  rowRender=84  rowUnmount=84  rowMount=84     ← six visible rows
```

**Every row unmounted and remounted on every render, 16×/second.** `<Tree>`'s
`children` is a *component type* to react-arborist (`renderNode =
this.props.children`), so the inline arrow — a fresh closure per render — was a
new element type each time, and React tore down the whole subtree. A remounted
element has no CSS `:hover` until the pointer moves again (the "blink"), and a
click on an element being destroyed mid-gesture goes nowhere. `TreeRow` is now a
single module-scope component with its inputs arriving by context, which updates
through arborist's `React.memo` so badges still refresh. After: `render=2
rowRender=12`, zero unmounts.

**Row order churned.** A sync run rewrites files, and "Recently modified" sorts on
mtime — a bulk wave moved 1,372 of a 1,560-note vault's mtimes inside three
minutes, re-sorting every folder under the pointer. `pinModified()` freezes each
row's sort key while the pointer is in the sidebar or a bulk run is in flight, and
thaws after; new files still land in their true position.

**The index lock was held for seconds.** `resolve_all_links` re-scanned every link
row on every pass — `index_notes: 176 files in 27128 ms` on the damaged vault,
charged while the watcher's drain thread held the mutex every UI command waits on.
Now `LinkScope::Touched` narrows it to `dst_note_id IS NULL OR src/dst IN touched`
(2,025,307 rows/1.29 s → 283,600/0.14 s on the real DB), `CHUNK` is 128 with a 2 ms
gap so a std mutex can't hand the lock back to itself, `VaultWatcher` joins its
drain thread on drop (two SQLite writers were causing a `database is locked`
storm), and `MAX_INDEX_BYTES`/`maxIngestBytes` (10 MB) stop one damaged note from
poisoning the index. Also: egest no longer writes bytes the file already holds.

## 7. The UI can talk to the dev terminal

`console.log` in a WKWebView reaches only the Web Inspector, which is how two
wrong diagnoses of the blink survived. `tauri-plugin-log` is registered for debug
builds with a Stdout target (`log:default` in the capability), so
`@tauri-apps/plugin-log` calls appear next to the Rust ones as one timeline. The
temporary probe counters have been removed; only the channel remains.

## Verification

- 396 server tests (against a scratch DB), 714 desktop TS, 95 Rust — all passing;
  `tsc --noEmit` clean in both workspaces.
- Migration 023 applied and re-run idempotently; the pre-existing duplicate-folder
  test now drops and re-creates the CI index around its deliberate seeding.
- The loop remediation was done reversibly (CSV backups, soft-delete only,
  `doc_updates` untouched) and the write rate dropped ~5000×.

## Not in this PR

- The header badge still reads "Synced" whenever nothing is *queued*, even with
  local notes unregistered — the per-folder `0/174` was honest, the header was not.
- ~500 MB of already-damaged notes remain on disk in one local vault (9 notes
  > 5 MB); no user files were touched.
- A separate daily ~2,000-doc mass re-push at 07:00 UTC is still uninvestigated.
