### PR TITLE
Stop the client re-registering case-merged notes forever (Syncing 225/235 loop)

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.44",
+  "version": "0.1.45",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.44"
+version = "0.1.45"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -441,3 +441,48 @@ describe("path safety", () => {
     expect(p.rejected[0]).toMatchObject({ kind: "rename", docId: "d1" });
   });
 });
+
+/**
+ * The BenAI OS vault, 2026-09-04, after migration 023 merged its 71
+ * case-duplicated folders and 164 notes.
+ *
+ * The merge keeps ONE server row per case-insensitive path, and the one it kept
+ * spells the folder `Projects/Community`. The directory on disk is
+ * `Projects/community`. Compared exactly, every one of those notes is "on disk
+ * under one path, on the server under another" — 164 renames a pass, each a
+ * no-op or a refusal on a filesystem that has only one such directory — while
+ * `reconcile` separately re-registered all 235. The header read
+ * "Syncing 225/235", finished nothing, and started again.
+ */
+describe("planInbound — a case-variant spelling is the same file", () => {
+  const server = new Map([["doc-1", "Projects/Community/a.md"]]);
+  const local = new Map([["doc-1", "Projects/community/a.md"]]);
+
+  it("plans no rename when only the case differs", () => {
+    const p = plan({ server, local, baseline: new Map(local) });
+    expect(p.renames).toEqual([]);
+    expect(p.trash).toEqual([]);
+    expect(p.suppress.size).toBe(0);
+  });
+
+  it("still moves a note the server genuinely renamed", () => {
+    const p = plan({
+      server: new Map([["doc-1", "Projects/Community/renamed.md"]]),
+      local,
+      baseline: new Map(local),
+    });
+    expect(p.renames).toEqual([
+      { docId: "doc-1", from: "Projects/community/a.md", to: "Projects/Community/renamed.md" },
+    ]);
+  });
+
+  it("leaves an outbound case-only rename to the outbound side", () => {
+    // We moved it, the server has not caught up: `srv === prev` up to case.
+    const p = plan({
+      server: new Map([["doc-1", "Projects/Community/a.md"]]),
+      local: new Map([["doc-1", "Projects/community/moved.md"]]),
+      baseline: new Map([["doc-1", "Projects/community/a.md"]]),
+    });
+    expect(p.renames).toEqual([]);
+  });
+});

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -151,6 +151,19 @@ export interface InboundPlan {
 // doc map". Hence an explicit allowlist on this side.
 
 /** Mirrors `IGNORED_DIRS` in src-tauri/src/vault.rs. */
+/**
+ * Two vault paths that name the same file.
+ *
+ * Case-insensitively, because that is what the filesystems we ship on do:
+ * macOS/APFS and Windows store ONE entry per case-insensitive name, so
+ * `Projects/community/a.md` and `Projects/Community/a.md` are the same file, not
+ * two. The server agrees since migration 023 (case-insensitive unique paths), so
+ * treating them as distinct here only ever produced work that could not land.
+ */
+export function samePath(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
 const IGNORED_DIRS = [".context", ".git"];
 /** Mirrors `DENIED_DIRS` in src-tauri/src/vault.rs. */
 const DENIED_DIRS = [
@@ -318,7 +331,7 @@ export function planInbound(input: InboundInput): InboundPlan {
   // ---- notes --------------------------------------------------------------
   // Every note path on disk, for the "we lost this doc's local identity" case
   // below. `input.local` is docId → path, so its values are exactly that set.
-  const localPaths = new Set(input.local.values());
+  const localPaths = new Set([...input.local.values()].map((p) => p.toLowerCase()));
   const docIds = new Set<string>([...input.baseline.keys(), ...input.server.keys()]);
   for (const docId of docIds) {
     const prev = input.baseline.get(docId);
@@ -329,7 +342,16 @@ export function planInbound(input: InboundInput): InboundPlan {
     if (srv !== undefined) {
       // Already where the server wants it (or we've never seen this doc, in which
       // case the existing materialize step writes it). Nothing to do.
-      if (loc === srv || loc === undefined) continue;
+      //
+      // Compared case-insensitively, because the filesystem is: `community/a.md`
+      // and `Community/a.md` are ONE file on macOS and Windows, so a spelling
+      // disagreement with the server is not a move and renaming to "fix" it
+      // moves the file onto itself. After migration 023 merged the
+      // case-duplicated server rows, a vault that had them disagrees on exactly
+      // that for every merged note — 164 renames a pass, each one a no-op or a
+      // refusal, on top of the re-registration wave. The server's own uniqueness
+      // is case-insensitive now too, so nothing is lost by matching it here.
+      if (loc === undefined || samePath(loc, srv)) continue;
       if (prev === undefined) {
         // On disk under one path, on the server under another, and no baseline to
         // say which one moved. Leave it: without a prior agreement, "the server
@@ -337,10 +359,10 @@ export function planInbound(input: InboundInput): InboundPlan {
         // guessing here would rename a file on a hunch.
         continue;
       }
-      if (loc === prev) {
+      if (samePath(loc, prev)) {
         // The server moved it and we didn't. THE rename-duplicate fix.
         pushRename(plan, docId, loc, srv);
-      } else if (srv === prev) {
+      } else if (samePath(srv, prev)) {
         // We moved it and the server didn't — outbound's job (`renamePath`), not
         // ours. Left alone rather than dragged back.
         continue;
@@ -367,7 +389,7 @@ export function planInbound(input: InboundInput): InboundPlan {
         // match we can't prove the file at that path is still this note, and a
         // wrong guess here deletes someone's work. It stays on disk as a purely
         // local note the user can remove themselves.
-        if (prev !== undefined && localPaths.has(prev)) {
+        if (prev !== undefined && localPaths.has(prev.toLowerCase())) {
           plan.suppress.add(prev);
           plan.stubs.push(prev);
         }

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -1348,29 +1348,83 @@ export class VaultRegistry {
     // it, and registered any note inside it with the MOVED folder's id. The server
     // rightly refused that as `path_folder_mismatch`, on every pull, forever:
     // "1 not synced" with nothing the user could do about it.
-    const serverFolderByPath = new Map(serverFolders.map((f) => [f.path, f.id] as const));
+    //
+    // Matched case-INSENSITIVELY, and the local spelling wins. macOS and Windows
+    // store one directory per case-insensitive name, so `Projects/community` on
+    // disk and `Projects/Community` on the server are the same folder — and after
+    // migration 023 merged the case-duplicated rows, that disagreement is exactly
+    // what a vault that had them looks like. Compared exactly, all 71 merged
+    // folders (and the 164 notes under them) read as "missing from the server" on
+    // every pass: the client registered them, the server adopted them
+    // case-insensitively and answered with ITS spelling, the client filed the
+    // mapping under that, and the local paths were still unmatched next pass.
+    // A 235-item wave that could never empty — "Syncing 225/235", restart, loop.
+    const serverFolderByPathCi = new Map(
+      serverFolders.map((f) => [f.path.toLowerCase(), f.id] as const),
+    );
     for (const [rp, id] of [...this.folderByPath]) {
-      if (serverFolderByPath.get(rp) !== id) this.folderByPath.delete(rp);
+      if (serverFolderByPathCi.get(rp.toLowerCase()) !== id) this.folderByPath.delete(rp);
     }
-    for (const f of serverFolders) this.folderByPath.set(f.path, f.id);
+    // The path we keep is the one on DISK: every other lookup in this class is
+    // made with a local path, so mapping the server's spelling instead would
+    // leave those lookups missing. The id is the identity; the spelling is ours.
+    const localFolderPathCi = new Map(folders.map((f) => [f.path.toLowerCase(), f.path] as const));
+    for (const f of serverFolders) {
+      this.folderByPath.set(localFolderPathCi.get(f.path.toLowerCase()) ?? f.path, f.id);
+    }
+    // …and drop the twin the merge left behind. Both spellings are in the
+    // persisted map for a vault that had case-duplicated rows, and neither is
+    // wrong enough for the prune above to remove (they carry the same id), so
+    // without this they stay in `config.json` for good.
+    for (const rp of [...this.folderByPath.keys()]) {
+      const onDisk = localFolderPathCi.get(rp.toLowerCase());
+      if (onDisk !== undefined && onDisk !== rp) {
+        this.folderByPath.delete(rp);
+        mutated = true;
+      }
+    }
     const missingFolders = folders.filter((f) => !this.folderByPath.has(f.path));
 
     // 3. Notes: adopt by relPath, create missing. Any first-run seeding happened
     //    in reconcile before this runs; the seeded files register here as docs.
+    // Case-insensitive for the same reason as the folders above, and again the
+    // local spelling is the one mapped.
+    const localNotePathCi = new Map(notes.map((n) => [n.path.toLowerCase(), n.path] as const));
+    /** Every path the server accounted for, in the spelling we MAPPED it under. */
     const resolvedNotePaths = new Set<string>();
+    /** The same set, lower-cased — what every membership test below compares on. */
+    const resolvedNotePathsCi = new Set<string>();
+    const resolveNote = (serverPath: string, docId: string) => {
+      const mapped = localNotePathCi.get(serverPath.toLowerCase()) ?? serverPath;
+      this.setMapping(mapped, docId, vaultId);
+      resolvedNotePaths.add(mapped);
+      resolvedNotePathsCi.add(mapped.toLowerCase());
+    };
     for (const n of serverNotes) {
       const rp = noteRelPath(n);
-      if (rp) {
-        this.setMapping(rp, noteDocId(n), vaultId);
-        resolvedNotePaths.add(rp);
-      }
+      if (rp) resolveNote(rp, noteDocId(n));
     }
+    // The note twin of the folder collapse above: a mapping under a spelling this
+    // pass did not resolve, whose case-variant it DID, is the leftover of a
+    // merged pair. `byDocId` already points at the spelling we kept, so only the
+    // path index needs the removal.
+    for (const [rp, m] of [...this.byPath]) {
+      if (resolvedNotePaths.has(rp)) continue;
+      if (!resolvedNotePathsCi.has(rp.toLowerCase())) continue;
+      if (m.vaultId !== vaultId) continue;
+      this.byPath.delete(rp);
+      this.notifyMapChanged();
+      mutated = true;
+    }
+
     // `inboundSuppressed` is what stops the ghost. A note the server has DELETED
     // (or that we've lost access to) is still on disk, so it looks "missing from
     // the server" here and used to be re-created — which the server answers 201 to
     // without clearing `deleted_at`, leaving a sidebar entry that can never sync.
     const missingNotes = notes.filter(
-      (n) => !resolvedNotePaths.has(n.path) && !this.inboundSuppressed.has(n.path),
+      (n) =>
+        !resolvedNotePathsCi.has(n.path.toLowerCase()) &&
+        !this.inboundSuppressed.has(n.path),
     );
 
     this.sink.phase("registering", missingFolders.length + missingNotes.length);
@@ -1445,8 +1499,11 @@ export class VaultRegistry {
           { isTerminal: isTerminalApiError, shouldStop: () => this.stopRun() },
         );
         if (out.ok) {
+          // Keep `rp` (the local spelling) even when the server adopted a
+          // case-variant and answered with its own — see `resolveNote`.
           this.setMapping(rp, noteDocId(out.value), vaultId);
           resolvedNotePaths.add(rp);
+          resolvedNotePathsCi.add(rp.toLowerCase());
           checkpoint.touch();
           mutated = true;
           this.sink.item("ok");
@@ -1480,7 +1537,7 @@ export class VaultRegistry {
     // 4. Prune mappings for notes that no longer exist anywhere (deleted on the
     //    server AND absent locally), then checkpoint the map.
     for (const [rp, m] of [...this.byPath]) {
-      if (!resolvedNotePaths.has(rp)) {
+      if (!resolvedNotePathsCi.has(rp.toLowerCase())) {
         this.byPath.delete(rp);
         this.byDocId.delete(m.docId);
         this.notifyMapChanged();
@@ -1519,8 +1576,13 @@ export class VaultRegistry {
     //    full tree itself, which fixes the wrong input; this call makes the same
     //    mistake non-destructive if it ever recurs. Both, deliberately: one bug
     //    here is worth a belt and braces.
-    const localNotePaths = new Set(notes.map((n) => n.path));
-    const toMaterialize = [...resolvedNotePaths].filter((rp) => !localNotePaths.has(rp));
+    // Case-insensitive, or a note whose server spelling differs from the one on
+    // disk would be "server-only" here and get an empty file written at the other
+    // spelling — which on a case-insensitive filesystem is the SAME file.
+    const localNotePaths = new Set(notes.map((n) => n.path.toLowerCase()));
+    const toMaterialize = [...resolvedNotePaths].filter(
+      (rp) => !localNotePaths.has(rp.toLowerCase()),
+    );
     this.sink.addTotal(toMaterialize.length);
     await runPool(
       toMaterialize,


### PR DESCRIPTION
Follow-up to #87. The server side of the case-collision fix works — the write
loop is gone (**1 CRDT update in 10 minutes** on the BenAI OS vault, down from
189 MB/hour) and migration 023 merged its duplicates cleanly (0 live collisions
left, all 164 merged pairs resolved to a live winner). But the desktop then
re-registered the merged notes on every pass and never finished a wave:
**"Syncing 225/235", restart, repeat.**

## Why 235

That number is exact, and it is the whole diagnosis:

| in `.context/config.json` | case-variant path pairs |
|---|---|
| `docs` (notes)  | 164 |
| `folders`       | 71 |
| **total**       | **235** |

Migration 023 keeps one server row per case-insensitive path — for this vault,
`Projects/Community`, the row that held the CRDT. The directory **on disk** is
`Projects/community`. Every path comparison in the client was an exact string
compare, so:

1. `reconcile` builds `resolvedNotePaths` from the server's spellings, finds no
   match for the local ones, and calls all 235 "missing from the server".
2. It registers them. The server (since #87) *adopts* the case-variant instead of
   forking, and answers with its own canonical spelling.
3. The client files the mapping under the server's spelling. The local paths are
   still unmatched — so the next pass finds the same 235.

`planInbound` had the same defect from the other direction: `loc !== srv` for
those notes, so it planned 164 renames a pass, each one moving a file onto itself
on a filesystem that has only one such directory.

Nothing was being corrupted — that is why the server was quiet — but the wave
could never empty.

## The fix

Paths are now compared case-insensitively wherever the client matches its own
disk against the server, and **the local spelling is the one kept in the map**:
every other lookup in `NoteRegistry` is made with a disk path, and the `doc_id` is
the identity anyway — the spelling is ours.

- `inbound.ts` — new exported `samePath()`; `loc`/`srv`/`prev` comparisons and the
  `localPaths` set use it. A genuine rename still moves; an outbound case-only
  rename is still left to the outbound side (both covered by tests).
- `registry.ts` — `serverFolderByPathCi` and `resolvedNotePathsCi` replace the
  exact-match sets; the mapping is keyed by the on-disk spelling
  (`localFolderPathCi` / `localNotePathCi`); `toMaterialize` is case-insensitive
  too, or it would write an empty file at the other spelling — which on macOS is
  the same file.
- Both maps now **collapse the leftover twin**, so `config.json` sheds the stale
  spelling instead of carrying it forever (the pair shares an id, so the existing
  prune could not tell it was redundant).

## Tests

Three new cases in `inbound.test.ts` reproducing this vault's exact state
(`server: Projects/Community/a.md`, `local: Projects/community/a.md`): no rename
planned, a real rename still planned, an outbound case-rename still deferred.
Verified the first fails without the fix. Full suites: 717 desktop TS, 95 Rust,
`tsc --noEmit` clean, `cargo check --locked` clean.

## After merge

The vault heals itself on the next reconcile: the 235 stop being "missing", the
twin map entries are dropped, and the wave completes. Ships as **0.1.45**.
