### PR TITLE
Stop oversized notes from looping the sync socket, and collect dead CRDT docs

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.46"
+version = "0.1.47"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.46"
+version = "0.1.47"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -6,8 +6,8 @@ use crate::attachments::{self, AttachmentMeta};
 use crate::error::{AppError, AppResult};
 use crate::import_export::{self, ImportSummary};
 use crate::index::{
-    Backlink, GraphEdge, Index, NoteMeta, NoteTitle, ResolvedLink, SearchResult, YjsState,
-    YjsStateVector,
+    Backlink, GraphEdge, Index, NoteMeta, NoteTitle, ResolvedLink, SearchResult, YjsPruneReport,
+    YjsState, YjsStateVector,
 };
 use crate::notefile;
 use crate::state::AppState;
@@ -1123,6 +1123,45 @@ pub async fn save_yjs_state_vectors(
     let (_, index) = require_vault_at(&state, expected_epoch)?;
     let guard = index.lock().unwrap();
     guard.save_yjs_state_vectors(&entries)
+}
+
+/// Discard one doc's local CRDT (the local half of an oversized-note repair).
+#[tauri::command]
+pub async fn clear_yjs_doc(
+    state: State<'_, AppState>,
+    doc_id: String,
+    expected_epoch: Option<u64>,
+) -> AppResult<()> {
+    let (_, index) = require_vault_at(&state, expected_epoch)?;
+    let guard = index.lock().unwrap();
+    guard.clear_yjs_doc(&doc_id)
+}
+
+/// Collect dead CRDT docs, then reclaim the file.
+///
+/// `live` is the caller's COMPLETE set of doc ids still in use — the TS registry
+/// owns that map (`.context/config.json`), which is why this is driven from the
+/// UI layer rather than derived here: Rust's `notes.id` and the server's
+/// `doc_id` are not guaranteed to be the same value in a vault whose index was
+/// built before it was registered, so a Rust-side guess would delete live docs.
+///
+/// One command rather than two so a caller cannot prune and then skip the
+/// vacuum, which is the combination that frees nothing a user can see.
+#[tauri::command]
+pub async fn prune_yjs_docs(
+    state: State<'_, AppState>,
+    live: Vec<String>,
+    expected_epoch: Option<u64>,
+) -> AppResult<YjsPruneReport> {
+    let (_, index) = require_vault_at(&state, expected_epoch)?;
+    let guard = index.lock().unwrap();
+    let mut report = guard.prune_yjs_docs(&live)?;
+    // Only rewrite the file when the prune actually freed something; VACUUM on a
+    // clean 900 MB database is minutes of pointless I/O on every vault open.
+    if report.docs_removed > 0 || report.updates_removed > 0 {
+        report.bytes_reclaimed = guard.vacuum()?;
+    }
+    Ok(report)
 }
 
 /// Every state vector this vault holds, for the sync engine's `hello` manifest.

--- a/app/apps/desktop/src-tauri/src/index.rs
+++ b/app/apps/desktop/src-tauri/src/index.rs
@@ -1205,6 +1205,131 @@ impl Index {
         })?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
+
+    /// Drop every CRDT row whose `doc_id` is not in `live`, then report what went.
+    ///
+    /// The CRDT tables are the one part of the index that `rebuild` deliberately
+    /// never touches — that is what lets a rebuild preserve unsynced edits. The
+    /// cost of that safety is that nothing ever removed a doc's rows either, so
+    /// a vault accumulated the CRDT of every note it had ever held: notes
+    /// deleted, renamed into a new id, or forked by a past path collision. One
+    /// production vault carried 953 such docs inside a 900 MB `index.sqlite`.
+    ///
+    /// SAFETY: `live` is the caller's complete set of doc ids that still matter
+    /// (the registry map ∪ the local index ∪ anything open). An EMPTY set is
+    /// refused rather than obeyed — "I know of no live docs" is what a caller
+    /// looks like when it failed to load its map, and honouring it would erase
+    /// every unsynced edit in the vault. A caller that genuinely wants that
+    /// deletes the file.
+    pub fn prune_yjs_docs(&self, live: &[String]) -> AppResult<YjsPruneReport> {
+        if live.is_empty() {
+            return Err(AppError(
+                "refusing to prune CRDT rows against an empty live set".into(),
+            ));
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        // A temp table + anti-join keeps this one pass regardless of vault size;
+        // an `NOT IN (?,?,…)` with 6 000 binds would exceed SQLite's parameter
+        // limit long before it got slow.
+        tx.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS _live_docs (doc_id TEXT PRIMARY KEY);
+             DELETE FROM _live_docs;",
+        )?;
+        {
+            let mut stmt = tx.prepare("INSERT OR IGNORE INTO _live_docs (doc_id) VALUES (?1)")?;
+            for id in live {
+                stmt.execute(params![id])?;
+            }
+        }
+        let snapshot_bytes: i64 = tx
+            .query_row(
+                "SELECT COALESCE(SUM(LENGTH(snapshot)), 0) FROM yjs_snapshot
+                 WHERE doc_id NOT IN (SELECT doc_id FROM _live_docs)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        let update_bytes: i64 = tx
+            .query_row(
+                "SELECT COALESCE(SUM(LENGTH(\"update\")), 0) FROM yjs_updates
+                 WHERE doc_id NOT IN (SELECT doc_id FROM _live_docs)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        let docs_removed = tx.execute(
+            "DELETE FROM yjs_snapshot WHERE doc_id NOT IN (SELECT doc_id FROM _live_docs)",
+            [],
+        )? as i64;
+        let updates_removed = tx.execute(
+            "DELETE FROM yjs_updates WHERE doc_id NOT IN (SELECT doc_id FROM _live_docs)",
+            [],
+        )? as i64;
+        tx.execute_batch("DROP TABLE IF EXISTS _live_docs;")?;
+        tx.commit()?;
+        Ok(YjsPruneReport {
+            docs_removed,
+            updates_removed,
+            bytes_reclaimed: snapshot_bytes + update_bytes,
+        })
+    }
+
+    /// Drop ONE doc's CRDT rows: its snapshot, state vector and update log.
+    ///
+    /// The local half of the oversized-note repair. Unlike `prune_yjs_docs` this
+    /// targets a doc that is still very much live — the caller is deliberately
+    /// discarding its history because the server has discarded the same history,
+    /// and leaving the local copy would merge the old state straight back in on
+    /// the next connect.
+    pub fn clear_yjs_doc(&self, doc_id: &str) -> AppResult<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute("DELETE FROM yjs_updates WHERE doc_id = ?1", params![doc_id])?;
+        tx.execute("DELETE FROM yjs_snapshot WHERE doc_id = ?1", params![doc_id])?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// `VACUUM` the index, returning the bytes the file gave back.
+    ///
+    /// Deleting rows only frees SQLite *pages*, which the file keeps. After a
+    /// prune that dropped hundreds of megabytes of blobs the file on disk is
+    /// unchanged until this runs, so the user sees no space back — which is the
+    /// entire point of the exercise.
+    ///
+    /// Cannot run inside a transaction, and rewrites the whole file, so it is a
+    /// maintenance operation and never part of a hot path.
+    pub fn vacuum(&self) -> AppResult<i64> {
+        let before = self.db_size_bytes();
+        self.conn.execute_batch("VACUUM;")?;
+        let after = self.db_size_bytes();
+        Ok((before - after).max(0))
+    }
+
+    /// Size of the SQLite file itself (page_count × page_size), so callers can
+    /// report reclaimed space without knowing where the file lives.
+    pub fn db_size_bytes(&self) -> i64 {
+        let page_count: i64 = self
+            .conn
+            .query_row("PRAGMA page_count", [], |r| r.get(0))
+            .unwrap_or(0);
+        let page_size: i64 = self
+            .conn
+            .query_row("PRAGMA page_size", [], |r| r.get(0))
+            .unwrap_or(0);
+        page_count * page_size
+    }
+}
+
+/// What one {@link Index::prune_yjs_docs} pass removed.
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct YjsPruneReport {
+    /// Docs whose snapshot row was dropped.
+    pub docs_removed: i64,
+    /// Rows dropped from the update log.
+    pub updates_removed: i64,
+    /// Blob bytes freed inside the database (see `vacuum` for file bytes).
+    pub bytes_reclaimed: i64,
 }
 
 /// A doc's persisted CRDT state, as loaded from SQLite (spec 02 §4).
@@ -2039,6 +2164,62 @@ mod tests {
         // An empty batch is a no-op rather than an error.
         idx.save_yjs_state_vectors(&[]).unwrap();
         assert_eq!(idx.list_yjs_state_vectors().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn prune_yjs_docs_removes_only_unreachable_docs() {
+        let idx = Index::open_in_memory().unwrap();
+        idx.append_yjs_update("live-a", &[1, 2, 3]).unwrap();
+        idx.append_yjs_update("live-b", &[4]).unwrap();
+        idx.append_yjs_update("dead", &[5, 6, 7, 8]).unwrap();
+        idx.save_yjs_snapshot("dead", &[9; 64], &[1]).unwrap();
+        idx.append_yjs_update("dead", &[11]).unwrap();
+        // Snapshotting truncates the doc's update log, so append AFTER it to
+        // give live-a both halves — the state a doc edited since its last
+        // compaction is really in.
+        idx.save_yjs_snapshot("live-a", &[7; 32], &[1]).unwrap();
+        idx.append_yjs_update("live-a", &[10]).unwrap();
+
+        let report = idx
+            .prune_yjs_docs(&["live-a".to_string(), "live-b".to_string()])
+            .unwrap();
+
+        assert_eq!(report.docs_removed, 1, "only the unreachable snapshot goes");
+        assert_eq!(report.updates_removed, 1, "only the unreachable update log goes");
+        assert!(report.bytes_reclaimed >= 64);
+        // The live docs keep BOTH halves of their state. A doc that lost its
+        // update log but kept its snapshot would silently lose recent edits.
+        assert_eq!(idx.load_yjs_state("live-a").unwrap().update_count, 1);
+        assert!(idx.load_yjs_state("live-a").unwrap().snapshot.is_some());
+        assert_eq!(idx.load_yjs_state("live-b").unwrap().update_count, 1);
+        let gone = idx.load_yjs_state("dead").unwrap();
+        assert!(gone.snapshot.is_none() && gone.updates.is_empty());
+    }
+
+    #[test]
+    fn prune_yjs_docs_refuses_an_empty_live_set() {
+        // "I know of no live docs" is what a caller looks like when its registry
+        // map failed to load. Obeying it would erase every unsynced edit in the
+        // vault, so this must be an error and not a very efficient wipe.
+        let idx = Index::open_in_memory().unwrap();
+        idx.append_yjs_update("doc-a", &[1, 2]).unwrap();
+        assert!(idx.prune_yjs_docs(&[]).is_err());
+        assert_eq!(idx.load_yjs_state("doc-a").unwrap().update_count, 1);
+    }
+
+    #[test]
+    fn clear_yjs_doc_drops_both_halves_of_one_doc() {
+        let idx = Index::open_in_memory().unwrap();
+        idx.append_yjs_update("target", &[1, 2]).unwrap();
+        idx.save_yjs_snapshot("target", &[3; 16], &[1]).unwrap();
+        idx.append_yjs_update("target", &[4]).unwrap();
+        idx.append_yjs_update("bystander", &[5]).unwrap();
+
+        idx.clear_yjs_doc("target").unwrap();
+
+        let cleared = idx.load_yjs_state("target").unwrap();
+        assert!(cleared.snapshot.is_none() && cleared.updates.is_empty());
+        assert_eq!(idx.load_yjs_state("bystander").unwrap().update_count, 1);
     }
 
     #[test]

--- a/app/apps/desktop/src-tauri/src/lib.rs
+++ b/app/apps/desktop/src-tauri/src/lib.rs
@@ -111,6 +111,8 @@ pub fn run() {
             commands::save_yjs_snapshot,
             commands::save_yjs_state_vectors,
             commands::list_yjs_state_vectors,
+            commands::prune_yjs_docs,
+            commands::clear_yjs_doc,
             commands::read_binary_file,
             commands::write_binary_file,
             commands::list_attachments,

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -197,7 +197,7 @@ export function AccountMenu() {
   const presence =
     syncStatus === "no-access"
       ? "blocked"
-      : syncStatus === "connecting" || syncStatus === "error"
+      : syncStatus === "connecting" || syncStatus === "error" || syncStatus === "too-large"
         ? "idle"
         : connected
           ? // online → "active"; away/busy pass through; invisible → "offline".

--- a/app/apps/desktop/src/components/Identity.tsx
+++ b/app/apps/desktop/src/components/Identity.tsx
@@ -126,6 +126,11 @@ export function syncBadgeLabel(args: {
     if (status === "no-access") return "No access";
     if (status === "read-only") return "Read-only";
   }
+  // Terminal and vault-wide-relevant: this note will never reach the server on
+  // its own, so it outranks run progress whether or not it is the open note.
+  // Saying "Syncing…" over a doc the server has permanently refused is the lie
+  // the whole badge exists to avoid.
+  if (status === "too-large") return "Too large to sync";
   if (progress && isSyncRunActive(progress)) {
     if (progress.total <= 0) return "Syncing…";
     // One verb for every phase. The old per-phase labels ("Uploading",
@@ -173,6 +178,8 @@ export function syncBadgeTone(args: {
   if (noteOpen !== false && (status === "no-access" || status === "read-only")) {
     return status;
   }
+  // Red, not amber: nothing about this resolves on its own.
+  if (status === "too-large") return "error";
   if (isSyncRunActive(progress)) return "connecting";
   if (progress?.phase === "error") return "error";
   if (noteOpen === false) {

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -1071,6 +1071,47 @@ export class ApiClient {
     return data;
   }
 
+  /**
+   * How many bytes of CRDT the server holds for a note, and whether that puts it
+   * over the sync cap. Needs `edit` — it is only actionable by someone who could
+   * reset the doc. See `resetNoteHistory`.
+   */
+  async noteCrdtSize(
+    docId: string,
+  ): Promise<{ docId: string; bytes: number; capBytes: number; overCap: boolean }> {
+    const { data } = await this.request<{
+      docId: string;
+      bytes: number;
+      capBytes: number;
+      overCap: boolean;
+    }>("GET", `/api/notes/${encodeURIComponent(docId)}/crdt-size`);
+    return data;
+  }
+
+  /**
+   * Discard a note's edit history server-side and re-seed it from `content`.
+   *
+   * The repair for a note whose Yjs state has grown past the server's cap: it is
+   * refused on every connect, so it can never be edited back down through normal
+   * means. DESTRUCTIVE — the text survives (you are supplying it), the history
+   * does not. Callers must clear the LOCAL CRDT too, or the old state merges
+   * straight back in; `SyncManager.resetNoteHistory` does both in the right
+   * order.
+   */
+  async resetNoteHistory(
+    docId: string,
+    content: string,
+  ): Promise<{ docId: string; bytesBefore: number; bytesAfter: number }> {
+    const { data } = await this.request<{
+      docId: string;
+      bytesBefore: number;
+      bytesAfter: number;
+    }>("POST", `/api/notes/${encodeURIComponent(docId)}/reset-crdt`, {
+      body: { content },
+    });
+    return data;
+  }
+
   /** A note collection's checkpoints, newest first (any vault member). */
   async listCheckpoints(vaultId: string): Promise<VaultCheckpoint[]> {
     const { data } = await this.request<{ checkpoints: VaultCheckpoint[] }>(

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -370,6 +370,32 @@ export const saveYjsStateVectors = (
   });
 
 /** Every state vector this vault holds, to rebuild the manifest on launch. */
+/** Discard one doc's local CRDT — the local half of an oversized-note repair.
+ *  Pair with `api.resetNoteHistory`, never on its own. */
+export const clearYjsDoc = (docId: string, expectedEpoch?: VaultEpoch) =>
+  invoke<void>("clear_yjs_doc", { docId, expectedEpoch: expectedEpoch ?? null });
+
+/** What one CRDT garbage-collection pass removed (Rust `YjsPruneReport`). */
+export interface YjsPruneReport {
+  docsRemoved: number;
+  updatesRemoved: number;
+  /** Bytes the SQLite FILE gave back after the vacuum. */
+  bytesReclaimed: number;
+}
+
+/**
+ * Drop the CRDT of every doc not in `live`, then vacuum the index.
+ *
+ * `live` must be the COMPLETE set of doc ids still in use — Rust refuses an
+ * empty one rather than wiping the vault. The caller owns this list because the
+ * registry map (`.context/config.json`) is TS-side state; see `collectCrdtGarbage`.
+ */
+export const pruneYjsDocs = (live: string[], expectedEpoch?: VaultEpoch) =>
+  invoke<YjsPruneReport>("prune_yjs_docs", {
+    live,
+    expectedEpoch: expectedEpoch ?? null,
+  });
+
 export const listYjsStateVectors = (expectedEpoch?: VaultEpoch) =>
   invoke<{ docId: string; stateVector: number[] }[]>("list_yjs_state_vectors", {
     expectedEpoch: expectedEpoch ?? null,

--- a/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/contentUpload.test.ts
@@ -230,6 +230,51 @@ describe("ContentUploader — pre-network checks (readFile)", () => {
     expect(r.harness.fs.get("Placeholder.md")).toBe("content from a teammate");
   });
 
+  it("fails a note whose CRDT is over the ceiling behind a ZERO-BYTE file", async () => {
+    // The production regression (benai-os, Sept 2026). Four notes held 10–17 MB
+    // of Yjs history behind 0-byte files: the text had been truncated on disk
+    // while the duplication garbage from an earlier fork stayed in the doc.
+    //
+    // The file-bytes check passed (0 < 10 MB) and the empty-everywhere check
+    // did not fire (the DOC was not empty), so a socket opened, the server
+    // rejected the ~17 MB message and closed it, and the provider reconnected —
+    // about once a second, forever, strobing the sync badge. The cap has to be
+    // applied to what actually goes on the wire.
+    const r = rig({
+      files: { "Truncated.md": "", "Small.md": "fine" },
+      notes: [
+        { docId: "fat", relPath: "Truncated.md" },
+        { docId: "small", relPath: "Small.md" },
+      ],
+      readFile: true,
+      concurrency: 1,
+      failureStreakLimit: 1,
+    });
+    // Fat doc, empty file — exactly the production shape.
+    const bridge = await r.store.promote("fat", "Truncated.md", {
+      seedFromFile: false,
+      markRecent: false,
+      pin: true,
+    });
+    bridge.doc.getText("content").insert(0, "y".repeat(MAX_NOTE_BYTES + 1));
+    expect(r.harness.fs.get("Truncated.md")).toBe("");
+
+    const result = await r.uploader.run();
+
+    expect(r.uploader.failedDocs()).toEqual([
+      expect.objectContaining({
+        docId: "fat",
+        permanent: true,
+        reason: expect.stringContaining("edit history"),
+      }),
+    ]);
+    // The whole point: no socket was ever opened for it.
+    expect(r.connects).toEqual(["small"]);
+    // And it did not count toward the streak, so the run finished its work.
+    expect(result.aborted).toBe(false);
+    expect(r.marked).toEqual(["small"]);
+  });
+
   it("fails a note over the size ceiling permanently, without a socket or a streak hit", async () => {
     const huge = "x".repeat(MAX_NOTE_BYTES + 1);
     const r = rig({

--- a/app/apps/desktop/src/lib/sync/__tests__/crdtGc.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/crdtGc.test.ts
@@ -1,0 +1,75 @@
+// CRDT garbage collection — the allow-list is the whole safety argument.
+//
+// These tests exist because the failure mode of getting this wrong is not a bug
+// report, it is a user's unsynced edits being deleted. Every case here is about
+// what must SURVIVE a sweep, not what gets removed.
+
+import { describe, expect, it, vi } from "vitest";
+import { collectCrdtGarbage } from "../crdtGc";
+
+const report = { docsRemoved: 0, updatesRemoved: 0, bytesReclaimed: 0 };
+
+describe("collectCrdtGarbage", () => {
+  it("passes the union of BOTH live id spaces", async () => {
+    // A local CRDT can be keyed by the registry's server docId or by the local
+    // index's notes.id. They are the same value in a vault registered from a
+    // fresh index and diverge in one whose index predates its registration —
+    // where the doc is keyed by whichever id opened the note first. Sending one
+    // space and not the other deletes live docs.
+    const prune = vi.fn().mockResolvedValue(report);
+    await collectCrdtGarbage({
+      registryDocIds: () => ["server-1", "shared"],
+      localNotes: async () => [{ id: "local-1" }, { id: "shared" }],
+      prune,
+    });
+    expect(prune).toHaveBeenCalledTimes(1);
+    expect([...prune.mock.calls[0][0]].sort()).toEqual(["local-1", "server-1", "shared"]);
+  });
+
+  it("includes pinned ids that are in neither space yet", async () => {
+    const prune = vi.fn().mockResolvedValue(report);
+    await collectCrdtGarbage(
+      { registryDocIds: () => ["a"], localNotes: async () => [], prune },
+      { pinned: ["open-note"] },
+    );
+    expect([...prune.mock.calls[0][0]].sort()).toEqual(["a", "open-note"]);
+  });
+
+  it("REFUSES to prune when nothing is known to be live", async () => {
+    // "I know of no live docs" is what a caller looks like when its map failed
+    // to load, not a request to erase the vault's CRDT.
+    const prune = vi.fn().mockResolvedValue(report);
+    const out = await collectCrdtGarbage({
+      registryDocIds: () => [],
+      localNotes: async () => [],
+      prune,
+    });
+    expect(prune).not.toHaveBeenCalled();
+    expect(out).toBeNull();
+  });
+
+  it("never throws — a vault that cannot be tidied must still open", async () => {
+    const out = await collectCrdtGarbage({
+      registryDocIds: () => ["a"],
+      localNotes: async () => {
+        throw new Error("index unavailable");
+      },
+      prune: vi.fn(),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("does not prune when the live set could not be completed", async () => {
+    // A failed localNotes read must abort the sweep, not fall through to a
+    // prune against the registry ids alone — every local-only doc would go.
+    const prune = vi.fn().mockResolvedValue(report);
+    await collectCrdtGarbage({
+      registryDocIds: () => ["a"],
+      localNotes: async () => {
+        throw new Error("index unavailable");
+      },
+      prune,
+    });
+    expect(prune).not.toHaveBeenCalled();
+  });
+});

--- a/app/apps/desktop/src/lib/sync/__tests__/syncManager.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/syncManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveWsUrl } from "../syncManager";
+import { CLOSE_NOTE_TOO_LARGE, deriveWsUrl, isTerminalSyncStatus } from "../syncManager";
 
 describe("deriveWsUrl", () => {
   it("appends /sync on the same origin/port for a no-port https host", () => {
@@ -31,5 +31,32 @@ describe("deriveWsUrl", () => {
 
   it("falls back to the local default on the HTTP port for unparseable input", () => {
     expect(deriveWsUrl("not a url")).toBe("ws://localhost:3010/sync");
+  });
+});
+
+describe("terminal sync statuses", () => {
+  it("treats both refusals as terminal, and nothing else", () => {
+    // The distinction this encodes: a status you can retry out of, versus one
+    // where every retry produces the identical refusal. Reconnecting on the
+    // latter is an infinite loop — 403→reconnect→403 for `no-access`, and
+    // oversized-state→close→reconnect for `too-large`, which is what strobed
+    // the badge about once a second.
+    expect(isTerminalSyncStatus("no-access")).toBe(true);
+    expect(isTerminalSyncStatus("too-large")).toBe(true);
+    for (const s of ["offline", "connecting", "synced", "read-only", "error"] as const) {
+      expect(isTerminalSyncStatus(s)).toBe(false);
+    }
+  });
+
+  it("pins the close code the server sends for an oversized doc", () => {
+    // Must equal `CLOSE_NOTE_TOO_LARGE` in apps/server/src/sync/hocuspocus.ts.
+    // The two are in separate packages with no shared module, so this literal is
+    // the only thing holding them in lockstep — and if they drift, the client
+    // silently goes back to reconnecting forever. Asserted on both sides.
+    expect(CLOSE_NOTE_TOO_LARGE).toBe(4413);
+    // Deliberately in the private 4000–4999 range: those are reserved for
+    // application use and always sendable, unlike the protocol-level 1009.
+    expect(CLOSE_NOTE_TOO_LARGE).toBeGreaterThanOrEqual(4000);
+    expect(CLOSE_NOTE_TOO_LARGE).toBeLessThanOrEqual(4999);
   });
 });

--- a/app/apps/desktop/src/lib/sync/contentUpload.ts
+++ b/app/apps/desktop/src/lib/sync/contentUpload.ts
@@ -35,6 +35,7 @@
 // creation, timers) is injected, so the whole engine runs under vitest in Node.
 
 import type * as Y from "yjs";
+import { encodeStateAsUpdate } from "yjs";
 import type { NoteBridge } from "../bridge";
 import { UPLOAD_CONCURRENCY, runPool } from "./pool";
 import { nullProgressSink, type SyncProgressSink } from "./progress";
@@ -78,8 +79,34 @@ export interface ContentUploadDeps {
  * the next `ready.empty` queued it again. Two such files in one production vault
  * cost a rejected socket apiece on every reconnect of every member, forever.
  * Here the doc fails ONCE, permanently, with a reason a person can act on.
+ *
+ * ── Measure the DOC, not just the file ───────────────────────────────────────
+ * The cap has to be applied to both, because they are different numbers and the
+ * server only ever sees one of them. What goes on the wire is the encoded Yjs
+ * state; the `.md` on disk is just the text that state currently serializes to.
+ * A doc carrying megabytes of CRDT history — duplication garbage from a past
+ * fork/ping-pong, say — can sit behind a file of ZERO bytes.
+ *
+ * Checking only the file is how this bug came back: four notes in a production
+ * vault held 10–17 MB of Yjs state behind 0-byte files, so the file check
+ * passed, a socket opened, the server rejected the ~17 MB message and closed the
+ * connection, the provider reconnected — about once a second, forever, strobing
+ * the sync badge. {@link crdtBytes} is the measurement that matches the server's.
  */
 export const MAX_NOTE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * What this doc would put on the wire: its full encoded Yjs state.
+ *
+ * Deliberately the conservative measure. The provider actually sends only the
+ * diff the server lacks, which can be smaller — but a doc whose ENTIRE state is
+ * over the cap is pathological for a markdown note however you slice it, and
+ * refusing it locally is strictly better than learning the same thing from a
+ * closed socket. Costs one encode per doc per run, on a doc already in memory.
+ */
+export function crdtBytes(doc: Y.Doc): number {
+  return encodeStateAsUpdate(doc).byteLength;
+}
 
 const utf8 = new TextEncoder();
 
@@ -327,6 +354,26 @@ export class ContentUploader {
     // any network work binds this doc to a collection that is no longer current.
     if (this.shouldStop()) {
       await this.releaseQuietly(docId);
+      return false;
+    }
+
+    // THE size ceiling, measured the way the server measures it: on the encoded
+    // Yjs state, which is what the socket would actually carry. Runs before the
+    // file checks below and independently of `readFile`, because a doc can be
+    // over the cap with no file at all (or, as in the production vault that
+    // brought this back, with a 0-byte one). See {@link MAX_NOTE_BYTES}.
+    const stateBytes = crdtBytes(bridge.doc);
+    if (stateBytes > MAX_NOTE_BYTES) {
+      await this.releaseQuietly(docId);
+      const mb = (stateBytes / (1024 * 1024)).toFixed(1);
+      const cap = Math.round(MAX_NOTE_BYTES / (1024 * 1024));
+      this.fail(
+        docId,
+        relPath,
+        `too large to sync (${mb} MB of edit history; the limit is ${cap} MB) — ` +
+          `reset this note's history to sync it again`,
+        { permanent: true },
+      );
       return false;
     }
 

--- a/app/apps/desktop/src/lib/sync/crdtGc.ts
+++ b/app/apps/desktop/src/lib/sync/crdtGc.ts
@@ -1,0 +1,83 @@
+// CRDT garbage collection — the half of the index nothing ever cleaned up.
+//
+// `Index::rebuild` deliberately preserves the CRDT tables: that is what lets a
+// rebuild keep unsynced edits. The cost is that nothing removed a doc's rows
+// either, so a vault accumulated the Yjs state of every note it had ever held —
+// notes deleted, notes renamed into a fresh id, and every doc forked by a past
+// path collision. A production vault reached 953 such docs inside a 900 MB
+// `index.sqlite`; none of them were reachable from any note on disk.
+//
+// ── Why the LIVE set, and not a "dead" set ───────────────────────────────────
+// Deletion is driven by an allow-list, never a guess. Two independent id spaces
+// can key a local CRDT and a caller must supply both:
+//
+//   1. the registry's server doc ids (`.context/config.json`), and
+//   2. the LOCAL index's `notes.id`.
+//
+// Those are the same value in a vault registered from a fresh index — the open
+// path passes the local id so the server adopts it — but they diverge in a vault
+// whose index predates its registration, and there the CRDT is keyed by whichever
+// id opened the note first. Passing one and not the other would delete live docs,
+// so `collectCrdtGarbage` takes both and unions them; Rust additionally refuses an
+// EMPTY live set, because "I know of no live docs" is what a caller looks like
+// when its map failed to load, not a request to erase the vault.
+//
+// Runs at most once per vault open, immediately after the registry reconcile and
+// before the download phase — the one moment when the registry map is complete
+// and no backfill has begun. Anything created afterwards is therefore younger
+// than the sweep and cannot be caught by it.
+
+import * as ipc from "../ipc";
+import type { VaultEpoch } from "../ipc";
+
+export interface CrdtGcDeps {
+  /** Every doc id the registry has mapped (`registry.allDocIds()`). */
+  registryDocIds: () => string[];
+  /** Every note in the local index — its `id` is the second live id space. */
+  localNotes: (epoch?: VaultEpoch) => Promise<Array<{ id: string }>>;
+  prune: (live: string[], epoch?: VaultEpoch) => Promise<ipc.YjsPruneReport>;
+}
+
+const defaultDeps: CrdtGcDeps = {
+  registryDocIds: () => [],
+  localNotes: (epoch) => ipc.listNoteTitles(epoch),
+  prune: (live, epoch) => ipc.pruneYjsDocs(live, epoch),
+};
+
+/**
+ * Sweep unreachable CRDT rows and reclaim the file.
+ *
+ * `pinned` is anything the caller knows is in use but may not be in either id
+ * space yet — the open note, a doc mid-upload. Cheap insurance: a few extra ids
+ * in the allow-list cost nothing, while one missing id costs a note's unsynced
+ * edits.
+ *
+ * Never throws. This is maintenance: a vault that cannot be tidied must still
+ * open, sync, and be edited.
+ */
+export async function collectCrdtGarbage(
+  deps: Partial<CrdtGcDeps> & Pick<CrdtGcDeps, "registryDocIds">,
+  opts: { epoch?: VaultEpoch; pinned?: Iterable<string> } = {},
+): Promise<ipc.YjsPruneReport | null> {
+  const d = { ...defaultDeps, ...deps };
+  try {
+    const live = new Set<string>(d.registryDocIds());
+    for (const n of await d.localNotes(opts.epoch)) live.add(n.id);
+    for (const id of opts.pinned ?? []) live.add(id);
+    // Belt and braces around the Rust guard: an empty allow-list here means we
+    // failed to learn what is live, and pruning against it would be a wipe.
+    if (live.size === 0) return null;
+    const report = await d.prune([...live], opts.epoch);
+    if (report.docsRemoved > 0 || report.updatesRemoved > 0) {
+      console.info(
+        `[crdt-gc] removed ${report.docsRemoved} dead doc(s), ` +
+          `${report.updatesRemoved} update row(s), reclaimed ` +
+          `${(report.bytesReclaimed / (1024 * 1024)).toFixed(1)} MB`,
+      );
+    }
+    return report;
+  } catch (e) {
+    console.warn("[crdt-gc] sweep skipped", e);
+    return null;
+  }
+}

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -20,6 +20,7 @@ import { colorForUser, presenceUser } from "../presence/color";
 import type { ActivityStatus } from "../prefs";
 import { AttachmentSync } from "./attachments";
 import { ContentUploader, type UploadFailure } from "./contentUpload";
+import { collectCrdtGarbage } from "./crdtGc";
 import { runPool } from "./pool";
 import { SyncProgressReporter } from "./progress";
 import { decideSeed } from "./startup";
@@ -338,7 +339,7 @@ export class SyncManager implements InboundHost {
       const state: DocSyncState =
         s === "synced" || s === "read-only"
           ? "synced"
-          : s === "no-access" || s === "error"
+          : s === "no-access" || s === "too-large" || s === "error"
             ? "error"
             : "syncing";
       this.reportOpenDocState(docId, state);
@@ -1021,6 +1022,15 @@ export class SyncManager implements InboundHost {
       // folder is open — exactly the state that merged two vaults.
       if (!scope.isCurrent()) return { ok: false, reason: "vault changed", scope };
       this.enabled = true;
+      // Sweep unreachable CRDT rows HERE and nowhere else: the registry map is
+      // complete as of the line above, and the download phase below has not yet
+      // begun to create docs. Fire-and-forget — a vault that cannot be tidied
+      // must still open. See `crdtGc.ts` for why the allow-list is built from
+      // two id spaces.
+      void collectCrdtGarbage(
+        { registryDocIds: () => this.registry.allDocIds() },
+        { epoch: scope.vaultEpoch ?? undefined, pinned: this.currentDocId ? [this.currentDocId] : [] },
+      );
       this.setupAttachments(scope);
       // Initial attachment reconcile (fire-and-forget; errors are logged rather
       // than left to surface as an unhandled rejection).
@@ -1053,6 +1063,61 @@ export class SyncManager implements InboundHost {
     // The disk probe behind a `ready` runs before the run it may start.
     while (this.emptyProbe) await this.emptyProbe;
     await (this.bulkRun ?? Promise.resolve());
+  }
+
+  /**
+   * Repair a note the server has permanently refused for being over its size cap.
+   *
+   * Nothing else can unstick such a note. It is rejected before a single update
+   * is applied, so it cannot be edited down; and its bulk is edit HISTORY, not
+   * text, so compaction cannot shrink it either. The only exit is to discard the
+   * history on both sides and start the doc again from the text.
+   *
+   * DESTRUCTIVE, and deliberately explicit: the note's text survives (the file on
+   * disk is the durable source of truth and is what re-seeds the doc), its
+   * history does not. Never call this automatically — a doc over the cap with a
+   * legitimately large file needs a smaller note, not a silently emptied one.
+   *
+   * ── Order is the whole correctness argument ─────────────────────────────────
+   *   1. SERVER first. While the server still holds the old state, any client —
+   *      including this one — can re-upload it.
+   *   2. LOCAL second. A surviving local CRDT merges the old state back on the
+   *      next connect, which is the fork this is undoing.
+   *   3. Re-seed from the file, then re-queue. The bridge rebuilds a fresh doc
+   *      with a new clientID and no shared history with the discarded one.
+   *
+   * Reversing 1 and 2 leaves a window where the local copy is gone but the
+   * server's is not, and the next pull restores the megabytes.
+   */
+  async resetNoteHistory(docId: string): Promise<{ bytesFreed: number }> {
+    const scope = this.scope;
+    if (!this.enabled || !scope || !scope.isCurrent()) {
+      throw new Error("sync is not enabled for this vault");
+    }
+    const relPath = this.registry.pathForDocId(docId);
+    if (!relPath) throw new Error(`no note is mapped to ${docId}`);
+
+    // The file is the truth we re-seed from. An unreadable file is not a reason
+    // to reset to empty — bail instead, so a transient read error cannot be the
+    // thing that blanks a note.
+    const content = await ipc.readNote(relPath, scope.vaultEpoch ?? undefined);
+    if (!scope.isCurrent()) throw new Error("vault changed");
+
+    const { bytesBefore, bytesAfter } = await api.resetNoteHistory(docId, content);
+    if (!scope.isCurrent()) throw new Error("vault changed");
+    await ipc.clearYjsDoc(docId, scope.vaultEpoch ?? undefined);
+
+    // It is no longer permanently failed, and the server no longer has its
+    // content — so it must be re-queued rather than left believed-pushed.
+    this.permanentFailures.delete(docId);
+    this.registry.unmarkPushed(docId);
+    this.divergedDocs.add(docId);
+    console.info(
+      `[sync] reset history for ${relPath}: ` +
+        `${(bytesBefore / (1024 * 1024)).toFixed(1)} MB → ` +
+        `${(bytesAfter / 1024).toFixed(1)} KB`,
+    );
+    return { bytesFreed: Math.max(0, bytesBefore - bytesAfter) };
   }
 
   /**

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -577,6 +577,20 @@ export class VaultRegistry {
     this.checkpoint?.touch();
   }
 
+  /**
+   * Forget that `docId`'s content is on the server.
+   *
+   * The counterpart to `markPushed`, for the one case where the server's copy
+   * genuinely goes away underneath a live checkpoint: a history reset
+   * (`SyncManager.resetNoteHistory`). Leaving the doc marked pushed there would
+   * skip it in every future content run, so the freshly-emptied server doc would
+   * never be re-filled from the file.
+   */
+  unmarkPushed(docId: string): void {
+    if (!this.pushed.delete(docId)) return;
+    this.checkpoint?.touch();
+  }
+
   /** Flush any owed checkpoint now (end of a phase / before teardown). */
   async flushCheckpoint(): Promise<void> {
     await this.checkpoint?.flush();

--- a/app/apps/desktop/src/lib/sync/syncManager.ts
+++ b/app/apps/desktop/src/lib/sync/syncManager.ts
@@ -20,7 +20,27 @@ export type SyncStatus =
   | "synced" // read-write, converged with server
   | "read-only" // synced but the grant is view-only
   | "no-access" // server refused a token (403) — not shared with this user
+  | "too-large" // doc's Yjs state exceeds the server cap — TERMINAL, no retry
   | "error"; // transient failure (will retry)
+
+/**
+ * Close code the server sends when a doc's sync message is over `MAX_NOTE_MB`
+ * (`apps/server/src/sync/hocuspocus.ts` `CLOSE_NOTE_TOO_LARGE`). Keep in lockstep.
+ *
+ * This exists so the two failures that both arrive as "the server closed us" can
+ * be told apart. A generic reset means retry; this one means the server will
+ * refuse this doc identically every time, so retrying is an infinite loop —
+ * which is precisely what it did: reconnect → 17 MB message → close → reconnect,
+ * about once a second, flipping the badge Syncing/Synced for as long as the app
+ * stayed open.
+ */
+export const CLOSE_NOTE_TOO_LARGE = 4413;
+
+/** Statuses from which no reconnect will ever help. Reaching one must stop the
+ *  provider's own retry loop, not merely paint a different colour. */
+export function isTerminalSyncStatus(s: SyncStatus): boolean {
+  return s === "no-access" || s === "too-large";
+}
 
 export interface DocSyncOptions {
   api: ApiClient;
@@ -180,7 +200,7 @@ export class DocSync {
         // the server always rejects): reject → reconnect → reject, as fast as the
         // socket can cycle. That spins the CPU, floods the server log, and — since
         // each lap flips status error→connecting→error — strobes the sync badge.
-        if (!this.destroyed && this._status !== "no-access") {
+        if (!this.destroyed && !isTerminalSyncStatus(this._status)) {
           this.setStatus("error");
           this.scheduleAuthRetry();
         }
@@ -194,7 +214,29 @@ export class DocSync {
         // would keep its stale grant until the note is reopened. An open socket
         // is what distinguishes the in-band kick from a real disconnect (which
         // the provider's own backoff already handles).
-        if (this.destroyed || this._status === "no-access") return;
+        if (this.destroyed || isTerminalSyncStatus(this._status)) return;
+        // The server named this one: our Yjs state is over its cap. Reconnecting
+        // re-sends the same oversized state for the same close, forever. Go
+        // terminal and take the socket down so the provider's own backoff loop
+        // stops too — the status alone would not, and that loop is the strobe.
+        if (event.code === CLOSE_NOTE_TOO_LARGE) {
+          this.setStatus("too-large");
+          this.refresher.cancel();
+          // Anything awaiting a flush will never get one; failing them is what
+          // keeps this doc OUT of the pushed checkpoint (so it is reported, not
+          // silently claimed synced).
+          this.releaseFlushWaiters(false);
+          if (this.authRetryTimer) {
+            clearTimeout(this.authRetryTimer);
+            this.authRetryTimer = null;
+          }
+          try {
+            this.provider.configuration.websocketProvider?.disconnect();
+          } catch {
+            // Already gone — the terminal status is what matters.
+          }
+          return;
+        }
         const ws = this.provider.configuration.websocketProvider?.webSocket;
         if (event.code === 1000 && ws && ws.readyState === ws.OPEN) {
           this.reconnectWithFreshToken();
@@ -212,14 +254,14 @@ export class DocSync {
           // overwrite no-access, reopening the guard on every other handler here.
           // A doc we've been refused then retried forever: 403 → no-access →
           // "connecting" clears it → empty token → rejected → repeat, ~4×/second.
-          if (this._status === "no-access") return;
+          if (isTerminalSyncStatus(this._status)) return;
           this.setStatus("connecting");
         } else if (status === "disconnected") {
-          if (this._status !== "no-access") this.setStatus("offline");
+          if (!isTerminalSyncStatus(this._status)) this.setStatus("offline");
         }
       },
       onSynced: () => {
-        if (!this.destroyed && this._status !== "no-access") {
+        if (!this.destroyed && !isTerminalSyncStatus(this._status)) {
           this.noteAuthSuccess();
           this.setStatus(this._readOnly ? "read-only" : "synced");
         }
@@ -248,7 +290,7 @@ export class DocSync {
         if (this.settleTimer) clearTimeout(this.settleTimer);
         this.settleTimer = setTimeout(() => {
           this.settleTimer = null;
-          if (this.destroyed || this._status === "no-access") return;
+          if (this.destroyed || isTerminalSyncStatus(this._status)) return;
           const wasPending = this._pending;
           this.setPending(false);
           // Only stamp "synced just now" on the real pending→settled edge.
@@ -286,7 +328,7 @@ export class DocSync {
       this.provider.on("synced", onSynced);
       const timer = setTimeout(() => finish(resolve), timeoutMs); // resolve anyway → offline-first
       // If access was already refused, don't wait the full timeout.
-      if (this._status === "no-access") finish(() => reject(new Error("no access")));
+      if (isTerminalSyncStatus(this._status)) finish(() => reject(new Error(this._status)));
     });
   }
 
@@ -302,7 +344,7 @@ export class DocSync {
    */
   whenFlushed(timeoutMs = 30_000): Promise<boolean> {
     if (this.destroyed) return Promise.resolve(false);
-    if (this._status === "no-access") return Promise.resolve(false);
+    if (isTerminalSyncStatus(this._status)) return Promise.resolve(false);
     if (this.unsyncedCount === 0 && this.provider.isSynced) return Promise.resolve(true);
     return new Promise<boolean>((resolve) => {
       let done = false;
@@ -342,7 +384,7 @@ export class DocSync {
     this.authFailures++;
     this.authRetryTimer = setTimeout(() => {
       this.authRetryTimer = null;
-      if (this.destroyed || this._status === "no-access") return;
+      if (this.destroyed || isTerminalSyncStatus(this._status)) return;
       this.reconnectWithFreshToken();
     }, delay);
   }
@@ -368,7 +410,7 @@ export class DocSync {
       // then rejected still flashed success first. Read-only is a property of the
       // grant rather than the connection, so it's safe to reflect immediately;
       // "synced" now waits for onStatus/onSynced.
-      if (this._status !== "no-access" && res.readOnly) {
+      if (!isTerminalSyncStatus(this._status) && res.readOnly) {
         this.setStatus("read-only");
       }
       return res.token;
@@ -409,6 +451,10 @@ export class DocSync {
 
   private reconnectWithFreshToken(): void {
     if (this.destroyed || this.reconnectPending) return;
+    // Terminal means terminal, whoever calls: the token refresher, an auth
+    // retry, or an in-band kick. Without this the single guard in `onClose` is
+    // one missed caller away from the reconnect storm coming back.
+    if (isTerminalSyncStatus(this._status)) return;
     const wsp = this.provider.configuration.websocketProvider;
     // v4 gotcha: connect() silently no-ops while the socket status is still
     // "connected" — and disconnect()'s close event only flips it to

--- a/app/apps/server/src/http/app.ts
+++ b/app/apps/server/src/http/app.ts
@@ -16,6 +16,7 @@ import { createShareRoutes, type ShareDeps } from "./routes/shares.js";
 import { createOrgRoutes } from "./routes/orgs.js";
 import { graphRoutes } from "./routes/graph.js";
 import { createMcpRoutes } from "./routes/mcp.js";
+import { createRepairRoutes } from "./routes/repair.js";
 import { createVersionRoutes } from "./routes/versions.js";
 import { createBillingRoutes } from "./routes/billing.js";
 import { PolarBillingProvider } from "../billing/polar.js";
@@ -25,6 +26,15 @@ import type { DocWriter } from "../mcp/doc-writer.js";
 export interface AppDeps extends ShareDeps {
   /** Server-side note writer for the MCP tools (backed by the sync server). */
   docWriter: DocWriter;
+  /**
+   * Close every socket on a doc AND drop the server's cached copy of it.
+   *
+   * Stronger than `disconnectDoc`, and required by any route that rewrites a
+   * doc's rows underneath the sync server: without the unload, Hocuspocus keeps
+   * the loaded `Y.Doc` and hands that stale copy to the next client, undoing the
+   * write. Backed by `sync/hocuspocus.ts` `evictDoc`.
+   */
+  evictDoc: (vaultId: string, docId: string) => Promise<void> | void;
   /** Payment provider. Defaults to Polar; tests inject a fake. */
   billingProvider?: BillingProvider;
   /**
@@ -187,6 +197,7 @@ export function createApp(deps: AppDeps): Hono {
       onRegistryChanged: deps.onRegistryChanged,
     }),
   );
+  app.route("/api", createRepairRoutes({ evictDoc: deps.evictDoc }));
   app.route("/api", createShareRoutes(deps));
   app.route("/api", publicLinkApiRoutes);
   const billingProvider = deps.billingProvider ?? new PolarBillingProvider();

--- a/app/apps/server/src/http/routes/repair.ts
+++ b/app/apps/server/src/http/routes/repair.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import { pool } from "../../db/pool.js";
+import { config } from "../../config.js";
+import { canEditDoc } from "../../permissions/http-gates.js";
+import { docStoredBytes, resetDocCrdt } from "../../yjs/persistence.js";
+import { getSession } from "../session.js";
+
+/**
+ * Repair endpoints for docs the sync layer cannot fix on its own.
+ *
+ *   GET  /api/notes/:id/crdt-size    how big this doc is, and whether it is stuck
+ *   POST /api/notes/:id/reset-crdt   discard its history and re-seed it (edit)
+ *
+ * ── Why this has to exist ────────────────────────────────────────────────────
+ * A doc whose Yjs state exceeds `MAX_NOTE_MB` is refused by the sync server on
+ * every connect. That makes it unfixable through the product's normal surfaces:
+ * you cannot edit it down, because editing requires a connection, and every
+ * connection is closed before a single update is applied. The client-side size
+ * guard stops the resulting reconnect storm but cannot un-stick the note — only
+ * discarding the history can, and only the server owns the canonical copy.
+ *
+ * Resetting is destructive in a specific and bounded way: the note's TEXT is
+ * preserved (the caller sends what it should be), its edit HISTORY is not. That
+ * is the trade being made deliberately — in every case seen so far the history
+ * was duplication garbage from a past fork, and the text was the salvageable
+ * part.
+ */
+
+export interface RepairRouteDeps {
+  /** Close every socket on a doc and drop the server's cached copy, so clients
+   *  re-pull the reset doc instead of merging the old one back in. */
+  evictDoc: (vaultId: string, docId: string) => Promise<void> | void;
+}
+
+/** Live note → its collection id, or null when the note is gone. */
+async function noteVaultId(docId: string): Promise<string | null> {
+  const { rows } = await pool.query<{ vault_id: string }>(
+    "SELECT vault_id FROM notes WHERE id = $1 AND deleted_at IS NULL",
+    [docId],
+  );
+  return rows[0]?.vault_id ?? null;
+}
+
+export function createRepairRoutes(deps: RepairRouteDeps): Hono {
+  const routes = new Hono();
+  const capBytes = config.maxNoteMb * 1024 * 1024;
+
+  routes.get("/notes/:id/crdt-size", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const docId = c.req.param("id");
+    const vaultId = await noteVaultId(docId);
+    if (!vaultId) return c.json({ error: "Note not found" }, 404);
+    // Size is an edit-level fact here: it is only actionable by someone who
+    // could reset the doc, and it leaks how much content a doc holds.
+    if (!(await canEditDoc(session.userId, docId))) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+    const bytes = await docStoredBytes(docId);
+    return c.json({ docId, bytes, capBytes, overCap: bytes > capBytes });
+  });
+
+  routes.post("/notes/:id/reset-crdt", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const docId = c.req.param("id");
+    const vaultId = await noteVaultId(docId);
+    if (!vaultId) return c.json({ error: "Note not found" }, 404);
+    if (!(await canEditDoc(session.userId, docId))) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+
+    let body: { content?: unknown } = {};
+    try {
+      body = await c.req.json();
+    } catch {
+      body = {}; // no body ⇒ reset to empty
+    }
+    const content = typeof body.content === "string" ? body.content : "";
+    // The replacement must itself fit, or the reset would hand back a doc that
+    // is stuck in exactly the same way.
+    if (Buffer.byteLength(content, "utf8") > capBytes) {
+      return c.json(
+        { error: "content_too_large", capBytes },
+        413,
+      );
+    }
+
+    const before = await docStoredBytes(docId);
+    const { bytes: after } = await resetDocCrdt(docId, content);
+    // Evict AFTER the write: a client that reconnects in between must find the
+    // new state, never the old cached doc.
+    await deps.evictDoc(vaultId, docId);
+    return c.json({ docId, bytesBefore: before, bytesAfter: after });
+  });
+
+  return routes;
+}

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -2,7 +2,7 @@ import { serve } from "@hono/node-server";
 import type { Server as HttpServer } from "node:http";
 import { config } from "./config.js";
 import { createApp } from "./http/app.js";
-import { createSyncServer, disconnectDoc } from "./sync/hocuspocus.js";
+import { createSyncServer, disconnectDoc, evictDoc } from "./sync/hocuspocus.js";
 import { attachSyncUpgrade } from "./sync/http-upgrade.js";
 import { createPubSub } from "./sync/pubsub.js";
 import { VaultChannel } from "./sync/vault-channel.js";
@@ -88,6 +88,7 @@ async function main() {
 
   const app = createApp({
     disconnectDoc: (vaultId, docId) => disconnectDoc(sync, vaultId, docId),
+    evictDoc: (vaultId, docId) => evictDoc(sync, vaultId, docId),
     // Share create/revoke → subscribers re-evaluate their readable-doc set.
     onAclChanged: (vaultId) =>
       void vaultChannel.publishAclChanged(vaultId).catch(broadcastFailed("acl-changed")),

--- a/app/apps/server/src/sync/hocuspocus.ts
+++ b/app/apps/server/src/sync/hocuspocus.ts
@@ -22,6 +22,31 @@ import { redisExtensions } from "./redis-extension.js";
 // load echo apart from real client edits and skip persisting it.
 const LOAD_ORIGIN = "hocuspocus:load";
 
+/**
+ * WebSocket close code for "this doc's Yjs state is over `MAX_NOTE_MB`".
+ *
+ * In the private 4000–4999 range on purpose: those are reserved for application
+ * use and every WebSocket implementation lets an endpoint send them, where the
+ * protocol-level 1009 ("Message Too Big") is filtered by some stacks. Hocuspocus
+ * copies `code`/`reason` off a thrown error onto the close frame
+ * (`Connection.handleMessage`), which is how this reaches the client.
+ *
+ * The desktop client mirrors this constant in `src/lib/sync/syncManager.ts` and
+ * treats it as TERMINAL — no reconnect. Keep the two in lockstep.
+ */
+export const CLOSE_NOTE_TOO_LARGE = 4413;
+
+/** Thrown by `beforeHandleMessage`; shaped so Hocuspocus emits a close frame
+ *  the client can act on rather than a generic reset. */
+class NoteTooLargeError extends Error {
+  readonly code = CLOSE_NOTE_TOO_LARGE;
+  readonly reason = "note exceeds the maximum size";
+  constructor() {
+    super("note exceeds the maximum size");
+    this.name = "NoteTooLargeError";
+  }
+}
+
 export interface SyncContext {
   docId: string;
   vaultId: string;
@@ -81,6 +106,14 @@ export function createSyncServer(
      * duplicating the content on every bounce. Throwing rejects the message and
      * closes the connection BEFORE the update is applied or broadcast, so the
      * oversized state can neither persist nor fan out.
+     *
+     * The thrown error carries {@link CLOSE_NOTE_TOO_LARGE} so the close frame
+     * NAMES this cause. Hocuspocus otherwise falls back to `ResetConnection`
+     * (4205) — the same code a transient server-side reset uses — and a client
+     * cannot tell "retry me" from "I will refuse this doc forever". That
+     * ambiguity is the bug: the provider reconnected, re-sent the same
+     * oversized state, was closed again, and strobed the sync badge about once
+     * a second for as long as the app was open.
      */
     async beforeHandleMessage(data) {
       const cap = config.maxNoteMb * 1024 * 1024;
@@ -89,7 +122,7 @@ export function createSyncServer(
           `Rejecting oversized sync message for ${data.documentName}: ` +
             `${data.update.byteLength} bytes (cap ${cap})`,
         );
-        throw new Error("note exceeds the maximum size");
+        throw new NoteTooLargeError();
       }
     },
 
@@ -219,4 +252,26 @@ export function disconnectDoc(
   docId: string,
 ): void {
   server.hocuspocus.closeConnections(formatDocName(vaultId, docId));
+}
+
+/**
+ * Close every connection to a doc AND drop it from memory.
+ *
+ * `disconnectDoc` alone is not enough after the doc's rows change underneath the
+ * server: Hocuspocus keeps the loaded `Y.Doc` and would serve that cached copy
+ * to the next client, re-materialising the very state we just deleted. Unloading
+ * forces the next connect through `onLoadDocument`, i.e. back to Postgres.
+ *
+ * Order matters — `unloadDocument` no-ops while connections remain.
+ */
+export async function evictDoc(
+  server: Server<SyncContext>,
+  vaultId: string,
+  docId: string,
+): Promise<void> {
+  const name = formatDocName(vaultId, docId);
+  const hp = server.hocuspocus;
+  hp.closeConnections(name);
+  const doc = hp.documents.get(name);
+  if (doc) await hp.unloadDocument(doc);
 }

--- a/app/apps/server/src/yjs/persistence.ts
+++ b/app/apps/server/src/yjs/persistence.ts
@@ -300,3 +300,64 @@ export async function countUpdates(
   );
   return Number.parseInt(rows[0]?.count ?? "0", 10);
 }
+
+
+/**
+ * Discard a doc's entire CRDT history and re-seed it from `content`.
+ *
+ * The repair for a doc that has grown past `MAX_NOTE_MB`. Such a doc is stuck in
+ * a way nothing else here can undo: it is refused by `beforeHandleMessage` on
+ * every connect, so no client can ever edit it down, and its bulk is *history*
+ * (tombstones, duplicated inserts from a past fork) rather than text — one
+ * production doc decoded to 29 580 lines of which 68 were distinct.
+ *
+ * Discarding history is the point, not a side effect, so this is intentionally
+ * NOT `compact`: compaction merges the updates into a snapshot and keeps every
+ * tombstone, which is why a 44 MB doc stays 44 MB however often it compacts.
+ *
+ * The new doc gets a fresh clientID and no shared history with the old one, so
+ * every client MUST be evicted (see `evictDoc`) rather than left to merge —
+ * merging the old state back in is exactly the fork this undoes.
+ */
+export async function resetDocCrdt(
+  docId: string,
+  content: string,
+  db: Queryable = defaultPool,
+): Promise<{ bytes: number }> {
+  const doc = new Y.Doc();
+  try {
+    if (content.length > 0) doc.getText("content").insert(0, content);
+    const snapshot = Buffer.from(Y.encodeStateAsUpdate(doc));
+    const stateVector = Buffer.from(Y.encodeStateVector(doc));
+    await db.query("DELETE FROM doc_updates WHERE doc_id = $1", [docId]);
+    await db.query(
+      `INSERT INTO doc_snapshots (doc_id, snapshot, state_vector, seq, updated_at)
+       VALUES ($1, $2, $3, '0', now())
+       ON CONFLICT (doc_id) DO UPDATE
+         SET snapshot = EXCLUDED.snapshot,
+             state_vector = EXCLUDED.state_vector,
+             seq = EXCLUDED.seq,
+             updated_at = now()`,
+      [docId, snapshot, stateVector],
+    );
+    return { bytes: snapshot.byteLength };
+  } finally {
+    doc.destroy();
+  }
+}
+
+/** Total persisted bytes for a doc — snapshot plus its un-compacted update log.
+ *  The number the size cap is really about, reportable without loading the doc. */
+export async function docStoredBytes(
+  docId: string,
+  db: Queryable = defaultPool,
+): Promise<number> {
+  const { rows } = await db.query<{ bytes: string }>(
+    `SELECT (
+       COALESCE((SELECT SUM(octet_length(snapshot)) FROM doc_snapshots WHERE doc_id = $1), 0)
+     + COALESCE((SELECT SUM(octet_length(update))   FROM doc_updates   WHERE doc_id = $1), 0)
+     )::text AS bytes`,
+    [docId],
+  );
+  return Number(rows[0]?.bytes ?? 0);
+}

--- a/app/apps/server/tests/helpers/app.ts
+++ b/app/apps/server/tests/helpers/app.ts
@@ -66,6 +66,7 @@ export function memoryDocWriter(): MemoryDocWriter {
 export function testAppDeps(overrides: Partial<AppDeps> = {}): AppDeps {
   return {
     disconnectDoc: () => {},
+    evictDoc: () => {},
     docWriter: memoryDocWriter(),
     onRegistryChanged: () => {},
     onAclChanged: () => {},
@@ -81,6 +82,8 @@ export interface RecordingAppDeps {
   aclBroadcasts: string[];
   /** Docs whose live sync sockets were force-closed. */
   disconnected: Array<{ vaultId: string; docId: string }>;
+  /** Docs closed AND dropped from the server's memory (see `AppDeps.evictDoc`). */
+  evicted: Array<{ vaultId: string; docId: string }>;
   docWriter: MemoryDocWriter;
   /** Clear all recordings (call from `beforeEach`). */
   reset(): void;
@@ -96,22 +99,26 @@ export function recordingAppDeps(overrides: Partial<AppDeps> = {}): RecordingApp
   const registryBroadcasts: RecordingAppDeps["registryBroadcasts"] = [];
   const aclBroadcasts: string[] = [];
   const disconnected: RecordingAppDeps["disconnected"] = [];
+  const evicted: RecordingAppDeps["evicted"] = [];
   const docWriter = memoryDocWriter();
   return {
     registryBroadcasts,
     aclBroadcasts,
     disconnected,
+    evicted,
     docWriter,
     reset() {
       registryBroadcasts.length = 0;
       aclBroadcasts.length = 0;
       disconnected.length = 0;
+      evicted.length = 0;
       docWriter.store.clear();
       docWriter.writes.length = 0;
     },
     deps: {
       docWriter,
       disconnectDoc: (vaultId, docId) => disconnected.push({ vaultId, docId }),
+      evictDoc: (vaultId, docId) => evicted.push({ vaultId, docId }),
       onRegistryChanged: (vaultId, originId) => registryBroadcasts.push({ vaultId, originId }),
       onAclChanged: (vaultId) => aclBroadcasts.push(vaultId),
       ...overrides,

--- a/app/apps/server/tests/repair-oversized-doc.test.ts
+++ b/app/apps/server/tests/repair-oversized-doc.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { createApp } from "../src/http/app.js";
+import { config } from "../src/config.js";
+import { pool } from "../src/db/pool.js";
+import { CLOSE_NOTE_TOO_LARGE } from "../src/sync/hocuspocus.js";
+import { appendUpdate, docStoredBytes, loadDocState, resetDocCrdt } from "../src/yjs/persistence.js";
+import { recordingAppDeps, type RecordingAppDeps } from "./helpers/app.js";
+import { signUp, type TestUser } from "./helpers/auth.js";
+import { resetDb } from "./helpers/db.js";
+import { seedMember, seedNote, seedOrg, seedShare, seedVault } from "./helpers/seed.js";
+
+/**
+ * Repairing a doc that has grown past `MAX_NOTE_MB`.
+ *
+ * Such a doc is stuck in a way nothing else can undo: `beforeHandleMessage`
+ * refuses it before a single update is applied, so no client can edit it back
+ * down, and its bulk is edit HISTORY rather than text, so compaction cannot
+ * shrink it either. A production vault had four (10–17 MB each, behind 0-byte
+ * files), and each one cost a rejected socket on every reconnect of every
+ * member — about one a second.
+ */
+
+let rec: RecordingAppDeps;
+let app: ReturnType<typeof createApp>;
+
+function api(user: TestUser | null, path: string, init: RequestInit = {}) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (user) headers.authorization = `Bearer ${user.token}`;
+  return app.fetch(new Request(`http://local${path}`, { ...init, headers }));
+}
+
+/** A doc carrying `chars` of text, persisted the way a client's updates arrive. */
+async function seedDocContent(docId: string, text: string): Promise<void> {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, text);
+  await appendUpdate(docId, Buffer.from(Y.encodeStateAsUpdate(doc)));
+  doc.destroy();
+}
+
+describe("oversized-doc repair", () => {
+  beforeEach(async () => {
+    await resetDb();
+    rec = recordingAppDeps();
+    app = createApp(rec.deps);
+  });
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("pins the close code the desktop client keys its terminal state on", () => {
+    // Mirrored as `CLOSE_NOTE_TOO_LARGE` in
+    // apps/desktop/src/lib/sync/syncManager.ts. Separate packages, no shared
+    // module — this literal is the only thing holding them in lockstep, and a
+    // drift silently restores the infinite reconnect loop.
+    expect(CLOSE_NOTE_TOO_LARGE).toBe(4413);
+  });
+
+  it("resets a doc's history and re-seeds it from the supplied text", async () => {
+    const user = await signUp("reset@t.com");
+    const org = await seedOrg("Acme", "acme-r1");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "fat.md", user.userId);
+
+    await seedDocContent(docId, "x".repeat(200_000));
+    const before = await docStoredBytes(docId);
+    expect(before).toBeGreaterThan(100_000);
+
+    const res = await api(user, `/api/notes/${docId}/reset-crdt`, {
+      method: "POST",
+      body: JSON.stringify({ content: "# Recovered\n" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { bytesBefore: number; bytesAfter: number };
+    expect(body.bytesBefore).toBe(before);
+    expect(body.bytesAfter).toBeLessThan(1_000);
+
+    // The text survives, the history does not — that is the whole trade.
+    const state = await loadDocState(docId);
+    const doc = new Y.Doc();
+    if (state) Y.applyUpdate(doc, state);
+    expect(doc.getText("content").toString()).toBe("# Recovered\n");
+    expect(await docStoredBytes(docId)).toBeLessThan(1_000);
+  });
+
+  it("EVICTS the doc, not merely disconnecting it", async () => {
+    // `disconnectDoc` closes sockets but leaves Hocuspocus holding the loaded
+    // Y.Doc, which it would then serve to the next client — re-materialising
+    // the exact state the reset just deleted.
+    const user = await signUp("evict@t.com");
+    const org = await seedOrg("Acme", "acme-r2");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+    await seedDocContent(docId, "hello");
+
+    const res = await api(user, `/api/notes/${docId}/reset-crdt`, {
+      method: "POST",
+      body: JSON.stringify({ content: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    expect(rec.evicted).toEqual([{ vaultId: vault, docId }]);
+  });
+
+  it("refuses a replacement that is itself over the cap", async () => {
+    // Otherwise the repair hands back a doc stuck in exactly the same way.
+    const user = await signUp("big@t.com");
+    const org = await seedOrg("Acme", "acme-r3");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+
+    const res = await api(user, `/api/notes/${docId}/reset-crdt`, {
+      method: "POST",
+      body: JSON.stringify({ content: "z".repeat(config.maxNoteMb * 1024 * 1024 + 1) }),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("is gated by the same per-doc ACL as every other write", async () => {
+    const owner = await signUp("owner-r@t.com");
+    const viewer = await signUp("viewer-r@t.com");
+    const stranger = await signUp("stranger-r@t.com");
+    const org = await seedOrg("Acme", "acme-r4");
+    await seedMember(org, owner.userId, "owner");
+    await seedMember(org, viewer.userId, "member");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", owner.userId);
+    await seedDocContent(docId, "secret");
+    await seedShare(org, "file", docId, viewer.userId, "view");
+
+    // A view grant may not reset history...
+    const asViewer = await api(viewer, `/api/notes/${docId}/reset-crdt`, {
+      method: "POST",
+      body: JSON.stringify({ content: "" }),
+    });
+    expect(asViewer.status).toBe(403);
+    // ...nor may a non-member, and size is an edit-level fact too.
+    expect((await api(stranger, `/api/notes/${docId}/crdt-size`)).status).toBe(403);
+    expect((await api(null, `/api/notes/${docId}/crdt-size`)).status).toBe(401);
+
+    // The content is untouched by the refusals.
+    expect(await docStoredBytes(docId)).toBeGreaterThan(0);
+  });
+
+  it("reports whether a doc is over the cap", async () => {
+    const user = await signUp("size@t.com");
+    const org = await seedOrg("Acme", "acme-r5");
+    await seedMember(org, user.userId, "owner");
+    const vault = await seedVault(org);
+    const docId = await seedNote(vault, null, "n.md", user.userId);
+    await seedDocContent(docId, "small");
+
+    const res = await api(user, `/api/notes/${docId}/crdt-size`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { bytes: number; capBytes: number; overCap: boolean };
+    expect(body.overCap).toBe(false);
+    expect(body.capBytes).toBe(config.maxNoteMb * 1024 * 1024);
+    expect(body.bytes).toBeGreaterThan(0);
+  });
+
+  it("resetDocCrdt drops the update log, not just the snapshot", async () => {
+    // Compaction merges updates INTO a snapshot and keeps every tombstone,
+    // which is why a 44 MB doc stays 44 MB however often it compacts. Discarding
+    // is the point here, so both halves must go.
+    const docId = "00000000-0000-4000-8000-00000000dead";
+    await seedDocContent(docId, "a".repeat(50_000));
+    await seedDocContent(docId, "b".repeat(50_000));
+    expect(await docStoredBytes(docId)).toBeGreaterThan(50_000);
+
+    await resetDocCrdt(docId, "tiny");
+
+    const { rows } = await pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM doc_updates WHERE doc_id = $1",
+      [docId],
+    );
+    expect(Number(rows[0].n)).toBe(0);
+    expect(await docStoredBytes(docId)).toBeLessThan(1_000);
+  });
+});


### PR DESCRIPTION
## The bug

A production vault's sync badge flipped `Syncing…` / `Synced` about once a second, indefinitely. Railway logs showed why:

```
Rejecting oversized sync message for vault:…/note:…: 22264370 bytes (cap 10485760)
[beforeHandleMessage] note exceeds the maximum size
closing connection … because of exception Error: note exceeds the maximum size
```

...on a loop. The client reconnected, re-sent the same oversized state, was closed again.

`contentUpload.ts` already had a guard written for exactly this, and its comment described the symptom precisely. **It measured the wrong number.** The guard measured the markdown bytes on disk; the server measures the encoded Yjs update. Those are different quantities, and in this vault four notes held 10–17 MB of CRDT history behind **0-byte files** — so the file check passed (0 < 10 MB), the empty-everywhere shortcut didn't fire (the *doc* wasn't empty), a socket opened, and the server killed it.

The history was duplication garbage from an earlier fork: one doc decoded to 29,580 lines of which **68 were distinct**.

## Changes

**Measure what goes on the wire** (`contentUpload.ts`) — new `crdtBytes()` checks the encoded doc state before any provider is opened, independently of `readFile`. This is the fix; the rest is defence in depth.

**Name the failure in the close frame** (`sync/hocuspocus.ts`) — the thrown error now carries `CLOSE_NOTE_TOO_LARGE` (4413). Hocuspocus previously fell back to `ResetConnection` (4205), the same code a transient reset uses, so a client could not tell "retry me" from "I will refuse this forever". That ambiguity *was* the loop.

**Treat it as terminal** (`syncManager.ts`) — new `too-large` status, `isTerminalSyncStatus()`, and a guard in `reconnectWithFreshToken` so no caller can restart the loop. Covers the editor path, which the uploader guard doesn't.

**Collect dead CRDT docs** (`index.rs`, `crdtGc.ts`) — `rebuild` deliberately never touches the CRDT tables (that's what preserves unsynced edits), so nothing ever removed a doc's rows either. The affected vault carried 953 unreachable docs in a 900 MB `index.sqlite`. New `prune_yjs_docs` + `VACUUM`, run once per vault open right after the registry reconcile.

Deletion is driven by an **allow-list**, never a guess: a local CRDT can be keyed by the registry's server `docId` *or* the local index's `notes.id`, and those diverge in a vault whose index predates its registration. Both spaces are unioned; Rust refuses an empty live set rather than obeying it.

**Repair path** (`routes/repair.ts`, `resetNoteHistory`) — an over-cap doc is otherwise unfixable: it can't be edited down (every connection is closed first) and compaction can't shrink it (merging keeps every tombstone). `POST /api/notes/:id/reset-crdt` discards the history and re-seeds from supplied text, gated by the same per-doc ACL. `evictDoc` unloads the cached `Y.Doc` too — `disconnectDoc` alone leaves Hocuspocus serving the state we just deleted.

## Verification

- Desktop TS **727 passed**, server **403 passed**, Rust **99 passed**
- The regression test was confirmed to fail with the guard removed
- GC dry-run against a copy of the real 900 MB index: 952 dead docs, 2,123 update rows, **858 MB → 376 MB**

## Note on scope

Zero-byte files are **not** deleted. In the affected vault 237 of 332 were placeholders awaiting hydration — legitimate server-only notes the registry materializes empty on purpose. Only unreachable CRDT rows are collected.
