### PR TITLE
Move Railway service settings to Infrastructure as Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,9 @@ script/style/iframe, strip `on*`/`javascript:`).
 Two listeners, one Node process (`index.ts`): Hocuspocus WS (:3011) + Hono HTTP (:3010). The same
 Hocuspocus instance is also served on the HTTP port at `/sync` (`sync/http-upgrade.ts`) so the whole
 server runs behind a single port/domain — that's what production deploys use (Dockerfile +
-`railway.json` + `docs/DEPLOY.md`; migrations run pre-deploy via `node dist/db/migrate.js`). MCP writes
+Railway IaC in `app/.railway/railway.ts`, applied with `railway config apply` from `app/` — the repo-root
+`railway.json` is the legacy copy new Railway services ignore — + `docs/DEPLOY.md`; migrations run
+pre-deploy via `node dist/db/migrate.js`). MCP writes
 flow through the same sync server via `createDocWriter` so AI edits persist/broadcast like human edits.
 - `auth/auth.ts` — Better Auth; **argon2id** (overrides default scrypt) via `@node-rs/argon2`; `bearer` +
   `organization` plugins (org = **vault**, the user-facing unified entity — Local / Synced / Remote states;

--- a/app/.railway/railway.ts
+++ b/app/.railway/railway.ts
@@ -1,0 +1,94 @@
+// Railway Infrastructure as Code for the Baalda server service.
+//
+// Successor of the repo-root `railway.json`: Railway's legacy "Config as Code"
+// is no longer read by services created after mid-2026 and stops being read
+// everywhere on 2026-12-01. This file carries the same generic settings —
+// Dockerfile build, pre-deploy migration, health check, restart policy, memory
+// cap — so a Railway-hosted server gets them from code instead of the dashboard.
+//
+// Scope. `partial` limits the file to the `baalda-server` service; Postgres,
+// volumes and domains belong to the Railway project and are never planned,
+// changed or deleted from here. Every environment variable the server reads is
+// listed with `preserve()`, which keeps whatever value the service already has
+// and adds NOTHING when the variable is absent — a variable that is not listed
+// would be deleted on apply, so add new server env vars here as well as to
+// `apps/server/.env.example`. Source is repeated because an omitted source is
+// treated as "detach the repo"; forks change the repo string.
+//
+// Run from `app/` (the SDK is a workspace devDependency there):
+//
+//   railway link            # pick the project + environment
+//   railway config plan     # preview (never changes anything)
+//   railway config apply    # apply after review
+//
+// Settings live on the service afterwards, so this only needs re-applying when
+// the file changes — ordinary pushes deploy with whatever was last applied.
+import { defineRailway, github, preserve, project, service } from "railway/iac";
+
+export const partial = "baalda-server";
+
+// Server env vars (see apps/server/.env.example and docs/DEPLOY.md). All optional
+// here: `preserve()` keeps an existing value and creates nothing.
+const SERVER_ENV = [
+  "DATABASE_URL",
+  "JWT_SECRET",
+  "BETTER_AUTH_URL",
+  "PORT",
+  "HOCUSPOCUS_PORT",
+  "NODE_ENV",
+  "NODE_OPTIONS",
+  "SYNC_TOKEN_TTL_SECONDS",
+  "COMPACTION_THRESHOLD",
+  "CORS_ORIGINS",
+  "OPENAI_API_KEY",
+  "REDIS_URL",
+  "PG_POOL_MAX",
+  "MAX_NOTE_MB",
+  "MAX_BLOB_BYTES",
+  "MAX_INFLIGHT_UPLOAD_BYTES",
+  "BACKFILL_CONCURRENCY",
+  "VERSION_IDLE_MS",
+  "VAULT_SYNC_PATH",
+  "VAULT_HEARTBEAT_MS",
+  "VAULT_SEND_CAP_BYTES",
+  "VAULT_SEND_POLL_MS",
+  "VAULT_SEND_STALL_MS",
+  "FREE_MAX_VAULTS",
+  "FREE_MAX_MEMBERS",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "POLAR_ACCESS_TOKEN",
+  "POLAR_SERVER",
+  "POLAR_PRODUCT_MONTHLY_ID",
+  "POLAR_PRODUCT_YEARLY_ID",
+  "POLAR_WEBHOOK_SECRET",
+] as const;
+
+export default defineRailway((ctx) => {
+  // A project whose name contains "staging" deploys the `staging` branch;
+  // every other project deploys `main`.
+  const branch = ctx.projectName.toLowerCase().includes("staging") ? "staging" : "main";
+
+  const server = service("baalda-server", {
+    source: github("naveedharri/baalda", { branch }),
+    build: {
+      builder: "DOCKERFILE",
+      // Build context is the repo root (pnpm monorepo), so the path is from there.
+      dockerfilePath: "app/apps/server/Dockerfile",
+    },
+    deploy: {
+      // Migrations run in a one-off container before the new version takes
+      // traffic; a failed migration fails the deploy and the old version keeps
+      // serving.
+      preDeployCommand: ["node dist/db/migrate.js"],
+      healthcheckPath: "/health",
+      healthcheckTimeout: 300,
+      restartPolicyType: "ON_FAILURE",
+      restartPolicyMaxRetries: 5,
+      limitOverride: { containers: { memoryBytes: 1073741824 } },
+    },
+    env: Object.fromEntries(SERVER_ENV.map((name) => [name, preserve()])),
+  });
+
+  return project(ctx.projectName, { resources: [server] });
+});

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "test": "turbo run test"
   },
   "devDependencies": {
+    "railway": "^3.11.0",
     "turbo": "^2.10.5"
   }
 }

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   .:
     devDependencies:
+      railway:
+        specifier: ^3.11.0
+        version: 3.11.0
       turbo:
         specifier: ^2.10.5
         version: 2.10.5
@@ -880,6 +883,11 @@ packages:
   '@fontsource/radio-canada-big@5.2.7':
     resolution: {integrity: sha512-FbFwPzj/PsWA9s0/V5Zol4GlfECeFHYby9f6UkX5+vG7IL40SXQff0SpzlR5984gXQ77NXlOffV7gmtC9g1nvw==}
 
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@hocuspocus/common@4.4.0':
     resolution: {integrity: sha512-cPSlPu/ws2JzBHW6OzctyaQMyDCq/YUS4nhXSbyMdkQwJzhjCkvfmmRnVtcmgLR3TBLaNwToNDwR/mNaJFOYsg==}
 
@@ -1678,6 +1686,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -1873,6 +1885,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  railway@3.11.0:
+    resolution: {integrity: sha512-ehLFHCxV+gITWeBlIVaXulXaVRg4LCxqm0bq64iXSwYL1DESd0pUeLYMP/BMBhnZWeFFBYyJCREaq+Nka7Wgmw==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   react-arborist@3.13.2:
     resolution: {integrity: sha512-Qa5h2MwBGflTZXsg8vXOHOonF04w31u6DyPL06iyboe+A8CMqxRxgI/Imd5mwTo679iNNJ4e7CuinJGe3rGqgg==}
@@ -2792,6 +2809,10 @@ snapshots:
 
   '@fontsource/radio-canada-big@5.2.7': {}
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
+    dependencies:
+      graphql: 16.14.2
+
   '@hocuspocus/common@4.4.0':
     dependencies:
       lib0: 0.2.117
@@ -3462,6 +3483,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  graphql@16.14.2: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -3650,6 +3673,12 @@ snapshots:
       xtend: 4.0.2
 
   punycode@2.3.1: {}
+
+  railway@3.11.0:
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      graphql: 16.14.2
+      tsx: 4.23.1
 
   react-arborist@3.13.2(@types/node@24.13.3)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -24,8 +24,8 @@ Then in the desktop app: **account menu → Server settings →** your
 
 The ordering is the point: `server` waits on `migrate` finishing successfully,
 which waits on Postgres being healthy. A deploy can therefore never briefly
-answer requests against an old schema. Same guarantee `railway.json` gets from
-its `preDeployCommand`.
+answer requests against an old schema. Same guarantee a Railway service gets from
+the `preDeployCommand` in `app/.railway/railway.ts`.
 
 **One port, not two.** The CRDT WebSocket is served on the HTTP port at `/sync`,
 so there is nothing else to open or route. The dedicated `HOCUSPOCUS_PORT` exists

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -112,27 +112,48 @@ Generate a real `JWT_SECRET` for anything beyond local testing:
 
 ## Option B: Railway
 
-The repo ships a checked-in `railway.json` at the repo root, so Railway needs
-almost no manual configuration:
+The server's Railway settings are checked in as Infrastructure as Code at
+`app/.railway/railway.ts` — Dockerfile build, pre-deploy migration, `/health`
+check, restart policy and a 1 GiB memory cap — so Railway needs almost no manual
+configuration:
 
-1. Create a new Railway project and deploy from this repo. Railway
-   reads `railway.json` and builds `app/apps/server/Dockerfile` with the repo
-   root as build context.
-2. Add a **Postgres** database service to the project (Railway's own Postgres
-   plugin works fine).
-3. On the server service, set the environment variables:
+1. Create a new Railway project, add a **Postgres** database service, and add a
+   service that deploys this repo from GitHub.
+2. On the server service, set the environment variables:
    - `DATABASE_URL`: reference the Postgres service's connection string
      (Railway lets you wire this as a variable reference instead of copying
      a literal value).
    - `JWT_SECRET`: generate one with `openssl rand -base64 32`.
    - `BETTER_AUTH_URL`: the server's public HTTPS URL (Railway gives you a
      `*.up.railway.app` domain, or attach your own).
-4. Deploy. `railway.json`'s `deploy.preDeployCommand` runs
-   `node dist/db/migrate.js` before every deploy, and `deploy.healthcheckPath`
-   is `/health`, so Railway won't cut over traffic until migrations have run
-   and the server is answering.
+3. Apply the checked-in settings from a clone. Needs the Railway CLI 5.42 or
+   newer and a `pnpm install` in `app/` (which brings the `railway` SDK):
+
+   ```bash
+   cd app
+   railway link            # choose the project, its environment and the server service
+   railway config plan     # preview — only that service's build/deploy settings change
+   railway config apply
+   ```
+
+   The file is scoped to the server service (`export const partial`), keeps every
+   variable the service already has (`preserve()`) and never touches Postgres,
+   volumes or domains. It pins the GitHub source to `naveedharri/baalda` (a
+   project whose name contains "staging" deploys the `staging` branch, anything
+   else `main`); a fork changes that one string. The settings then live on the
+   service, so this is only re-run when the file changes.
+4. Deploy (`apply` triggers one). `preDeployCommand` runs `node dist/db/migrate.js`
+   before every deploy and the health check is `/health`, so Railway won't cut
+   over traffic until migrations have run and the server is answering.
 5. Expose only the one HTTP port (Railway does this automatically from
    `PORT`); nothing else needs to be public.
+
+> **`railway.json` is legacy.** The repo-root `railway.json` is Railway's older
+> "Config as Code" form of the same settings. Only services created before
+> mid-2026 still read it, and Railway stops reading it everywhere on 2026-12-01;
+> a newer service that has nothing but `railway.json` builds with Railpack, runs
+> no migrations, and answers every sign-in with HTTP 500 (`relation "user" does
+> not exist`). Keep the two files in step until `railway.json` is removed.
 
 Then point the desktop app at it — see
 [Point the desktop app at your server](#point-the-desktop-app-at-your-server)
@@ -180,8 +201,8 @@ live on the managed service or **your own server**, and the generated
 ### Maintaining the template
 
 The service config lives in Railway's template editor, **not** in this repo — the
-only parts version-controlled here are `railway.json` (builder, pre-deploy
-migration, healthcheck) and the Dockerfile. Changing the required env vars means
+only parts version-controlled here are `app/.railway/railway.ts` (builder,
+pre-deploy migration, healthcheck) and the Dockerfile. Changing the required env vars means
 editing the template in the dashboard too, or one-click deploys will boot
 misconfigured.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -148,6 +148,19 @@ overlay is ever fumbled.
 | Windows bundle | `.msi` + `.exe` | `.exe` (NSIS) only |
 | `cancel-in-progress` | `false` | `true` |
 
+### The staging server
+
+`STAGING_SERVER_URL` points at a **separate Railway project** whose server
+service deploys the `staging` branch (production deploys `main`); a push to
+`staging` therefore redeploys it. Its build and deploy settings — Dockerfile
+build, pre-deploy `node dist/db/migrate.js`, `/health`, restart policy, memory
+cap — come from the same checked-in `app/.railway/railway.ts` as production,
+applied once per settings change with `railway link` (pick the staging project)
+then `railway config apply` from `app/`. See [DEPLOY.md → Option B](DEPLOY.md#option-b-railway).
+Services created after mid-2026 do **not** read the legacy `railway.json`: a
+staging service that only had that file built with Railpack, skipped migrations,
+and answered every sign-in with HTTP 500 until the IaC was applied (2026-09-07).
+
 **The version is a semver prerelease** — `<base>-staging.<run_number>`, where base
 is `tauri.conf.json`'s version. It sorts *below* the base version, so nothing on
 the production channel would ever treat it as an upgrade, and it is monotonic

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -16,8 +16,8 @@ tags: [baalda, status, roadmap]
   and desktop (bridge + auth + per-doc sync + presence + sharing UI + attachment sync)
   are wired end-to-end and tested.
 - **Deployment:** 🟢 Production-ready (2026-07-15). The sync WebSocket is served on the HTTP
-  port at `/sync` (single-port topology), and the repo ships a Dockerfile, `railway.json`
-  (pre-deploy migrations + healthcheck), and [[DEPLOY]]. The managed backend is live at
+  port at `/sync` (single-port topology), and the repo ships a Dockerfile, Railway IaC at
+  `app/.railway/railway.ts` (Dockerfile build, pre-deploy migrations + healthcheck), and [[DEPLOY]]. The managed backend is live at
   `https://api.baalda.com`; desktop releases ship via `v*` tags → signed installers → Tauri updater.
 - **Next action:** Phase 4 polish / launch decisions (WYSIWYG, vector search, OAuth, iOS).
 


### PR DESCRIPTION
Railway deprecated its `railway.json` "Config as Code": services created after mid-2026 never read it (the API refuses to set the config-file path) and it stops being read everywhere on 2026-12-01. The new staging service therefore built with Railpack, ran no migrations, and answered every sign-in with HTTP 500 (`relation "user" does not exist`), while production (an older service) still read the file.

- Add `app/.railway/railway.ts`: Dockerfile build, `node dist/db/migrate.js` pre-deploy, `/health` (300 s), on-failure restart ×5, 1 GiB memory cap. Scoped to the `baalda-server` service (`partial`), preserves every server env var by name, never touches Postgres/volumes/domains. Branch is `staging` when the project name contains "staging", else `main`.
- Add the `railway` SDK as a workspace devDependency (the CLI engine resolves it from `app/`).
- Docs: DEPLOY.md Option B rewritten for `railway config plan/apply`, RELEASE.md gains "The staging server", STATUS.md / compose README / CLAUDE.md updated. `railway.json` is kept as the legacy copy until production is switched.

Already applied to the staging project: the resulting deployment logged "Migrations applied", `/health` is 200 and a bad-credentials sign-in returns 401. Production has not been changed.