### PR TITLE
Confirm before making a note, folder or vault private

### DIFF
--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -5816,6 +5816,70 @@ button.is-done:disabled {
   color: var(--success);
 }
 
+/* ---- Confirm dialog (destructive access changes, etc.) ---- */
+.confirm-dialog {
+  width: 440px;
+  padding: var(--sp-8) var(--sp-8) var(--sp-6);
+  text-align: center;
+}
+.confirm-badge {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  margin: 0 auto var(--sp-4);
+  border-radius: var(--radius-lg);
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+.confirm-dialog.tone-accent .confirm-badge {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.confirm-title {
+  margin: 0 0 var(--sp-3);
+  font-family: var(--font-display);
+  font-size: var(--fs-xl);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+.confirm-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin: 0 auto var(--sp-6);
+  max-width: 38ch;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-body);
+}
+.confirm-body p {
+  margin: 0;
+}
+.confirm-body strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.confirm-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--sp-2);
+}
+.confirm-actions .primary,
+.confirm-actions .ghost-pill {
+  min-width: 128px;
+  padding: var(--sp-3) var(--sp-5);
+  font-size: var(--fs-md);
+}
+.confirm-actions .primary.danger {
+  background: var(--danger);
+}
+.confirm-actions .primary.danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 88%, black);
+}
+
 /* ---- Vault switching ---- */
 /* The header renames itself to the destination at once; these two rules are the
    supporting evidence that the rename is a *pending* claim, not a finished one. */

--- a/app/apps/desktop/src/components/AccessPanel.tsx
+++ b/app/apps/desktop/src/components/AccessPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { lockScopesByPath, resourceIdsByPath } from "../lib/locks";
 import { syncManager } from "../lib/sync/docSession";
 import { useStore } from "../store";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { Avatar } from "./Identity";
 import { MenuSelect, type MenuSelectOption } from "./MenuSelect";
 import { Spinner } from "./Spinner";
@@ -190,6 +191,15 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
    * someone who is halfway through configuring a note inside it.
    */
   const [selected, setSelected] = useState<Resource | null>(null);
+  // A "make private" waiting on a yes. Private is the one access change that
+  // REMOVES data from teammates' devices (their local copy of the note/folder
+  // goes with the access), so it is confirmed rather than applied on click.
+  const [confirm, setConfirm] = useState<{
+    title: string;
+    body: React.ReactNode;
+    label: string;
+    apply: () => void;
+  } | null>(null);
   const selectedKey = selected?.key ?? "";
   /** Folder paths currently open in the list. */
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
@@ -476,6 +486,33 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   // is no baseline edit to cap, and a grant is what GIVES the team read).
   const setGeneral = (mode: Mode) => {
     if (!selected || mode === generalMode || inheritedOrgLock || privateSource) return;
+    if (mode === "private") {
+      const what = selected.kind === "folder" ? "folder" : "note";
+      setConfirm({
+        title: `Make “${selected.name}” private?`,
+        label: "Make private",
+        apply: () => applyGeneral(mode),
+        body: (
+          <>
+            <p>
+              The team loses access to this {what}
+              {selected.kind === "folder" ? " and everything inside it" : ""}. It is
+              removed from their devices, <strong>including the local copy on disk</strong>.
+            </p>
+            <p>
+              You, the vault's owners and admins, and anyone you have shared it with by
+              name keep it. Setting it back to Shared restores access.
+            </p>
+          </>
+        ),
+      });
+      return;
+    }
+    applyGeneral(mode);
+  };
+
+  const applyGeneral = (mode: Mode) => {
+    if (!selected) return;
     void run(async () => {
       await clearResourceOrgRows();
       if (mode === "private") {
@@ -525,6 +562,29 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
   // the same (resource, principal) key.
   const setVaultPosture = (mode: Mode) => {
     if (!orgId || mode === wsPosture) return;
+    if (mode === "private") {
+      setConfirm({
+        title: "Make this vault private?",
+        label: "Make vault private",
+        apply: () => applyVaultPosture(mode),
+        body: (
+          <>
+            <p>
+              Members will only see notes they created or that you share with them by
+              name. Everything else is removed from their devices,{" "}
+              <strong>including the local copies on disk</strong>.
+            </p>
+            <p>Owners and admins keep the whole vault. You can switch back to Shared at any time.</p>
+          </>
+        ),
+      });
+      return;
+    }
+    applyVaultPosture(mode);
+  };
+
+  const applyVaultPosture = (mode: Mode) => {
+    if (!orgId) return;
     void run(async () => {
       if (wsGrant) await authManager.api.revokeShare(wsGrant.id);
       if (mode !== "private") {
@@ -566,7 +626,32 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
     return "default";
   };
 
-  const setMember = (userId: string, choice: MemberChoice) => {
+  const setMember = (userId: string, choice: MemberChoice, who = "this person") => {
+    if (!selected) return;
+    if (choice === "none") {
+      const what = selected.kind === "folder" ? "folder" : "note";
+      setConfirm({
+        title: `Hide “${selected.name}” from ${who}?`,
+        label: "Hide from them",
+        apply: () => applyMember(userId, choice),
+        body: (
+          <>
+            <p>
+              {who} loses access to this {what}
+              {selected.kind === "folder" ? " and everything inside it" : ""}. It is
+              removed from their devices, <strong>including the local copy on disk</strong>
+              {" "}— even if they created it.
+            </p>
+            <p>Setting them back to Default restores their access.</p>
+          </>
+        ),
+      });
+      return;
+    }
+    applyMember(userId, choice);
+  };
+
+  const applyMember = (userId: string, choice: MemberChoice) => {
     if (!selected) return;
     void run(async () => {
       // Clear any existing direct rows for this user on this resource — the
@@ -657,6 +742,19 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
       )}
 
       {error && <div className="auth-error">{error}</div>}
+      {confirm && (
+        <ConfirmDialog
+          title={confirm.title}
+          confirmLabel={confirm.label}
+          onCancel={() => setConfirm(null)}
+          onConfirm={() => {
+            confirm.apply();
+            setConfirm(null);
+          }}
+        >
+          {confirm.body}
+        </ConfirmDialog>
+      )}
 
       <div className="access-body">
         {/* master list */}
@@ -921,7 +1019,7 @@ export function AccessPanel({ canManage }: { canManage: boolean }) {
                           <MenuSelect
                             value={choice}
                             options={memberOptions(everyoneReadonly)}
-                            onSelect={(next) => setMember(m.userId, next)}
+                            onSelect={(next) => setMember(m.userId, next, m.name || m.email || "this person")}
                             disabled={busy}
                             ariaLabel={`Access for ${m.name || m.email || m.userId}`}
                             triggerClassName="access-choice-trigger"

--- a/app/apps/desktop/src/components/ConfirmDialog.tsx
+++ b/app/apps/desktop/src/components/ConfirmDialog.tsx
@@ -1,0 +1,76 @@
+import { useEffect, type ReactNode } from "react";
+import { AsyncButton } from "./AsyncButton";
+
+/**
+ * A confirm for actions that are hard to take back. Rides the shared
+ * `.modal-backdrop` / `.modal` shell so it stacks above Settings and the
+ * access panel wherever it is raised from.
+ *
+ * `onConfirm` may be async: the confirm button reports on it and the dialog
+ * is closed by the caller once it lands (or stays open on failure, so the
+ * error has somewhere to show).
+ */
+export function ConfirmDialog({
+  title,
+  children,
+  confirmLabel,
+  cancelLabel = "Cancel",
+  tone = "danger",
+  onConfirm,
+  onCancel,
+}: {
+  title: ReactNode;
+  children: ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  tone?: "danger" | "accent";
+  onConfirm: () => Promise<unknown> | unknown;
+  onCancel: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div className="modal-backdrop" onClick={onCancel}>
+      <div
+        className={`modal confirm-dialog tone-${tone}`}
+        role="alertdialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="confirm-badge" aria-hidden="true">
+          {tone === "danger" ? (
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+              <path d="M12 9v4M12 17h.01" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="9" />
+              <path d="M12 8h.01M11 12h1v4h1" />
+            </svg>
+          )}
+        </div>
+        <h2 className="confirm-title">{title}</h2>
+        <div className="confirm-body">{children}</div>
+        <div className="confirm-actions">
+          <button type="button" className="ghost-pill" onClick={onCancel}>
+            {cancelLabel}
+          </button>
+          <AsyncButton
+            className={`primary${tone === "danger" ? " danger" : ""}`}
+            spinnerTone="on-accent"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </AsyncButton>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Making something Private is the one access change that removes data from teammates' devices (their local copy of the note/folder leaves with the access). It now asks first instead of applying on click.

- New reusable `ConfirmDialog` on the shared `.modal` shell: warning tile, title, short explanation, Cancel + red confirm. Escape / backdrop cancels.
- Three paths in the Access panel confirm: note/folder → Private, whole vault → Private, per-member → Private ("Hide from …"). Each explains the local-copy removal, who keeps access, and how to undo it.
- Shared / Read-only still apply immediately (they add access rather than remove it).

Desktop suite green.