### PR TITLE
Give the Staging app its own baalda-staging:// scheme

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -484,6 +484,9 @@ jobs:
           # falls back to the PRODUCTION url in a release build otherwise — which
           # is why `prepare` refuses to run without it.
           VITE_SERVER_URL: ${{ vars.STAGING_SERVER_URL }}
+          # The scheme this build registers (tauri.staging.conf.json) — the JS
+          # side builds its own links with it (src/lib/deepLinkScheme.ts).
+          VITE_DEEP_LINK_SCHEME: baalda-staging
           # Same minisign updater key as production, on purpose: the pubkey is
           # compiled into tauri.conf.json and the overlay does not touch it, so
           # the staging app must be signed by the same key or it would reject its
@@ -527,6 +530,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_SERVER_URL: ${{ vars.STAGING_SERVER_URL }}
+          # The scheme this build registers (tauri.staging.conf.json) — the JS
+          # side builds its own links with it (src/lib/deepLinkScheme.ts).
+          VITE_DEEP_LINK_SCHEME: baalda-staging
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}

--- a/app/.railway/railway.ts
+++ b/app/.railway/railway.ts
@@ -68,6 +68,9 @@ const SERVER_ENV = [
   "SMTP_URL",
   "RESEND_API_KEY",
   "EMAIL_TRANSPORT",
+  // Desktop URL scheme the server's pages bounce into; `baalda-staging` on the
+  // staging project so its links open the Staging app, not the released one.
+  "DEEP_LINK_SCHEME",
 ] as const;
 
 export default defineRailway((ctx) => {

--- a/app/apps/desktop/src-tauri/tauri.staging.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.staging.conf.json
@@ -3,6 +3,11 @@
   "productName": "Baalda Staging",
   "identifier": "com.baalda.context.staging",
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["baalda-staging"]
+      }
+    },
     "updater": {
       "endpoints": [
         "https://github.com/naveedharri/baalda/releases/download/staging/latest.json"

--- a/app/apps/desktop/src/lib/__tests__/accountLink.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/accountLink.test.ts
@@ -11,6 +11,10 @@ describe("parseAccountLink", () => {
     expect(parseAccountLink("baalda:///signin/")).toBe("signin");
   });
 
+  it("accepts the Staging app's scheme too", () => {
+    expect(parseAccountLink("baalda-staging://verified")).toBe("verified");
+  });
+
   it("refuses anything else", () => {
     for (const bad of [
       "baalda://verified/extra",

--- a/app/apps/desktop/src/lib/__tests__/connectLink.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/connectLink.test.ts
@@ -17,6 +17,12 @@ describe("parseConnectLink", () => {
     expect(parseConnectLink(link!)).toBe("https://notes.example.com");
   });
 
+  it("accepts the Staging app's scheme (the two builds must not share one)", () => {
+    expect(parseConnectLink("baalda-staging://connect?server=https%3A%2F%2Fnotes.example.com")).toBe(
+      "https://notes.example.com",
+    );
+  });
+
   it("accepts the path-folded form some platforms deliver", () => {
     expect(parseConnectLink("baalda:///connect?server=https%3A%2F%2Fnotes.example.com")).toBe(
       "https://notes.example.com",

--- a/app/apps/desktop/src/lib/accountLink.ts
+++ b/app/apps/desktop/src/lib/accountLink.ts
@@ -9,6 +9,8 @@
 // deliver `baalda://verified` with host "verified", others `baalda:///verified`
 // with it in the path.
 
+import { isAppProtocol } from "./deepLinkScheme";
+
 export type AccountLinkKind = "verified" | "signin";
 
 export function parseAccountLink(url: string): AccountLinkKind | null {
@@ -18,7 +20,7 @@ export function parseAccountLink(url: string): AccountLinkKind | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== "baalda:") return null;
+  if (!isAppProtocol(parsed.protocol)) return null;
   const segments = [parsed.host, ...parsed.pathname.split("/")].filter((s) => s.length > 0);
   if (segments.length !== 1) return null;
   return segments[0] === "verified" || segments[0] === "signin" ? segments[0] : null;

--- a/app/apps/desktop/src/lib/connectLink.ts
+++ b/app/apps/desktop/src/lib/connectLink.ts
@@ -12,9 +12,10 @@
 // CONTENT (only http(s) survives `normalizeServerUrl`).
 
 import { normalizeServerUrl } from "./auth/serverChoice";
+import { APP_SCHEME, isAppProtocol } from "./deepLinkScheme";
 
-/** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
-export const CONNECT_SCHEME = "baalda";
+/** URL scheme this build registers (tauri.conf.json → deep-link; staging differs). */
+export const CONNECT_SCHEME = APP_SCHEME;
 
 /**
  * Build the deep link an admin shares. The server also serves an https mirror
@@ -43,7 +44,7 @@ export function parseConnectLink(url: string): string | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== `${CONNECT_SCHEME}:`) return null;
+  if (!isAppProtocol(parsed.protocol)) return null;
   const segments = [parsed.host, ...parsed.pathname.split("/")].filter(
     (s) => s.length > 0,
   );

--- a/app/apps/desktop/src/lib/deepLinkScheme.ts
+++ b/app/apps/desktop/src/lib/deepLinkScheme.ts
@@ -1,0 +1,25 @@
+// Which `<scheme>://` this build of the app owns, and which ones its link
+// parsers accept.
+//
+// The released app registers `baalda://`; the Staging app registers
+// `baalda-staging://` (tauri.staging.conf.json overrides the deep-link schemes,
+// and staging-release.yml inlines VITE_DEEP_LINK_SCHEME to match). They HAVE to
+// differ: with both apps installed on one machine and both claiming `baalda://`,
+// the OS hands every link — a production invitation email included — to
+// whichever app registered the scheme last, which is how clicking a link from
+// the production server opened the Staging app.
+//
+// Parsers accept both schemes regardless of build. Being strict about the
+// scheme buys nothing (the OS already routed the link here) and would make a
+// link pasted between builds silently do nothing.
+
+/** The scheme this build registers and puts in links it constructs itself. */
+export const APP_SCHEME: string =
+  (import.meta.env.VITE_DEEP_LINK_SCHEME as string | undefined)?.trim() || "baalda";
+
+const ACCEPTED_PROTOCOLS = new Set(["baalda:", "baalda-staging:", `${APP_SCHEME}:`]);
+
+/** Is this `URL.protocol` (with its trailing colon) one of ours? */
+export function isAppProtocol(protocol: string): boolean {
+  return ACCEPTED_PROTOCOLS.has(protocol);
+}

--- a/app/apps/desktop/src/lib/inviteLink.ts
+++ b/app/apps/desktop/src/lib/inviteLink.ts
@@ -13,9 +13,10 @@
 // and the server re-checks it on accept; this module only routes.
 
 import { normalizeServerUrl } from "./auth/serverChoice";
+import { APP_SCHEME, isAppProtocol } from "./deepLinkScheme";
 
-/** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
-export const INVITE_SCHEME = "baalda";
+/** URL scheme this build registers (tauri.conf.json → deep-link; staging differs). */
+export const INVITE_SCHEME = APP_SCHEME;
 
 /**
  * The shape an invitation id may take. Better Auth emits UUIDs, but ids are
@@ -66,7 +67,7 @@ export function parseInviteDeepLink(url: string): InviteDeepLink | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== `${INVITE_SCHEME}:`) return null;
+  if (!isAppProtocol(parsed.protocol)) return null;
   const segments = [parsed.host, ...parsed.pathname.split("/")]
     .filter((s) => s.length > 0)
     .map((s) => decodeURIComponent(s));

--- a/app/apps/desktop/src/lib/shareLink.ts
+++ b/app/apps/desktop/src/lib/shareLink.ts
@@ -14,7 +14,9 @@
 // `setActiveOrganization` takes.
 
 /** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
-export const SHARE_SCHEME = "baalda";
+import { APP_SCHEME, isAppProtocol } from "./deepLinkScheme";
+
+export const SHARE_SCHEME = APP_SCHEME;
 
 export interface NoteLinkTarget {
   /** Better Auth organization id — the user-facing vault. */
@@ -64,7 +66,7 @@ export function parseNoteLink(url: string): NoteLinkTarget | null {
   } catch {
     return null;
   }
-  const isScheme = parsed.protocol === `${SHARE_SCHEME}:`;
+  const isScheme = isAppProtocol(parsed.protocol);
   const isWeb = parsed.protocol === "https:" || parsed.protocol === "http:";
   if (!isScheme && !isWeb) return null;
   // `baalda://note/<org>/<doc>` parses with host "note" and pathname

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -71,6 +71,12 @@ VAULT_SYNC_PATH=/vault-sync
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 
+# URL scheme of the desktop app that this server's pages (/open/*, /invite/:id,
+# /email-verified, /reset-password) hand off to. Leave unset for `baalda` (the
+# released app). A server behind the "Baalda Staging" app must say
+# `baalda-staging`, or its links open whichever app registered baalda:// last.
+# DEEP_LINK_SCHEME=baalda
+
 # --- Outbound email (password reset, sign-up verification, invitations) ---
 
 # Email is OFF unless configured, and every feature that needs it is then simply

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -54,6 +54,15 @@ function int(name: string, fallback: number): number {
   return n;
 }
 
+/** `DEEP_LINK_SCHEME`, validated to the shape a URL scheme may take. */
+function deepLinkScheme(): string {
+  const v = optional("DEEP_LINK_SCHEME") ?? "baalda";
+  if (!/^[a-z][a-z0-9+.-]{0,63}$/.test(v)) {
+    throw new Error(`DEEP_LINK_SCHEME must be a URL scheme like "baalda" (got "${v}")`);
+  }
+  return v;
+}
+
 /** An env var that may be absent; empty string is treated as unset. */
 function optional(name: string): string | undefined {
   const v = process.env[name];
@@ -134,6 +143,14 @@ export const config = {
    *  on email+password alone. Set only via env (never committed). */
   googleClientId: optional("GOOGLE_CLIENT_ID"),
   googleClientSecret: optional("GOOGLE_CLIENT_SECRET"),
+  /**
+   * URL scheme of the desktop app this server's pages bounce into (`/open/*`,
+   * `/invite/:id`, `/email-verified`, `/reset-password`). The released app
+   * registers `baalda`; the Staging app registers `baalda-staging`, so a staging
+   * server must say so or its links open whichever app grabbed `baalda://` last
+   * on a machine that has both installed.
+   */
+  deepLinkScheme: deepLinkScheme(),
   // ---- Outbound email (issue #99) ----
   /** Sender address, e.g. `Baalda <no-reply@example.com>`. Required to send
    *  anything; with it and ONE transport below, password reset + sign-up

--- a/app/apps/server/src/http/routes/account-pages.ts
+++ b/app/apps/server/src/http/routes/account-pages.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { pool } from "../../db/pool.js";
 import { BRAND_NAME } from "../../brand.js";
+import { config } from "../../config.js";
 import { emailEnabled } from "../../email/mailer.js";
 import { esc, page } from "../pages.js";
 import { publicBaseUrl } from "./open-link.js";
@@ -30,12 +31,13 @@ const ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 
 /**
  * Deep links back into the desktop app (`lib/accountLink.ts` on the desktop
- * side). Neither carries data: `verified` makes the app re-read its session so
+ * side); the scheme is `DEEP_LINK_SCHEME` (staging apps register their own).
+ * Neither carries data: `verified` makes the app re-read its session so
  * the verified state appears without a reload; `signin` makes it re-check the
  * (now revoked) session and open the sign-in card.
  */
-const VERIFIED_DEEP_LINK = "baalda://verified";
-const SIGNIN_DEEP_LINK = "baalda://signin";
+const VERIFIED_DEEP_LINK = `${config.deepLinkScheme}://verified`;
+const SIGNIN_DEEP_LINK = `${config.deepLinkScheme}://signin`;
 
 function notAvailable() {
   return page({
@@ -226,7 +228,7 @@ accountPageRoutes.get("/invite/:id", async (c) => {
   }
 
   const server = publicBaseUrl(c);
-  const deepLink = `baalda://invite/${encodeURIComponent(id)}?server=${encodeURIComponent(server)}`;
+  const deepLink = `${config.deepLinkScheme}://invite/${encodeURIComponent(id)}?server=${encodeURIComponent(server)}`;
   const who = inv.inviterName?.trim() || "A teammate";
   const body = `
     <h1>Join ${esc(inv.organizationName)}</h1>

--- a/app/apps/server/src/http/routes/open-link.ts
+++ b/app/apps/server/src/http/routes/open-link.ts
@@ -37,7 +37,7 @@ openLinkRoutes.get("/open/note/:orgId/:docId", (c) => {
   }
   // Re-encoded on the way out even after the shape check, so the deep link is
   // inert as markup no matter what future id shapes are allowed through.
-  const deepLink = `baalda://note/${encodeURIComponent(orgId)}/${encodeURIComponent(docId)}`;
+  const deepLink = `${config.deepLinkScheme}://note/${encodeURIComponent(orgId)}/${encodeURIComponent(docId)}`;
   return c.html(`<!doctype html>
 <html lang="en">
 <head>
@@ -89,7 +89,7 @@ openLinkRoutes.get("/open/note/:orgId/:docId", (c) => {
  */
 openLinkRoutes.get("/open/connect", (c) => {
   const server = publicBaseUrl(c);
-  const deepLink = `baalda://connect?server=${encodeURIComponent(server)}`;
+  const deepLink = `${config.deepLinkScheme}://connect?server=${encodeURIComponent(server)}`;
   return c.html(`<!doctype html>
 <html lang="en">
 <head>

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -282,6 +282,7 @@ confirm `/health` and a real sync round-trip, then promote.
 | `POLAR_SERVER` | no | `sandbox` | `sandbox` or `production` Polar environment. |
 | `FREE_MAX_VAULTS` | no | `3` | Free-tier cap on unsubscribed vaults per user (only enforced when billing is enabled). |
 | `FREE_MAX_MEMBERS` | no | `3` | Free-tier cap on members + pending invitations per unsubscribed vault (only enforced when billing is enabled). Gates new invitations and join-code redemptions only; lowering it never removes existing members. |
+| `DEEP_LINK_SCHEME` | no | `baalda` | URL scheme of the desktop app the server's pages bounce into. Set `baalda-staging` on the server behind the Staging app so production and staging links open the right app on a machine that has both. |
 | `EMAIL_FROM` | for email | unset | **Outbound email (optional).** Sender address, e.g. `Baalda <no-reply@example.com>`. With this and ONE transport below, password reset ("Forgot password?"), sign-up verification and invitation emails switch on. Unset ⇒ email off and none of those is offered (invitations are shared as a link instead). |
 | `SMTP_URL` | one transport | unset | Any SMTP server: `smtp://user:pass@host:587` (STARTTLS) or `smtps://user:pass@host:465` (TLS). |
 | `RESEND_API_KEY` | one transport | unset | [Resend](https://resend.com) API key — the HTTPS alternative to SMTP. |


### PR DESCRIPTION
Both the released app and the Staging app registered `baalda://`, so on a machine with both installed the OS handed every link, including production invitation emails, to whichever app registered last.

- Staging Tauri overlay registers `baalda-staging://`; staging-release inlines `VITE_DEEP_LINK_SCHEME` to match.
- Server pages build their deep link from `DEEP_LINK_SCHEME` (default `baalda`); set to `baalda-staging` on the staging server, registered in the Railway IaC.
- Desktop parsers accept both schemes.

Refs #99