### PR TITLE
Release v0.1.53

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.52",
+  "version": "0.1.53",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.52"
+version = "0.1.53"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,1 +1,1 @@
-- Forgot password? by email, invitation emails with one-click join, and clearer sign-up and invite feedback
+- Fixed the sync badge flickering forever and re-syncing the same notes on every reload; edits that were stuck on one device now upload automatically


### PR DESCRIPTION
Version bump for the #106 sync fixes so the promotion to main ships a release. Release notes updated.