### PR TITLE
Release v0.1.53: stop the sync heartbeat and the per-reload re-sync (#98)

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -484,6 +484,9 @@ jobs:
           # falls back to the PRODUCTION url in a release build otherwise — which
           # is why `prepare` refuses to run without it.
           VITE_SERVER_URL: ${{ vars.STAGING_SERVER_URL }}
+          # The scheme this build registers (tauri.staging.conf.json) — the JS
+          # side builds its own links with it (src/lib/deepLinkScheme.ts).
+          VITE_DEEP_LINK_SCHEME: baalda-staging
           # Same minisign updater key as production, on purpose: the pubkey is
           # compiled into tauri.conf.json and the overlay does not touch it, so
           # the staging app must be signed by the same key or it would reject its
@@ -527,6 +530,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_SERVER_URL: ${{ vars.STAGING_SERVER_URL }}
+          # The scheme this build registers (tauri.staging.conf.json) — the JS
+          # side builds its own links with it (src/lib/deepLinkScheme.ts).
+          VITE_DEEP_LINK_SCHEME: baalda-staging
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,17 @@ Pure TS with dependency-injected I/O so it runs under vitest in Node. `adapter.t
   stubs used to "re-sync 307 notes" on every reload). Files over `MAX_NOTE_BYTES` (10 MB, the server's
   `MAX_NOTE_MB`) fail once, permanently, without a socket (`permanentFailures`) instead of being rejected
   by the server on every reconnect.
+- **`ready.behind` is the other authority** (`SyncManager.handleServerBehind`, #98): the server's backfill
+  diff (`loadDocDiff`) treats a client whose state vector *covers* the server's as up to date — unequal is
+  not behind — and flags `clientAhead` when the client holds ops the server never received; those docs are
+  named on `ready.behind` and queued for a push exactly like `ready.empty` ones. Before this, 40 notes with
+  unflushed local edits re-downloaded a 2-byte empty diff on every connect ("Syncing 40/40" on each
+  reload) and the edits never left the device.
+- **Paths compare case-insensitively everywhere** — notes (`samePath`) AND folders in `planInbound`, like
+  the server's `lower(path)` unique indexes and the outbound `registry.ts` adoption. A vault whose disk
+  said `Projects/community` while the server said `Projects/Community` (with empty server folders under
+  it) used to create and remove the same directories on alternate pulls, each pass re-triggering the next
+  through the watcher's `tree` event: one idle client pulled the full registry every ~1.5 s (#98).
 
 ### Desktop — React (`src/`)
 `store.ts` is a Zustand **UI view-state mirror only** (vault, tree, open note, auth/session, org members,

--- a/app/.railway/railway.ts
+++ b/app/.railway/railway.ts
@@ -68,6 +68,9 @@ const SERVER_ENV = [
   "SMTP_URL",
   "RESEND_API_KEY",
   "EMAIL_TRANSPORT",
+  // Desktop URL scheme the server's pages bounce into; `baalda-staging` on the
+  // staging project so its links open the Staging app, not the released one.
+  "DEEP_LINK_SCHEME",
 ] as const;
 
 export default defineRailway((ctx) => {

--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.52",
+  "version": "0.1.53",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.52"
+version = "0.1.53"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/src/commands.rs
+++ b/app/apps/desktop/src-tauri/src/commands.rs
@@ -1019,10 +1019,9 @@ pub async fn ensure_folder(
     state: State<'_, AppState>,
     path: String,
     expected_epoch: Option<u64>,
-) -> AppResult<()> {
+) -> AppResult<bool> {
     let (vault, _) = require_vault_at(&state, expected_epoch)?;
-    notefile::ensure_folder(&vault, &path)?;
-    Ok(())
+    notefile::ensure_folder(&vault, &path)
 }
 
 /// Move a note into the vault's recoverable trash (see `notefile::trash_note`).

--- a/app/apps/desktop/src-tauri/src/notefile.rs
+++ b/app/apps/desktop/src-tauri/src/notefile.rs
@@ -150,15 +150,24 @@ pub fn rename_path(vault: &Path, old_rel: &str, new_rel: &str) -> AppResult<Stri
 /// registry change and must be a no-op the second time. Sniffing
 /// `create_folder`'s error string across the IPC boundary to tell "already there"
 /// from a real failure is how idempotency quietly breaks.
-pub fn ensure_folder(vault: &Path, rel: &str) -> AppResult<()> {
+///
+/// Returns true when THIS call created the directory, false when it already
+/// existed. The caller (an inbound registry pull) uses that to tell a real disk
+/// change — one the watcher is about to echo — from a no-op: counting every
+/// `ensure_folder` as a change made a pull that changed nothing report "disk
+/// changed", re-read the registry, and refresh the whole UI on every pass.
+pub fn ensure_folder(vault: &Path, rel: &str) -> AppResult<bool> {
     if crate::vault::rel_path_is_ignored(rel) {
         return Err(AppError::new(
             "refusing to create a folder in an ignored dir",
         ));
     }
     let abs = resolve_in_vault(vault, rel)?;
+    if abs.is_dir() {
+        return Ok(false);
+    }
     std::fs::create_dir_all(&abs)?;
-    Ok(())
+    Ok(true)
 }
 
 /// Move a note OUT of the note pipeline into `.context/trash/<stamp>/<rel>`
@@ -279,7 +288,9 @@ pub fn delete_folder_if_empty(vault: &Path, rel: &str) -> AppResult<bool> {
     }
     let abs = resolve_in_vault(vault, rel)?;
     if !abs.exists() {
-        return Ok(true); // already gone — the goal state
+        // Already gone — the goal state, but NOT something this call did: the
+        // caller counts `true` as a disk change the watcher will echo.
+        return Ok(false);
     }
     if !abs.is_dir() {
         return Ok(false); // a file lives at this path; not ours to remove
@@ -589,11 +600,17 @@ mod tests {
     #[test]
     fn ensure_folder_is_idempotent_and_makes_parents() {
         let tmp = tempfile::tempdir().unwrap();
-        ensure_folder(tmp.path(), "A/B/C").unwrap();
+        assert!(ensure_folder(tmp.path(), "A/B/C").unwrap());
         assert!(tmp.path().join("A/B/C").is_dir());
         // Unlike `create_folder`, a second call is a no-op rather than an error —
-        // reconciliation runs on every registry change.
-        ensure_folder(tmp.path(), "A/B/C").unwrap();
+        // reconciliation runs on every registry change — and says so.
+        assert!(!ensure_folder(tmp.path(), "A/B/C").unwrap());
+        // On a case-insensitive filesystem a spelling variant IS the same dir, so
+        // it too is a no-op — the report must not claim a change that never
+        // happened (that claim is what kept a registry pull loop alive, #98).
+        if tmp.path().join("a/b/c").is_dir() {
+            assert!(!ensure_folder(tmp.path(), "a/b/c").unwrap());
+        }
     }
 
     #[test]
@@ -617,8 +634,8 @@ mod tests {
         assert!(delete_folder_if_empty(tmp.path(), "A/B").unwrap());
         assert!(delete_folder_if_empty(tmp.path(), "A").unwrap());
         assert!(!tmp.path().join("A").exists());
-        // Already gone is the goal state, not an error.
-        assert!(delete_folder_if_empty(tmp.path(), "A").unwrap());
+        // Already gone is the goal state, not an error — but nothing was removed.
+        assert!(!delete_folder_if_empty(tmp.path(), "A").unwrap());
         // A FILE at the path is not ours to remove.
         std::fs::write(tmp.path().join("f.md"), "x").unwrap();
         assert!(!delete_folder_if_empty(tmp.path(), "f.md").unwrap());

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src-tauri/tauri.staging.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.staging.conf.json
@@ -3,6 +3,11 @@
   "productName": "Baalda Staging",
   "identifier": "com.baalda.context.staging",
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["baalda-staging"]
+      }
+    },
     "updater": {
       "endpoints": [
         "https://github.com/naveedharri/baalda/releases/download/staging/latest.json"

--- a/app/apps/desktop/src/lib/__tests__/accountLink.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/accountLink.test.ts
@@ -11,6 +11,10 @@ describe("parseAccountLink", () => {
     expect(parseAccountLink("baalda:///signin/")).toBe("signin");
   });
 
+  it("accepts the Staging app's scheme too", () => {
+    expect(parseAccountLink("baalda-staging://verified")).toBe("verified");
+  });
+
   it("refuses anything else", () => {
     for (const bad of [
       "baalda://verified/extra",

--- a/app/apps/desktop/src/lib/__tests__/connectLink.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/connectLink.test.ts
@@ -17,6 +17,12 @@ describe("parseConnectLink", () => {
     expect(parseConnectLink(link!)).toBe("https://notes.example.com");
   });
 
+  it("accepts the Staging app's scheme (the two builds must not share one)", () => {
+    expect(parseConnectLink("baalda-staging://connect?server=https%3A%2F%2Fnotes.example.com")).toBe(
+      "https://notes.example.com",
+    );
+  });
+
   it("accepts the path-folded form some platforms deliver", () => {
     expect(parseConnectLink("baalda:///connect?server=https%3A%2F%2Fnotes.example.com")).toBe(
       "https://notes.example.com",

--- a/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
@@ -688,6 +688,16 @@ describe("parseServerControl — ready", () => {
     ).toEqual({ t: "ready", empty: ["a"], emptyTruncated: true });
   });
 
+  it("reads the `behind` list (docs this device holds unpushed ops for) and its flag", () => {
+    expect(parseServerControl(JSON.stringify({ t: "ready", behind: ["x", 3, ""] }))).toEqual({
+      t: "ready",
+      behind: ["x"],
+    });
+    expect(
+      parseServerControl(JSON.stringify({ t: "ready", empty: ["a"], behind: ["b"], behindTruncated: true })),
+    ).toEqual({ t: "ready", empty: ["a"], behind: ["b"], behindTruncated: true });
+  });
+
   it("tolerates an older server that omits both fields", () => {
     expect(parseServerControl(JSON.stringify({ t: "ready" }))).toEqual({ t: "ready" });
   });

--- a/app/apps/desktop/src/lib/accountLink.ts
+++ b/app/apps/desktop/src/lib/accountLink.ts
@@ -9,6 +9,8 @@
 // deliver `baalda://verified` with host "verified", others `baalda:///verified`
 // with it in the path.
 
+import { isAppProtocol } from "./deepLinkScheme";
+
 export type AccountLinkKind = "verified" | "signin";
 
 export function parseAccountLink(url: string): AccountLinkKind | null {
@@ -18,7 +20,7 @@ export function parseAccountLink(url: string): AccountLinkKind | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== "baalda:") return null;
+  if (!isAppProtocol(parsed.protocol)) return null;
   const segments = [parsed.host, ...parsed.pathname.split("/")].filter((s) => s.length > 0);
   if (segments.length !== 1) return null;
   return segments[0] === "verified" || segments[0] === "signin" ? segments[0] : null;

--- a/app/apps/desktop/src/lib/connectLink.ts
+++ b/app/apps/desktop/src/lib/connectLink.ts
@@ -12,9 +12,10 @@
 // CONTENT (only http(s) survives `normalizeServerUrl`).
 
 import { normalizeServerUrl } from "./auth/serverChoice";
+import { APP_SCHEME, isAppProtocol } from "./deepLinkScheme";
 
-/** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
-export const CONNECT_SCHEME = "baalda";
+/** URL scheme this build registers (tauri.conf.json → deep-link; staging differs). */
+export const CONNECT_SCHEME = APP_SCHEME;
 
 /**
  * Build the deep link an admin shares. The server also serves an https mirror
@@ -43,7 +44,7 @@ export function parseConnectLink(url: string): string | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== `${CONNECT_SCHEME}:`) return null;
+  if (!isAppProtocol(parsed.protocol)) return null;
   const segments = [parsed.host, ...parsed.pathname.split("/")].filter(
     (s) => s.length > 0,
   );

--- a/app/apps/desktop/src/lib/deepLinkScheme.ts
+++ b/app/apps/desktop/src/lib/deepLinkScheme.ts
@@ -1,0 +1,25 @@
+// Which `<scheme>://` this build of the app owns, and which ones its link
+// parsers accept.
+//
+// The released app registers `baalda://`; the Staging app registers
+// `baalda-staging://` (tauri.staging.conf.json overrides the deep-link schemes,
+// and staging-release.yml inlines VITE_DEEP_LINK_SCHEME to match). They HAVE to
+// differ: with both apps installed on one machine and both claiming `baalda://`,
+// the OS hands every link — a production invitation email included — to
+// whichever app registered the scheme last, which is how clicking a link from
+// the production server opened the Staging app.
+//
+// Parsers accept both schemes regardless of build. Being strict about the
+// scheme buys nothing (the OS already routed the link here) and would make a
+// link pasted between builds silently do nothing.
+
+/** The scheme this build registers and puts in links it constructs itself. */
+export const APP_SCHEME: string =
+  (import.meta.env.VITE_DEEP_LINK_SCHEME as string | undefined)?.trim() || "baalda";
+
+const ACCEPTED_PROTOCOLS = new Set(["baalda:", "baalda-staging:", `${APP_SCHEME}:`]);
+
+/** Is this `URL.protocol` (with its trailing colon) one of ours? */
+export function isAppProtocol(protocol: string): boolean {
+  return ACCEPTED_PROTOCOLS.has(protocol);
+}

--- a/app/apps/desktop/src/lib/inviteLink.ts
+++ b/app/apps/desktop/src/lib/inviteLink.ts
@@ -13,9 +13,10 @@
 // and the server re-checks it on accept; this module only routes.
 
 import { normalizeServerUrl } from "./auth/serverChoice";
+import { APP_SCHEME, isAppProtocol } from "./deepLinkScheme";
 
-/** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
-export const INVITE_SCHEME = "baalda";
+/** URL scheme this build registers (tauri.conf.json → deep-link; staging differs). */
+export const INVITE_SCHEME = APP_SCHEME;
 
 /**
  * The shape an invitation id may take. Better Auth emits UUIDs, but ids are
@@ -66,7 +67,7 @@ export function parseInviteDeepLink(url: string): InviteDeepLink | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== `${INVITE_SCHEME}:`) return null;
+  if (!isAppProtocol(parsed.protocol)) return null;
   const segments = [parsed.host, ...parsed.pathname.split("/")]
     .filter((s) => s.length > 0)
     .map((s) => decodeURIComponent(s));

--- a/app/apps/desktop/src/lib/ipc.ts
+++ b/app/apps/desktop/src/lib/ipc.ts
@@ -325,9 +325,12 @@ export const createFolder = (parent: string, name: string, expectedEpoch?: Vault
 // opened.
 export const renamePath = (from: string, to: string, expectedEpoch?: VaultEpoch) =>
   invoke<string>("rename_path", { from, to, expectedEpoch: expectedEpoch ?? null });
-/** Idempotent folder create — safe to call on every reconcile. */
+/** Idempotent folder create — safe to call on every reconcile. Resolves true
+ *  when THIS call created the directory (the watcher will echo it), false when
+ *  it already existed — including under another spelling on a case-insensitive
+ *  filesystem. */
 export const ensureFolder = (path: string, expectedEpoch?: VaultEpoch) =>
-  invoke<void>("ensure_folder", { path, expectedEpoch: expectedEpoch ?? null });
+  invoke<boolean>("ensure_folder", { path, expectedEpoch: expectedEpoch ?? null });
 /**
  * Move a note into `.context/trash/<stamp>/…` instead of deleting it, and return
  * the trash-relative destination. Used for remote deletes, so applying a
@@ -339,8 +342,9 @@ export const deletePath = (path: string, expectedEpoch?: VaultEpoch) =>
   invoke<void>("delete_path", { path, expectedEpoch: expectedEpoch ?? null });
 /**
  * Remove a folder the server has deleted — only if it is empty by now. Resolves
- * true when removed (or already gone); false when anything still lives inside,
- * in which case the folder stays, deliberately.
+ * true only when THIS call removed it (the watcher will echo that); false when
+ * it was already gone, or when anything still lives inside, in which case the
+ * folder stays, deliberately.
  */
 export const deleteFolderIfEmpty = (path: string, expectedEpoch?: VaultEpoch) =>
   invoke<boolean>("delete_folder_if_empty", { path, expectedEpoch: expectedEpoch ?? null });

--- a/app/apps/desktop/src/lib/shareLink.ts
+++ b/app/apps/desktop/src/lib/shareLink.ts
@@ -14,7 +14,9 @@
 // `setActiveOrganization` takes.
 
 /** URL scheme registered by the desktop app (tauri.conf.json → deep-link). */
-export const SHARE_SCHEME = "baalda";
+import { APP_SCHEME, isAppProtocol } from "./deepLinkScheme";
+
+export const SHARE_SCHEME = APP_SCHEME;
 
 export interface NoteLinkTarget {
   /** Better Auth organization id — the user-facing vault. */
@@ -64,7 +66,7 @@ export function parseNoteLink(url: string): NoteLinkTarget | null {
   } catch {
     return null;
   }
-  const isScheme = parsed.protocol === `${SHARE_SCHEME}:`;
+  const isScheme = isAppProtocol(parsed.protocol);
   const isWeb = parsed.protocol === "https:" || parsed.protocol === "http:";
   if (!isScheme && !isWeb) return null;
   // `baalda://note/<org>/<doc>` parses with host "note" and pathname

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
@@ -379,6 +379,41 @@ describe("SyncManager — ready.empty is the authority", () => {
     expect(engineHooks.refreshes).toBe(0); // nothing was truncated
   });
 
+  it("pushes a doc the server says this device is AHEAD on, despite the local checkpoint", async () => {
+    // The other way the checkpoint lies: the server HAS the note, but not all of
+    // it — this device holds ops (an edit typed offline, a push cut short) the
+    // server never received. `pushed` says done; the server's `ready.behind`
+    // outranks it. Before this, such a doc was badged synced forever, its edits
+    // never left the machine, and every connect re-delivered a 2-byte empty diff
+    // for it — 40 of them made one vault "sync 40 notes" on every reload.
+    fakeRegistry.mappedNotes.mockReturnValue([
+      { docId: "same", relPath: "Same.md" },
+      { docId: "ahead", relPath: "Ahead.md" },
+    ]);
+    fakeRegistry.pushed.add("same");
+    fakeRegistry.pushed.add("ahead");
+    const sm = new SyncManager();
+    await enable(sm);
+    engineHooks.settled = true;
+
+    // The server's `ready`: `behind` lands right before `empty`, as the engine
+    // delivers them.
+    engineHooks.opts!.onServerBehind?.(["ahead"]);
+    engineHooks.opts!.onServerEmpty?.([], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+
+    expect(connects.order).toEqual(["ahead"]);
+
+    // Confirmed by that push: the next `ready` that no longer names it queues
+    // nothing — no loop.
+    engineHooks.opts!.onServerBehind?.([]);
+    engineHooks.opts!.onServerEmpty?.([], false);
+    await sm.whenBulkSyncSettled();
+    await flush();
+    expect(connects.order).toEqual(["ahead"]);
+  });
+
   it("settles a server-empty doc whose local file is empty too - no push, ever", async () => {
     // The production loop behind "310 files re-syncing on every reload": the
     // vault holds hundreds of zero-byte placeholder notes. The server has no

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionBulkOrder.test.ts
@@ -662,6 +662,32 @@ describe("SyncManager.handleLocalFilesChanged", () => {
     vi.useRealTimers();
   });
 
+  it("ignores the watcher echo of a folder the pull itself created or removed — no pull chain", async () => {
+    // #98's engine. A pull created (or removed) a directory; the watcher reported
+    // it as a `tree` change; `tree` meant "structural, pull again"; that pull
+    // undid the first one's write… Each pass's own disk write requested the next,
+    // ~1.5 s apart, for days. The pull now remembers the folders it touches and
+    // their echo is consumed here, so no planner mistake can chain pulls again.
+    vi.useFakeTimers();
+    fakeRegistry.materialized = new Set(["Projects/Community/Content/pipeline"]);
+    const sm = new SyncManager();
+    await enable(sm);
+    fakeRegistry.pull.mockClear();
+
+    sm.handleLocalFilesChanged([{ path: "Projects/Community/Content/pipeline", kind: "tree" }]);
+    expect(sm.hasPendingRegistryPull()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fakeRegistry.pull).not.toHaveBeenCalled();
+    expect(fakeRegistry.materialized.size).toBe(0); // one echo, consumed
+
+    // The same path changing AGAIN is a real structural change and pulls.
+    sm.handleLocalFilesChanged([{ path: "Projects/Community/Content/pipeline", kind: "tree" }]);
+    expect(sm.hasPendingRegistryPull()).toBe(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fakeRegistry.pull).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
   it("the single-event form still routes exactly like one batch of one", async () => {
     vi.useFakeTimers();
     const sm = new SyncManager();

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -125,6 +125,59 @@ describe("planInbound — folders", () => {
     expect(p.removeFolders).toEqual([]);
   });
 
+  // The #98 heartbeat. Disk says `Projects/community`, the server says
+  // `Projects/Community` (a rename-by-case on one device, or migration 023
+  // merging case-duplicated rows), and the server holds an EMPTY folder under
+  // it. On a case-insensitive filesystem those are one directory, so neither
+  // half of the plan may act on the spelling alone — creating it and removing it
+  // alternated on every pull, forever, each pass re-triggering the next through
+  // the watcher.
+  it("treats a folder that differs from the server only by case as already present", () => {
+    const p = plan({
+      serverFolders: new Set(["Projects/Community", "Projects/Community/Content/pipeline"]),
+      localFolders: new Set(["Projects/community", "Projects/community/Content/pipeline"]),
+    });
+    expect(p.createFolders).toEqual([]);
+    expect(p.removeFolders).toEqual([]);
+  });
+
+  it("does not read a spelling disagreement as a remote MOVE of the folder", () => {
+    // The id recorded under the local spelling now "lives" at the server's
+    // spelling of the same directory. That is not a move: nothing to remove.
+    const p = plan({
+      localFolderIds: new Map([["Projects/community/Content/pipeline", "f-pipe"]]),
+      serverFolderIds: new Map([["f-pipe", "Projects/Community/Content/pipeline"]]),
+      localFolders: new Set(["Projects/community", "Projects/community/Content/pipeline"]),
+      serverFolders: new Set(["Projects/Community", "Projects/Community/Content/pipeline"]),
+    });
+    expect(p.removeFolders).toEqual([]);
+    expect(p.createFolders).toEqual([]);
+  });
+
+  it("still removes the old directory when the server moved the folder for real", () => {
+    // Guard against over-correcting: a genuine move (different name, not just
+    // different case) must keep working exactly as before.
+    const p = plan({
+      localFolderIds: new Map([["Projects/vid", "f1"]]),
+      serverFolderIds: new Map([["f1", "Archive/vid"]]),
+      localFolders: new Set(["Projects", "Projects/vid"]),
+      serverFolders: new Set(["Projects", "Archive", "Archive/vid"]),
+    });
+    expect(p.removeFolders).toEqual(["Projects/vid"]);
+  });
+
+  it("matches a tombstoned folder's local spelling against the server's re-creation case-insensitively", () => {
+    // Deleted under one spelling, re-created under another: same directory on
+    // disk, so the tombstone must not remove it.
+    const p = plan({
+      localFolderIds: new Map([["Archive", "old-id"]]),
+      folderTombstones: new Set(["old-id"]),
+      localFolders: new Set(["Archive"]),
+      serverFolders: new Set(["archive"]),
+    });
+    expect(p.removeFolders).toEqual([]);
+  });
+
   it("refuses an unsafe folder path", () => {
     const p = plan({ serverFolders: new Set([".context/evil", "../up", "ok"]) });
     expect(p.createFolders).toEqual(["ok"]);

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -84,7 +84,9 @@ function install(disk: FakeDisk) {
   vi.mocked(ipc.readNote).mockImplementation((async (p: string) =>
     disk.bodies.get(p) ?? "") as never);
   vi.mocked(ipc.ensureFolder).mockImplementation((async (p: string) => {
+    if (disk.folders.has(p)) return false; // already there — not a disk change
     disk.folders.add(p);
+    return true;
   }) as never);
   vi.mocked(ipc.writeNoteIfMissing).mockImplementation((async (p: string) => {
     if (disk.notes.has(p)) return false;
@@ -105,7 +107,7 @@ function install(disk: FakeDisk) {
     return to;
   }) as never);
   vi.mocked(ipc.deleteFolderIfEmpty).mockImplementation((async (p: string) => {
-    if (!disk.folders.has(p)) return true; // already gone — the goal state
+    if (!disk.folders.has(p)) return false; // already gone — nothing removed
     const prefix = p + "/";
     const occupied =
       [...disk.notes.keys()].some((n) => n.startsWith(prefix)) ||

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -334,6 +334,19 @@ export class SyncManager implements InboundHost {
    *  names, so another `hello` is owed once this run drains them. */
   private serverEmptyTruncated = false;
   /**
+   * docIds the SERVER says this device is AHEAD on (`ready.behind`): our
+   * manifest carries ops it has never received. Replaced on every `ready`.
+   *
+   * The second authority the run keys off, for the opposite failure of
+   * `serverEmpty`: the server HAS content, but not all of ours. `pushed` cannot
+   * see this either — an edit typed offline and never flushed, a push cut short
+   * by a failed mint — so the doc sat "synced" with local-only bytes while every
+   * connect re-delivered a 2-byte empty diff for it (the "40 notes syncing on
+   * every reload"). Named docs are queued exactly like `serverEmpty` ones; the
+   * per-doc socket's sync then carries the missing ops up.
+   */
+  private serverBehind = new Set<string>();
+  /**
    * Docs named by `ready.empty` whose LOCAL file is empty too — nothing anywhere.
    *
    * `ready.empty` is the authority on what the server lacks, but it cannot know
@@ -1030,6 +1043,7 @@ export class SyncManager implements InboundHost {
         this.localChanges.delete(d.docId);
         this.divergedDocs.delete(d.docId);
         this.serverEmpty.delete(d.docId);
+        this.serverBehind.delete(d.docId);
         this.emptyEverywhere.delete(d.docId);
         this.permanentFailures.delete(d.docId);
         this.progress?.forgetDoc(d.docId);
@@ -1210,6 +1224,7 @@ export class SyncManager implements InboundHost {
       markPushed: (docId) => {
         this.registry.markPushed(docId);
         this.divergedDocs.delete(docId); // its local-only ops are now on the server
+        this.serverBehind.delete(docId);
       },
       skip: (docId) => store.suppressedDoc() === docId,
       force: true,
@@ -1395,7 +1410,12 @@ export class SyncManager implements InboundHost {
     if (!progress) return;
     const open = this.docStore?.suppressedDoc() ?? null;
     for (const { docId } of this.registry.mappedNotes()) {
-      if (docId !== open && this.registry.isPushed(docId) && !this.serverEmpty.has(docId)) {
+      if (
+        docId !== open &&
+        this.registry.isPushed(docId) &&
+        !this.serverEmpty.has(docId) &&
+        !this.serverBehind.has(docId)
+      ) {
         progress.doc(docId, "synced");
       }
     }
@@ -1423,8 +1443,22 @@ export class SyncManager implements InboundHost {
           // fix — neither is work (see the field comments).
           !this.emptyEverywhere.has(n.docId) &&
           !this.permanentFailures.has(n.docId) &&
-          (!this.registry.isPushed(n.docId) || this.serverEmpty.has(n.docId)),
+          (!this.registry.isPushed(n.docId) ||
+            this.serverEmpty.has(n.docId) ||
+            this.serverBehind.has(n.docId)),
       );
+  }
+
+  /**
+   * A `ready` frame named the readable docs this device holds ops the server
+   * lacks for. Arrives right before the same frame's `empty` list, whose
+   * handler starts the run — so by then these are already in the work list.
+   * Also recorded as diverged: "file == doc" is not "nothing to send" for them.
+   */
+  private handleServerBehind(docIds: string[], scope: VaultScope): void {
+    if (!scope.isCurrent()) return;
+    this.serverBehind = new Set(docIds);
+    for (const docId of docIds) this.divergedDocs.add(docId);
   }
 
   /**
@@ -1776,7 +1810,9 @@ export class SyncManager implements InboundHost {
       // The server's word beats our checkpoint: a doc it holds no content for is
       // queued even when `pushed` claims it, which is the only way a note
       // stranded by a crashed run (or a restored `.context/`) is ever recovered.
-      include: (docId) => this.serverEmpty.has(docId),
+      // …or one it holds an incomplete copy of (`ready.behind`): the missing
+      // ops are on this device and nowhere else.
+      include: (docId) => this.serverEmpty.has(docId) || this.serverBehind.has(docId),
       // …and it goes FIRST. Those notes have nothing at all on the server, so if
       // the run is cut short they are the work that had to happen.
       priority: (docId) => this.serverEmpty.has(docId),
@@ -1784,6 +1820,7 @@ export class SyncManager implements InboundHost {
         this.registry.markPushed(docId);
         this.divergedDocs.delete(docId); // a confirmed push carries any merged ops
         this.serverEmpty.delete(docId); // the server has its content now
+        this.serverBehind.delete(docId); // …all of it
       },
       // Never touch the open note: its editor session owns a provider for that doc.
       skip: (docId) => store.suppressedDoc() === docId,
@@ -1995,6 +2032,7 @@ export class SyncManager implements InboundHost {
     // list would put ITS doc ids at the head of this vault's upload queue.
     this.serverEmpty.clear();
     this.serverEmptyTruncated = false;
+    this.serverBehind.clear();
     this.emptyEverywhere.clear();
     this.permanentFailures.clear();
     this.emptyProbe = null; // a probe still in flight sees a stale scope and drops
@@ -2272,6 +2310,9 @@ export class SyncManager implements InboundHost {
       // `ready`, so it also re-arms a run the uploader's failure streak paused.
       onServerEmpty: (docIds, truncated) =>
         this.handleServerEmpty(docIds, truncated, scope),
+      // Which readable docs THIS device holds ops the server lacks for. Fired
+      // right before `onServerEmpty`, so the run that starts sees them queued.
+      onServerBehind: (docIds) => this.handleServerBehind(docIds, scope),
     });
     this.vaultEngine.start();
     // Seed our own presence into the fresh engine (it flushes on `ready`).

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -780,6 +780,14 @@ export class SyncManager implements InboundHost {
         // the children never vanish at all. Nothing is deleted there; the pull
         // below reconciles the paths, and anything it re-materializes now comes
         // back WITH its content. Both outcomes are the safe direction.
+        //
+        // …unless the directory is one the pull itself just created or removed.
+        // That echo is not an external change, and treating it as one is how a
+        // pull that (wrongly) created a folder its successor removed became a
+        // self-sustaining loop: every pass's own disk write requested the next
+        // pass, ~1.5 s apart, for days (#98). The plan bug is fixed too, but no
+        // planner asymmetry may ever be able to chain pulls through us again.
+        if (this.registry.consumeMaterialized(relPath)) continue;
         pullRegistry = true;
         continue;
       }

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -273,8 +273,24 @@ export function planInbound(input: InboundInput): InboundPlan {
   // folder id, exactly like note tombstones) is what makes the delete provable;
   // without it, a device still holding the folder locally re-registered it on
   // its next pull and the deleted folder came back for the whole team.
+  //
+  // Every comparison here is case-insensitive, exactly like the notes below
+  // (`samePath`), because the filesystem is: on macOS and Windows
+  // `Projects/community` and `Projects/Community` are ONE directory. Comparing
+  // spellings instead of directories made a vault whose disk and server
+  // disagreed on one letter (a rename-by-case on one device, or migration 023
+  // merging case-duplicated rows) loop forever: `Content/pipeline` — an EMPTY
+  // server folder under the mis-cased parent — read as "missing locally", so
+  // pull N `ensureFolder`ed it (create_dir_all lands inside the existing
+  // directory regardless of case); the watcher's `tree` event requested pull
+  // N+1, which now saw the local spelling of that same id "moved" to the
+  // server's spelling and removed the empty directory again; the watcher
+  // requested pull N+2… One idle client pulled the whole registry (450 KB)
+  // every 1.5 s for days, with the sync badge blinking Syncing/Synced (#98).
+  const localFoldersCi = new Set([...input.localFolders].map((p) => p.toLowerCase()));
+  const serverFoldersCi = new Set([...input.serverFolders].map((p) => p.toLowerCase()));
   for (const path of input.serverFolders) {
-    if (input.localFolders.has(path)) continue;
+    if (localFoldersCi.has(path.toLowerCase())) continue;
     if (!isSafeFolderPath(path)) {
       plan.rejected.push({
         kind: "folder",
@@ -297,9 +313,10 @@ export function planInbound(input: InboundInput): InboundPlan {
   if (input.serverFolderIds && input.localFolderIds) {
     for (const [path, id] of input.localFolderIds) {
       const now = input.serverFolderIds.get(id);
-      if (now === undefined || now === path) continue;
-      if (!input.localFolders.has(path)) continue; // already gone locally
-      if (input.serverFolders.has(path)) continue; // re-created server-side
+      // A spelling disagreement is not a move: same directory on disk.
+      if (now === undefined || samePath(now, path)) continue;
+      if (!localFoldersCi.has(path.toLowerCase())) continue; // already gone locally
+      if (serverFoldersCi.has(path.toLowerCase())) continue; // re-created server-side
       if (!isSafeFolderPath(path)) continue;
       plan.removeFolders.push(path);
     }
@@ -311,8 +328,8 @@ export function planInbound(input: InboundInput): InboundPlan {
   if (input.folderTombstones && input.localFolderIds) {
     for (const [path, id] of input.localFolderIds) {
       if (!input.folderTombstones.has(id)) continue;
-      if (!input.localFolders.has(path)) continue; // already gone locally
-      if (input.serverFolders.has(path)) continue; // re-created server-side
+      if (!localFoldersCi.has(path.toLowerCase())) continue; // already gone locally
+      if (serverFoldersCi.has(path.toLowerCase())) continue; // re-created server-side
       if (!isSafeFolderPath(path)) {
         plan.rejected.push({
           kind: "folder",

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -843,8 +843,13 @@ export class VaultRegistry {
     for (const path of plan.createFolders) {
       if (this.stopRun()) break;
       try {
-        await ipc.ensureFolder(path, this.epoch());
-        changedDisk = true;
+        // Only a directory this call actually created is a disk change — and it
+        // is OUR change, so its watcher echo is remembered and consumed rather
+        // than read as an external edit that needs another pull (#98).
+        if (await ipc.ensureFolder(path, this.epoch())) {
+          changedDisk = true;
+          this.markMaterialized(path);
+        }
       } catch (e) {
         if (ipc.isVaultMismatch(e)) return none;
         this.recordFailure({
@@ -1013,7 +1018,10 @@ export class VaultRegistry {
       if (this.stopRun()) break;
       try {
         const removed = await ipc.deleteFolderIfEmpty(path, this.epoch());
-        if (removed) changedDisk = true;
+        if (removed) {
+          changedDisk = true;
+          this.markMaterialized(path); // our removal; one watcher echo to swallow
+        }
       } catch (e) {
         if (ipc.isVaultMismatch(e)) return { changedDisk, suppress: plan.suppress };
         this.recordFailure({
@@ -1677,8 +1685,11 @@ export class VaultRegistry {
           // says whether THIS pass created the file, so an existing real note is
           // never touched by the hydrate below.
           const created = await ipc.writeNoteIfMissing(rp, "", this.epoch());
-          mutated = true;
+          // A path that already held a file is not a change: claiming one made a
+          // pull with nothing to do report "changed" (and re-read the registry,
+          // and refresh the UI) on every pass it ran.
           if (created) {
+            mutated = true;
             // Remember it for one watcher echo, so the sync layer does not treat
             // our own placeholder as an external edit worth pushing.
             this.markMaterialized(rp);

--- a/app/apps/desktop/src/lib/sync/vaultProtocol.ts
+++ b/app/apps/desktop/src/lib/sync/vaultProtocol.ts
@@ -58,6 +58,20 @@ export type ServerControl =
       /** The server had more empty docs than it would name in one frame (cap
        *  2000), so another `hello` is needed to fetch the next batch. */
       emptyTruncated?: boolean;
+      /**
+       * Readable docIds for which OUR manifest ran ahead of the server: this
+       * device holds ops the server has never received (typed offline and never
+       * flushed, a push cut short, a mint that failed). The backfill is
+       * downstream-only, so these must be pushed over their per-doc sockets —
+       * whatever the local `pushed` checkpoint claims. Until the server said so,
+       * such a doc re-downloaded an empty diff on every connect (40 notes
+       * "syncing" on every reload of one vault) and its edits stayed local.
+       *
+       * Absent when there are none.
+       */
+      behind?: string[];
+      /** More than one frame would name (cap 2000). */
+      behindTruncated?: boolean;
     }
   | { t: "drop"; docId: string }
   | { t: "reauth" }
@@ -97,13 +111,16 @@ export function parseServerControl(text: string): ServerControl | null {
     // future one may widen it. Anything that isn't an array of non-empty strings
     // is dropped rather than trusted — a bad entry here would put a bogus docId
     // at the FRONT of the upload queue.
-    const empty = Array.isArray(o.empty)
-      ? o.empty.filter((d): d is string => typeof d === "string" && d.length > 0)
-      : null;
+    const ids = (v: unknown): string[] | null =>
+      Array.isArray(v) ? v.filter((d): d is string => typeof d === "string" && d.length > 0) : null;
+    const empty = ids(o.empty);
+    const behind = ids(o.behind);
     return {
       t: "ready",
       ...(empty && empty.length > 0 ? { empty } : {}),
       ...(o.emptyTruncated === true ? { emptyTruncated: true } : {}),
+      ...(behind && behind.length > 0 ? { behind } : {}),
+      ...(o.behindTruncated === true ? { behindTruncated: true } : {}),
     };
   }
   if (t === "reauth") return { t: "reauth" };

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -146,6 +146,13 @@ export interface VaultSyncEngineOptions {
    * pushed no matter what the local `pushed` checkpoint claims.
    */
   onServerEmpty?: (docIds: string[], truncated: boolean) => void;
+  /**
+   * The server found THIS device ahead on these readable docs (`ready.behind`):
+   * our manifest carries ops it has never received. Fired on every `ready`,
+   * right before {@link onServerEmpty}, so the content run that `ready` starts
+   * already has them queued.
+   */
+  onServerBehind?: (docIds: string[]) => void;
   /** Injected in tests. Defaults to the global WebSocket. */
   wsFactory?: WsFactory;
   /** Backoff bounds (ms). */
@@ -202,6 +209,7 @@ export class VaultSyncEngine {
   private readonly onInboundProgress?: (done: number, total: number) => void;
   private readonly onInboundIdle?: () => void;
   private readonly onServerEmpty?: (docIds: string[], truncated: boolean) => void;
+  private readonly onServerBehind?: (docIds: string[]) => void;
   private readonly wsFactory: WsFactory;
   private readonly inboundMaxBytes: number;
   private readonly baseMs: number;
@@ -269,6 +277,7 @@ export class VaultSyncEngine {
     this.onInboundProgress = opts.onInboundProgress;
     this.onInboundIdle = opts.onInboundIdle;
     this.onServerEmpty = opts.onServerEmpty;
+    this.onServerBehind = opts.onServerBehind;
     this.inboundMaxBytes = opts.inboundQueueMaxBytes ?? INBOUND_QUEUE_MAX_BYTES;
     this.wsFactory =
       opts.wsFactory ?? ((url) => new WebSocket(url) as unknown as WebSocketLike);
@@ -504,6 +513,7 @@ export class VaultSyncEngine {
         // BEFORE the idle signal: `maybeSignalIdle` is what starts the content
         // run, and a run that starts without this frame's `empty` list would
         // work from the stale one (or none at all on a first connect).
+        this.onServerBehind?.(control.behind ?? []);
         this.onServerEmpty?.(control.empty ?? [], control.emptyTruncated === true);
         // `ready` routinely arrives AFTER the last backfill frame has already been
         // applied, so this is the edge that settles the download phase. Checking

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -71,6 +71,12 @@ VAULT_SYNC_PATH=/vault-sync
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 
+# URL scheme of the desktop app that this server's pages (/open/*, /invite/:id,
+# /email-verified, /reset-password) hand off to. Leave unset for `baalda` (the
+# released app). A server behind the "Baalda Staging" app must say
+# `baalda-staging`, or its links open whichever app registered baalda:// last.
+# DEEP_LINK_SCHEME=baalda
+
 # --- Outbound email (password reset, sign-up verification, invitations) ---
 
 # Email is OFF unless configured, and every feature that needs it is then simply

--- a/app/apps/server/src/config.ts
+++ b/app/apps/server/src/config.ts
@@ -54,6 +54,15 @@ function int(name: string, fallback: number): number {
   return n;
 }
 
+/** `DEEP_LINK_SCHEME`, validated to the shape a URL scheme may take. */
+function deepLinkScheme(): string {
+  const v = optional("DEEP_LINK_SCHEME") ?? "baalda";
+  if (!/^[a-z][a-z0-9+.-]{0,63}$/.test(v)) {
+    throw new Error(`DEEP_LINK_SCHEME must be a URL scheme like "baalda" (got "${v}")`);
+  }
+  return v;
+}
+
 /** An env var that may be absent; empty string is treated as unset. */
 function optional(name: string): string | undefined {
   const v = process.env[name];
@@ -134,6 +143,14 @@ export const config = {
    *  on email+password alone. Set only via env (never committed). */
   googleClientId: optional("GOOGLE_CLIENT_ID"),
   googleClientSecret: optional("GOOGLE_CLIENT_SECRET"),
+  /**
+   * URL scheme of the desktop app this server's pages bounce into (`/open/*`,
+   * `/invite/:id`, `/email-verified`, `/reset-password`). The released app
+   * registers `baalda`; the Staging app registers `baalda-staging`, so a staging
+   * server must say so or its links open whichever app grabbed `baalda://` last
+   * on a machine that has both installed.
+   */
+  deepLinkScheme: deepLinkScheme(),
   // ---- Outbound email (issue #99) ----
   /** Sender address, e.g. `Baalda <no-reply@example.com>`. Required to send
    *  anything; with it and ONE transport below, password reset + sign-up

--- a/app/apps/server/src/http/routes/account-pages.ts
+++ b/app/apps/server/src/http/routes/account-pages.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { pool } from "../../db/pool.js";
 import { BRAND_NAME } from "../../brand.js";
+import { config } from "../../config.js";
 import { emailEnabled } from "../../email/mailer.js";
 import { esc, page } from "../pages.js";
 import { publicBaseUrl } from "./open-link.js";
@@ -30,12 +31,13 @@ const ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 
 /**
  * Deep links back into the desktop app (`lib/accountLink.ts` on the desktop
- * side). Neither carries data: `verified` makes the app re-read its session so
+ * side); the scheme is `DEEP_LINK_SCHEME` (staging apps register their own).
+ * Neither carries data: `verified` makes the app re-read its session so
  * the verified state appears without a reload; `signin` makes it re-check the
  * (now revoked) session and open the sign-in card.
  */
-const VERIFIED_DEEP_LINK = "baalda://verified";
-const SIGNIN_DEEP_LINK = "baalda://signin";
+const VERIFIED_DEEP_LINK = `${config.deepLinkScheme}://verified`;
+const SIGNIN_DEEP_LINK = `${config.deepLinkScheme}://signin`;
 
 function notAvailable() {
   return page({
@@ -226,7 +228,7 @@ accountPageRoutes.get("/invite/:id", async (c) => {
   }
 
   const server = publicBaseUrl(c);
-  const deepLink = `baalda://invite/${encodeURIComponent(id)}?server=${encodeURIComponent(server)}`;
+  const deepLink = `${config.deepLinkScheme}://invite/${encodeURIComponent(id)}?server=${encodeURIComponent(server)}`;
   const who = inv.inviterName?.trim() || "A teammate";
   const body = `
     <h1>Join ${esc(inv.organizationName)}</h1>

--- a/app/apps/server/src/http/routes/open-link.ts
+++ b/app/apps/server/src/http/routes/open-link.ts
@@ -37,7 +37,7 @@ openLinkRoutes.get("/open/note/:orgId/:docId", (c) => {
   }
   // Re-encoded on the way out even after the shape check, so the deep link is
   // inert as markup no matter what future id shapes are allowed through.
-  const deepLink = `baalda://note/${encodeURIComponent(orgId)}/${encodeURIComponent(docId)}`;
+  const deepLink = `${config.deepLinkScheme}://note/${encodeURIComponent(orgId)}/${encodeURIComponent(docId)}`;
   return c.html(`<!doctype html>
 <html lang="en">
 <head>
@@ -89,7 +89,7 @@ openLinkRoutes.get("/open/note/:orgId/:docId", (c) => {
  */
 openLinkRoutes.get("/open/connect", (c) => {
   const server = publicBaseUrl(c);
-  const deepLink = `baalda://connect?server=${encodeURIComponent(server)}`;
+  const deepLink = `${config.deepLinkScheme}://connect?server=${encodeURIComponent(server)}`;
   return c.html(`<!doctype html>
 <html lang="en">
 <head>

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -81,6 +81,9 @@ export interface VaultChannelDeps {
  *  ~1,100 per-subscriber ACL recomputes) and a handful. */
 export const REGISTRY_COALESCE_MS = 120;
 
+/** Most docs one `ready.behind` names — the same bound `ready.empty` uses. */
+export const BEHIND_CAP = 2000;
+
 export class VaultChannel {
   private readonly pubsub: PubSub;
   private readonly listReadableDocs: typeof listReadableDocsInVault;
@@ -471,12 +474,18 @@ class VaultConnection {
     } catch (err) {
       console.error("Vault channel empty-doc probe failed:", err);
     }
+    // Docs the backfill found this client AHEAD on — it holds ops the server has
+    // never received. Named so the client pushes them; the feed itself cannot.
+    const behind = this.behind;
+    const behindTruncated = this.behindTruncated;
     this.send({
       t: "ready",
       // Omitted when nothing is empty, so the common frame is byte-identical to
       // what every shipped client already parses.
       ...(empty.length > 0 ? { empty } : {}),
       ...(empty.length > 0 && emptyTruncated ? { emptyTruncated: true as const } : {}),
+      ...(behind.length > 0 ? { behind } : {}),
+      ...(behind.length > 0 && behindTruncated ? { behindTruncated: true as const } : {}),
     });
   }
 
@@ -588,8 +597,19 @@ class VaultConnection {
     return true;
   }
 
+  /**
+   * Docs whose backfill found the CLIENT ahead of the server (see
+   * `DocDiff.clientAhead`), collected during {@link backfill} and named on the
+   * `ready` that terminates it. Capped like `ready.empty`: one frame must stay
+   * bounded however large the vault.
+   */
+  private behind: string[] = [];
+  private behindTruncated = false;
+
   /** Stream missing ops for every readable doc, priority docs first. */
   private async backfill(manifest: Record<string, string>, priority: string[]): Promise<void> {
+    this.behind = [];
+    this.behindTruncated = false;
     const prioritized = priority.filter((d) => this.readable.has(d));
     const prioritySet = new Set(prioritized);
     const rest = [...this.readable].filter((d) => !prioritySet.has(d));
@@ -616,6 +636,10 @@ class VaultConnection {
     } catch (err) {
       console.error(`Vault channel backfill failed for ${docId}:`, err);
       return;
+    }
+    if (diff?.clientAhead) {
+      if (this.behind.length < BEHIND_CAP) this.behind.push(docId);
+      else this.behindTruncated = true;
     }
     if (!diff || diff.upToDate) return; // nothing new for this client
     this.sendBinary(encodeWsUpdate(docId, diff.update));

--- a/app/apps/server/src/sync/vault-protocol.ts
+++ b/app/apps/server/src/sync/vault-protocol.ts
@@ -75,13 +75,27 @@ export type ServerControl =
    * client's cue to seed from its own disk. `emptyTruncated` means the list hit
    * the server's cap and another pass is needed.
    *
-   * Both fields are OMITTED when nothing is empty, so the overwhelmingly common
-   * frame stays byte-identical to `{"t":"ready"}`. Old clients ignore unknown
-   * keys (`parseServerControl` switches on `t` and reads only what it knows),
-   * which is why this could be added without a capability flag — unlike a new
-   * *binary* frame, see {@link HelloFrame.caps}.
+   * `behind` names the readable docs for which the CLIENT'S manifest ran ahead
+   * of the server — it holds ops we have never received (an edit typed while
+   * offline and never flushed, a push cut short). The backfill is downstream
+   * only, so this is the client's cue to push those docs over their per-doc
+   * sockets; without it they stayed local forever while every connect
+   * re-delivered an empty diff for them (see `DocDiff.clientAhead`).
+   * `behindTruncated` means the list hit the cap.
+   *
+   * Every field is OMITTED when it has nothing to say, so the overwhelmingly
+   * common frame stays byte-identical to `{"t":"ready"}`. Old clients ignore
+   * unknown keys (`parseServerControl` switches on `t` and reads only what it
+   * knows), which is why these could be added without a capability flag —
+   * unlike a new *binary* frame, see {@link HelloFrame.caps}.
    */
-  | { t: "ready"; empty?: string[]; emptyTruncated?: true }
+  | {
+      t: "ready";
+      empty?: string[];
+      emptyTruncated?: true;
+      behind?: string[];
+      behindTruncated?: true;
+    }
   | { t: "drop"; docId: string } // access lost / doc removed -> client evicts
   | { t: "reauth" } // ACL changed in this vault -> client re-mints its open doc's token
   | { t: "registry" } // folders/notes structure changed -> client re-pulls the registry

--- a/app/apps/server/src/yjs/persistence.ts
+++ b/app/apps/server/src/yjs/persistence.ts
@@ -90,7 +90,58 @@ function mergeParts(
 export interface DocDiff {
   update: Uint8Array;
   serverStateVector: Uint8Array;
+  /** The client already holds every op the server has; `update` is empty. */
   upToDate: boolean;
+  /**
+   * The CLIENT holds ops the server has never seen — its state vector runs past
+   * ours for at least one client id. Nothing here can fetch those (this is a
+   * downstream feed), so the vault channel names such docs on `ready.behind`
+   * and the client pushes them over its per-doc socket.
+   *
+   * This is also why `upToDate` is "covered", not "equal": a client that is
+   * strictly ahead has NOTHING to receive, and treating the unequal vectors as
+   * "behind" shipped it a 2-byte empty diff on every connect — 40 docs holding
+   * unpushed edits made one vault re-download "40 notes" on every reload,
+   * forever, while the edits themselves never went anywhere.
+   */
+  clientAhead: boolean;
+}
+
+/**
+ * How a client's state vector relates to the server's. `serverCovered` means
+ * the client has at least the server's clock for every client id the server
+ * knows (the backfill diff would be empty); `clientAhead` means the client has a
+ * clock the server lacks (it holds ops we have never received). Both can be true.
+ * A vector that fails to decode is treated as unknown: not covered, not ahead —
+ * the caller then ships the full diff, which is the safe direction.
+ */
+export function compareStateVectors(
+  client: Uint8Array,
+  server: Uint8Array,
+): { serverCovered: boolean; clientAhead: boolean } {
+  let c: Map<number, number>;
+  let s: Map<number, number>;
+  try {
+    c = Y.decodeStateVector(client);
+    s = Y.decodeStateVector(server);
+  } catch {
+    return { serverCovered: false, clientAhead: false };
+  }
+  let serverCovered = true;
+  for (const [id, clock] of s) {
+    if ((c.get(id) ?? 0) < clock) {
+      serverCovered = false;
+      break;
+    }
+  }
+  let clientAhead = false;
+  for (const [id, clock] of c) {
+    if ((s.get(id) ?? 0) < clock) {
+      clientAhead = true;
+      break;
+    }
+  }
+  return { serverCovered, clientAhead };
 }
 
 export async function loadDocDiff(
@@ -120,7 +171,18 @@ export async function loadDocDiff(
   } else if (row.state_vector && !row.pending && clientStateVector) {
     const serverStateVector = new Uint8Array(row.state_vector);
     if (bytesEqual(clientStateVector, serverStateVector)) {
-      return { update: new Uint8Array(0), serverStateVector, upToDate: true };
+      return { update: new Uint8Array(0), serverStateVector, upToDate: true, clientAhead: false };
+    }
+    // Unequal is not "behind": a client that is a superset of us has nothing to
+    // receive either, and the probe can say so without touching the snapshot.
+    const cmp = compareStateVectors(clientStateVector, serverStateVector);
+    if (cmp.serverCovered) {
+      return {
+        update: new Uint8Array(0),
+        serverStateVector,
+        upToDate: true,
+        clientAhead: cmp.clientAhead,
+      };
     }
   }
   // Fall through: uncompacted doc, a pre-`state_vector` snapshot row (the column
@@ -140,14 +202,18 @@ export async function loadDocDiff(
 
   const merged = mergeParts(snapshotBuf, updates.rows);
   const serverStateVector = Y.encodeStateVectorFromUpdate(merged);
-  const upToDate =
-    clientStateVector != null && bytesEqual(clientStateVector, serverStateVector);
+  const cmp = clientStateVector
+    ? bytesEqual(clientStateVector, serverStateVector)
+      ? { serverCovered: true, clientAhead: false }
+      : compareStateVectors(clientStateVector, serverStateVector)
+    : { serverCovered: false, clientAhead: false };
+  const upToDate = cmp.serverCovered;
   const update = upToDate
     ? new Uint8Array(0)
     : clientStateVector
       ? Y.diffUpdate(merged, clientStateVector)
       : merged;
-  return { update, serverStateVector, upToDate };
+  return { update, serverStateVector, upToDate, clientAhead: cmp.clientAhead };
 }
 
 /**

--- a/app/apps/server/tests/persistence.test.ts
+++ b/app/apps/server/tests/persistence.test.ts
@@ -290,6 +290,51 @@ describe("loadDocDiff (vault-channel backfill)", () => {
     expect(diff!.serverStateVector).toEqual(Y.encodeStateVector(doc));
   });
 
+  it("a client that is AHEAD of the server is up to date, not behind — and is named as ahead", async () => {
+    // One vault re-downloaded "40 notes" on every reload: each held an edit the
+    // server had never received, so the vectors were unequal, so the diff was
+    // computed — and it was EMPTY (2 bytes), applied to nothing, and computed
+    // again on the next connect. Unequal is not behind; covered is up to date.
+    const doc = await seedDoc("shared");
+    await compact(DOC, pool); // probe path: state_vector present, log empty
+
+    const client = new Y.Doc();
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(doc));
+    client.getText("content").insert(6, " + local only"); // never reached the server
+    const aheadSv = Y.encodeStateVector(client);
+
+    const { db, sql } = countingDb();
+    const diff = await loadDocDiff(DOC, aheadSv, db);
+    expect(diff!.upToDate).toBe(true);
+    expect(diff!.update.length).toBe(0);
+    expect(diff!.clientAhead).toBe(true);
+    // Answered by the probe: the snapshot BYTEA was never read for it.
+    expect(sql.some((q) => q.includes(SNAPSHOT_READ))).toBe(false);
+
+    // The slow path (a pending logged update) reaches the same verdict, and a
+    // client that is BOTH ahead and behind gets the ops it lacks plus the flag.
+    const later: Uint8Array[] = [];
+    doc.on("update", (u: Uint8Array) => later.push(u));
+    doc.getText("content").insert(0, "# ");
+    for (const u of later) await appendUpdate(DOC, u, pool, 1000);
+    const both = await loadDocDiff(DOC, aheadSv);
+    expect(both!.upToDate).toBe(false);
+    expect(both!.clientAhead).toBe(true);
+    Y.applyUpdate(client, both!.update);
+    expect(client.getText("content").toString()).toBe("# shared + local only");
+  });
+
+  it("an equal or merely behind client is not `clientAhead`", async () => {
+    const doc = await seedDoc("base");
+    const equal = await loadDocDiff(DOC, Y.encodeStateVector(doc));
+    expect(equal!.upToDate).toBe(true);
+    expect(equal!.clientAhead).toBe(false);
+    const behind = await loadDocDiff(DOC, Y.encodeStateVector(new Y.Doc()));
+    expect(behind!.upToDate).toBe(false);
+    expect(behind!.clientAhead).toBe(false);
+    expect((await loadDocDiff(DOC, null))!.clientAhead).toBe(false);
+  });
+
   it("a client with no state vector gets the full state", async () => {
     const doc = await seedDoc("# Full\nbody");
     const diff = await loadDocDiff(DOC, null);

--- a/app/apps/server/tests/vault-channel-reauth.test.ts
+++ b/app/apps/server/tests/vault-channel-reauth.test.ts
@@ -67,6 +67,7 @@ function channelWith(readable: () => Set<string>): {
       update: new Uint8Array([docId.charCodeAt(0)]),
       serverStateVector: new Uint8Array(),
       upToDate: false,
+      clientAhead: false,
     }),
     listEmpty: async () => ({ empty: [] as string[], truncated: false }),
     backfillConcurrency: 4,

--- a/app/apps/server/tests/vault-channel.test.ts
+++ b/app/apps/server/tests/vault-channel.test.ts
@@ -70,7 +70,12 @@ class FakeWs extends EventEmitter {
 }
 
 function diffFor(docId: string): DocDiff {
-  return { update: new Uint8Array([docId.charCodeAt(0)]), serverStateVector: new Uint8Array(), upToDate: false };
+  return {
+    update: new Uint8Array([docId.charCodeAt(0)]),
+    serverStateVector: new Uint8Array(),
+    upToDate: false,
+    clientAhead: false,
+  };
 }
 
 async function waitFor(fn: () => boolean, ms = 1000): Promise<void> {
@@ -91,6 +96,7 @@ const noEmpty = async () => ({ empty: [] as string[], truncated: false });
 function channelWith(
   readable: () => Set<string>,
   listEmpty: VaultChannelDeps["listEmpty"] = noEmpty,
+  loadDiff: (docId: string) => Promise<DocDiff | null> = async (docId) => diffFor(docId),
 ): { channel: VaultChannel; pubsub: InMemoryPubSub } {
   const pubsub = new InMemoryPubSub();
   pubsubs.push(pubsub);
@@ -101,7 +107,7 @@ function channelWith(
       return { userId: "u1", vaultId: "v1" };
     },
     listReadableDocs: async () => readable(),
-    loadDiff: async (docId: string) => diffFor(docId),
+    loadDiff: loadDiff as VaultChannelDeps["loadDiff"],
     listEmpty,
     backfillConcurrency: 4,
   });
@@ -544,6 +550,30 @@ describe("ready.empty (server-side-empty notes)", () => {
     );
     const ws = await connectAndWait(channel);
     expect(readyFrame(ws)).toEqual({ t: "ready" });
+  });
+
+  it("names the docs the backfill found the CLIENT ahead on (`behind`), and sends them no frame", async () => {
+    // "B" is a doc this device holds unpushed ops for: the server's copy is a
+    // strict subset, so there is nothing to send down — but the client has to be
+    // told to push, or those ops stay on one machine forever while every connect
+    // re-computes an empty diff for the doc (the 40-notes-per-reload bug).
+    const { channel } = channelWith(
+      () => new Set(["A", "B"]),
+      noEmpty,
+      async (docId) =>
+        docId === "B"
+          ? { update: new Uint8Array(0), serverStateVector: new Uint8Array(), upToDate: true, clientAhead: true }
+          : diffFor(docId),
+    );
+    const ws = await connectAndWait(channel);
+    expect(readyFrame(ws)).toEqual({ t: "ready", behind: ["B"] });
+    expect(ws.updates().map((u) => u.docId)).toEqual(["A"]);
+  });
+
+  it("omits `behind` when no client is ahead — the common frame is unchanged", async () => {
+    const { channel } = channelWith(() => new Set(["A"]));
+    const ws = await connectAndWait(channel);
+    expect("behind" in readyFrame(ws)!).toBe(false);
   });
 
   it("sends `ready` after the backfill frames, never before", async () => {

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -282,6 +282,7 @@ confirm `/health` and a real sync round-trip, then promote.
 | `POLAR_SERVER` | no | `sandbox` | `sandbox` or `production` Polar environment. |
 | `FREE_MAX_VAULTS` | no | `3` | Free-tier cap on unsubscribed vaults per user (only enforced when billing is enabled). |
 | `FREE_MAX_MEMBERS` | no | `3` | Free-tier cap on members + pending invitations per unsubscribed vault (only enforced when billing is enabled). Gates new invitations and join-code redemptions only; lowering it never removes existing members. |
+| `DEEP_LINK_SCHEME` | no | `baalda` | URL scheme of the desktop app the server's pages bounce into. Set `baalda-staging` on the server behind the Staging app so production and staging links open the right app on a machine that has both. |
 | `EMAIL_FROM` | for email | unset | **Outbound email (optional).** Sender address, e.g. `Baalda <no-reply@example.com>`. With this and ONE transport below, password reset ("Forgot password?"), sign-up verification and invitation emails switch on. Unset ⇒ email off and none of those is offered (invitations are shared as a link instead). |
 | `SMTP_URL` | one transport | unset | Any SMTP server: `smtp://user:pass@host:587` (STARTTLS) or `smtps://user:pass@host:465` (TLS). |
 | `RESEND_API_KEY` | one transport | unset | [Resend](https://resend.com) API key — the HTTPS alternative to SMTP. |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,1 +1,1 @@
-- Forgot password? by email, invitation emails with one-click join, and clearer sign-up and invite feedback
+- Fixed the sync badge flickering forever and re-syncing the same notes on every reload; edits that were stuck on one device now upload automatically


### PR DESCRIPTION
Promotes `staging` to production. Merge with **Create a merge commit**, then fast-forward `staging` onto `main`.

Contents since v0.1.52:
- #105 — Staging app gets its own `baalda-staging://` scheme.
- #106 — Fixes #98: case-insensitive folder planning (the pull loop / flickering badge), `ready.behind` so notes the client is ahead on are pushed instead of re-downloaded as empty diffs on every connect, and echo hardening so the app's own folder writes can never chain registry pulls.
- #107 — Release v0.1.53 version bump + release notes.

The server half (`loadDocDiff` covered-vs-equal + `ready.behind`) deploys with this merge via Railway; old clients ignore the new `ready` field.