### PR TITLE
Subscription lifecycle: cancel-first vault delete, tombstones, transfer, Subscriptions list (#109 #110 #111)

### DIFF
--- a/.claude/skills/baalda-guide/SKILL.md
+++ b/.claude/skills/baalda-guide/SKILL.md
@@ -92,6 +92,9 @@ That is about 110 words. It names every format asked about, says what does not w
   limits; the managed service is free up to 3 vaults per user and 3 members per vault, then Pro
   at $10 per vault per month or $97 per year, bought in-app under Vault Settings → Billing. Do not
   say "early access" or "contact us for pricing"; that wording on the website is out of date.
+- "What if I delete a paid vault?" Billing stops at the end of the period already paid for, and
+  the subscription can be transferred to another vault the owner has (Vault Settings → Billing).
+  One vault holds at most one subscription. See `faq.md`.
 - "Is there a mobile / web app?" No. iOS is planned; public links open read-only in a browser.
 - "Does it have AI built in?" It has an AI *connection point* (MCP) and works with any local
   agent; it ships no model and no chat panel.

--- a/.claude/skills/baalda-guide/evals/evals.json
+++ b/.claude/skills/baalda-guide/evals/evals.json
@@ -42,6 +42,33 @@
         "Gives at least one concrete in-app location (e.g. right-click → Share, Vault Settings → MCP)",
         "Under 300 words"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "I deleted my paid Baalda vault last week and started a fresh one. Am I still being charged, and can I just move the subscription over instead of paying again?",
+      "expected_output": "Billing was set to stop at the end of the already-paid period when the vault was deleted, so no new charge; the subscription is kept under Vault Settings → Billing → \"From deleted vaults\" and Transfer moves it to another vault the person owns that is not already on Pro, at the same price and period, and it starts renewing again.",
+      "files": [],
+      "assertions": [
+        "Says deleting the vault stopped the billing at the end of the period already paid for, not immediately",
+        "Says the subscription can be transferred to the new vault instead of buying again",
+        "Names the in-app location: Vault Settings → Billing, under \"From deleted vaults\", Transfer",
+        "States that the target vault must be one they own and not already on Pro",
+        "Does not claim a refund is issued",
+        "Under 250 words"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Two admins on my vault both clicked Upgrade to Pro. Are we paying twice, and what happens if the payment provider is down when I try to delete a vault?",
+      "expected_output": "No double charge: a vault can hold only one subscription and a second checkout is refused. If the payment provider cannot be reached to stop billing, the vault is not deleted at all and the app shows the error.",
+      "files": [],
+      "assertions": [
+        "Says a vault can have only one subscription and the second purchase is refused",
+        "Says deleting a Pro vault cancels the subscription at the end of the current period first",
+        "Says that if the provider cannot be reached the vault is not deleted and an error is shown",
+        "Points at Vault Settings → Billing for checking the current plan",
+        "Does not use the words CRDT, Yjs, or Hocuspocus"
+      ]
     }
   ]
 }

--- a/.claude/skills/baalda-guide/references/faq.md
+++ b/.claude/skills/baalda-guide/references/faq.md
@@ -14,12 +14,32 @@ free forever, and you can run your own server for free with no limits. The manag
 vault. Past that, upgrade a vault to Pro from inside the app.
 
 ## What does the paid plan cost, and can my team start today?
-Yes, today. Sign up in the app, turn on sync, invite the team. The free tier already covers a
-team of up to 10 in one vault. When you need more members or more vaults, go to Vault Settings →
+Yes, today. Sign up in the app, turn on sync, invite the team. The free tier covers 3 people per
+vault and 3 vaults per person. When you need more members or more vaults, go to Vault Settings →
 Billing → Upgrade to Pro: $10 per vault per month or $97 per vault per year, priced per vault,
 not per person, with unlimited members. Only the vault owner or an admin pays; everyone else just
 needs a free account. baalda.com/pricing is the place to ask questions or talk to the team, but
 nobody has to wait for a call to get started.
+
+## What happens to my subscription if I delete a vault?
+Deleting the vault stops the billing, but not mid-month: it is set to finish at the end of the
+period you have already paid for, so there is no further charge and no refund needed. If Baalda
+cannot reach the payment provider to do that, it refuses to delete the vault and shows you the
+error, so you never end up paying for something that is gone. The subscription stays visible
+under Vault Settings → Billing → "From deleted vaults", where you can move it to another vault,
+cancel it straight away, or open the billing portal.
+
+## I deleted my Pro vault and made a new one. Can I move the subscription?
+Yes. Open Vault Settings → Billing, find it under "From deleted vaults", and choose **Transfer**.
+Pick the new vault (it has to be one you own that is not already on Pro) and it takes over the
+same price and the same billing period. Because the old vault was deleted, the subscription had
+been set to stop at the end of the period; transferring it starts it renewing again on the new
+vault. Only the owner can do this.
+
+## Can one vault have two subscriptions?
+No. A vault is either Free or on one Pro subscription. If you try to buy Pro for a vault that
+already has it, Baalda refuses instead of charging you twice. If you want to change how you pay
+(monthly to yearly, say), use "Manage subscription" to open the billing portal.
 
 ## I forgot my password.
 On the sign-in screen choose **Forgot password?**, enter your email, and follow the link we

--- a/.claude/skills/baalda-guide/references/features.md
+++ b/.claude/skills/baalda-guide/references/features.md
@@ -37,6 +37,11 @@ collaborative apps (Notion, Confluence) keep your data in their database. Baalda
   for teams under about 50 people editing at once. Quote the measured numbers to a buyer.
 - **Freeze vault root**: a setting that stops anyone, including owners, from adding new items at
   the top level once the structure is settled.
+- **Deleting a vault** is the owner's call and it is permanent on the server: the notes, the
+  history and everyone's access go. Your own `.md` files stay on your disk unless you also
+  choose to move the folder to the Trash. If the vault is on Pro, deleting it also stops the
+  subscription (see "Hosting options"); if that step fails, nothing is deleted and Baalda shows
+  the error.
 
 ## Writing
 
@@ -177,6 +182,22 @@ collaborative apps (Notion, Confluence) keep your data in their database. Baalda
   - **How to buy**: Vault Settings → Billing → Upgrade to Pro (owners and admins). Checkout opens
     in the browser; the app flips to Pro as soon as payment lands. "Manage subscription" opens the
     billing portal for invoices, plan changes and cancellation.
+  - **One subscription per vault.** A vault that is already on Pro cannot be bought a second
+    time; the app refuses the checkout instead of charging twice.
+  - **Your subscriptions in one place**: Vault Settings → Billing lists every vault you are in —
+    plan, status, renewal date and price, how many people are in it, and who looks after billing.
+    It also says how many of your 3 free vaults are in use. The tab opens even when the vault you
+    have open is a local one.
+  - **Deleting a Pro vault stops the billing**, at the end of the period you already paid for:
+    no further charges, and the paid time is not cut short. If the payment provider cannot be
+    reached, the vault is *not* deleted and the app tells you why. The subscription itself is
+    kept in a "From deleted vaults" list so you can still move it, cancel it outright, or open
+    the billing portal for it.
+  - **Move a subscription to another vault** (owners only): Vault Settings → Billing → Transfer,
+    from a live vault or from one in "From deleted vaults". The target has to be a vault you own
+    that is not already on Pro. Same price, same billing period; if the subscription had been set
+    to end because its vault was deleted, transferring makes it renew again. The vault it came
+    from drops to Free.
   - The public pricing page (baalda.com/pricing) may still describe the Team plan as early access
     or "talk to us". The app is ahead of the page: tell people they can upgrade in-app now, and
     to use the pricing page as the contact route if they want to talk first.

--- a/.claude/skills/baalda-guide/references/sources.md
+++ b/.claude/skills/baalda-guide/references/sources.md
@@ -63,6 +63,7 @@ Do a targeted read of one file, never a sweep. Good entry points:
 | Drag-drop / paste attachment behaviour | `app/apps/desktop/src/lib/attachments.ts` |
 | Server limits and free-tier caps | `app/apps/server/src/config.ts`, `app/apps/server/.env.example` |
 | Paid plan prices and checkout | `app/apps/server/src/http/routes/billing.ts`, `app/apps/desktop/src/components/UpgradeDialog.tsx` |
+| Subscription state, cancel/transfer, deleted-vault tombstones | `app/apps/server/src/billing/store.ts`, `app/apps/server/migrations/024_subscription_tombstones.sql` |
 | Attachment size limit | `app/apps/server/src/http/routes/blobs.ts` |
 | Permission rules | `app/apps/server/src/permissions/resolver.ts` |
 | MCP tools list | `app/apps/server/src/mcp/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,10 +214,18 @@ flow through the same sync server via `createDocWriter` so AI edits persist/broa
   roles owner/admin/member; 48h invitations). Session token is
   opaque (instant revocation), stored client-side only in the OS keychain.
 - `http/routes/` — `registry` (vaults/folders/notes/files), `shares` (folder/file ACL), `orgs` (join codes),
-  `graph` (nodes/edges + semantic search), `sync-token`, `blobs` (attachment store), `mcp`,
+  `graph` (nodes/edges + semantic search), `sync-token`, `blobs` (attachment store), `mcp`, `billing`,
   `public-links` (`/api/notes/:docId/public-link` mint/inspect/revoke + public `GET /p/:token`
   read-only page — token is the capability; renders via the escape-first `render/note-html.ts`,
   no renderer deps).
+- `billing/` — Polar behind `provider.ts`; `store.ts` is the ONLY writer of a `subscriptions` row and
+  always persists the provider's returned state. One vault = one subscription (409 `already_subscribed`).
+  Deleting a vault cancels **at period end first** and aborts the delete if the provider refuses (502
+  `subscription_cancel_failed`; Better Auth's own org-delete is off via `disableOrganizationDeletion`).
+  The row then outlives the org as a **tombstone** — migration 024 dropped the cascade and added
+  `deleted_at`/`org_name`/`owner_user_id` — so a late webhook is stored, not FK-failed and retried
+  forever. Webhooks resolve by `provider_subscription_id` first, then metadata, which is what lets
+  `POST /api/billing/orgs/:orgId/transfer` (owner; un-cancels at Polar) move one; `/mine` reconciles.
 - `sync/hocuspocus.ts` — `onAuthenticate` verifies the per-doc JWT & sets `readOnly` for view grants;
   `onChange` appends the binary update + schedules re-index. `disconnectDoc` force-closes sockets on revoke.
 - `yjs/persistence.ts` — binary-only store: `doc_updates` append log + `doc_snapshots` (compact past

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -5540,6 +5540,52 @@ button.secondary:disabled {
   margin-top: var(--sp-1);
 }
 
+/* ---- Subscriptions list (#109) ----
+   A `.member-list` row that has to carry a second line (renewal, price, seats)
+   under the vault name, so its name cell stops being one ellipsised span.
+   Everything else on the row is the existing pill and action vocabulary. */
+.billing-sub-row {
+  align-items: flex-start;
+}
+.billing-sub-name {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  color: var(--text-primary);
+}
+.billing-sub-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.billing-sub-meta {
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+/* Up to three actions plus two pills — more than the vault list carries. Let
+   them wrap rather than squeeze the vault name down to an ellipsis. */
+.billing-sub-row .vault-row-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.billing-transfer-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+}
+/* Vault names are names: the role menu's `capitalize` would rewrite them. */
+.context-menu.billing-transfer-menu li {
+  text-transform: none;
+}
+/* One line of prose introducing a section's list. */
+.billing-section-note {
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: var(--lh-body);
+}
+
 /* ============================================================
    Upgrade dialog — first-class plan-selection surface
    ============================================================ */

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -3,13 +3,22 @@ import {
   type McpToolInfo,
   type McpTokenRow,
   type Member,
+  type MyBillingVault,
+  type OrgBilling,
   type VaultCheckpoint,
 } from "../lib/api";
 import { toast } from "../lib/toast";
 import { agoFromIso, checkpointTitle, noteCountLabel } from "./versionFormat";
 import { ITEM_COLORS, itemColorValue } from "../lib/appearance";
 import { authManager } from "../lib/auth/authManager";
-import { classifyLimitError, type LimitKind, limitFromError } from "../lib/billing";
+import {
+  classifyLimitError,
+  type LimitKind,
+  limitFromError,
+  planPillLabel,
+  subscriptionStatusLine,
+  transferTargets,
+} from "../lib/billing";
 import * as ipc from "../lib/ipc";
 import type { RecentVault } from "../lib/ipc";
 import {
@@ -32,13 +41,15 @@ import { AccessPanel } from "./AccessPanel";
 import { AccountSettings } from "./AccountSettings";
 import { AsyncButton } from "./AsyncButton";
 import { AuthDialog } from "./AuthDialog";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { MenuSelect } from "./MenuSelect";
 import { canActOnMember } from "./memberRoles";
 import { RoleSelect } from "./RoleSelect";
 import { Avatar, SyncBadge } from "./Identity";
 import { SettingsModal } from "./SettingsModal";
 import { Switch } from "./Switch";
 import { ThemeToggle } from "./ThemeToggle";
-import { UpgradeDialog } from "./UpgradeDialog";
+import { formatPrice, perLabel, UpgradeDialog } from "./UpgradeDialog";
 
 // The sign-in modal moved to its own file when it grew a server-choice step
 // (#91). It has three mount sites that import it from here, so it is
@@ -802,9 +813,14 @@ type SettingsTab =
 
 // Sections that only make sense once the vault is synced to an org. On a
 // local vault they're shown but locked, with a "Turn on sync" gate.
+//
+// Billing is deliberately NOT one of them (#109). Someone working in a local
+// folder can still own vaults that are billing, and a subscription left behind
+// by a DELETED vault has to be reachable from somewhere or the money is
+// unrecoverable. Only the per-vault card at the top of that tab needs a synced
+// vault, and it says so itself.
 const TEAM_TABS = new Set<SettingsTab>([
   "members",
-  "billing",
   "access",
   "mcp",
   "versioning",
@@ -1043,7 +1059,7 @@ function VaultSettingsDialog({
           ) : tab === "members" ? (
             <MembersTab canManage={canManage} />
           ) : tab === "billing" ? (
-            <BillingTab canManage={canManage} />
+            <BillingTab canManage={canManage} isSynced={isSynced} />
           ) : tab === "access" ? (
             <AccessPanel canManage={canManage} />
           ) : tab === "mcp" ? (
@@ -1319,6 +1335,7 @@ function VaultsTab() {
   const members = useStore((s) => s.members);
   const vault = useStore((s) => s.vault);
   const syncEnabled = useStore((s) => s.syncEnabled);
+  const billingEnabled = useStore((s) => s.billingConfig?.enabled === true);
   // Bumped after a local remove/delete so the recents list re-fetches.
   const [localsNonce, setLocalsNonce] = useState(0);
   const locals = useLocalVaults(localsNonce);
@@ -1334,6 +1351,12 @@ function VaultsTab() {
   const [busy, setBusy] = useState(false);
   // orgId whose permanent deletion is awaiting a second confirming click.
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  // A vault that is actually PAYING, whose deletion needs the full dialog
+  // instead: the two-click row has nowhere to say what happens to the money
+  // (#111). Its billing snapshot rides along so the copy can name the date.
+  const [subDelete, setSubDelete] = useState<
+    { orgId: string; name: string; billing: OrgBilling } | null
+  >(null);
   // local-vault path whose file deletion is awaiting a second confirming click.
   const [confirmDeleteLocal, setConfirmDeleteLocal] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -1415,17 +1438,61 @@ function VaultsTab() {
     }
   };
 
-  // Permanently delete a vault everywhere (owner only, two-click confirm).
+  /**
+   * Ask before deleting. A vault that is actually paying gets the full
+   * ConfirmDialog, because "Delete everything?" cannot say the one thing its
+   * owner needs to know: the subscription stops at the END of the current
+   * period, and until then it can be moved to another vault (#111). Every
+   * other vault keeps today's two-click row.
+   *
+   * A billing lookup that fails is treated as free — an unreachable billing
+   * endpoint must not block a delete the user is entitled to make.
+   */
+  const askDelete = async (orgId: string, name: string) => {
+    setActionError(null);
+    if (!billingEnabled) {
+      setConfirmDelete(orgId);
+      return;
+    }
+    let billing: OrgBilling | null = null;
+    try {
+      billing = await authManager.api.getOrgBilling(orgId);
+    } catch {
+      billing = null;
+    }
+    if (billing && (billing.status === "active" || billing.status === "past_due")) {
+      setSubDelete({ orgId, name, billing });
+    } else {
+      setConfirmDelete(orgId);
+    }
+  };
+
+  // Permanently delete a vault everywhere (owner only, confirmed above).
   const deletePermanently = async (orgId: string) => {
     if (busy) return;
     setBusy(true);
     setActionError(null);
     try {
-      await useStore.getState().deleteRemoteVault(orgId);
+      const result = await useStore.getState().deleteRemoteVault(orgId);
       setBound(readOrgVaults());
       setConfirmDelete(null);
+      setSubDelete(null);
+      if (result.subscription) {
+        // Neutral, not success: the vault is gone, but the user is still paying
+        // for the rest of the period and that time is recoverable.
+        const ends = result.subscription.currentPeriodEnd;
+        toast(
+          ends
+            ? `Vault deleted. Pro ends on ${formatDate(ends)} — move it from Billing if you want to keep it.`
+            : "Vault deleted. Pro ends when the current period does — move it from Billing if you want to keep it.",
+          "neutral",
+        );
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
+      // Covers the 502 `subscription_cancel_failed` case: the server's message
+      // rides `ApiError.message`, and NOTHING was deleted. The dialog stays
+      // open (only success clears it) so the error has somewhere to show.
       setActionError(message);
       // Destructive path: a failure here must never look like a success (#85).
       toast(`Couldn't delete the vault — ${message}`, "error");
@@ -1590,17 +1657,14 @@ function VaultsTab() {
                     Remove from device
                   </AsyncButton>
                   {canDelete(o.id) && (
-                    <button
+                    <AsyncButton
                       className="link-btn danger"
                       disabled={busy}
                       title="Permanently delete this vault and all its notes for everyone"
-                      onClick={() => {
-                        setActionError(null);
-                        setConfirmDelete(o.id);
-                      }}
+                      onClick={() => askDelete(o.id, o.name)}
                     >
                       Delete
-                    </button>
+                    </AsyncButton>
                   )}
                 </span>
               )}
@@ -1825,6 +1889,35 @@ function VaultsTab() {
       )}
 
       {upgradeOpen && <UpgradeDialog onClose={() => setUpgradeOpen(false)} />}
+
+      {subDelete && (
+        <ConfirmDialog
+          title={`Delete ${subDelete.name}?`}
+          confirmLabel="Delete vault"
+          onCancel={() => setSubDelete(null)}
+          onConfirm={() => deletePermanently(subDelete.orgId)}
+        >
+          <p>
+            This vault is on <strong>Pro</strong>
+            {subDelete.billing.currentPeriodEnd
+              ? subDelete.billing.cancelAtPeriodEnd
+                ? `, ending ${formatDate(subDelete.billing.currentPeriodEnd)}`
+                : `, renewing ${formatDate(subDelete.billing.currentPeriodEnd)}`
+              : ""}
+            .
+          </p>
+          <p>
+            Deleting it stops the subscription at the end of the current period.
+            You won't be charged again, and until then you can move the
+            subscription to another vault from <strong>Billing</strong>.
+          </p>
+          <p>
+            Every note, folder and attachment in this vault is deleted for
+            everyone. That part can't be undone.
+          </p>
+          {actionError && <div className="auth-error">{actionError}</div>}
+        </ConfirmDialog>
+      )}
     </>
   );
 }
@@ -2174,31 +2267,63 @@ function MembersTab({ canManage }: { canManage: boolean }) {
 }
 
 /**
- * BillingTab: this vault's plan + seat usage (spec 04). Facts are visible to
- * every member (read-only); the Upgrade/Manage actions are gated to owners/admins
- * the same way MembersTab gates its controls. Only rendered when the server has
- * billing enabled (the tab itself is hidden otherwise).
+ * BillingTab: the current vault's plan and seats, then every subscription the
+ * signed-in user can act on (spec 04, #109/#110).
+ *
+ * Three sections, in the order someone reaching for this page needs them:
+ * this vault (what am I on?), all my vaults (what am I paying for?), and
+ * subscriptions from deleted vaults (what am I paying for that no longer
+ * exists?). Facts are visible to every member; each action is gated to the
+ * role the server will actually accept — Upgrade and Manage for owners and
+ * admins, Transfer for owners only, because it changes who pays for what.
+ *
+ * Only the first section needs a synced vault; the other two are account-wide,
+ * which is why this tab is no longer in TEAM_TABS.
  */
-function BillingTab({ canManage }: { canManage: boolean }) {
+function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boolean }) {
   const billingConfig = useStore((s) => s.billingConfig);
   const orgBilling = useStore((s) => s.orgBilling);
+  const myBilling = useStore((s) => s.myBilling);
   const orgId = useStore((s) => s.session?.activeOrganizationId ?? null);
 
-  const [upgradeOpen, setUpgradeOpen] = useState(false);
+  // The vault the upgrade dialog should charge: the active one from the card
+  // at the top, or any owned free vault picked out of the list below.
+  const [upgradeOrg, setUpgradeOrg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A transfer waiting to be confirmed. It moves money between vaults, so it
+  // never fires straight off the picker.
+  const [transfer, setTransfer] = useState<{
+    sourceOrgId: string;
+    sourceLabel: string;
+    targetOrgId: string;
+    targetName: string;
+  } | null>(null);
+  // An orphaned subscription waiting on a "cancel now" confirmation.
+  const [cancelling, setCancelling] = useState<{ orgId: string; label: string } | null>(
+    null,
+  );
 
-  // Refresh seat usage / plan whenever this tab is opened.
+  // Refresh this vault's seats AND the account-wide list whenever the tab opens.
   useEffect(() => {
     void useStore.getState().refreshOrgBilling();
+    void useStore.getState().refreshMyBilling();
   }, []);
 
-  const manage = async () => {
-    if (!orgId || busy) return;
+  const refreshAll = async () => {
+    await Promise.all([
+      useStore.getState().refreshMyBilling(),
+      useStore.getState().refreshOrgBilling(),
+    ]);
+  };
+
+  /** Open a vault's provider portal in the OS browser (owner/admin). */
+  const openPortal = async (portalOrgId: string) => {
+    if (busy) return;
     setBusy(true);
     setError(null);
     try {
-      const { url } = await authManager.api.getBillingPortalUrl(orgId);
+      const { url } = await authManager.api.getBillingPortalUrl(portalOrgId);
       await ipc.openExternal(url);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -2207,29 +2332,104 @@ function BillingTab({ canManage }: { canManage: boolean }) {
     }
   };
 
+  // Both confirmed actions leave their dialog OPEN on failure and report into
+  // it, rather than closing over an error nobody sees. Neither re-throws — the
+  // dialog's own AsyncButton has finished reporting by then.
+  const runTransfer = async () => {
+    if (!transfer) return;
+    const { sourceOrgId, targetOrgId, targetName } = transfer;
+    setError(null);
+    try {
+      await authManager.api.transferSubscription(sourceOrgId, targetOrgId);
+      setTransfer(null);
+      await refreshAll();
+      toast(`Pro moved to ${targetName}.`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      toast(`Couldn't move the subscription — ${message}`, "error");
+    }
+  };
+
+  const runCancelNow = async () => {
+    if (!cancelling) return;
+    const { orgId: target, label } = cancelling;
+    setError(null);
+    try {
+      await authManager.api.cancelSubscription(target, "now");
+      setCancelling(null);
+      await refreshAll();
+      toast(`Subscription for ${label} canceled.`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      toast(`Couldn't cancel the subscription — ${message}`, "error");
+    }
+  };
+
   if (!billingConfig?.enabled) {
     return (
       <div className="muted perm-empty">Billing isn't enabled on this server.</div>
     );
   }
-  if (!orgId) {
+
+  const vaults = myBilling?.vaults ?? [];
+  const orphaned = myBilling?.orphaned ?? [];
+  const freeLimits = myBilling?.freeLimits ?? null;
+
+  /**
+   * The Transfer control for one row: a picker over the eligible targets, or a
+   * disabled button that says why there are none. `value` is a LABEL, not a
+   * selection — nothing is currently chosen here, and MenuSelect renders the
+   * raw value whenever no option matches it.
+   */
+  const transferControl = (sourceOrgId: string, sourceLabel: string) => {
+    const targets = transferTargets(vaults, sourceOrgId);
+    if (targets.length === 0) {
+      return (
+        <button
+          className="link-btn"
+          disabled
+          title="Nowhere to move it — you need another vault you own that isn't already on Pro."
+        >
+          Transfer
+        </button>
+      );
+    }
     return (
-      <div className="muted perm-empty">
-        Billing needs an active vault — create or switch to one first.
-      </div>
+      <MenuSelect
+        value={TRANSFER_TRIGGER_LABEL}
+        options={targets.map((t) => ({ value: t.orgId, label: t.name }))}
+        onSelect={(targetOrgId) => {
+          const target = targets.find((t) => t.orgId === targetOrgId);
+          if (!target) return;
+          setError(null);
+          setTransfer({ sourceOrgId, sourceLabel, targetOrgId, targetName: target.name });
+        }}
+        disabled={busy}
+        ariaLabel={`Move ${sourceLabel}'s subscription to another vault`}
+        triggerClassName="link-btn billing-transfer-trigger"
+        menuClassName="billing-transfer-menu"
+      />
     );
-  }
-  if (!orgBilling) {
-    return <div className="muted">Loading…</div>;
-  }
+  };
 
-  const isPro = orgBilling.plan === "pro";
-  const { members, pendingInvitations, limit } = orgBilling.seats;
-  const used = members + pendingInvitations;
+  /** Section 1 — the vault currently open. A plain render helper, NOT a nested
+   *  component: a component declared in here would remount its whole subtree
+   *  on every state change of this page. */
+  const renderVaultCard = () => {
+    if (!isSynced || !orgId) {
+      return (
+        <div className="muted perm-empty">
+          This vault isn't synced, so it has no plan of its own. The vaults on
+          your account are listed below.
+        </div>
+      );
+    }
+    if (!orgBilling) return <div className="muted">Loading…</div>;
 
-  return (
-    <>
-      {isPro ? (
+    if (orgBilling.plan === "pro") {
+      return (
         <div className="billing-card plan-pro">
           <div className="billing-plan-head">
             <span className="billing-plan-name">Pro</span>
@@ -2257,12 +2457,11 @@ function BillingTab({ canManage }: { canManage: boolean }) {
               </span>
             </div>
           )}
-          {error && <div className="auth-error">{error}</div>}
           {canManage ? (
             <AsyncButton
               className="secondary billing-action"
               disabled={busy}
-              onClick={manage}
+              onClick={() => openPortal(orgId)}
             >
               Manage subscription
             </AsyncButton>
@@ -2270,45 +2469,218 @@ function BillingTab({ canManage }: { canManage: boolean }) {
             <div className="muted">Ask an owner or admin to manage the subscription.</div>
           )}
         </div>
-      ) : (
-        <div className="billing-card">
-          <div className="billing-plan-head">
-            <span className="billing-plan-name">Free</span>
+      );
+    }
+
+    const { members, pendingInvitations, limit } = orgBilling.seats;
+    const used = members + pendingInvitations;
+    return (
+      <div className="billing-card">
+        <div className="billing-plan-head">
+          <span className="billing-plan-name">Free</span>
+        </div>
+        <div className="menu-row">
+          <span className="menu-row-label">Members</span>
+          <span>
+            {used} of {limit ?? "∞"}
+            {limit != null && used >= limit ? " · full" : ""}
+          </span>
+        </div>
+        {pendingInvitations > 0 && (
+          <div className="muted">
+            Includes {pendingInvitations} pending invitation
+            {pendingInvitations === 1 ? "" : "s"}.
           </div>
-          <div className="menu-row">
-            <span className="menu-row-label">Members</span>
-            <span>
-              {used} of {limit ?? "∞"}
-              {limit != null && used >= limit ? " · full" : ""}
+        )}
+
+        <div className="subhead">Upgrade to Pro unlocks</div>
+        <ul className="upgrade-features">
+          <li>Unlimited team members</li>
+          <li>Unlimited notes, devices &amp; AI edits</li>
+          <li>Doesn't count toward your free vaults</li>
+          <li>Priority support</li>
+        </ul>
+
+        {canManage ? (
+          <button className="primary billing-action" onClick={() => setUpgradeOrg(orgId)}>
+            Upgrade to Pro
+          </button>
+        ) : (
+          <div className="muted">Ask an owner or admin to upgrade this vault.</div>
+        )}
+      </div>
+    );
+  };
+
+  /** One row of section 2. */
+  const renderVaultRow = (v: MyBillingVault) => {
+    const line = subscriptionStatusLine(v, LINE_FORMAT);
+    const seatsUsed = v.seats.members + v.seats.pendingInvitations;
+    return (
+      <li key={v.orgId} className="billing-sub-row">
+        <span className="billing-sub-name">
+          <span className="billing-sub-title">
+            {v.name}
+            {v.orgId === orgId && <span className="muted"> · Current</span>}
+          </span>
+          {line && <span className="billing-sub-meta">{line}</span>}
+          <span className="billing-sub-meta">
+            {seatsUsed} of {v.seats.limit ?? "∞"} member{seatsUsed === 1 ? "" : "s"}
+          </span>
+          {!v.canManage && v.billingOwner && (
+            <span className="billing-sub-meta">
+              Billing managed by {v.billingOwner.name}
             </span>
+          )}
+        </span>
+        <span className={`member-role ${v.role}`}>{v.role}</span>
+        <span className={`billing-status ${v.status}`}>{planPillLabel(v)}</span>
+        <span className="vault-row-actions">
+          {v.canManage && v.plan === "free" && (
+            <AsyncButton
+              className="link-btn"
+              disabled={busy}
+              onClick={() => setUpgradeOrg(v.orgId)}
+            >
+              Upgrade
+            </AsyncButton>
+          )}
+          {v.canManage && v.plan === "pro" && (
+            <AsyncButton
+              className="link-btn"
+              disabled={busy}
+              onClick={() => openPortal(v.orgId)}
+            >
+              Manage
+            </AsyncButton>
+          )}
+          {v.canTransfer && transferControl(v.orgId, v.name)}
+        </span>
+      </li>
+    );
+  };
+
+  return (
+    <>
+      {renderVaultCard()}
+
+      {/* ---- 2. Every vault on the account ---- */}
+      <div className="subhead">Subscriptions</div>
+      {vaults.length === 0 ? (
+        <div className="muted perm-empty">
+          {myBilling ? "No vaults on this account yet." : "Loading…"}
+        </div>
+      ) : (
+        <ul className="member-list">{vaults.map(renderVaultRow)}</ul>
+      )}
+
+      {/* ---- 3. Tombstones: paid time that outlived its vault ---- */}
+      {orphaned.length > 0 && (
+        <>
+          <div className="subhead">From deleted vaults</div>
+          <div className="billing-section-note">
+            These subscriptions belonged to vaults that were deleted. They still
+            bill until they end — move one to a vault to use the time you've paid
+            for, or cancel it now.
           </div>
-          {pendingInvitations > 0 && (
-            <div className="muted">
-              Includes {pendingInvitations} pending invitation
-              {pendingInvitations === 1 ? "" : "s"}.
-            </div>
-          )}
-
-          <div className="subhead">Upgrade to Pro unlocks</div>
-          <ul className="upgrade-features">
-            <li>Unlimited team members</li>
-            <li>Unlimited notes, devices &amp; AI edits</li>
-            <li>Doesn't count toward your free vaults</li>
-            <li>Priority support</li>
+          <ul className="member-list">
+            {orphaned.map((o) => {
+              const label = o.orgName ?? "Deleted vault";
+              const line = subscriptionStatusLine(o, LINE_FORMAT);
+              return (
+                <li key={o.orgId} className="billing-sub-row">
+                  <span className="billing-sub-name">
+                    <span className="billing-sub-title">
+                      {label}
+                      <span className="muted"> · deleted {formatDate(o.deletedAt)}</span>
+                    </span>
+                    {line && <span className="billing-sub-meta">{line}</span>}
+                  </span>
+                  <span className={`billing-status ${o.status}`}>
+                    {o.status === "past_due" ? "Past due" : "Pro"}
+                  </span>
+                  <span className="vault-row-actions">
+                    {transferControl(o.orgId, label)}
+                    <AsyncButton
+                      className="link-btn danger"
+                      disabled={busy}
+                      onClick={() => {
+                        setError(null);
+                        setCancelling({ orgId: o.orgId, label });
+                      }}
+                    >
+                      Cancel now
+                    </AsyncButton>
+                    <AsyncButton
+                      className="link-btn"
+                      disabled={busy}
+                      onClick={() => openPortal(o.orgId)}
+                    >
+                      Manage
+                    </AsyncButton>
+                  </span>
+                </li>
+              );
+            })}
           </ul>
+        </>
+      )}
 
-          {error && <div className="auth-error">{error}</div>}
-          {canManage ? (
-            <button className="primary billing-action" onClick={() => setUpgradeOpen(true)}>
-              Upgrade to Pro
-            </button>
-          ) : (
-            <div className="muted">Ask an owner or admin to upgrade this vault.</div>
-          )}
+      {/* ---- 4. What the free tier allows ---- */}
+      {freeLimits && (
+        <div className="menu-row">
+          <span className="menu-row-label">Free vaults</span>
+          <span>
+            {freeLimits.freeVaultsUsed} of {freeLimits.vaultsPerUser} used
+          </span>
         </div>
       )}
 
-      {upgradeOpen && <UpgradeDialog onClose={() => setUpgradeOpen(false)} />}
+      {error && <div className="auth-error">{error}</div>}
+
+      {upgradeOrg && (
+        <UpgradeDialog orgId={upgradeOrg} onClose={() => setUpgradeOrg(null)} />
+      )}
+
+      {transfer && (
+        <ConfirmDialog
+          tone="accent"
+          title={`Move Pro to ${transfer.targetName}?`}
+          confirmLabel="Move subscription"
+          onCancel={() => setTransfer(null)}
+          onConfirm={runTransfer}
+        >
+          <p>
+            <strong>{transfer.targetName}</strong> becomes Pro immediately, on the
+            same billing period and price.
+          </p>
+          <p>
+            <strong>{transfer.sourceLabel}</strong> drops to Free — its members and
+            notes stay, but free-plan limits apply to it again.
+          </p>
+          {error && <div className="auth-error">{error}</div>}
+        </ConfirmDialog>
+      )}
+
+      {cancelling && (
+        <ConfirmDialog
+          title={`Cancel the subscription for ${cancelling.label}?`}
+          confirmLabel="Cancel subscription"
+          cancelLabel="Keep it"
+          onCancel={() => setCancelling(null)}
+          onConfirm={runCancelNow}
+        >
+          <p>
+            Billing stops now and the rest of the period is given up. There is no
+            vault left to use it on, so nothing else is lost.
+          </p>
+          <p>
+            If you'd rather keep the time you've paid for, move it to another vault
+            instead.
+          </p>
+          {error && <div className="auth-error">{error}</div>}
+        </ConfirmDialog>
+      )}
     </>
   );
 }
@@ -2319,6 +2691,24 @@ function formatDate(iso: string): string {
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
+
+/**
+ * The MenuSelect trigger label for a transfer picker. Typed `string` rather
+ * than the literal so it can never collide with an org-id option — it is a
+ * label, not a value that could be selected.
+ */
+const TRANSFER_TRIGGER_LABEL: string = "Transfer";
+
+/**
+ * How a subscription row writes its date and price. Both formatters already
+ * exist — reused here rather than re-implemented so `lib/billing.ts` can stay
+ * pure and there is exactly one definition of how we print money.
+ */
+const LINE_FORMAT = {
+  date: formatDate,
+  price: (amount: number, currency: string, interval: "month" | "year" | null) =>
+    `${formatPrice({ amount, currency })}${interval ? perLabel(interval) : ""}`,
+};
 
 /**
  * Inline upgrade nudge shown in the create-vault / invite-member error slot

--- a/app/apps/desktop/src/components/UpgradeDialog.tsx
+++ b/app/apps/desktop/src/components/UpgradeDialog.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { type BillingPlan } from "../lib/api";
 import { authManager } from "../lib/auth/authManager";
 import * as ipc from "../lib/ipc";
 import { useStore } from "../store";
@@ -9,13 +8,19 @@ import { useStore } from "../store";
 const POLL_INTERVAL_MS = 3_000;
 const POLL_BUDGET_MS = 3 * 60 * 1000;
 
-/** Format a plan's amount (minor units) as a compact price, e.g. "$10", "$97". */
-function formatPrice(plan: BillingPlan): string {
-  const major = plan.amount / 100;
+/**
+ * Format an amount (minor units) as a compact price, e.g. "$10", "$97".
+ *
+ * Takes the two fields it reads rather than a `BillingPlan` so the
+ * Subscriptions list can price a row from the provider snapshot on it
+ * (`amount`/`currency`), which is not a plan (#109).
+ */
+export function formatPrice(money: { amount: number; currency: string }): string {
+  const major = money.amount / 100;
   try {
     return new Intl.NumberFormat(undefined, {
       style: "currency",
-      currency: plan.currency.toUpperCase(),
+      currency: money.currency.toUpperCase(),
       maximumFractionDigits: Number.isInteger(major) ? 0 : 2,
     }).format(major);
   } catch {
@@ -24,17 +29,29 @@ function formatPrice(plan: BillingPlan): string {
   }
 }
 
-const perLabel = (interval: "month" | "year") => (interval === "month" ? "/mo" : "/yr");
+export const perLabel = (interval: "month" | "year") =>
+  interval === "month" ? "/mo" : "/yr";
 
 /**
  * Upgrade-to-Pro flow (ShareDialog modal pattern). Shows the plan card with a
  * monthly/yearly toggle built from `billingConfig.plans`, kicks off a hosted
  * checkout, then WAITS: the browser redirect is never treated as proof of
  * payment — only a `status: "active"` from polling `getOrgBilling` unlocks Pro.
+ *
+ * `orgId` names the vault being upgraded, defaulting to the active one. The
+ * Subscriptions list passes it explicitly: it can upgrade any vault the user
+ * owns, including one they are not currently working in (#109).
  */
-export function UpgradeDialog({ onClose }: { onClose: () => void }) {
+export function UpgradeDialog({
+  onClose,
+  orgId: orgIdProp,
+}: {
+  onClose: () => void;
+  orgId?: string;
+}) {
   const billingConfig = useStore((s) => s.billingConfig);
-  const orgId = useStore((s) => s.session?.activeOrganizationId ?? null);
+  const activeOrgId = useStore((s) => s.session?.activeOrganizationId ?? null);
+  const orgId = orgIdProp ?? activeOrgId;
 
   const plans = billingConfig?.plans ?? [];
   const monthly = plans.find((p) => p.interval === "month");
@@ -81,6 +98,10 @@ export function UpgradeDialog({ onClose }: { onClose: () => void }) {
       if (b.status === "active") {
         setPhase("success");
         await useStore.getState().refreshOrgBilling();
+        // The Subscriptions list this may have been opened from is a second
+        // reader of the same fact — leaving it stale would show the vault we
+        // just upgraded as Free.
+        await useStore.getState().refreshMyBilling();
         return true;
       }
     } catch {

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -370,8 +370,80 @@ export interface OrgBilling {
   status: "none" | "active" | "past_due" | "canceled";
   currentPeriodEnd: string | null;
   cancelAtPeriodEnd: boolean;
+  /** Cadence + price of the live subscription, straight from the provider's
+   *  snapshot — so a row can be priced without matching it back to a
+   *  `BillingPlan`. All three are null on a vault with no subscription
+   *  (#109). `amount` is minor units, like {@link BillingPlan.amount}. */
+  interval: "month" | "year" | null;
+  amount: number | null;
+  currency: string | null;
   /** `limit: null` = unlimited (paid). */
   seats: { members: number; pendingInvitations: number; limit: number | null };
+}
+
+/** One row of the Subscriptions list: a vault the caller belongs to. */
+export interface MyBillingVault {
+  orgId: string;
+  name: string;
+  role: "owner" | "admin" | "member";
+  plan: "free" | "pro";
+  status: "none" | "active" | "past_due" | "canceled";
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  interval: "month" | "year" | null;
+  amount: number | null;
+  currency: string | null;
+  seats: { members: number; pendingInvitations: number; limit: number | null };
+  /** The vault's owner — who to point a member at when they can't act. */
+  billingOwner: { userId: string; name: string; email: string } | null;
+  /** Owner or admin: may upgrade this vault or open its portal. */
+  canManage: boolean;
+  /** Owner AND the subscription is live: may move it to another vault. */
+  canTransfer: boolean;
+}
+
+/**
+ * A subscription whose vault is gone. Deleting a vault cancels its
+ * subscription at the period end rather than instantly, so the paid time the
+ * user already bought survives the vault — and has to be reachable from
+ * somewhere (#109/#111). The server keeps the row as a tombstone; this is it.
+ */
+export interface OrphanedSubscription {
+  orgId: string;
+  orgName: string | null;
+  deletedAt: string;
+  status: "active" | "past_due";
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  interval: "month" | "year" | null;
+  amount: number | null;
+  currency: string | null;
+}
+
+/**
+ * Every subscription the caller can see or act on, in one shot. The per-vault
+ * `GET /api/billing/orgs/:orgId` can't answer this: role is only known for the
+ * active org and plan is only known one org at a time.
+ */
+export interface MyBilling {
+  vaults: MyBillingVault[];
+  orphaned: OrphanedSubscription[];
+  freeLimits: {
+    vaultsPerUser: number;
+    membersPerVault: number;
+    /** Owned vaults with no subscription — what counts against the cap. */
+    freeVaultsUsed: number;
+  };
+}
+
+/** What `DELETE /api/orgs/:orgId` reports back. */
+export interface VaultDeleteResult {
+  deleted: boolean;
+  vaults: number;
+  docs: number;
+  /** Set when the deleted vault carried a live subscription: the server told
+   *  the provider to stop at the period end, and this is when that is. */
+  subscription: { cancelAtPeriodEnd: boolean; currentPeriodEnd: string | null } | null;
 }
 
 /** A rejected server response — carries the HTTP status for callers to branch on. */
@@ -935,11 +1007,14 @@ export class ApiClient {
    * cascades members/note-collections/folders/notes/shares and purges the FK-less
    * CRDT stores. Throws ApiError 403 if the caller isn't the owner.
    * (The vault's server identity is the Better Auth organization id.)
+   *
+   * A vault on Pro is cancelled at the provider FIRST, at the period end; if
+   * the provider refuses, nothing is deleted and this throws 502
+   * `subscription_cancel_failed` (#111). On success `subscription` says when
+   * the paid period runs out — until then it can be moved to another vault.
    */
-  async deleteRemoteVault(
-    organizationId: string,
-  ): Promise<{ deleted: boolean; vaults: number; docs: number }> {
-    const { data } = await this.request<{ deleted: boolean; vaults: number; docs: number }>(
+  async deleteRemoteVault(organizationId: string): Promise<VaultDeleteResult> {
+    const { data } = await this.request<VaultDeleteResult>(
       "DELETE",
       `/api/orgs/${encodeURIComponent(organizationId)}`,
     );
@@ -1090,6 +1165,56 @@ export class ApiClient {
       "POST",
       `/api/billing/orgs/${encodeURIComponent(orgId)}/portal`,
     );
+    return data;
+  }
+
+  /**
+   * Every vault the caller belongs to with its plan/seats/role, plus any
+   * subscription left behind by a deleted vault. One request rather than an
+   * N+1 over {@link getOrgBilling}: the server also reconciles stale rows
+   * against the provider while it is in there.
+   */
+  async getMyBilling(): Promise<MyBilling> {
+    const { data } = await this.request<MyBilling>("GET", "/api/billing/mine");
+    return data;
+  }
+
+  /**
+   * Cancel a vault's subscription (owner only; admins use the portal).
+   * `period_end` keeps the paid time and stops the next charge; `now` revokes
+   * immediately — which is what a subscription from an already-deleted vault
+   * wants, since there is no vault left to spend the rest of the period on.
+   */
+  async cancelSubscription(
+    orgId: string,
+    mode: "period_end" | "now",
+  ): Promise<OrgBilling> {
+    const { data } = await this.request<OrgBilling>(
+      "POST",
+      `/api/billing/orgs/${encodeURIComponent(orgId)}/cancel`,
+      { body: { mode } },
+    );
+    return data;
+  }
+
+  /**
+   * Move a live subscription from one vault to another the caller owns. The
+   * source may be a deleted vault's tombstone, which is the whole point: it
+   * turns "I deleted the wrong vault" into a recoverable mistake instead of a
+   * refund request. Un-cancels at the provider when the source was set to
+   * cancel at the period end.
+   */
+  async transferSubscription(
+    sourceOrgId: string,
+    targetOrgId: string,
+  ): Promise<{ transferred: boolean; orgId: string; billing: OrgBilling }> {
+    const { data } = await this.request<{
+      transferred: boolean;
+      orgId: string;
+      billing: OrgBilling;
+    }>("POST", `/api/billing/orgs/${encodeURIComponent(sourceOrgId)}/transfer`, {
+      body: { targetOrgId },
+    });
     return data;
   }
 

--- a/app/apps/desktop/src/lib/billing.test.ts
+++ b/app/apps/desktop/src/lib/billing.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { ApiError } from "./api";
-import { classifyLimitError, limitFromError } from "./billing";
+import {
+  classifyLimitError,
+  limitFromError,
+  planPillLabel,
+  subscriptionStatusLine,
+  transferTargets,
+  type SubscriptionFacts,
+  type SubscriptionLineFormat,
+} from "./billing";
 
 describe("classifyLimitError", () => {
   it("returns null for non-ApiError values", () => {
@@ -59,5 +67,152 @@ describe("limitFromError", () => {
     expect(limitFromError(new ApiError(402, "member_limit_reached", { error: "x" }))).toBeNull();
     expect(limitFromError(new ApiError(402, "x", "string body"))).toBeNull();
     expect(limitFromError(new Error("boom"))).toBeNull();
+  });
+});
+
+// Deterministic stand-ins for the real formatters, so these assertions don't
+// depend on the test machine's locale.
+const FMT: SubscriptionLineFormat = {
+  date: (iso) => `D(${iso})`,
+  price: (amount, currency, interval) => `${currency}${amount / 100}${interval ?? "?"}`,
+};
+
+const facts = (over: Partial<SubscriptionFacts> = {}): SubscriptionFacts => ({
+  status: "active",
+  currentPeriodEnd: "2026-10-03T00:00:00.000Z",
+  cancelAtPeriodEnd: false,
+  interval: "month",
+  amount: 1000,
+  currency: "usd",
+  ...over,
+});
+
+describe("subscriptionStatusLine", () => {
+  it("says nothing about a vault with no subscription", () => {
+    expect(subscriptionStatusLine(facts({ status: "none" }), FMT)).toBeNull();
+  });
+
+  it("writes the renewal date and the price for a live subscription", () => {
+    expect(subscriptionStatusLine(facts(), FMT)).toBe(
+      "Renews D(2026-10-03T00:00:00.000Z) · usd10month",
+    );
+  });
+
+  it("writes an end date, never a renewal, once it is cancelling", () => {
+    const line = subscriptionStatusLine(facts({ cancelAtPeriodEnd: true }), FMT);
+    expect(line).toBe("Ends D(2026-10-03T00:00:00.000Z)");
+    expect(line).not.toContain("Renews");
+  });
+
+  it("falls back to prose when a cancelling subscription has no end date", () => {
+    expect(
+      subscriptionStatusLine(facts({ cancelAtPeriodEnd: true, currentPeriodEnd: null }), FMT),
+    ).toBe("Ends at the end of the current period");
+  });
+
+  it("lets past_due outrank the date and the price", () => {
+    expect(subscriptionStatusLine(facts({ status: "past_due" }), FMT)).toBe("Past due");
+    // Even mid-cancellation: the money is the thing to say.
+    expect(
+      subscriptionStatusLine(facts({ status: "past_due", cancelAtPeriodEnd: true }), FMT),
+    ).toBe("Past due");
+  });
+
+  it("reports a canceled subscription in the past tense", () => {
+    expect(subscriptionStatusLine(facts({ status: "canceled" }), FMT)).toBe(
+      "Ended D(2026-10-03T00:00:00.000Z)",
+    );
+    expect(
+      subscriptionStatusLine(facts({ status: "canceled", currentPeriodEnd: null }), FMT),
+    ).toBe("Canceled");
+  });
+
+  it("omits the price when the provider gave us none", () => {
+    expect(subscriptionStatusLine(facts({ amount: null, currency: null }), FMT)).toBe(
+      "Renews D(2026-10-03T00:00:00.000Z)",
+    );
+  });
+
+  it("prices a subscription with no renewal date on its own", () => {
+    expect(subscriptionStatusLine(facts({ currentPeriodEnd: null }), FMT)).toBe("usd10month");
+  });
+
+  it("returns null for a live subscription we know nothing else about", () => {
+    expect(
+      subscriptionStatusLine(
+        facts({ currentPeriodEnd: null, amount: null, currency: null }),
+        FMT,
+      ),
+    ).toBeNull();
+  });
+
+  it("treats a zero amount as a real price, not a missing one", () => {
+    expect(subscriptionStatusLine(facts({ amount: 0, currentPeriodEnd: null }), FMT)).toBe(
+      "usd0month",
+    );
+  });
+});
+
+describe("planPillLabel", () => {
+  it("labels every free vault Free, whatever its dead subscription says", () => {
+    expect(planPillLabel({ plan: "free", status: "none" })).toBe("Free");
+    expect(planPillLabel({ plan: "free", status: "canceled" })).toBe("Free");
+  });
+
+  it("labels a healthy Pro just Pro", () => {
+    expect(planPillLabel({ plan: "pro", status: "active" })).toBe("Pro");
+  });
+
+  it("surfaces the states worth interrupting for", () => {
+    expect(planPillLabel({ plan: "pro", status: "past_due" })).toBe("Past due");
+    expect(planPillLabel({ plan: "pro", status: "canceled" })).toBe("Canceled");
+  });
+});
+
+describe("transferTargets", () => {
+  const v = (
+    orgId: string,
+    role: "owner" | "admin" | "member",
+    plan: "free" | "pro",
+    status: SubscriptionFacts["status"] = plan === "pro" ? "active" : "none",
+  ) => ({ orgId, role, plan, status });
+
+  const all = [
+    v("src", "owner", "pro"),
+    v("mine-free", "owner", "free"),
+    v("mine-pro", "owner", "pro"),
+    v("admin-free", "admin", "free"),
+    v("member-free", "member", "free"),
+    v("mine-canceled", "owner", "free", "canceled"),
+  ];
+
+  it("offers owned free vaults, including one whose old subscription is canceled", () => {
+    expect(transferTargets(all, "src").map((t) => t.orgId)).toEqual([
+      "mine-free",
+      "mine-canceled",
+    ]);
+  });
+
+  it("never offers the source itself", () => {
+    expect(transferTargets(all, "mine-free").map((t) => t.orgId)).toEqual(["mine-canceled"]);
+  });
+
+  it("refuses vaults the caller only administers or belongs to", () => {
+    const ids = transferTargets(all, "src").map((t) => t.orgId);
+    expect(ids).not.toContain("admin-free");
+    expect(ids).not.toContain("member-free");
+  });
+
+  it("refuses a vault that is already paying", () => {
+    const ids = transferTargets(all, "src").map((t) => t.orgId);
+    expect(ids).not.toContain("mine-pro");
+    expect(
+      transferTargets([v("t", "owner", "free", "past_due")], "src").map((t) => t.orgId),
+    ).toEqual([]);
+  });
+
+  it("returns an empty list when there is nowhere to move it", () => {
+    expect(transferTargets([v("src", "owner", "pro")], "src")).toEqual([]);
+    expect(transferTargets([], "src")).toEqual([]);
   });
 });

--- a/app/apps/desktop/src/lib/billing.ts
+++ b/app/apps/desktop/src/lib/billing.ts
@@ -50,3 +50,110 @@ export function limitFromError(e: unknown): number | null {
   }
   return null;
 }
+
+// ---- Subscriptions list (#109) -------------------------------------------
+//
+// The Billing tab lists every vault the user belongs to plus any subscription
+// left behind by a deleted vault, and each row needs the same derived facts:
+// what to say about its state, what to call its plan, and which vaults a
+// transfer could move it to. They live here rather than in the component so
+// they stay testable without React, the store, or a server.
+
+/** The subset of a billing row these helpers actually read. */
+export interface SubscriptionFacts {
+  status: "none" | "active" | "past_due" | "canceled";
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  interval: "month" | "year" | null;
+  amount: number | null;
+  currency: string | null;
+}
+
+/**
+ * How a row's date and price get written. Injected rather than imported:
+ * `formatDate` (AccountMenu) and `formatPrice`/`perLabel` (UpgradeDialog)
+ * already exist, and a second copy of "how we write a price" is exactly the
+ * drift to avoid. It also keeps this module free of `Intl`, whose output is
+ * locale-dependent and therefore untestable as a fixed string.
+ */
+export interface SubscriptionLineFormat {
+  date: (iso: string) => string;
+  price: (amount: number, currency: string, interval: "month" | "year" | null) => string;
+}
+
+/**
+ * The secondary line under a vault in the Subscriptions list — "Renews 3 Oct
+ * 2026 · $10/mo", "Ends 3 Oct 2026", "Past due" — or null when there is
+ * nothing to say (a free vault).
+ *
+ * Order matters: `past_due` outranks everything (the money is the problem, not
+ * the date), and a cancelling subscription reads as an end date, never a
+ * renewal — telling someone their cancelled plan "renews" is the worst thing
+ * this line could do.
+ */
+export function subscriptionStatusLine(
+  row: SubscriptionFacts,
+  fmt: SubscriptionLineFormat,
+): string | null {
+  if (row.status === "none") return null;
+  if (row.status === "past_due") return "Past due";
+  if (row.status === "canceled") {
+    return row.currentPeriodEnd ? `Ended ${fmt.date(row.currentPeriodEnd)}` : "Canceled";
+  }
+  if (row.cancelAtPeriodEnd) {
+    return row.currentPeriodEnd
+      ? `Ends ${fmt.date(row.currentPeriodEnd)}`
+      : "Ends at the end of the current period";
+  }
+  const parts: string[] = [];
+  if (row.currentPeriodEnd) parts.push(`Renews ${fmt.date(row.currentPeriodEnd)}`);
+  if (row.amount != null && row.currency) {
+    parts.push(fmt.price(row.amount, row.currency, row.interval));
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+/**
+ * Text for a row's plan pill. Pro carries its status when that status is worth
+ * interrupting for; a healthy Pro just says Pro, because the line under it
+ * already carries the renewal.
+ */
+export function planPillLabel(row: {
+  plan: "free" | "pro";
+  status: SubscriptionFacts["status"];
+}): string {
+  if (row.plan !== "pro") return "Free";
+  if (row.status === "past_due") return "Past due";
+  if (row.status === "canceled") return "Canceled";
+  return "Pro";
+}
+
+/** The shape {@link transferTargets} filters on — a `MyBillingVault`, loosened
+ *  so the helper doesn't drag the API types into its tests. */
+export interface TransferCandidate {
+  orgId: string;
+  role: "owner" | "admin" | "member";
+  plan: "free" | "pro";
+  status: SubscriptionFacts["status"];
+}
+
+/**
+ * Vaults a subscription could be moved to: another vault the caller OWNS
+ * (admin isn't enough — this changes who pays for what) that isn't already
+ * paying. The `status` guard is belt-and-braces for the server's
+ * `target_already_subscribed`: a target whose row is merely `canceled` still
+ * reads as free and is a legal destination.
+ */
+export function transferTargets<T extends TransferCandidate>(
+  vaults: readonly T[],
+  sourceOrgId: string,
+): T[] {
+  return vaults.filter(
+    (v) =>
+      v.orgId !== sourceOrgId &&
+      v.role === "owner" &&
+      v.plan === "free" &&
+      v.status !== "active" &&
+      v.status !== "past_due",
+  );
+}

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -21,6 +21,7 @@ import {
   type Invitation,
   type InvitationPreview,
   type Member,
+  type MyBilling,
   type NoteLastEdited,
   type NoteVersion,
   type OrgBilling,
@@ -28,6 +29,7 @@ import {
   type SessionInfo,
   type Share,
   type VaultCheckpoint,
+  type VaultDeleteResult,
   type VaultRevertResult,
   vaultOrgId,
   vaultRootFrozen,
@@ -320,6 +322,11 @@ interface AppStore {
   billingConfig: BillingConfig | null;
   /** The active vault's subscription state + seat usage; null when unknown. */
   orgBilling: OrgBilling | null;
+  /** Every vault's plan plus the subscriptions left behind by deleted vaults —
+   *  what the Billing tab's Subscriptions list renders. This can't be derived
+   *  from `organizations` + `orgBilling`: role is only known for the active
+   *  org, and `orgBilling` covers one vault at a time (#109). */
+  myBilling: MyBilling | null;
 
   // ---- Account-level preferences (follow the app, not any vault) ----
   /** The user's chosen activity status; broadcast to teammates via presence. */
@@ -460,8 +467,11 @@ interface AppStore {
   /** Detach a vault from THIS device (forget its folder, stop syncing it).
    *  Server data and membership are untouched — it can be re-opened later. */
   removeVaultLocally: (organizationId: string) => Promise<void>;
-  /** Permanently delete a vault everywhere (owner only), then detach it. */
-  deleteRemoteVault: (organizationId: string) => Promise<void>;
+  /** Permanently delete a vault everywhere (owner only), then detach it.
+   *  Hands back the server's report so the caller can say what became of the
+   *  vault's subscription — deleting a Pro vault stops it at the END of the
+   *  period rather than instantly, and that date is the whole message (#111). */
+  deleteRemoteVault: (organizationId: string) => Promise<VaultDeleteResult>;
 
   /** Open a plain local folder as the current (unsynced) vault — leaving any
    *  synced vault's sync context behind. Used by the switcher's local rows
@@ -536,6 +546,8 @@ interface AppStore {
   refreshBillingConfig: () => Promise<void>;
   /** Refresh the active vault's subscription state + seats. */
   refreshOrgBilling: () => Promise<void>;
+  /** Refresh every vault's plan + any subscription from a deleted vault. */
+  refreshMyBilling: () => Promise<void>;
 
   // Sync
   setSyncStatus: (status: SyncStatus) => void;
@@ -1113,6 +1125,7 @@ export const useStore = create<AppStore>((set, get) => ({
   rootFrozen: false,
   billingConfig: null,
   orgBilling: null,
+  myBilling: null,
   activityStatus: readActivityStatus(),
   mentionSound: readMentionSound(),
   treeSort: readTreeSort(),
@@ -1960,6 +1973,7 @@ export const useStore = create<AppStore>((set, get) => ({
       pendingVaultFolder: null,
       billingConfig: null,
       orgBilling: null,
+      myBilling: null,
       // Close the open vault so the app returns to the VaultPicker "home" screen
       // (choose / reopen a vault) instead of leaving the old vault's files
       // on screen after sign-out.
@@ -2007,7 +2021,7 @@ export const useStore = create<AppStore>((set, get) => ({
       if (peekPendingInvite()) await consumeQueuedInvite(get, set);
     } else {
       syncManager.disable();
-      set({ syncEnabled: false, billingConfig: null, orgBilling: null });
+      set({ syncEnabled: false, billingConfig: null, orgBilling: null, myBilling: null });
       // Same invitation, no session on the new server: raise the sign-in card
       // for it rather than leaving the queue to be discovered by the next
       // unrelated sign-in.
@@ -2567,9 +2581,14 @@ export const useStore = create<AppStore>((set, get) => ({
 
   deleteRemoteVault: async (organizationId) => {
     // Permanent, server-side, owner-only. 403s here if the caller isn't owner.
-    await authManager.api.deleteRemoteVault(organizationId);
+    // A vault on Pro is cancelled at the provider FIRST, so a 502 here means
+    // nothing was deleted — which is also why the result is handed back rather
+    // than swallowed: only the caller can tell the user when the paid period
+    // ends and that it can still be moved to another vault until then (#111).
+    const result = await authManager.api.deleteRemoteVault(organizationId);
     // Then tear down the same local state as a device-level removal.
     await get().removeVaultLocally(organizationId);
+    return result;
   },
 
   // ---- Vault folder resolution ----
@@ -2957,6 +2976,24 @@ export const useStore = create<AppStore>((set, get) => ({
     } catch (e) {
       console.warn("[billing] refresh failed", e);
       set({ orgBilling: null });
+    }
+  },
+
+  refreshMyBilling: async () => {
+    // Account-wide, so it needs a session rather than an active vault — the
+    // Billing tab is reachable from a local vault now. Failures are swallowed
+    // like refreshOrgBilling's: the list simply doesn't render, it never takes
+    // the settings page down with it.
+    if (!get().session || !get().billingConfig?.enabled) {
+      set({ myBilling: null });
+      return;
+    }
+    try {
+      const myBilling = await authManager.api.getMyBilling();
+      set({ myBilling });
+    } catch (e) {
+      console.warn("[billing] mine refresh failed", e);
+      set({ myBilling: null });
     }
   },
 

--- a/app/apps/server/.env.example
+++ b/app/apps/server/.env.example
@@ -103,11 +103,11 @@ VAULT_SYNC_PATH=/vault-sync
 
 # Billing is OFF unless POLAR_ACCESS_TOKEN is set. Self-hosters should leave this
 # ENTIRE block unset: with billing off there are NO free-tier limits — unlimited
-# workspaces and unlimited members — and GET /api/billing/config reports
+# vaults and unlimited members — and GET /api/billing/config reports
 # { enabled: false } while every other /api/billing/* route returns 404.
 #
 # To turn billing on (the managed baalda.com option does this), create a Polar
-# organization + two products (monthly $10, yearly $96), then set:
+# organization + two products (monthly $10, yearly $97), then set:
 # POLAR_ACCESS_TOKEN=polar_oat_...
 # POLAR_WEBHOOK_SECRET=          # from the Polar webhook endpoint you register
 # POLAR_SERVER=sandbox           # 'sandbox' (default) or 'production'

--- a/app/apps/server/migrations/024_subscription_tombstones.sql
+++ b/app/apps/server/migrations/024_subscription_tombstones.sql
@@ -1,0 +1,48 @@
+-- A subscription must OUTLIVE the vault it paid for (#109, #111).
+--
+-- Migration 010 made `subscriptions.organization_id` a primary key with
+-- `REFERENCES organization (id) ON DELETE CASCADE`. Deleting a vault therefore
+-- erased every trace of its subscription while Polar happily kept charging:
+--
+--  1. `DELETE /api/orgs/:orgId` asked Polar to cancel *best-effort* — a provider
+--     outage only logged, the vault was deleted anyway, and the row that named
+--     the live subscription vanished with it. Nothing could ever retry, and no
+--     screen could tell the owner they were still paying.
+--  2. Every later Polar webhook for that subscription hit the FK on insert, the
+--     transaction rolled back (undoing the `billing_events` idempotency claim
+--     with it), the route 500'd, and Polar retried the same event forever.
+--
+-- So the FK goes and the row becomes a **tombstone**: `deleted_at` marks that
+-- the org is gone, `org_name` keeps a display name for a vault we can no longer
+-- read one from, and `owner_user_id` records who may still manage or transfer
+-- it once the `member` rows have cascaded away. There is deliberately NO FK on
+-- `owner_user_id` either — a tombstone must survive anything, and account
+-- deletion silently nulling it would strand the subscription again.
+--
+-- `interval` / `amount` / `currency` come along in the same pass: every
+-- provider mutation now returns Polar's authoritative snapshot and we persist
+-- all of it, so "Subscriptions" can show a real price without a provider round
+-- trip on the request path (the rule from 010: our Postgres answers "is this
+-- vault paid", never the network).
+
+ALTER TABLE subscriptions DROP CONSTRAINT IF EXISTS subscriptions_organization_id_fkey;
+
+ALTER TABLE subscriptions
+  ADD COLUMN deleted_at    TIMESTAMPTZ,  -- when the vault (org) was deleted; NULL = org alive
+  ADD COLUMN org_name      TEXT,         -- display snapshot, kept current on write while the org lives
+  ADD COLUMN owner_user_id TEXT,         -- who may manage/transfer once the org row is gone (no FK on purpose)
+  ADD COLUMN interval      TEXT,         -- 'month' | 'year'
+  ADD COLUMN amount        INTEGER,      -- minor units, from the provider
+  ADD COLUMN currency      TEXT;
+
+-- Backfill the two display/authority columns for rows that predate this.
+UPDATE subscriptions s SET org_name = o.name FROM organization o WHERE o.id = s.organization_id;
+UPDATE subscriptions s SET owner_user_id = m."userId" FROM member m
+ WHERE m."organizationId" = s.organization_id AND m.role = 'owner' AND s.owner_user_id IS NULL;
+
+-- Webhooks now resolve the row by provider subscription id FIRST, so a
+-- transferred subscription's events land on the vault that holds it now rather
+-- than on whatever `metadata.organization_id` still names.
+CREATE INDEX subscriptions_provider_sub_idx ON subscriptions (provider_subscription_id);
+-- "Subscriptions from deleted vaults" lists tombstones by their owner.
+CREATE INDEX subscriptions_owner_idx ON subscriptions (owner_user_id);

--- a/app/apps/server/src/auth/auth.ts
+++ b/app/apps/server/src/auth/auth.ts
@@ -185,6 +185,15 @@ export const auth = betterAuth({
     organization({
       creatorRole: "owner",
       invitationExpiresIn: config.invitationExpiresInSeconds, // 48h
+      // Better Auth's own delete-organization endpoint is closed off entirely,
+      // the same way `beforeUpdateMemberRole` closes off role changes below.
+      // DELETE /api/orgs/:orgId (routes/orgs.ts) is the ONLY path: it cancels
+      // the vault's subscription at the provider first and refuses to delete
+      // anything if that fails (#109/#111), purges the FK-less CRDT stores,
+      // force-closes live sockets and broadcasts the ACL change. Better Auth's
+      // endpoint does none of that — it would drop the org row and leave the
+      // provider billing a vault nobody can reach.
+      disableOrganizationDeletion: true,
       // Inviting an address that is already pending re-sends instead of
       // failing with "already invited": the old row is canceled and a fresh
       // one (new id, new 48h) goes out. That is what an admin clicking Invite

--- a/app/apps/server/src/billing/entitlements.ts
+++ b/app/apps/server/src/billing/entitlements.ts
@@ -1,12 +1,13 @@
 import type pg from "pg";
 import { pool as defaultPool } from "../db/pool.js";
 import { config, billingEnabled } from "../config.js";
+import type { BillingInterval } from "./provider.js";
 
 /**
  * Entitlement checks. These read ONLY our own tables (`subscriptions`, `member`,
  * `invitation`) — never the payment provider — so they're cheap and correct on
  * the request path. The `subscriptions` table is the single source of truth,
- * written only by webhook processing.
+ * written only through `billing/store.ts`.
  *
  * Every gate returns "allowed" when billing is disabled (self-host = unlimited).
  */
@@ -26,6 +27,16 @@ export interface Entitlement {
   providerSubscriptionId: string | null;
   /** True when the org has an active (or past_due grace) subscription. */
   active: boolean;
+  /**
+   * Price the provider is actually charging, persisted from its snapshots so
+   * "Subscriptions" can render a real figure without a provider round trip on
+   * the request path. Null on rows written before migration 024, and on any
+   * row the provider never reported a price for.
+   */
+  interval: BillingInterval | null;
+  /** Minor units (cents). */
+  amount: number | null;
+  currency: string | null;
 }
 
 interface SubRow {
@@ -35,16 +46,27 @@ interface SubRow {
   cancel_at_period_end: boolean;
   provider_customer_id: string | null;
   provider_subscription_id: string | null;
+  interval: string | null;
+  amount: number | null;
+  currency: string | null;
 }
 
-/** Read the current entitlement for an org from OUR subscriptions table. */
+/**
+ * Read the current entitlement for an org from OUR subscriptions table.
+ *
+ * A tombstone row (`deleted_at` set, the vault deleted) resolves exactly like a
+ * live one on purpose: the subscription is still real and still being charged,
+ * which is the whole point of keeping the row (#109). Callers that care about
+ * the difference read `deleted_at` through `billing/store.ts` instead.
+ */
 export async function getEntitlement(
   orgId: string,
   db: Queryable = defaultPool,
 ): Promise<Entitlement> {
   const { rows } = await db.query<SubRow>(
     `SELECT plan, status, current_period_end, cancel_at_period_end,
-            provider_customer_id, provider_subscription_id
+            provider_customer_id, provider_subscription_id,
+            interval, amount, currency
        FROM subscriptions WHERE organization_id = $1`,
     [orgId],
   );
@@ -58,6 +80,9 @@ export async function getEntitlement(
       providerCustomerId: null,
       providerSubscriptionId: null,
       active: false,
+      interval: null,
+      amount: null,
+      currency: null,
     };
   }
   const active = (ACTIVE_STATUSES as readonly string[]).includes(row.status);
@@ -71,6 +96,9 @@ export async function getEntitlement(
     providerCustomerId: row.provider_customer_id,
     providerSubscriptionId: row.provider_subscription_id,
     active,
+    interval: normalizeIntervalForApi(row.interval),
+    amount: row.amount === null ? null : Number(row.amount),
+    currency: row.currency,
   };
 }
 
@@ -79,6 +107,11 @@ function normalizeStatusForApi(status: string): Entitlement["status"] {
     return status;
   }
   return "none";
+}
+
+/** Only the two intervals we sell survive to the wire; anything else is null. */
+export function normalizeIntervalForApi(interval: string | null): BillingInterval | null {
+  return interval === "month" || interval === "year" ? interval : null;
 }
 
 /** Does the org have an active (unlimited-members) subscription right now? */

--- a/app/apps/server/src/billing/polar.ts
+++ b/app/apps/server/src/billing/polar.ts
@@ -3,9 +3,11 @@ import { Webhook, WebhookVerificationError } from "standardwebhooks";
 import { config } from "../config.js";
 import {
   WebhookSignatureError,
+  type BillingInterval,
   type BillingProvider,
   type CreateCheckoutArgs,
   type NormalizedBillingEvent,
+  type SubscriptionSnapshot,
 } from "./provider.js";
 
 /**
@@ -20,7 +22,17 @@ import {
  *    subscription webhooks — that's how we key entitlements without a lookup.
  *  - `polar.customerSessions.create({ customerId })` → `{ customerPortalUrl }`
  *    (hosted manage/cancel page).
- *  - `polar.subscriptions.revoke({ id })` — cancel immediately (org delete).
+ *  - `polar.subscriptions.update({ id, subscriptionUpdate: { cancelAtPeriodEnd } })`
+ *    — schedule a cancellation at period end, or take one back (uncancel).
+ *  - `polar.subscriptions.revoke({ id })` — cancel immediately.
+ *  - `polar.subscriptions.get({ id })` — reconcile a row we suspect is stale.
+ *    Each of those returns the full `Subscription`, which `toSnapshot` maps to
+ *    a `SubscriptionSnapshot` the caller writes straight into our row: after a
+ *    mutation Polar's answer IS the state, so we never wait on a webhook to
+ *    learn what we just did.
+ *  - `PATCH /v1/subscriptions/:id` by raw fetch for metadata (see
+ *    `setSubscriptionOrg`): SDK 0.48.1's `SubscriptionUpdate` union has no
+ *    `metadata` variant even though the REST API accepts one.
  *  - Webhook signatures are verified HERE with `standardwebhooks` directly
  *    (see `verifyWebhookSignature`), NOT with the SDK's `validateEvent`. Polar
  *    changed how it derives the signing key: endpoints whose secret was
@@ -39,6 +51,18 @@ import {
 /** Metadata keys we stamp on checkout so the subscription webhooks self-identify. */
 const META_ORG = "organization_id";
 const META_USER = "user_id";
+
+/**
+ * Polar answered 404 for the id we asked about. Its own class so
+ * `getSubscription` can turn it into `null` while every other caller still
+ * sees a plain failure.
+ */
+class PolarNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PolarNotFoundError";
+  }
+}
 
 /**
  * Run one Polar SDK call, converting its errors into something diagnosable.
@@ -68,6 +92,14 @@ async function polarCall<T>(op: string, fn: () => Promise<T>): Promise<T> {
       rawValue?: unknown;
       pretty?: () => string;
     };
+    // A 404 is not a failure for every caller: reconciliation asks about ids
+    // that may have been deleted at Polar and must be able to tell "gone" from
+    // "call broke". Every Polar error class extends `PolarError`, which carries
+    // `statusCode`, so this fires before the neutral-Error rewrite below —
+    // otherwise the status would only survive inside a prose message.
+    if (e.statusCode === 404) {
+      throw new PolarNotFoundError(`Polar ${op}: not found (HTTP 404)`);
+    }
     if (typeof e.pretty === "function") {
       const body = typeof e.body === "string" ? e.body.slice(0, 2000) : "";
       console.error(
@@ -93,7 +125,7 @@ function client(): Polar {
 }
 
 /** Map a Polar subscription status to the status we persist. */
-function normalizeStatus(polarStatus: string): string {
+function normalizeStatus(polarStatus: string): SubscriptionSnapshot["status"] {
   switch (polarStatus) {
     case "active":
     case "trialing":
@@ -104,6 +136,47 @@ function normalizeStatus(polarStatus: string): string {
       // canceled, unpaid, incomplete, incomplete_expired → treated as canceled.
       return "canceled";
   }
+}
+
+/** Map Polar's `recurringInterval` to our two-value interval (or null). */
+function normalizeInterval(raw: unknown): BillingInterval | null {
+  return raw === "month" || raw === "year" ? raw : null;
+}
+
+/** A finite number or null — Polar sends `amount` as an int, but not always. */
+function normalizeAmount(raw: unknown): number | null {
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Map a Polar `Subscription` (the read model returned by get/update/revoke)
+ * onto our neutral snapshot. Reads defensively through `unknown` rather than
+ * the SDK's declared type: the same shape arrives from the webhook JSON in
+ * snake_case, and the 2026-09-08 outage was caused by trusting the SDK's strict
+ * parse of a payload that had drifted.
+ */
+function toSnapshot(raw: unknown): SubscriptionSnapshot {
+  const sub = (raw ?? {}) as Record<string, unknown>;
+  const pick = (snake: string, camel: string): unknown => sub[snake] ?? sub[camel];
+  const periodEnd = pick("current_period_end", "currentPeriodEnd") as
+    | Date
+    | string
+    | null
+    | undefined;
+  const modified = pick("modified_at", "modifiedAt") as Date | string | null | undefined;
+  const modifiedAt = modified ? new Date(modified) : new Date();
+  return {
+    providerSubscriptionId: String(sub.id ?? ""),
+    providerCustomerId: String(pick("customer_id", "customerId") ?? ""),
+    status: normalizeStatus(String(pick("status", "status") ?? "")),
+    currentPeriodEnd: periodEnd ? new Date(periodEnd) : null,
+    cancelAtPeriodEnd: Boolean(pick("cancel_at_period_end", "cancelAtPeriodEnd")),
+    interval: normalizeInterval(pick("recurring_interval", "recurringInterval")),
+    amount: normalizeAmount(pick("amount", "amount")),
+    currency: pick("currency", "currency") ? String(pick("currency", "currency")) : null,
+    modifiedAt: Number.isNaN(modifiedAt.getTime()) ? new Date() : modifiedAt,
+  };
 }
 
 /** Map a Polar webhook `type` to our normalized event type (or null to ignore). */
@@ -159,10 +232,95 @@ export class PolarBillingProvider implements BillingProvider {
     return { url: session.customerPortalUrl };
   }
 
-  async cancelSubscription(providerSubscriptionId: string): Promise<void> {
-    await polarCall("subscriptions.revoke", () =>
-      client().subscriptions.revoke({ id: providerSubscriptionId }),
+  async cancelSubscription(
+    providerSubscriptionId: string,
+    mode: "period_end" | "now",
+  ): Promise<SubscriptionSnapshot> {
+    if (mode === "now") {
+      const sub = await polarCall("subscriptions.revoke", () =>
+        client().subscriptions.revoke({ id: providerSubscriptionId }),
+      );
+      return toSnapshot(sub);
+    }
+    // `cancelAtPeriodEnd: true` is Polar's "stop renewing but keep access"
+    // switch — the same one their customer portal flips, so a cancel we make
+    // and a cancel the owner makes end up in identical provider state.
+    const sub = await polarCall("subscriptions.update(cancelAtPeriodEnd)", () =>
+      client().subscriptions.update({
+        id: providerSubscriptionId,
+        subscriptionUpdate: { cancelAtPeriodEnd: true },
+      }),
     );
+    return toSnapshot(sub);
+  }
+
+  async resumeSubscription(providerSubscriptionId: string): Promise<SubscriptionSnapshot> {
+    // Same field, other way round: Polar documents `cancelAtPeriodEnd: false`
+    // as "uncancel a subscription currently set to be revoked at period end".
+    const sub = await polarCall("subscriptions.update(uncancel)", () =>
+      client().subscriptions.update({
+        id: providerSubscriptionId,
+        subscriptionUpdate: { cancelAtPeriodEnd: false },
+      }),
+    );
+    return toSnapshot(sub);
+  }
+
+  async getSubscription(
+    providerSubscriptionId: string,
+  ): Promise<SubscriptionSnapshot | null> {
+    try {
+      const sub = await polarCall("subscriptions.get", () =>
+        client().subscriptions.get({ id: providerSubscriptionId }),
+      );
+      return toSnapshot(sub);
+    } catch (err) {
+      // Unknown at Polar. Reconciliation must not read that as "canceled" —
+      // it means our row points at something that is simply not there, which
+      // is a data question for a human, not a status to write.
+      if (err instanceof PolarNotFoundError) return null;
+      throw err;
+    }
+  }
+
+  async setSubscriptionOrg(
+    providerSubscriptionId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<void> {
+    // Raw PATCH, not the SDK: `SubscriptionUpdate` in 0.48.1 is a six-way union
+    // (seats / billing period / cancel / revoke / clear-pending / base) and not
+    // one variant carries `metadata`, even though Polar's REST API accepts it
+    // on `SubscriptionUpdateBase`. Keeping Polar's metadata truthful is a
+    // courtesy — our own row decides who owns the subscription, and the webhook
+    // resolves by provider subscription id before consulting metadata — so the
+    // caller logs a failure and carries on.
+    if (!config.polarAccessToken) {
+      throw new Error("Polar access token not configured");
+    }
+    const base =
+      config.polarServer === "production"
+        ? "https://api.polar.sh"
+        : "https://sandbox-api.polar.sh";
+    const res = await fetch(
+      `${base}/v1/subscriptions/${encodeURIComponent(providerSubscriptionId)}`,
+      {
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${config.polarAccessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          metadata: { [META_ORG]: orgId, [META_USER]: userId },
+        }),
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `Polar PATCH /v1/subscriptions/${providerSubscriptionId} failed (HTTP ${res.status}): ${body.slice(0, 500)}`,
+      );
+    }
   }
 
   verifyAndNormalizeWebhook(
@@ -209,17 +367,27 @@ export class PolarBillingProvider implements BillingProvider {
       | null
       | undefined;
 
+    // The user who checked out. Rides in the same metadata and is the ONLY
+    // remaining answer to "whose subscription is this" once the vault has been
+    // deleted and its `member` rows have cascaded away (#109).
+    const userIdRaw = String(metadata?.[META_USER] ?? "");
+    const currency = pick("currency", "currency");
+
     return {
       eventId: this.eventId(event.type, sub, headers),
       occurredAt: this.occurredAt(modifiedAt, headers),
       type,
       organizationId: orgId,
+      userId: userIdRaw || null,
       providerCustomerId: String(pick("customer_id", "customerId") ?? ""),
       providerSubscriptionId: String(sub.id ?? ""),
       plan: "pro",
       status,
       currentPeriodEnd: currentPeriodEnd ? new Date(currentPeriodEnd) : null,
       cancelAtPeriodEnd: Boolean(pick("cancel_at_period_end", "cancelAtPeriodEnd")),
+      interval: normalizeInterval(pick("recurring_interval", "recurringInterval")),
+      amount: normalizeAmount(pick("amount", "amount")),
+      currency: currency ? String(currency) : null,
     };
   }
 

--- a/app/apps/server/src/billing/provider.ts
+++ b/app/apps/server/src/billing/provider.ts
@@ -59,11 +59,50 @@ export interface NormalizedBillingEvent {
   providerSubscriptionId: string;
   /** Our internal plan id (currently always "pro"). */
   plan: string;
+  /**
+   * The user who started this checkout (from the same metadata), when the
+   * provider still carries it. Needed because a webhook can arrive for a vault
+   * we have already deleted: the `member` rows are gone, so this is the only
+   * remaining answer to "whose subscription is this" (#109).
+   */
+  userId: string | null;
   /** Normalized status to persist: "active" | "past_due" | "canceled". */
   status: string;
   /** End of the current paid period, if known. */
   currentPeriodEnd: Date | null;
   cancelAtPeriodEnd: boolean;
+  /** Billing period the subscription renews on, when the provider reports one. */
+  interval: BillingInterval | null;
+  /** Price in minor units (cents), as the provider charges it. */
+  amount: number | null;
+  /** ISO-4217-ish currency code, lowercased by the provider (e.g. "usd"). */
+  currency: string | null;
+}
+
+/**
+ * The provider's authoritative view of one subscription, returned by every
+ * mutation so the caller can write it straight into our row.
+ *
+ * The rule this exists to enforce: Polar and our Postgres must never disagree.
+ * A mutation that only said "ok" would leave us waiting on a webhook that may
+ * be delayed, mis-signed, or dropped — which is how a canceled subscription
+ * kept showing as Pro. Every call therefore hands back the full state, and it
+ * goes through the SAME upsert (and the same `event_ts` ordering guard) the
+ * webhook uses, so a snapshot and a webhook racing each other still converge.
+ */
+export interface SubscriptionSnapshot {
+  providerSubscriptionId: string;
+  providerCustomerId: string;
+  /** Normalized the same way as the webhook: "active" | "past_due" | "canceled". */
+  status: "active" | "past_due" | "canceled";
+  currentPeriodEnd: Date | null;
+  cancelAtPeriodEnd: boolean;
+  interval: BillingInterval | null;
+  /** Price in minor units (cents). */
+  amount: number | null;
+  currency: string | null;
+  /** Provider `modifiedAt` — used as `event_ts` for the ordering guard. */
+  modifiedAt: Date;
 }
 
 export interface CreateCheckoutArgs {
@@ -80,8 +119,44 @@ export interface BillingProvider {
   createCheckout(args: CreateCheckoutArgs): Promise<{ url: string }>;
   /** Create a customer-portal session (manage / cancel) and return its URL. */
   getPortalUrl(args: { customerId: string }): Promise<{ url: string }>;
-  /** Cancel a subscription at the provider (best-effort on org delete). */
-  cancelSubscription(providerSubscriptionId: string): Promise<void>;
+  /**
+   * Stop a subscription.
+   *
+   *  - `"period_end"` — no further charges, access kept until the paid period
+   *    runs out. What vault deletion and the Cancel action use: the owner has
+   *    already paid for this month, so ending it early would be a refund we
+   *    never promised.
+   *  - `"now"` — revoke immediately (the deliberate "stop billing me today"
+   *    choice, and the only way to clear a tombstone the owner no longer wants).
+   */
+  cancelSubscription(
+    providerSubscriptionId: string,
+    mode: "period_end" | "now",
+  ): Promise<SubscriptionSnapshot>;
+  /**
+   * Un-cancel a subscription that is set to end at period end, putting it back
+   * on renewal. Transfer needs this: the "delete a vault, make a new one, move
+   * the subscription across" story has to end with a live Pro, not one that
+   * quietly lapses at the end of the month.
+   */
+  resumeSubscription(providerSubscriptionId: string): Promise<SubscriptionSnapshot>;
+  /**
+   * Read one subscription's current state. `null` means the provider does not
+   * know this id (404) — the row is referring to something that no longer
+   * exists, so the caller leaves it alone rather than inventing a status.
+   */
+  getSubscription(providerSubscriptionId: string): Promise<SubscriptionSnapshot | null>;
+  /**
+   * Re-point a subscription's `organization_id` / `user_id` metadata after a
+   * transfer. Best-effort: the caller logs and carries on, because our own row
+   * is the source of truth and webhooks resolve by provider subscription id
+   * before they ever look at metadata.
+   */
+  setSubscriptionOrg(
+    providerSubscriptionId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<void>;
   /**
    * Verify a raw webhook body + headers and normalize it. Returns `null` for a
    * valid signature carrying an event we don't act on (caller answers 202).

--- a/app/apps/server/src/billing/store.ts
+++ b/app/apps/server/src/billing/store.ts
@@ -1,0 +1,230 @@
+import type pg from "pg";
+import { pool as defaultPool } from "../db/pool.js";
+import { orgRole } from "../permissions/lookup.js";
+
+/**
+ * The ONE write path for the `subscriptions` table.
+ *
+ * Five callers change a subscription row — the Polar webhook, vault deletion,
+ * the cancel endpoint, transfer, and the reconcile pass in
+ * `GET /api/billing/mine` — and before this file existed only the webhook could
+ * write, so the other four had to improvise. `applySubscriptionState` gives
+ * them all the same upsert, the same `event_ts` ordering guard and the same
+ * tombstone bookkeeping, which is the only way "Polar and our DB always agree"
+ * can hold: a provider snapshot and a webhook describing the same change can
+ * arrive in either order and still converge on whichever the provider stamped
+ * later.
+ *
+ * Two column groups, written by two statements on purpose:
+ *
+ *  1. **Provider state** (status, period end, cancel flag, price) is subject to
+ *     the ordering guard — a stale redelivery must never overwrite newer state.
+ *  2. **Our bookkeeping** (`org_name`, `owner_user_id`, `deleted_at`) is not.
+ *     None of it comes from the provider, so provider event time says nothing
+ *     about it, and a stale event that is otherwise a no-op should still be
+ *     allowed to fill in an owner we were missing. That statement also bumps
+ *     `updated_at`, which is what marks a row as freshly checked for the
+ *     reconcile pass — otherwise a row whose guard suppressed the write would
+ *     be re-reconciled on every single request.
+ */
+
+type Queryable = Pick<pg.Pool, "query">;
+
+/** Statuses that mean "this vault is paid" (past_due is the grace period). */
+export const ACTIVE_SUBSCRIPTION_STATUSES = ["active", "past_due"] as const;
+
+/** Is this row one we should still be treating as a live subscription? */
+export function isActiveStatus(status: string): boolean {
+  return (ACTIVE_SUBSCRIPTION_STATUSES as readonly string[]).includes(status);
+}
+
+/** A `subscriptions` row exactly as stored. */
+export interface SubscriptionRow {
+  organization_id: string;
+  provider: string;
+  provider_customer_id: string | null;
+  provider_subscription_id: string | null;
+  plan: string;
+  status: string;
+  current_period_end: Date | null;
+  cancel_at_period_end: boolean;
+  event_ts: Date | null;
+  /** Non-null ⇒ the vault (org) has been deleted; this row is a tombstone. */
+  deleted_at: Date | null;
+  org_name: string | null;
+  owner_user_id: string | null;
+  interval: string | null;
+  amount: number | null;
+  currency: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/** Every column of `subscriptions`, for SELECTs that hand back a whole row. */
+export const SUBSCRIPTION_COLUMNS = `organization_id, provider, provider_customer_id,
+       provider_subscription_id, plan, status, current_period_end,
+       cancel_at_period_end, event_ts, deleted_at, org_name, owner_user_id,
+       interval, amount, currency, created_at, updated_at`;
+
+/** What a caller knows about a subscription and wants persisted. */
+export interface SubscriptionState {
+  organizationId: string;
+  providerCustomerId: string | null;
+  providerSubscriptionId: string | null;
+  /** Our internal plan id (currently always "pro"). */
+  plan: string;
+  /** "active" | "past_due" | "canceled". */
+  status: string;
+  currentPeriodEnd: Date | null;
+  cancelAtPeriodEnd: boolean;
+  /** Provider event/modification time — the ordering guard compares on this. */
+  eventTs: Date | null;
+  interval: string | null;
+  amount: number | null;
+  currency: string | null;
+  /**
+   * Tombstone marker. A `Date` sets it, `null` clears it (transfer onto a live
+   * vault), and leaving it `undefined` keeps whatever the row already had — a
+   * webhook for a live vault must not silently un-delete a tombstone, and one
+   * for a deleted vault must not have its marker cleared by the next event.
+   */
+  deletedAt?: Date | null;
+  /**
+   * Fallback owner, used only when the org has no `owner` member to derive one
+   * from — i.e. when the org row is already gone. `metadata.user_id` off the
+   * webhook, or the caller's own id for a delete/transfer.
+   */
+  ownerUserId?: string | null;
+}
+
+/**
+ * Upsert one subscription row and return it as stored.
+ *
+ * Pass the `client` that owns the surrounding transaction when there is one:
+ * the webhook's idempotency claim and this write MUST commit together, and
+ * vault deletion's tombstone must land with the `DELETE FROM organization`.
+ */
+export async function applySubscriptionState(
+  client: Queryable,
+  state: SubscriptionState,
+): Promise<SubscriptionRow | null> {
+  await client.query(
+    `INSERT INTO subscriptions (
+       organization_id, provider, provider_customer_id, provider_subscription_id,
+       plan, status, current_period_end, cancel_at_period_end, event_ts,
+       interval, amount, currency, updated_at
+     ) VALUES ($1, 'polar', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now())
+     ON CONFLICT (organization_id) DO UPDATE SET
+       -- COALESCE, not a bare overwrite: a snapshot that didn't carry the
+       -- customer id must not erase the one the portal needs to open.
+       provider_customer_id     = COALESCE(EXCLUDED.provider_customer_id, subscriptions.provider_customer_id),
+       provider_subscription_id = COALESCE(EXCLUDED.provider_subscription_id, subscriptions.provider_subscription_id),
+       plan                     = EXCLUDED.plan,
+       status                   = EXCLUDED.status,
+       current_period_end       = EXCLUDED.current_period_end,
+       cancel_at_period_end     = EXCLUDED.cancel_at_period_end,
+       event_ts                 = EXCLUDED.event_ts,
+       interval                 = COALESCE(EXCLUDED.interval, subscriptions.interval),
+       amount                   = COALESCE(EXCLUDED.amount, subscriptions.amount),
+       currency                 = COALESCE(EXCLUDED.currency, subscriptions.currency),
+       updated_at               = now()
+     WHERE subscriptions.event_ts IS NULL
+        OR EXCLUDED.event_ts >= subscriptions.event_ts`,
+    [
+      state.organizationId,
+      state.providerCustomerId || null,
+      state.providerSubscriptionId || null,
+      state.plan,
+      state.status,
+      state.currentPeriodEnd,
+      state.cancelAtPeriodEnd,
+      state.eventTs,
+      state.interval,
+      state.amount,
+      state.currency,
+    ],
+  );
+
+  // Bookkeeping, outside the ordering guard (see the file header). `org_name`
+  // is refreshed from the live org and otherwise kept — a tombstone has no org
+  // to read a name from, and losing the snapshot would leave the owner staring
+  // at an unnamed charge.
+  const { rows } = await client.query<SubscriptionRow>(
+    `UPDATE subscriptions SET
+       org_name      = COALESCE((SELECT name FROM organization WHERE id = $1), org_name),
+       owner_user_id = COALESCE(
+                         owner_user_id,
+                         (SELECT m."userId" FROM member m
+                           WHERE m."organizationId" = $1 AND m.role = 'owner'
+                           ORDER BY m."createdAt" LIMIT 1),
+                         $2),
+       deleted_at    = CASE WHEN $3 THEN $4::timestamptz ELSE deleted_at END,
+       updated_at    = now()
+     WHERE organization_id = $1
+     RETURNING ${SUBSCRIPTION_COLUMNS}`,
+    [
+      state.organizationId,
+      state.ownerUserId ?? null,
+      state.deletedAt !== undefined,
+      state.deletedAt ?? null,
+    ],
+  );
+  return rows[0] ?? null;
+}
+
+/** Read one org's subscription row, or null. */
+export async function findByOrg(
+  client: Queryable,
+  orgId: string,
+): Promise<SubscriptionRow | null> {
+  const { rows } = await client.query<SubscriptionRow>(
+    `SELECT ${SUBSCRIPTION_COLUMNS} FROM subscriptions WHERE organization_id = $1`,
+    [orgId],
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Find the row that currently holds a given provider subscription.
+ *
+ * Webhooks resolve through this FIRST and only fall back to
+ * `metadata.organization_id`. After a transfer Polar's metadata may still name
+ * the vault the subscription came from (the metadata PATCH is best-effort), so
+ * trusting metadata would walk a live subscription straight back onto a vault
+ * that no longer holds it — and, if that vault had been deleted, resurrect its
+ * tombstone as the paid one. There is no unique index on the column on purpose
+ * (a canceled row for an old vault may legitimately linger holding the same
+ * id), so the most recently written row wins.
+ */
+export async function findByProviderSubscription(
+  client: Queryable,
+  providerSubscriptionId: string,
+): Promise<SubscriptionRow | null> {
+  if (!providerSubscriptionId) return null;
+  const { rows } = await client.query<SubscriptionRow>(
+    `SELECT ${SUBSCRIPTION_COLUMNS} FROM subscriptions
+      WHERE provider_subscription_id = $1
+      ORDER BY updated_at DESC LIMIT 1`,
+    [providerSubscriptionId],
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * May this user cancel or transfer this subscription?
+ *
+ * While the vault lives, the answer is the vault's own authority: the `owner`
+ * role and only that (an admin manages billing through the provider portal,
+ * which can neither delete nor move anything of ours). Once the vault is gone
+ * there are no `member` rows left to ask, so the tombstone's recorded
+ * `owner_user_id` is the whole answer — which is exactly why migration 024
+ * records it.
+ */
+export async function canManageSubscriptionRow(
+  userId: string,
+  row: SubscriptionRow,
+  db: Queryable = defaultPool,
+): Promise<boolean> {
+  if (row.deleted_at) return row.owner_user_id === userId;
+  return (await orgRole(row.organization_id, userId, db)) === "owner";
+}

--- a/app/apps/server/src/http/routes/billing.ts
+++ b/app/apps/server/src/http/routes/billing.ts
@@ -8,22 +8,50 @@ import {
   type BillingInterval,
   type BillingProvider,
   type NormalizedBillingEvent,
+  type SubscriptionSnapshot,
 } from "../../billing/provider.js";
-import { getEntitlement, seatCount } from "../../billing/entitlements.js";
+import {
+  getEntitlement,
+  normalizeIntervalForApi,
+  seatCount,
+  countOwnedUnsubscribedOrgs,
+  type Entitlement,
+} from "../../billing/entitlements.js";
+import {
+  ACTIVE_SUBSCRIPTION_STATUSES,
+  SUBSCRIPTION_COLUMNS,
+  applySubscriptionState,
+  canManageSubscriptionRow,
+  findByOrg,
+  findByProviderSubscription,
+  isActiveStatus,
+  type SubscriptionRow,
+  type SubscriptionState,
+} from "../../billing/store.js";
 import { successPageHtml } from "./billing-success.js";
 
 /**
  * Subscription billing routes (frozen API contract).
  *
- *  GET  /api/billing/config              — public; advertises plans + limits.
- *  GET  /api/billing/orgs/:orgId         — member: this vault's plan/seats.
+ *  GET  /api/billing/config               — public; advertises plans + limits.
+ *  GET  /api/billing/mine                 — every vault I'm in + orphaned subs.
+ *  GET  /api/billing/orgs/:orgId          — member: this vault's plan/seats.
  *  POST /api/billing/orgs/:orgId/checkout — owner/admin: hosted checkout URL.
  *  POST /api/billing/orgs/:orgId/portal   — owner/admin: manage/cancel URL.
- *  POST /api/billing/webhook             — provider webhook (raw body, idempotent).
- *  GET  /api/billing/success             — checkout success landing page.
+ *  POST /api/billing/orgs/:orgId/cancel   — owner: stop at period end, or now.
+ *  POST /api/billing/orgs/:orgId/transfer — owner: move a sub to another vault.
+ *  POST /api/billing/webhook              — provider webhook (raw body, idempotent).
+ *  GET  /api/billing/success              — checkout success landing page.
  *
  * When billing is disabled (no provider token), /config reports
  * `{ enabled: false }` and every other route 404s — self-host stays unlimited.
+ *
+ * A subscription can OUTLIVE its vault (#109/#111). Deleting a vault leaves a
+ * **tombstone** row (`deleted_at` set) so the owner can still see, cancel or
+ * transfer what they are paying for, and so a webhook that arrives afterwards
+ * has somewhere to land instead of 500ing on a foreign key forever. Every
+ * per-org route below therefore accepts the tombstone's recorded owner as well
+ * as the live vault's members: `:orgId` may name a vault that no longer exists.
  */
 export interface BillingDeps {
   provider: BillingProvider;
@@ -33,6 +61,78 @@ const PLANS = [
   { id: "pro-monthly", label: "Pro", amount: 1000, currency: "usd", interval: "month" },
   { id: "pro-yearly", label: "Pro", amount: 9700, currency: "usd", interval: "year" },
 ] as const;
+
+/**
+ * How stale an active row may get before `GET /mine` re-reads it from the
+ * provider. Webhooks are the fast path; this is the backstop for the ones that
+ * never arrive (a mis-signed endpoint, a delivery dropped during an outage —
+ * 2026-09-08 was exactly that), so the two sides cannot stay diverged for
+ * longer than one visit to the Billing tab.
+ */
+const RECONCILE_STALE_MINUTES = 10;
+/** Cap the provider calls one request may make, so the tab can't hang on Polar. */
+const RECONCILE_MAX_PER_REQUEST = 5;
+
+/** Map a provider snapshot onto the shape `applySubscriptionState` persists. */
+function stateFromSnapshot(
+  orgId: string,
+  snap: SubscriptionSnapshot,
+  extra: Pick<SubscriptionState, "deletedAt" | "ownerUserId"> = {},
+): SubscriptionState {
+  return {
+    organizationId: orgId,
+    providerCustomerId: snap.providerCustomerId || null,
+    providerSubscriptionId: snap.providerSubscriptionId || null,
+    plan: "pro",
+    status: snap.status,
+    currentPeriodEnd: snap.currentPeriodEnd,
+    cancelAtPeriodEnd: snap.cancelAtPeriodEnd,
+    eventTs: snap.modifiedAt,
+    interval: snap.interval,
+    amount: snap.amount,
+    currency: snap.currency,
+    ...extra,
+  };
+}
+
+/** The `GET /api/billing/orgs/:orgId` body — shared with cancel and transfer. */
+function orgBillingBody(
+  ent: Entitlement,
+  seats: { members: number; pendingInvitations: number },
+) {
+  return {
+    plan: ent.plan,
+    status: ent.status,
+    currentPeriodEnd: ent.currentPeriodEnd,
+    cancelAtPeriodEnd: ent.cancelAtPeriodEnd,
+    interval: ent.interval,
+    amount: ent.amount,
+    currency: ent.currency,
+    seats: {
+      members: seats.members,
+      pendingInvitations: seats.pendingInvitations,
+      // Active subscription ⇒ unlimited (null); otherwise the free-tier cap.
+      limit: ent.active ? null : config.freeMaxMembers,
+    },
+  };
+}
+
+/** Read the billing view for one org (works for a tombstone: seats come back 0). */
+async function readOrgBilling(orgId: string) {
+  const [ent, seats] = await Promise.all([getEntitlement(orgId), seatCount(orgId)]);
+  return orgBillingBody(ent, seats);
+}
+
+/**
+ * Does this user own the tombstone for `orgId`? The fallback authority for
+ * every per-org route: the vault is gone, so `orgRole` has nothing to answer
+ * with, but the person still being charged must not be locked out of the
+ * subscription they are paying for.
+ */
+async function ownsTombstone(orgId: string, userId: string): Promise<boolean> {
+  const row = await findByOrg(pool, orgId);
+  return !!row && !!row.deleted_at && row.owner_user_id === userId;
+}
 
 export function createBillingRoutes(deps: BillingDeps): Hono {
   const billing = new Hono();
@@ -115,37 +215,57 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
         return c.body(null, 200); // already processed
       }
 
-      // Ordering guard: webhooks aren't delivery-ordered, so only apply when the
-      // incoming event is at least as new as the row we hold (event_ts). A stale
-      // redelivery is still recorded as processed (claim above) but must NOT
-      // overwrite newer state — the WHERE turns it into a no-op on conflict.
-      await client.query(
-        `INSERT INTO subscriptions (
-           organization_id, provider, provider_customer_id, provider_subscription_id,
-           plan, status, current_period_end, cancel_at_period_end, event_ts, updated_at
-         ) VALUES ($1, 'polar', $2, $3, $4, $5, $6, $7, $8, now())
-         ON CONFLICT (organization_id) DO UPDATE SET
-           provider_customer_id     = EXCLUDED.provider_customer_id,
-           provider_subscription_id = EXCLUDED.provider_subscription_id,
-           plan                     = EXCLUDED.plan,
-           status                   = EXCLUDED.status,
-           current_period_end       = EXCLUDED.current_period_end,
-           cancel_at_period_end     = EXCLUDED.cancel_at_period_end,
-           event_ts                 = EXCLUDED.event_ts,
-           updated_at               = now()
-         WHERE subscriptions.event_ts IS NULL
-            OR EXCLUDED.event_ts >= subscriptions.event_ts`,
-        [
-          event.organizationId,
-          event.providerCustomerId,
-          event.providerSubscriptionId,
-          event.plan,
-          event.status,
-          event.currentPeriodEnd,
-          event.cancelAtPeriodEnd,
-          event.occurredAt,
-        ],
+      // Which row does this subscription belong to? The provider subscription
+      // id wins over `metadata.organization_id`: after a transfer Polar's
+      // metadata can still name the vault the subscription came FROM, and
+      // following it would move a live subscription back onto a vault that no
+      // longer holds it.
+      const existing = await findByProviderSubscription(
+        client,
+        event.providerSubscriptionId,
       );
+      const orgId = existing?.organization_id ?? event.organizationId;
+
+      // No row yet and no such org ⇒ the vault was deleted and this event is
+      // about a subscription that outlived it. Record a tombstone and answer
+      // 200. Before migration 024 this hit the FK, rolled back the idempotency
+      // claim with it and 500'd, so Polar retried the same event forever (#109).
+      let deletedAt: Date | null | undefined;
+      if (!existing) {
+        const { rowCount } = await client.query(
+          "SELECT 1 FROM organization WHERE id = $1",
+          [orgId],
+        );
+        if (rowCount === 0) {
+          deletedAt = new Date();
+          console.warn(
+            `billing webhook for deleted vault ${orgId}: recorded as tombstone`,
+          );
+        }
+      }
+
+      // Ordering guard (inside applySubscriptionState): webhooks aren't
+      // delivery-ordered, so provider state only applies when the incoming
+      // event is at least as new as the row we hold. A stale redelivery is
+      // still recorded as processed by the claim above but must NOT overwrite
+      // newer state.
+      await applySubscriptionState(client, {
+        organizationId: orgId,
+        providerCustomerId: event.providerCustomerId,
+        providerSubscriptionId: event.providerSubscriptionId,
+        plan: event.plan,
+        status: event.status,
+        currentPeriodEnd: event.currentPeriodEnd,
+        cancelAtPeriodEnd: event.cancelAtPeriodEnd,
+        eventTs: event.occurredAt,
+        interval: event.interval,
+        amount: event.amount,
+        currency: event.currency,
+        deletedAt,
+        // With the org gone there are no `member` rows to derive an owner from,
+        // so checkout's `metadata.user_id` is the only remaining answer.
+        ownerUserId: event.userId,
+      });
 
       await client.query("COMMIT");
       return c.body(null, 200);
@@ -157,7 +277,189 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
     }
   });
 
-  // ── status for a vault (any member) ─────────────────────────────────────────
+  // ── every vault I'm in, plus subscriptions whose vault is gone ─────────────
+  billing.get("/billing/mine", async (c) => {
+    if (!billingEnabled()) return c.json({ error: "Not found" }, 404);
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const userId = session.userId;
+
+    const { rows: memberships } = await pool.query<{
+      org_id: string;
+      name: string;
+      role: string;
+    }>(
+      `SELECT o.id AS org_id, o.name AS name, m.role AS role
+         FROM member m
+         JOIN organization o ON o.id = m."organizationId"
+        WHERE m."userId" = $1
+        ORDER BY o.name ASC`,
+      [userId],
+    );
+
+    // Reconcile before assembling, so what we return is what Polar says. Only
+    // rows this user can actually act on, only ones that claim to be live, and
+    // only after they have gone stale — a fresh row was just written by a
+    // webhook or a mutation and re-reading it would be a wasted round trip.
+    const manageableOrgIds = memberships
+      .filter((m) => m.role === "owner" || m.role === "admin")
+      .map((m) => m.org_id);
+    const { rows: stale } = await pool.query<SubscriptionRow>(
+      `SELECT ${SUBSCRIPTION_COLUMNS} FROM subscriptions
+        WHERE (organization_id = ANY($1::text[])
+               OR (owner_user_id = $2 AND deleted_at IS NOT NULL))
+          AND status = ANY($3::text[])
+          AND provider_subscription_id IS NOT NULL
+          AND updated_at < now() - ($4 || ' minutes')::interval
+        ORDER BY updated_at ASC
+        LIMIT ${RECONCILE_MAX_PER_REQUEST}`,
+      [
+        manageableOrgIds,
+        userId,
+        ACTIVE_SUBSCRIPTION_STATUSES as unknown as string[],
+        String(RECONCILE_STALE_MINUTES),
+      ],
+    );
+    // Best-effort and never fatal: a provider outage must still render the tab.
+    await Promise.allSettled(
+      stale.map(async (row) => {
+        const subId = row.provider_subscription_id;
+        if (!subId) return;
+        try {
+          const snap = await deps.provider.getSubscription(subId);
+          if (!snap) {
+            // Unknown at Polar. Not "canceled" — our row points at something
+            // that isn't there, which is a data question for a human.
+            console.warn(
+              `billing reconcile: provider does not know subscription ${subId} (vault ${row.organization_id})`,
+            );
+            return;
+          }
+          await applySubscriptionState(pool, stateFromSnapshot(row.organization_id, snap));
+        } catch (err) {
+          console.warn(
+            `billing reconcile failed for vault ${row.organization_id}:`,
+            (err as Error).message,
+          );
+        }
+      }),
+    );
+
+    const orgIds = memberships.map((m) => m.org_id);
+    const subsByOrg = new Map<string, SubscriptionRow>();
+    const memberCounts = new Map<string, number>();
+    const inviteCounts = new Map<string, number>();
+    const owners = new Map<string, { userId: string; name: string; email: string }>();
+    if (orgIds.length) {
+      const [subs, members, invites, ownerRows] = await Promise.all([
+        pool.query<SubscriptionRow>(
+          `SELECT ${SUBSCRIPTION_COLUMNS} FROM subscriptions
+            WHERE organization_id = ANY($1::text[])`,
+          [orgIds],
+        ),
+        pool.query<{ org_id: string; c: number }>(
+          `SELECT "organizationId" AS org_id, count(*)::int AS c FROM member
+            WHERE "organizationId" = ANY($1::text[]) GROUP BY 1`,
+          [orgIds],
+        ),
+        pool.query<{ org_id: string; c: number }>(
+          `SELECT "organizationId" AS org_id, count(*)::int AS c FROM invitation
+            WHERE "organizationId" = ANY($1::text[])
+              AND status = 'pending' AND "expiresAt" > now()
+            GROUP BY 1`,
+          [orgIds],
+        ),
+        pool.query<{ org_id: string; user_id: string; name: string; email: string }>(
+          `SELECT m."organizationId" AS org_id, u.id AS user_id, u.name AS name, u.email AS email
+             FROM member m JOIN "user" u ON u.id = m."userId"
+            WHERE m."organizationId" = ANY($1::text[]) AND m.role = 'owner'
+            ORDER BY m."createdAt" ASC`,
+          [orgIds],
+        ),
+      ]);
+      for (const r of subs.rows) subsByOrg.set(r.organization_id, r);
+      for (const r of members.rows) memberCounts.set(r.org_id, Number(r.c));
+      for (const r of invites.rows) inviteCounts.set(r.org_id, Number(r.c));
+      // First owner by join time wins — the vault's creator, who pays for it.
+      for (const r of ownerRows.rows) {
+        if (!owners.has(r.org_id)) {
+          owners.set(r.org_id, { userId: r.user_id, name: r.name, email: r.email });
+        }
+      }
+    }
+
+    const vaults = memberships.map((m) => {
+      const row = subsByOrg.get(m.org_id);
+      const active = !!row && isActiveStatus(row.status);
+      const role = (m.role === "owner" || m.role === "admin" ? m.role : "member") as
+        | "owner"
+        | "admin"
+        | "member";
+      return {
+        orgId: m.org_id,
+        name: m.name,
+        role,
+        plan: (active ? "pro" : "free") as "free" | "pro",
+        status: apiStatus(row?.status),
+        currentPeriodEnd: row?.current_period_end
+          ? new Date(row.current_period_end).toISOString()
+          : null,
+        cancelAtPeriodEnd: row?.cancel_at_period_end ?? false,
+        interval: normalizeIntervalForApi(row?.interval ?? null),
+        amount: row?.amount === undefined || row.amount === null ? null : Number(row.amount),
+        currency: row?.currency ?? null,
+        seats: {
+          members: memberCounts.get(m.org_id) ?? 0,
+          pendingInvitations: inviteCounts.get(m.org_id) ?? 0,
+          limit: active ? null : config.freeMaxMembers,
+        },
+        billingOwner: owners.get(m.org_id) ?? null,
+        // Upgrade / Manage — the same owner-or-admin gate as checkout/portal.
+        canManage: role === "owner" || role === "admin",
+        // Moving money is the owner's alone, and only while there is something
+        // live to move.
+        canTransfer: role === "owner" && active,
+      };
+    });
+
+    // Tombstones this user owns that are STILL being charged. A canceled
+    // tombstone is history and deliberately not listed — there is nothing left
+    // to act on and it would only clutter the tab.
+    const { rows: orphanRows } = await pool.query<SubscriptionRow>(
+      `SELECT ${SUBSCRIPTION_COLUMNS} FROM subscriptions
+        WHERE owner_user_id = $1
+          AND deleted_at IS NOT NULL
+          AND status = ANY($2::text[])
+        ORDER BY deleted_at DESC`,
+      [userId, ACTIVE_SUBSCRIPTION_STATUSES as unknown as string[]],
+    );
+    const orphaned = orphanRows.map((row) => ({
+      orgId: row.organization_id,
+      orgName: row.org_name,
+      deletedAt: new Date(row.deleted_at as Date).toISOString(),
+      status: row.status as "active" | "past_due",
+      currentPeriodEnd: row.current_period_end
+        ? new Date(row.current_period_end).toISOString()
+        : null,
+      cancelAtPeriodEnd: row.cancel_at_period_end,
+      interval: normalizeIntervalForApi(row.interval),
+      amount: row.amount === null ? null : Number(row.amount),
+      currency: row.currency,
+    }));
+
+    return c.json({
+      vaults,
+      orphaned,
+      freeLimits: {
+        // Frozen wire field names, as in /config.
+        vaultsPerUser: config.freeMaxVaults,
+        membersPerVault: config.freeMaxMembers,
+        freeVaultsUsed: await countOwnedUnsubscribedOrgs(userId),
+      },
+    });
+  });
+
+  // ── status for a vault (any member, or a tombstone's owner) ────────────────
   billing.get("/billing/orgs/:orgId", async (c) => {
     if (!billingEnabled()) return c.json({ error: "Not found" }, 404);
     const session = await getSession(c);
@@ -165,22 +467,11 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
 
     const orgId = c.req.param("orgId");
     const role = await orgRole(orgId, session.userId);
-    if (!role) return c.json({ error: "Not a member of this vault" }, 403);
+    if (!role && !(await ownsTombstone(orgId, session.userId))) {
+      return c.json({ error: "Not a member of this vault" }, 403);
+    }
 
-    const ent = await getEntitlement(orgId);
-    const seats = await seatCount(orgId);
-    return c.json({
-      plan: ent.plan,
-      status: ent.status,
-      currentPeriodEnd: ent.currentPeriodEnd,
-      cancelAtPeriodEnd: ent.cancelAtPeriodEnd,
-      seats: {
-        members: seats.members,
-        pendingInvitations: seats.pendingInvitations,
-        // Active subscription ⇒ unlimited (null); otherwise the free-tier cap.
-        limit: ent.active ? null : config.freeMaxMembers,
-      },
-    });
+    return c.json(await readOrgBilling(orgId));
   });
 
   // ── create checkout (owner/admin) ──────────────────────────────────────────
@@ -193,6 +484,19 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
     const role = await orgRole(orgId, session.userId);
     if (role !== "owner" && role !== "admin") {
       return c.json({ error: "Only vault owner/admin can start checkout" }, 403);
+    }
+
+    // One vault, one subscription — always. `subscriptions` is keyed by
+    // organization_id, so a second checkout would charge the card again and
+    // then have nowhere to land: whichever subscription lost the upsert would
+    // be invisible to us while Polar kept billing for it (the #109 shape of
+    // problem, arrived at from the other direction). Refuse before the provider
+    // is ever asked, so no checkout session exists to be paid for. Changing
+    // plan or payment method goes through the portal; canceling goes through
+    // /cancel.
+    const existing = await findByOrg(pool, orgId);
+    if (existing && isActiveStatus(existing.status)) {
+      return c.json({ error: "already_subscribed" }, 409);
     }
 
     const body = (await c.req.json().catch(() => ({}))) as { interval?: unknown };
@@ -213,7 +517,7 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
     }
   });
 
-  // ── customer portal (owner/admin) ──────────────────────────────────────────
+  // ── customer portal (owner/admin, or a tombstone's owner) ─────────────────
   billing.post("/billing/orgs/:orgId/portal", async (c) => {
     if (!billingEnabled()) return c.json({ error: "Not found" }, 404);
     const session = await getSession(c);
@@ -221,7 +525,11 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
 
     const orgId = c.req.param("orgId");
     const role = await orgRole(orgId, session.userId);
-    if (role !== "owner" && role !== "admin") {
+    const allowed =
+      role === "owner" ||
+      role === "admin" ||
+      (await ownsTombstone(orgId, session.userId));
+    if (!allowed) {
       return c.json({ error: "Only vault owner/admin can manage billing" }, 403);
     }
 
@@ -239,5 +547,170 @@ export function createBillingRoutes(deps: BillingDeps): Hono {
     }
   });
 
+  // ── cancel (owner only; admins use the provider portal) ───────────────────
+  // `period_end` keeps the paid period the owner already bought; `now` revokes
+  // outright, which is the only way to stop paying for a vault that is gone.
+  billing.post("/billing/orgs/:orgId/cancel", async (c) => {
+    if (!billingEnabled()) return c.json({ error: "Not found" }, 404);
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+
+    const orgId = c.req.param("orgId");
+    const row = await findByOrg(pool, orgId);
+    if (!row) return c.json({ error: "no_subscription" }, 404);
+    if (!(await canManageSubscriptionRow(session.userId, row))) {
+      return c.json({ error: "Only the vault owner can cancel the subscription" }, 403);
+    }
+    if (!isActiveStatus(row.status) || !row.provider_subscription_id) {
+      return c.json({ error: "no_subscription" }, 404);
+    }
+
+    const body = (await c.req.json().catch(() => ({}))) as { mode?: unknown };
+    const mode: "period_end" | "now" = body.mode === "now" ? "now" : "period_end";
+
+    let snap: SubscriptionSnapshot;
+    try {
+      snap = await deps.provider.cancelSubscription(row.provider_subscription_id, mode);
+    } catch (err) {
+      return c.json(
+        {
+          error: "subscription_cancel_failed",
+          message: (err as Error).message || "provider cancel failed",
+        },
+        502,
+      );
+    }
+    // The provider's answer IS the state — write it now rather than waiting on
+    // a webhook that may be delayed or dropped.
+    await applySubscriptionState(pool, stateFromSnapshot(orgId, snap));
+    return c.json(await readOrgBilling(orgId));
+  });
+
+  // ── transfer a subscription to another vault I own (#110) ──────────────────
+  // `:orgId` is the SOURCE and may be a tombstone: "delete the vault, make a
+  // new one, move the subscription across" is the story this exists for, and
+  // the subscription is only reachable through its tombstone by then.
+  billing.post("/billing/orgs/:orgId/transfer", async (c) => {
+    if (!billingEnabled()) return c.json({ error: "Not found" }, 404);
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+
+    const sourceOrgId = c.req.param("orgId");
+    const body = (await c.req.json().catch(() => ({}))) as { targetOrgId?: unknown };
+    const targetOrgId = typeof body.targetOrgId === "string" ? body.targetOrgId : "";
+    if (!targetOrgId) return c.json({ error: "targetOrgId required" }, 400);
+
+    const source = await findByOrg(pool, sourceOrgId);
+    if (!source || !source.provider_subscription_id) {
+      return c.json({ error: "no_subscription" }, 404);
+    }
+    if (!(await canManageSubscriptionRow(session.userId, source))) {
+      return c.json({ error: "Only the vault owner can transfer the subscription" }, 403);
+    }
+    if (!isActiveStatus(source.status)) {
+      return c.json({ error: "subscription_not_active" }, 409);
+    }
+    // Checked before the target lookup: when source === target and the source
+    // is a tombstone, the target "org" doesn't exist either, and a 404 would
+    // hide the actual mistake.
+    if (targetOrgId === sourceOrgId) {
+      return c.json({ error: "same_vault" }, 400);
+    }
+
+    const { rows: targetOrgRows } = await pool.query<{ name: string }>(
+      "SELECT name FROM organization WHERE id = $1",
+      [targetOrgId],
+    );
+    const targetName = targetOrgRows[0]?.name;
+    if (targetName === undefined) return c.json({ error: "unknown_vault" }, 404);
+    if ((await orgRole(targetOrgId, session.userId)) !== "owner") {
+      return c.json({ error: "Only the target vault's owner can receive a subscription" }, 403);
+    }
+    const targetRow = await findByOrg(pool, targetOrgId);
+    if (targetRow && isActiveStatus(targetRow.status)) {
+      return c.json({ error: "target_already_subscribed" }, 409);
+    }
+
+    // Provider first, so a refusal changes nothing on our side. Un-cancel when
+    // the subscription was scheduled to lapse (which is exactly what deleting
+    // the source vault did to it) — otherwise the transfer would hand over a
+    // subscription that quietly dies at the end of the month.
+    let snap: SubscriptionSnapshot | null = null;
+    if (source.cancel_at_period_end) {
+      try {
+        snap = await deps.provider.resumeSubscription(source.provider_subscription_id);
+      } catch (err) {
+        return c.json(
+          {
+            error: "subscription_resume_failed",
+            message: (err as Error).message || "provider resume failed",
+          },
+          502,
+        );
+      }
+    }
+    // Best-effort: keep Polar's metadata honest for anyone reading it there.
+    // Our row decides ownership, and webhooks resolve by provider subscription
+    // id before they consult metadata, so a failure here costs us nothing.
+    try {
+      await deps.provider.setSubscriptionOrg(
+        source.provider_subscription_id,
+        targetOrgId,
+        session.userId,
+      );
+    } catch (err) {
+      console.error(
+        `billing transfer: could not re-point provider metadata for ${source.provider_subscription_id}:`,
+        (err as Error).message,
+      );
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      // A stale (canceled / none) row on the target would collide with the
+      // primary key; it holds nothing worth keeping.
+      if (targetRow) {
+        await client.query("DELETE FROM subscriptions WHERE organization_id = $1", [
+          targetOrgId,
+        ]);
+      }
+      await client.query(
+        `UPDATE subscriptions SET
+           organization_id = $2,
+           deleted_at      = NULL,
+           org_name        = $3,
+           owner_user_id   = $4,
+           updated_at      = now()
+         WHERE organization_id = $1`,
+        [sourceOrgId, targetOrgId, targetName, session.userId],
+      );
+      if (snap) {
+        await applySubscriptionState(
+          client,
+          stateFromSnapshot(targetOrgId, snap, { deletedAt: null }),
+        );
+      }
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    return c.json({
+      transferred: true,
+      orgId: targetOrgId,
+      billing: await readOrgBilling(targetOrgId),
+    });
+  });
+
   return billing;
+}
+
+/** Row status → the four values the wire contract allows. */
+function apiStatus(status: string | undefined): "none" | "active" | "past_due" | "canceled" {
+  if (status === "active" || status === "past_due" || status === "canceled") return status;
+  return "none";
 }

--- a/app/apps/server/src/http/routes/orgs.ts
+++ b/app/apps/server/src/http/routes/orgs.ts
@@ -4,6 +4,11 @@ import { pool } from "../../db/pool.js";
 import { orgRole } from "../../permissions/lookup.js";
 import { getSession } from "../session.js";
 import { canAddMember } from "../../billing/entitlements.js";
+import {
+  applySubscriptionState,
+  findByOrg,
+  isActiveStatus,
+} from "../../billing/store.js";
 import { announceMemberJoined } from "../../sync/member-events.js";
 import { billingEnabled } from "../../config.js";
 import type { BillingProvider } from "../../billing/provider.js";
@@ -23,6 +28,14 @@ import type { BillingProvider } from "../../billing/provider.js";
  *    the binary CRDT stores and derived caches (which have no FK) are purged by
  *    hand first. Non-owners cannot delete — they just remove it from their
  *    device client-side.
+ *
+ *    A paid vault stops billing FIRST, and the delete is abandoned if the
+ *    provider won't confirm it (502 `subscription_cancel_failed`) — a provider
+ *    outage used to delete the vault anyway and leave Polar charging for
+ *    something nobody could see (#109/#111). The `subscriptions` row then
+ *    SURVIVES the delete as a tombstone (`deleted_at` set, vault name + owner
+ *    snapshotted) so the owner can still cancel or transfer it from Billing,
+ *    and so a webhook arriving afterwards has somewhere to land.
  */
 export interface OrgDeps {
   /** Force-close live sync sockets for a doc (so a purge isn't re-populated). */
@@ -41,8 +54,16 @@ export interface OrgDeps {
    * a non-member with no shares — and drop every doc immediately.
    */
   onAclChanged: (vaultId: string) => void;
-  /** Billing provider for best-effort subscription cancellation on org delete.
-   *  Absent (self-host / billing off) ⇒ deletion just relies on FK cascade. */
+  /**
+   * Billing provider, used to STOP a paid vault's subscription before the vault
+   * is deleted. NOT best-effort any more: if the provider refuses, the delete
+   * refuses too (#109/#111). Deleting a vault whose subscription is still live
+   * leaves someone paying for something they can no longer see, and — with the
+   * row gone — no way for anyone to notice or retry.
+   *
+   * Absent (self-host / billing off) ⇒ there is nothing to cancel, and deletion
+   * relies on the FK cascade alone.
+   */
   billingProvider?: BillingProvider;
 }
 
@@ -223,6 +244,70 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
       return c.json({ error: "Only the vault owner can delete it" }, 403);
     }
 
+    // Stop the money BEFORE anything is destroyed. `period_end` keeps the paid
+    // period the owner already bought; if the provider refuses we abandon the
+    // whole delete with 502 rather than leave a live subscription that nothing
+    // records (#109/#111). This deliberately runs ahead of the socket teardown
+    // and the purge, so a 502 here costs nothing.
+    const { rows: orgNameRows } = await pool.query<{ name: string }>(
+      "SELECT name FROM organization WHERE id = $1",
+      [orgId],
+    );
+    const orgName = orgNameRows[0]?.name ?? null;
+
+    let subscription: {
+      cancelAtPeriodEnd: boolean;
+      currentPeriodEnd: string | null;
+    } | null = null;
+    if (billingEnabled() && deps.billingProvider) {
+      const row = await findByOrg(pool, orgId);
+      const subId = row?.provider_subscription_id;
+      if (row && subId && isActiveStatus(row.status)) {
+        // Always ask, even when our row already says "ending": the flag is
+        // idempotent at the provider, and our copy can be stale — an owner who
+        // un-cancelled in Polar's portal while that webhook went missing would
+        // otherwise have the vault deleted and the subscription still renewing.
+        // The provider's answer is what we record and report.
+        try {
+          const snap = await deps.billingProvider.cancelSubscription(subId, "period_end");
+          // The provider's answer IS the state — persist it through the same
+          // upsert (and the same ordering guard) the webhook uses, so a
+          // webhook describing this very change can't fight it.
+          await applySubscriptionState(pool, {
+            organizationId: orgId,
+            providerCustomerId: snap.providerCustomerId,
+            providerSubscriptionId: snap.providerSubscriptionId,
+            plan: "pro",
+            status: snap.status,
+            currentPeriodEnd: snap.currentPeriodEnd,
+            cancelAtPeriodEnd: snap.cancelAtPeriodEnd,
+            eventTs: snap.modifiedAt,
+            interval: snap.interval,
+            amount: snap.amount,
+            currency: snap.currency,
+          });
+          subscription = {
+            cancelAtPeriodEnd: snap.cancelAtPeriodEnd,
+            currentPeriodEnd: snap.currentPeriodEnd
+              ? snap.currentPeriodEnd.toISOString()
+              : null,
+          };
+        } catch (err) {
+          console.error(
+            `org-delete: refusing to delete vault ${orgId} — the provider would not cancel subscription ${subId}:`,
+            (err as Error).message,
+          );
+          return c.json(
+            {
+              error: "subscription_cancel_failed",
+              message: (err as Error).message || "provider cancel failed",
+            },
+            502,
+          );
+        }
+      }
+    }
+
     // `vaults` here = the org's note-collection rows (storage children), not the
     // user-facing vault (the organization) being deleted.
     const vaults = await pool.query<{ id: string }>(
@@ -244,27 +329,6 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
     // Instant-kill live sockets so onChange can't resurrect purged doc_updates.
     for (const d of docs.rows) deps.disconnectDoc(d.vault_id, d.id);
 
-    // Best-effort: cancel any live subscription at the provider so we don't keep
-    // billing a deleted vault. The subscriptions row itself is removed by FK
-    // cascade below; a provider failure must NOT block the delete (log + carry on).
-    if (billingEnabled() && deps.billingProvider) {
-      const sub = await pool.query<{ provider_subscription_id: string | null }>(
-        "SELECT provider_subscription_id FROM subscriptions WHERE organization_id = $1",
-        [orgId],
-      );
-      const subId = sub.rows[0]?.provider_subscription_id;
-      if (subId) {
-        try {
-          await deps.billingProvider.cancelSubscription(subId);
-        } catch (err) {
-          console.error(
-            `org-delete: failed to cancel subscription ${subId} for org ${orgId}:`,
-            (err as Error).message,
-          );
-        }
-      }
-    }
-
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
@@ -277,6 +341,16 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
         await client.query("DELETE FROM note_index WHERE vault_id = ANY($1)", [vaultIds]);
         await client.query("DELETE FROM note_links WHERE vault_id = ANY($1)", [vaultIds]);
       }
+      // The subscription row is NOT cascaded away any more (migration 024 drops
+      // the FK). Turn whatever is there into a tombstone — including a canceled
+      // row, where it is harmless — so a webhook arriving after this has
+      // somewhere to land and the owner can still see what they were paying for.
+      await client.query(
+        `UPDATE subscriptions
+            SET deleted_at = now(), org_name = $2, owner_user_id = $3, updated_at = now()
+          WHERE organization_id = $1`,
+        [orgId, orgName, session.userId],
+      );
       // Cascades: member, invitation, vaults→(folders, notes, files), shares,
       // org_join_codes, mcp_tokens.
       await client.query("DELETE FROM organization WHERE id = $1", [orgId]);
@@ -294,7 +368,12 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
     // streaming content from a deleted vault until their tokens expired.
     for (const vaultId of vaultIds) deps.onAclChanged(vaultId);
 
-    return c.json({ deleted: true, vaults: vaultIds.length, docs: docIds.length });
+    return c.json({
+      deleted: true,
+      vaults: vaultIds.length,
+      docs: docIds.length,
+      subscription,
+    });
   });
 
   // Remove a member from a vault (owner/admin). Revokes access on both paths

--- a/app/apps/server/tests/billing-lifecycle.test.ts
+++ b/app/apps/server/tests/billing-lifecycle.test.ts
@@ -1,0 +1,910 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { getEntitlement } from "../src/billing/entitlements.js";
+import { testAppDeps } from "./helpers/app.js";
+import { makeFakeProvider, makeSnapshot } from "./helpers/billing-provider.js";
+import { config } from "../src/config.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { createOrg, signUp, type TestUser } from "./helpers/auth.js";
+
+/**
+ * Subscription LIFECYCLE — the half of billing that outlives a vault
+ * (#109 orphaned subscriptions, #110 transfer, #111 the "mine" aggregate).
+ *
+ * `billing.test.ts` covers the steady state: config, entitlement reads,
+ * checkout, the 402 caps, webhook signatures and ordering. This suite covers
+ * what happens when the vault and the subscription stop agreeing about whether
+ * they exist — a webhook for a vault we deleted, a delete that must not
+ * proceed unless the provider confirms the cancel, and a subscription moving
+ * between vaults.
+ */
+
+const fakeProvider = makeFakeProvider();
+const app = createApp(testAppDeps({ billingProvider: fakeProvider }));
+
+function req(
+  method: string,
+  path: string,
+  opts: { token?: string; body?: unknown; headers?: Record<string, string> } = {},
+) {
+  const headers: Record<string, string> = { ...(opts.headers ?? {}) };
+  if (opts.body !== undefined && !headers["content-type"]) {
+    headers["content-type"] = "application/json";
+  }
+  if (opts.token) headers.authorization = `Bearer ${opts.token}`;
+  return app.fetch(
+    new Request(`http://local${path}`, {
+      method,
+      headers,
+      body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+    }),
+  );
+}
+
+/** Seed a subscription row the way a webhook would have written it. */
+async function seedSubscription(
+  orgId: string,
+  status: string,
+  extra: Partial<{
+    customerId: string;
+    subId: string;
+    periodEnd: Date;
+    cancelAtPeriodEnd: boolean;
+    ownerUserId: string;
+    deletedAt: Date;
+    orgName: string;
+    interval: string;
+    amount: number;
+    currency: string;
+  }> = {},
+) {
+  await pool.query(
+    `INSERT INTO subscriptions (organization_id, provider, provider_customer_id,
+       provider_subscription_id, plan, status, current_period_end,
+       cancel_at_period_end, deleted_at, org_name, owner_user_id,
+       interval, amount, currency)
+     VALUES ($1, 'polar', $2, $3, 'pro', $4, $5, $6, $7, $8, $9, $10, $11, $12)
+     ON CONFLICT (organization_id) DO UPDATE SET
+       status = EXCLUDED.status,
+       cancel_at_period_end = EXCLUDED.cancel_at_period_end`,
+    [
+      orgId,
+      extra.customerId ?? "cus_test",
+      extra.subId ?? "sub_test",
+      status,
+      extra.periodEnd ?? new Date(Date.now() + 30 * 86400_000),
+      extra.cancelAtPeriodEnd ?? false,
+      extra.deletedAt ?? null,
+      extra.orgName ?? null,
+      extra.ownerUserId ?? null,
+      extra.interval ?? "month",
+      extra.amount ?? 1000,
+      extra.currency ?? "usd",
+    ],
+  );
+}
+
+interface RawSub {
+  organization_id: string;
+  status: string;
+  cancel_at_period_end: boolean;
+  deleted_at: Date | null;
+  org_name: string | null;
+  owner_user_id: string | null;
+  provider_subscription_id: string | null;
+  interval: string | null;
+  amount: number | null;
+  currency: string | null;
+}
+
+async function readSub(orgId: string): Promise<RawSub | undefined> {
+  const { rows } = await pool.query<RawSub>(
+    `SELECT organization_id, status, cancel_at_period_end, deleted_at, org_name,
+            owner_user_id, provider_subscription_id, interval, amount, currency
+       FROM subscriptions WHERE organization_id = $1`,
+    [orgId],
+  );
+  return rows[0];
+}
+
+/** Add a member row directly — Better Auth has no "make this user an admin". */
+async function addMember(orgId: string, user: TestUser, role: string) {
+  await pool.query(
+    `INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+     VALUES ($1, $2, $3, $4, now())`,
+    [`m_${Math.random().toString(36).slice(2)}`, orgId, user.userId, role],
+  );
+}
+
+/** Pretend this row was last written a while ago, so /mine reconciles it. */
+async function backdate(orgId: string, minutes: number) {
+  await pool.query(
+    `UPDATE subscriptions SET updated_at = now() - ($2 || ' minutes')::interval
+      WHERE organization_id = $1`,
+    [orgId, String(minutes)],
+  );
+}
+
+describe("subscription lifecycle", () => {
+  beforeEach(async () => {
+    await resetDb();
+    fakeProvider.reset();
+    process.env.POLAR_ACCESS_TOKEN = "test-polar-access-token"; // billing ON
+  });
+  afterEach(() => {
+    delete process.env.POLAR_ACCESS_TOKEN;
+  });
+  afterAll(async () => {
+    delete process.env.POLAR_ACCESS_TOKEN;
+    await pool.end();
+  });
+
+  // ── (a) a webhook for a vault we no longer have ───────────────────────────
+  describe("webhook for a deleted vault", () => {
+    it("records a tombstone and answers 200 instead of looping on a FK error", async () => {
+      const ghostOrg = "org_ghost";
+      const ghostUser = "user_ghost";
+      fakeProvider.nextEvent = {
+        eventId: "evt_ghost_1",
+        occurredAt: new Date(Date.now() - 60_000),
+        type: "subscription_active",
+        organizationId: ghostOrg,
+        userId: ghostUser,
+        providerCustomerId: "cus_ghost",
+        providerSubscriptionId: "sub_ghost",
+        plan: "pro",
+        status: "active",
+        currentPeriodEnd: new Date(Date.now() + 30 * 86400_000),
+        cancelAtPeriodEnd: false,
+        interval: "year",
+        amount: 9700,
+        currency: "usd",
+      };
+
+      const res = await req("POST", "/api/billing/webhook", { body: {} });
+      expect(res.status).toBe(200);
+
+      const row = await readSub(ghostOrg);
+      expect(row).toBeDefined();
+      expect(row?.deleted_at).not.toBeNull();
+      // No `member` rows survive a vault delete, so checkout's metadata.user_id
+      // is the only remaining answer to "whose subscription is this".
+      expect(row?.owner_user_id).toBe(ghostUser);
+      expect(row?.org_name).toBeNull();
+      expect(row?.status).toBe("active");
+      expect(row?.interval).toBe("year");
+      expect(Number(row?.amount)).toBe(9700);
+    });
+
+    it("is idempotent on replay", async () => {
+      fakeProvider.nextEvent = {
+        eventId: "evt_ghost_replay",
+        occurredAt: new Date(),
+        type: "subscription_active",
+        organizationId: "org_ghost",
+        userId: "user_ghost",
+        providerCustomerId: "cus_ghost",
+        providerSubscriptionId: "sub_ghost",
+        plan: "pro",
+        status: "active",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        interval: "month",
+        amount: 1000,
+        currency: "usd",
+      };
+      expect((await req("POST", "/api/billing/webhook", { body: {} })).status).toBe(200);
+      expect((await req("POST", "/api/billing/webhook", { body: {} })).status).toBe(200);
+
+      const { rows } = await pool.query<{ c: number }>(
+        "SELECT count(*)::int AS c FROM billing_events",
+      );
+      expect(Number(rows[0].c)).toBe(1);
+      const { rows: subs } = await pool.query<{ c: number }>(
+        "SELECT count(*)::int AS c FROM subscriptions",
+      );
+      expect(Number(subs[0].c)).toBe(1);
+    });
+
+    it("flips an existing tombstone to canceled on a later revoke", async () => {
+      const base = {
+        organizationId: "org_ghost",
+        userId: "user_ghost",
+        providerCustomerId: "cus_ghost",
+        providerSubscriptionId: "sub_ghost",
+        plan: "pro",
+        interval: "month" as const,
+        amount: 1000,
+        currency: "usd",
+      };
+      fakeProvider.nextEvent = {
+        ...base,
+        eventId: "evt_ghost_active",
+        occurredAt: new Date(Date.now() - 60_000),
+        type: "subscription_active",
+        status: "active",
+        currentPeriodEnd: new Date(Date.now() + 30 * 86400_000),
+        cancelAtPeriodEnd: false,
+      };
+      await req("POST", "/api/billing/webhook", { body: {} });
+
+      fakeProvider.nextEvent = {
+        ...base,
+        eventId: "evt_ghost_revoked",
+        occurredAt: new Date(),
+        type: "subscription_revoked",
+        status: "canceled",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+      };
+      expect((await req("POST", "/api/billing/webhook", { body: {} })).status).toBe(200);
+
+      const row = await readSub("org_ghost");
+      expect(row?.status).toBe("canceled");
+      // Still a tombstone — the second event must not resurrect the vault.
+      expect(row?.deleted_at).not.toBeNull();
+    });
+  });
+
+  // ── (b) webhooks follow the subscription, not the metadata ────────────────
+  it("resolves a webhook by provider subscription id after a transfer", async () => {
+    const owner = await signUp("xfer-wh@billing.com");
+    const source = await createOrg(owner, "Source", "wh-source");
+    const target = await createOrg(owner, "Target", "wh-target");
+    await seedSubscription(source.id, "active", { subId: "sub_moved" });
+
+    const moved = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+      token: owner.token,
+      body: { targetOrgId: target.id },
+    });
+    expect(moved.status).toBe(200);
+
+    // Polar's metadata still names the OLD vault (the PATCH is best-effort and
+    // may not have landed); following it would walk the subscription back.
+    fakeProvider.nextEvent = {
+      eventId: "evt_after_xfer",
+      occurredAt: new Date(),
+      type: "subscription_updated",
+      organizationId: source.id,
+      userId: owner.userId,
+      providerCustomerId: "cus_test",
+      providerSubscriptionId: "sub_moved",
+      plan: "pro",
+      status: "past_due",
+      currentPeriodEnd: new Date(Date.now() + 5 * 86400_000),
+      cancelAtPeriodEnd: false,
+      interval: "month",
+      amount: 1000,
+      currency: "usd",
+    };
+    expect((await req("POST", "/api/billing/webhook", { body: {} })).status).toBe(200);
+
+    expect((await readSub(target.id))?.status).toBe("past_due");
+    // And no second row was created for the vault it came from.
+    expect(await readSub(source.id)).toBeUndefined();
+  });
+
+  // ── (c) deleting a vault ──────────────────────────────────────────────────
+  describe("DELETE /api/orgs/:orgId", () => {
+    it("cancels at period end and keeps the row as a tombstone", async () => {
+      const owner = await signUp("d1@billing.com");
+      const org = await createOrg(owner, "D1", "d1-org");
+      await seedSubscription(org.id, "active", { subId: "sub_d1" });
+
+      const res = await req("DELETE", `/api/orgs/${org.id}`, { token: owner.token });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        deleted: boolean;
+        subscription: { cancelAtPeriodEnd: boolean; currentPeriodEnd: string | null } | null;
+      };
+      expect(body.deleted).toBe(true);
+      expect(body.subscription?.cancelAtPeriodEnd).toBe(true);
+      // period_end, not revoke: the owner already paid for this month.
+      expect(fakeProvider.canceled).toEqual([{ id: "sub_d1", mode: "period_end" }]);
+
+      const row = await readSub(org.id);
+      expect(row?.deleted_at).not.toBeNull();
+      expect(row?.cancel_at_period_end).toBe(true);
+      expect(row?.owner_user_id).toBe(owner.userId);
+      expect(row?.org_name).toBe("D1");
+      const { rows: orgRows } = await pool.query("SELECT 1 FROM organization WHERE id = $1", [
+        org.id,
+      ]);
+      expect(orgRows.length).toBe(0);
+    });
+
+    it("still asks the provider when our row already says the subscription is ending", async () => {
+      // Our copy can be stale (an un-cancel made in the portal whose webhook
+      // never arrived); the provider call is idempotent, so always make it.
+      const owner = await signUp("d2@billing.com");
+      const org = await createOrg(owner, "D2", "d2-org");
+      await seedSubscription(org.id, "active", {
+        subId: "sub_d2",
+        cancelAtPeriodEnd: true,
+      });
+
+      const res = await req("DELETE", `/api/orgs/${org.id}`, { token: owner.token });
+      expect(res.status).toBe(200);
+      expect(fakeProvider.canceled).toEqual([{ id: "sub_d2", mode: "period_end" }]);
+      const body = (await res.json()) as {
+        subscription: { cancelAtPeriodEnd: boolean } | null;
+      };
+      expect(body.subscription?.cancelAtPeriodEnd).toBe(true);
+      expect((await readSub(org.id))?.deleted_at).not.toBeNull();
+    });
+
+    it("aborts the whole delete with 502 when the provider refuses", async () => {
+      const owner = await signUp("d3@billing.com");
+      const org = await createOrg(owner, "D3", "d3-org");
+      await seedSubscription(org.id, "active", { subId: "sub_d3" });
+      fakeProvider.failCancel = new Error("polar is down");
+
+      const res = await req("DELETE", `/api/orgs/${org.id}`, { token: owner.token });
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("subscription_cancel_failed");
+      expect(body.message).toContain("polar is down");
+
+      // Nothing was deleted — a provider outage must not cost someone a vault
+      // while Polar keeps charging for it.
+      const { rows: orgRows } = await pool.query("SELECT 1 FROM organization WHERE id = $1", [
+        org.id,
+      ]);
+      expect(orgRows.length).toBe(1);
+      const row = await readSub(org.id);
+      expect(row?.deleted_at).toBeNull();
+      expect(row?.status).toBe("active");
+    });
+
+    it("deletes a free vault without touching the provider", async () => {
+      const owner = await signUp("d4@billing.com");
+      const org = await createOrg(owner, "D4", "d4-org");
+
+      const res = await req("DELETE", `/api/orgs/${org.id}`, { token: owner.token });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { deleted: boolean; subscription: unknown };
+      expect(body.deleted).toBe(true);
+      expect(body.subscription).toBeNull();
+      expect(fakeProvider.canceled).toEqual([]);
+      expect(await readSub(org.id)).toBeUndefined();
+    });
+  });
+
+  // ── (d) transfer ──────────────────────────────────────────────────────────
+  describe("POST /api/billing/orgs/:orgId/transfer", () => {
+    it("moves a live subscription between two vaults the caller owns", async () => {
+      const owner = await signUp("t1@billing.com");
+      const source = await createOrg(owner, "T1 Source", "t1-source");
+      const target = await createOrg(owner, "T1 Target", "t1-target");
+      await seedSubscription(source.id, "active", { subId: "sub_t1" });
+
+      const res = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        transferred: boolean;
+        orgId: string;
+        billing: { plan: string; status: string; amount: number | null };
+      };
+      expect(body.transferred).toBe(true);
+      expect(body.orgId).toBe(target.id);
+      expect(body.billing.plan).toBe("pro");
+      expect(body.billing.amount).toBe(1000);
+
+      expect(await readSub(source.id)).toBeUndefined();
+      const row = await readSub(target.id);
+      expect(row?.status).toBe("active");
+      expect(row?.deleted_at).toBeNull();
+      expect(row?.org_name).toBe("T1 Target");
+      expect(row?.owner_user_id).toBe(owner.userId);
+      // Nothing was scheduled to lapse, so there was nothing to un-cancel.
+      expect(fakeProvider.resumed).toEqual([]);
+      expect(fakeProvider.metadataWrites).toEqual([
+        { id: "sub_t1", orgId: target.id, userId: owner.userId },
+      ]);
+    });
+
+    it("un-cancels and moves a tombstone left behind by a deleted vault", async () => {
+      const owner = await signUp("t2@billing.com");
+      const gone = await createOrg(owner, "T2 Gone", "t2-gone");
+      await seedSubscription(gone.id, "active", { subId: "sub_t2" });
+      expect((await req("DELETE", `/api/orgs/${gone.id}`, { token: owner.token })).status).toBe(
+        200,
+      );
+      // The delete scheduled it to lapse; the transfer has to take that back.
+      expect((await readSub(gone.id))?.cancel_at_period_end).toBe(true);
+
+      const target = await createOrg(owner, "T2 Target", "t2-target");
+      const res = await req("POST", `/api/billing/orgs/${gone.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(200);
+
+      expect(fakeProvider.resumed).toEqual(["sub_t2"]);
+      const row = await readSub(target.id);
+      expect(row?.deleted_at).toBeNull();
+      expect(row?.status).toBe("active");
+      expect(row?.cancel_at_period_end).toBe(false);
+      expect(await readSub(gone.id)).toBeUndefined();
+      // The moved subscription is live Pro on the new vault.
+      const ent = await getEntitlement(target.id);
+      expect(ent.plan).toBe("pro");
+      expect(ent.active).toBe(true);
+    });
+
+    it("refuses a target the caller does not own (403)", async () => {
+      const owner = await signUp("t3a@billing.com");
+      const other = await signUp("t3b@billing.com");
+      const source = await createOrg(owner, "T3 Source", "t3-source");
+      const target = await createOrg(other, "T3 Target", "t3-target");
+      await seedSubscription(source.id, "active", { subId: "sub_t3" });
+
+      const res = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(403);
+      expect((await readSub(source.id))?.organization_id).toBe(source.id);
+    });
+
+    it("refuses a target that already pays (409 target_already_subscribed)", async () => {
+      const owner = await signUp("t4@billing.com");
+      const source = await createOrg(owner, "T4 Source", "t4-source");
+      const target = await createOrg(owner, "T4 Target", "t4-target");
+      await seedSubscription(source.id, "active", { subId: "sub_t4a" });
+      await seedSubscription(target.id, "active", { subId: "sub_t4b" });
+
+      const res = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(409);
+      expect((await res.json()) as { error: string }).toEqual({
+        error: "target_already_subscribed",
+      });
+    });
+
+    it("refuses a source that is not active (409 subscription_not_active)", async () => {
+      const owner = await signUp("t5@billing.com");
+      const source = await createOrg(owner, "T5 Source", "t5-source");
+      const target = await createOrg(owner, "T5 Target", "t5-target");
+      await seedSubscription(source.id, "canceled", { subId: "sub_t5" });
+
+      const res = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(409);
+      expect((await res.json()) as { error: string }).toEqual({
+        error: "subscription_not_active",
+      });
+    });
+
+    it("refuses a transfer onto itself (400 same_vault)", async () => {
+      const owner = await signUp("t6@billing.com");
+      const org = await createOrg(owner, "T6", "t6-org");
+      await seedSubscription(org.id, "active", { subId: "sub_t6" });
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: org.id },
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: string }).toEqual({ error: "same_vault" });
+    });
+
+    it("replaces a stale canceled row on the target", async () => {
+      const owner = await signUp("t7@billing.com");
+      const source = await createOrg(owner, "T7 Source", "t7-source");
+      const target = await createOrg(owner, "T7 Target", "t7-target");
+      await seedSubscription(source.id, "active", { subId: "sub_t7_live" });
+      await seedSubscription(target.id, "canceled", { subId: "sub_t7_dead" });
+
+      const res = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(200);
+
+      const row = await readSub(target.id);
+      expect(row?.status).toBe("active");
+      expect(row?.provider_subscription_id).toBe("sub_t7_live");
+      const { rows } = await pool.query<{ c: number }>(
+        "SELECT count(*)::int AS c FROM subscriptions",
+      );
+      expect(Number(rows[0].c)).toBe(1);
+    });
+
+    it("404s with no subscription to move", async () => {
+      const owner = await signUp("t8@billing.com");
+      const source = await createOrg(owner, "T8 Source", "t8-source");
+      const target = await createOrg(owner, "T8 Target", "t8-target");
+      const res = await req("POST", `/api/billing/orgs/${source.id}/transfer`, {
+        token: owner.token,
+        body: { targetOrgId: target.id },
+      });
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: string }).toEqual({ error: "no_subscription" });
+    });
+  });
+
+  // ── (e) cancel ────────────────────────────────────────────────────────────
+  describe("POST /api/billing/orgs/:orgId/cancel", () => {
+    it("schedules a cancel at period end by default", async () => {
+      const owner = await signUp("c1@billing.com");
+      const org = await createOrg(owner, "C1", "c1-org");
+      await seedSubscription(org.id, "active", { subId: "sub_c1" });
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: owner.token,
+        body: {},
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { plan: string; cancelAtPeriodEnd: boolean };
+      expect(fakeProvider.canceled).toEqual([{ id: "sub_c1", mode: "period_end" }]);
+      expect(body.cancelAtPeriodEnd).toBe(true);
+      // Access continues until the period runs out.
+      expect(body.plan).toBe("pro");
+      expect((await readSub(org.id))?.cancel_at_period_end).toBe(true);
+    });
+
+    it("revokes immediately for mode=now", async () => {
+      const owner = await signUp("c2@billing.com");
+      const org = await createOrg(owner, "C2", "c2-org");
+      await seedSubscription(org.id, "active", { subId: "sub_c2" });
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: owner.token,
+        body: { mode: "now" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { plan: string; status: string };
+      expect(fakeProvider.canceled).toEqual([{ id: "sub_c2", mode: "now" }]);
+      expect(body.status).toBe("canceled");
+      expect(body.plan).toBe("free");
+    });
+
+    it("refuses an admin (403) — billing changes are the owner's", async () => {
+      const owner = await signUp("c3a@billing.com");
+      const admin = await signUp("c3b@billing.com");
+      const org = await createOrg(owner, "C3", "c3-org");
+      await addMember(org.id, admin, "admin");
+      await seedSubscription(org.id, "active", { subId: "sub_c3" });
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: admin.token,
+        body: {},
+      });
+      expect(res.status).toBe(403);
+      expect(fakeProvider.canceled).toEqual([]);
+    });
+
+    it("lets the owner of a tombstone stop paying for a vault that is gone", async () => {
+      const owner = await signUp("c4@billing.com");
+      const org = await createOrg(owner, "C4", "c4-org");
+      await seedSubscription(org.id, "active", { subId: "sub_c4" });
+      await req("DELETE", `/api/orgs/${org.id}`, { token: owner.token });
+      fakeProvider.reset();
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: owner.token,
+        body: { mode: "now" },
+      });
+      expect(res.status).toBe(200);
+      expect(fakeProvider.canceled).toEqual([{ id: "sub_c4", mode: "now" }]);
+      const row = await readSub(org.id);
+      expect(row?.status).toBe("canceled");
+      // Still a tombstone; canceling does not un-delete the vault.
+      expect(row?.deleted_at).not.toBeNull();
+    });
+
+    it("404s when there is nothing active to cancel", async () => {
+      const owner = await signUp("c5@billing.com");
+      const org = await createOrg(owner, "C5", "c5-org");
+      const missing = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: owner.token,
+        body: {},
+      });
+      expect(missing.status).toBe(404);
+
+      await seedSubscription(org.id, "canceled", { subId: "sub_c5" });
+      const inactive = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: owner.token,
+        body: {},
+      });
+      expect(inactive.status).toBe(404);
+    });
+
+    it("reports a provider failure as 502 and changes nothing", async () => {
+      const owner = await signUp("c6@billing.com");
+      const org = await createOrg(owner, "C6", "c6-org");
+      await seedSubscription(org.id, "active", { subId: "sub_c6" });
+      fakeProvider.failCancel = new Error("polar refused");
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+        token: owner.token,
+        body: {},
+      });
+      expect(res.status).toBe(502);
+      expect((await res.json()) as { error: string }).toMatchObject({
+        error: "subscription_cancel_failed",
+      });
+      expect((await readSub(org.id))?.cancel_at_period_end).toBe(false);
+    });
+  });
+
+  // ── one vault, one subscription ───────────────────────────────────────────
+  //    The steady-state 409 lives in billing.test.ts beside the other checkout
+  //    cases; these are the lifecycle angles — what the guard does once a
+  //    subscription has been canceled, and what a tombstone must NOT block.
+  describe("POST /api/billing/orgs/:orgId/checkout", () => {
+    it("refuses a second checkout, then allows one after a real cancel", async () => {
+      const owner = await signUp("k1@billing.com");
+      const org = await createOrg(owner, "K1", "k1-org");
+      await seedSubscription(org.id, "active", { subId: "sub_k1" });
+
+      const dup = await req("POST", `/api/billing/orgs/${org.id}/checkout`, {
+        token: owner.token,
+        body: { interval: "month" },
+      });
+      expect(dup.status).toBe(409);
+      expect((await dup.json()) as { error: string }).toEqual({ error: "already_subscribed" });
+      // Refused before the provider was ever asked, so no checkout session
+      // exists that someone could still go and pay for.
+      expect(fakeProvider.lastCheckout).toBeNull();
+
+      // Cancel for real, then the Upgrade button has to work again.
+      expect(
+        (
+          await req("POST", `/api/billing/orgs/${org.id}/cancel`, {
+            token: owner.token,
+            body: { mode: "now" },
+          })
+        ).status,
+      ).toBe(200);
+      expect((await readSub(org.id))?.status).toBe("canceled");
+
+      const again = await req("POST", `/api/billing/orgs/${org.id}/checkout`, {
+        token: owner.token,
+        body: { interval: "year" },
+      });
+      expect(again.status).toBe(200);
+      expect((fakeProvider.lastCheckout as { orgId: string; interval: string }).orgId).toBe(
+        org.id,
+      );
+    });
+
+    it("still refuses during the past_due grace, when access has not lapsed", async () => {
+      const owner = await signUp("k2@billing.com");
+      const org = await createOrg(owner, "K2", "k2-org");
+      await seedSubscription(org.id, "past_due", { subId: "sub_k2" });
+
+      const res = await req("POST", `/api/billing/orgs/${org.id}/checkout`, {
+        token: owner.token,
+        body: { interval: "month" },
+      });
+      expect(res.status).toBe(409);
+      expect(fakeProvider.lastCheckout).toBeNull();
+    });
+
+    it("does not let a deleted vault's tombstone block a new vault's checkout", async () => {
+      const owner = await signUp("k3@billing.com");
+      const gone = await createOrg(owner, "K3 Gone", "k3-gone");
+      await seedSubscription(gone.id, "active", { subId: "sub_k3" });
+      await req("DELETE", `/api/orgs/${gone.id}`, { token: owner.token });
+      expect((await readSub(gone.id))?.deleted_at).not.toBeNull();
+
+      // The guard is keyed to the vault being paid for, and a tombstone belongs
+      // to a vault that no longer exists. Starting again on a fresh vault is
+      // exactly the story #110 was written for.
+      const fresh = await createOrg(owner, "K3 Fresh", "k3-fresh");
+      const res = await req("POST", `/api/billing/orgs/${fresh.id}/checkout`, {
+        token: owner.token,
+        body: { interval: "month" },
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── (f) the aggregate the Billing tab renders ─────────────────────────────
+  describe("GET /api/billing/mine", () => {
+    it("lists every vault the caller is in, plus orphaned subscriptions", async () => {
+      const owner = await signUp("m1@billing.com");
+      const mate = await signUp("m1b@billing.com");
+      const paid = await createOrg(owner, "Paid", "m1-paid");
+      const free = await createOrg(owner, "Free", "m1-free");
+      await addMember(paid.id, mate, "member");
+      await seedSubscription(paid.id, "active", {
+        subId: "sub_m1",
+        interval: "year",
+        amount: 9700,
+      });
+      // A vault this owner deleted while it was still being charged.
+      const gone = await createOrg(owner, "Gone", "m1-gone");
+      await seedSubscription(gone.id, "active", { subId: "sub_m1_gone" });
+      await req("DELETE", `/api/orgs/${gone.id}`, { token: owner.token });
+
+      const res = await req("GET", "/api/billing/mine", { token: owner.token });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        vaults: Array<{
+          orgId: string;
+          name: string;
+          role: string;
+          plan: string;
+          status: string;
+          interval: string | null;
+          amount: number | null;
+          seats: { members: number; pendingInvitations: number; limit: number | null };
+          billingOwner: { userId: string; email: string } | null;
+          canManage: boolean;
+          canTransfer: boolean;
+        }>;
+        orphaned: Array<{ orgId: string; orgName: string | null; status: string }>;
+        freeLimits: {
+          vaultsPerUser: number;
+          membersPerVault: number;
+          freeVaultsUsed: number;
+        };
+      };
+
+      expect(body.vaults.map((v) => v.orgId).sort()).toEqual([free.id, paid.id].sort());
+      const paidCard = body.vaults.find((v) => v.orgId === paid.id)!;
+      expect(paidCard.role).toBe("owner");
+      expect(paidCard.plan).toBe("pro");
+      expect(paidCard.status).toBe("active");
+      expect(paidCard.interval).toBe("year");
+      expect(paidCard.amount).toBe(9700);
+      expect(paidCard.seats.members).toBe(2);
+      expect(paidCard.seats.limit).toBeNull(); // paid ⇒ unlimited
+      expect(paidCard.billingOwner?.userId).toBe(owner.userId);
+      expect(paidCard.canManage).toBe(true);
+      expect(paidCard.canTransfer).toBe(true);
+
+      const freeCard = body.vaults.find((v) => v.orgId === free.id)!;
+      expect(freeCard.plan).toBe("free");
+      expect(freeCard.status).toBe("none");
+      expect(freeCard.seats.limit).toBe(config.freeMaxMembers);
+      expect(freeCard.canTransfer).toBe(false);
+
+      expect(body.orphaned).toHaveLength(1);
+      expect(body.orphaned[0]).toMatchObject({
+        orgId: gone.id,
+        orgName: "Gone",
+        status: "active",
+      });
+      // Only the free vault counts toward the free-vault cap.
+      expect(body.freeLimits.freeVaultsUsed).toBe(1);
+      expect(body.freeLimits.vaultsPerUser).toBe(config.freeMaxVaults);
+      expect(body.freeLimits.membersPerVault).toBe(config.freeMaxMembers);
+    });
+
+    it("shows a teammate their role and hides someone else's orphans", async () => {
+      const owner = await signUp("m2a@billing.com");
+      const mate = await signUp("m2b@billing.com");
+      const org = await createOrg(owner, "Shared", "m2-shared");
+      await addMember(org.id, mate, "member");
+      const gone = await createOrg(owner, "Owner Gone", "m2-gone");
+      await seedSubscription(gone.id, "active", { subId: "sub_m2" });
+      await req("DELETE", `/api/orgs/${gone.id}`, { token: owner.token });
+
+      const res = await req("GET", "/api/billing/mine", { token: mate.token });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        vaults: Array<{ orgId: string; role: string; canManage: boolean; canTransfer: boolean }>;
+        orphaned: unknown[];
+      };
+      expect(body.vaults).toHaveLength(1);
+      expect(body.vaults[0]).toMatchObject({
+        orgId: org.id,
+        role: "member",
+        canManage: false,
+        canTransfer: false,
+      });
+      // The tombstone belongs to the owner, not to this teammate.
+      expect(body.orphaned).toEqual([]);
+    });
+
+    it("reconciles a stale active row against the provider", async () => {
+      const owner = await signUp("m3@billing.com");
+      const org = await createOrg(owner, "M3", "m3-org");
+      await seedSubscription(org.id, "active", { subId: "sub_m3" });
+      await backdate(org.id, 20);
+      // What Polar actually holds: already scheduled to end, on the yearly plan.
+      fakeProvider.snapshot = makeSnapshot({
+        cancelAtPeriodEnd: true,
+        interval: "year",
+        amount: 9700,
+      });
+
+      const res = await req("GET", "/api/billing/mine", { token: owner.token });
+      expect(res.status).toBe(200);
+      expect(fakeProvider.fetched).toEqual(["sub_m3"]);
+
+      const row = await readSub(org.id);
+      expect(row?.cancel_at_period_end).toBe(true);
+      expect(row?.interval).toBe("year");
+      expect(Number(row?.amount)).toBe(9700);
+      const card = ((await (
+        await req("GET", "/api/billing/mine", { token: owner.token })
+      ).json()) as { vaults: Array<{ cancelAtPeriodEnd: boolean }> }).vaults[0];
+      expect(card.cancelAtPeriodEnd).toBe(true);
+    });
+
+    it("leaves a freshly-written row alone", async () => {
+      const owner = await signUp("m4@billing.com");
+      const org = await createOrg(owner, "M4", "m4-org");
+      await seedSubscription(org.id, "active", { subId: "sub_m4" });
+
+      const res = await req("GET", "/api/billing/mine", { token: owner.token });
+      expect(res.status).toBe(200);
+      // A webhook or a mutation wrote it moments ago; re-reading Polar on every
+      // visit to the Billing tab would be a round trip for nothing.
+      expect(fakeProvider.fetched).toEqual([]);
+    });
+
+    it("keeps the row when the provider has never heard of the subscription", async () => {
+      const owner = await signUp("m5@billing.com");
+      const org = await createOrg(owner, "M5", "m5-org");
+      await seedSubscription(org.id, "active", { subId: "sub_m5" });
+      await backdate(org.id, 20);
+      fakeProvider.getResults.set("sub_m5", null); // 404 at Polar
+
+      const res = await req("GET", "/api/billing/mine", { token: owner.token });
+      expect(res.status).toBe(200);
+      // Unknown is not "canceled" — we do not invent a status.
+      expect((await readSub(org.id))?.status).toBe("active");
+    });
+
+    it("401s without a session and 404s when billing is off", async () => {
+      expect((await req("GET", "/api/billing/mine")).status).toBe(401);
+      const owner = await signUp("m6@billing.com");
+      delete process.env.POLAR_ACCESS_TOKEN;
+      expect((await req("GET", "/api/billing/mine", { token: owner.token })).status).toBe(404);
+    });
+  });
+
+  // ── (g) a tombstone's owner keeps the read + portal routes ────────────────
+  describe("tombstone access", () => {
+    it("serves GET /orgs/:orgId and the portal to the owner of a deleted vault", async () => {
+      const owner = await signUp("g1@billing.com");
+      const other = await signUp("g2@billing.com");
+      const org = await createOrg(owner, "G1", "g1-org");
+      await seedSubscription(org.id, "active", { subId: "sub_g1" });
+      await req("DELETE", `/api/orgs/${org.id}`, { token: owner.token });
+
+      const status = await req("GET", `/api/billing/orgs/${org.id}`, { token: owner.token });
+      expect(status.status).toBe(200);
+      const body = (await status.json()) as {
+        plan: string;
+        cancelAtPeriodEnd: boolean;
+        interval: string | null;
+        seats: { members: number };
+      };
+      expect(body.plan).toBe("pro");
+      expect(body.cancelAtPeriodEnd).toBe(true);
+      expect(body.interval).toBe("month");
+      expect(body.seats.members).toBe(0); // the members cascaded away with the org
+
+      const portal = await req("POST", `/api/billing/orgs/${org.id}/portal`, {
+        token: owner.token,
+      });
+      expect(portal.status).toBe(200);
+      expect((await portal.json()) as { url: string }).toEqual({
+        url: "https://polar.test/portal/cus_test",
+      });
+
+      // Nobody else gets in.
+      expect(
+        (await req("GET", `/api/billing/orgs/${org.id}`, { token: other.token })).status,
+      ).toBe(403);
+      expect(
+        (await req("POST", `/api/billing/orgs/${org.id}/portal`, { token: other.token })).status,
+      ).toBe(403);
+    });
+  });
+});

--- a/app/apps/server/tests/billing.test.ts
+++ b/app/apps/server/tests/billing.test.ts
@@ -9,11 +9,8 @@ import {
   getEntitlement,
   seatCount,
 } from "../src/billing/entitlements.js";
-import type {
-  BillingProvider,
-  NormalizedBillingEvent,
-} from "../src/billing/provider.js";
 import { testAppDeps } from "./helpers/app.js";
+import { makeFakeProvider } from "./helpers/billing-provider.js";
 import { config } from "../src/config.js";
 import { pool } from "../src/db/pool.js";
 import { resetDb } from "./helpers/db.js";
@@ -45,33 +42,9 @@ const WEBHOOK_SECRET = "test-polar-webhook-secret";
 
 // ── A controllable fake provider (no network). verifyAndNormalizeWebhook is
 //    scripted per-test via `fakeProvider.nextEvent`. Real signature checking is
-//    exercised separately with the actual PolarBillingProvider. ───────────────
-interface FakeProvider extends BillingProvider {
-  nextEvent: NormalizedBillingEvent | null;
-  lastCheckout: unknown;
-  canceled: string[];
-}
-function makeFakeProvider(): FakeProvider {
-  return {
-    nextEvent: null,
-    lastCheckout: null,
-    canceled: [],
-    async createCheckout(args) {
-      this.lastCheckout = args;
-      return { url: `https://polar.test/checkout/${args.interval}` };
-    },
-    async getPortalUrl(args) {
-      return { url: `https://polar.test/portal/${args.customerId}` };
-    },
-    async cancelSubscription(id) {
-      this.canceled.push(id);
-    },
-    verifyAndNormalizeWebhook() {
-      return this.nextEvent;
-    },
-  };
-}
-
+//    exercised separately with the actual PolarBillingProvider. It lives in
+//    tests/helpers so billing-lifecycle.test.ts shares exactly this fake and
+//    the two suites cannot drift. ─────────────────────────────────────────────
 const fakeProvider = makeFakeProvider();
 const app = createApp(testAppDeps({ billingProvider: fakeProvider }));
 const realApp = createApp(testAppDeps({ billingProvider: new PolarBillingProvider() }));
@@ -120,8 +93,7 @@ async function seedSubscription(
 describe("billing", () => {
   beforeEach(async () => {
     await resetDb();
-    fakeProvider.nextEvent = null;
-    fakeProvider.canceled = [];
+    fakeProvider.reset();
     process.env.POLAR_ACCESS_TOKEN = "test-polar-access-token"; // billing ON
   });
   afterEach(() => {
@@ -325,6 +297,39 @@ describe("billing", () => {
       expect(res.status).toBe(403);
     });
 
+    it("refuses a second checkout while the vault already pays (409)", async () => {
+      // One vault, one subscription: `subscriptions` is keyed by
+      // organization_id, so a second paid checkout would bill twice and the
+      // losing subscription would be invisible to us while Polar charged for
+      // it. The refusal must land BEFORE the provider is asked, so there is no
+      // checkout session for anyone to pay.
+      const owner = await signUp("co-dup@billing.com");
+      const org = await createOrg(owner, "Co3", "co-org3");
+
+      for (const status of ["active", "past_due"]) {
+        await seedSubscription(org.id, status, { subId: "sub_dup" });
+        const res = await req(app, "POST", `/api/billing/orgs/${org.id}/checkout`, {
+          token: owner.token,
+          body: { interval: "month" },
+        });
+        expect(res.status).toBe(409);
+        expect((await res.json()) as { error: string }).toEqual({
+          error: "already_subscribed",
+        });
+        expect(fakeProvider.lastCheckout).toBeNull();
+      }
+
+      // A row that is no longer paying is not a blocker — re-subscribing after
+      // a cancellation is the whole point of the Upgrade button still being there.
+      await seedSubscription(org.id, "canceled", { subId: "sub_dup" });
+      const again = await req(app, "POST", `/api/billing/orgs/${org.id}/checkout`, {
+        token: owner.token,
+        body: { interval: "month" },
+      });
+      expect(again.status).toBe(200);
+      expect(fakeProvider.lastCheckout).not.toBeNull();
+    });
+
     it("portal returns a URL when a customer exists, 400 otherwise", async () => {
       const owner = await signUp("po@billing.com");
       const org = await createOrg(owner, "Po", "po-org");
@@ -514,6 +519,10 @@ describe("billing", () => {
 
       fakeProvider.nextEvent = {
         eventId: "evt_active_1",
+        userId: owner.userId,
+        interval: "month",
+        amount: 1000,
+        currency: "usd",
         occurredAt: new Date(),
         type: "subscription_active",
         organizationId: org.id,
@@ -545,6 +554,10 @@ describe("billing", () => {
 
       fakeProvider.nextEvent = {
         eventId: "evt_active_2",
+        userId: owner.userId,
+        interval: "month",
+        amount: 1000,
+        currency: "usd",
         occurredAt: new Date(Date.now() - 60_000),
         type: "subscription_active",
         organizationId: org.id,
@@ -560,6 +573,10 @@ describe("billing", () => {
 
       fakeProvider.nextEvent = {
         eventId: "evt_revoked_2",
+        userId: owner.userId,
+        interval: "month",
+        amount: 1000,
+        currency: "usd",
         occurredAt: new Date(),
         type: "subscription_revoked",
         organizationId: org.id,
@@ -587,6 +604,10 @@ describe("billing", () => {
       // Newer event lands first: subscription revoked at t1.
       fakeProvider.nextEvent = {
         eventId: "evt_revoked_3",
+        userId: owner.userId,
+        interval: "month",
+        amount: 1000,
+        currency: "usd",
         occurredAt: t1,
         type: "subscription_revoked",
         organizationId: org.id,
@@ -605,6 +626,10 @@ describe("billing", () => {
       // so the canceled org does NOT silently regain Pro.
       fakeProvider.nextEvent = {
         eventId: "evt_active_3_stale",
+        userId: owner.userId,
+        interval: "month",
+        amount: 1000,
+        currency: "usd",
         occurredAt: t0,
         type: "subscription_active",
         organizationId: org.id,
@@ -623,17 +648,42 @@ describe("billing", () => {
     });
   });
 
-  // ── org delete cancels the subscription (best-effort) ───────────────────────
-  it("DELETE /api/orgs/:orgId cancels the provider subscription", async () => {
+  // ── org delete stops billing and leaves a tombstone (#109/#111) ────────────
+  //    The old contract was the opposite of this: cancel best-effort, then let
+  //    the FK cascade wipe the row. See tests/billing-lifecycle.test.ts for the
+  //    provider-refuses, already-canceling and free-vault variants.
+  it("DELETE /api/orgs/:orgId cancels at period end and keeps a tombstone", async () => {
     const owner = await signUp("del@billing.com");
     const org = await createOrg(owner, "Del", "del-org");
     await seedSubscription(org.id, "active", { subId: "sub_del" });
     const res = await req(app, "DELETE", `/api/orgs/${org.id}`, { token: owner.token });
     expect(res.status).toBe(200);
-    expect(fakeProvider.canceled).toContain("sub_del");
-    // FK cascade removed the subscriptions row.
-    const { rows } = await pool.query("SELECT 1 FROM subscriptions WHERE organization_id = $1", [org.id]);
-    expect(rows.length).toBe(0);
+    const body = (await res.json()) as {
+      subscription: { cancelAtPeriodEnd: boolean } | null;
+    };
+    // Period end, not revoke: the owner already paid for this month.
+    expect(fakeProvider.canceled).toEqual([{ id: "sub_del", mode: "period_end" }]);
+    expect(body.subscription?.cancelAtPeriodEnd).toBe(true);
+    // The row SURVIVES so the owner can still see, cancel or transfer it.
+    const { rows } = await pool.query<{
+      deleted_at: Date | null;
+      owner_user_id: string | null;
+      cancel_at_period_end: boolean;
+    }>(
+      `SELECT deleted_at, owner_user_id, cancel_at_period_end
+         FROM subscriptions WHERE organization_id = $1`,
+      [org.id],
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].deleted_at).not.toBeNull();
+    expect(rows[0].owner_user_id).toBe(owner.userId);
+    expect(rows[0].cancel_at_period_end).toBe(true);
+    // And the vault itself really is gone.
+    const { rows: orgRows } = await pool.query(
+      "SELECT 1 FROM organization WHERE id = $1",
+      [org.id],
+    );
+    expect(orgRows.length).toBe(0);
   });
 });
 

--- a/app/apps/server/tests/helpers/billing-provider.ts
+++ b/app/apps/server/tests/helpers/billing-provider.ts
@@ -1,0 +1,145 @@
+import type {
+  BillingProvider,
+  NormalizedBillingEvent,
+  SubscriptionSnapshot,
+} from "../../src/billing/provider.js";
+
+/**
+ * A controllable, network-free `BillingProvider` for the billing suites.
+ *
+ * Shared between `billing.test.ts` and `billing-lifecycle.test.ts` so the two
+ * cannot drift: every provider mutation now returns an authoritative snapshot
+ * that the routes write straight into our row, so a fake that modelled cancel
+ * as "record the id" would let a route pass while persisting nothing.
+ *
+ * Every call is recorded, and each one can be made to throw on demand — the
+ * "provider refuses, so nothing is deleted" and "resume fails, so nothing
+ * moves" paths are the whole point of #109/#110 and need a failing provider.
+ */
+
+export interface CancelCall {
+  id: string;
+  mode: "period_end" | "now";
+}
+
+export interface MetadataCall {
+  id: string;
+  orgId: string;
+  userId: string;
+}
+
+export interface FakeProvider extends BillingProvider {
+  /** Scripted result for the next `verifyAndNormalizeWebhook`. */
+  nextEvent: NormalizedBillingEvent | null;
+  lastCheckout: unknown;
+  canceled: CancelCall[];
+  resumed: string[];
+  fetched: string[];
+  metadataWrites: MetadataCall[];
+  /** Base state cancel/resume/get return (per-call fields are overlaid). */
+  snapshot: SubscriptionSnapshot;
+  /** Per-subscription overrides for `getSubscription` (null ⇒ 404 at Polar). */
+  getResults: Map<string, SubscriptionSnapshot | null>;
+  failCancel: Error | null;
+  failResume: Error | null;
+  failGet: Error | null;
+  failMetadata: Error | null;
+  reset(): void;
+}
+
+export function makeSnapshot(over: Partial<SubscriptionSnapshot> = {}): SubscriptionSnapshot {
+  return {
+    providerSubscriptionId: "sub_test",
+    providerCustomerId: "cus_test",
+    status: "active",
+    currentPeriodEnd: new Date(Date.now() + 30 * 86400_000),
+    cancelAtPeriodEnd: false,
+    interval: "month",
+    amount: 1000,
+    currency: "usd",
+    modifiedAt: new Date(),
+    ...over,
+  };
+}
+
+export function makeFakeProvider(): FakeProvider {
+  return {
+    nextEvent: null,
+    lastCheckout: null,
+    canceled: [],
+    resumed: [],
+    fetched: [],
+    metadataWrites: [],
+    snapshot: makeSnapshot(),
+    getResults: new Map(),
+    failCancel: null,
+    failResume: null,
+    failGet: null,
+    failMetadata: null,
+
+    reset() {
+      this.nextEvent = null;
+      this.lastCheckout = null;
+      this.canceled = [];
+      this.resumed = [];
+      this.fetched = [];
+      this.metadataWrites = [];
+      this.snapshot = makeSnapshot();
+      this.getResults = new Map();
+      this.failCancel = null;
+      this.failResume = null;
+      this.failGet = null;
+      this.failMetadata = null;
+    },
+
+    async createCheckout(args) {
+      this.lastCheckout = args;
+      return { url: `https://polar.test/checkout/${args.interval}` };
+    },
+
+    async getPortalUrl(args) {
+      return { url: `https://polar.test/portal/${args.customerId}` };
+    },
+
+    async cancelSubscription(id, mode) {
+      if (this.failCancel) throw this.failCancel;
+      this.canceled.push({ id, mode });
+      return {
+        ...this.snapshot,
+        providerSubscriptionId: id,
+        // period_end keeps access and only flags the schedule; now ends it.
+        status: mode === "now" ? "canceled" : this.snapshot.status,
+        cancelAtPeriodEnd: mode === "period_end",
+        modifiedAt: new Date(),
+      };
+    },
+
+    async resumeSubscription(id) {
+      if (this.failResume) throw this.failResume;
+      this.resumed.push(id);
+      return {
+        ...this.snapshot,
+        providerSubscriptionId: id,
+        status: "active",
+        cancelAtPeriodEnd: false,
+        modifiedAt: new Date(),
+      };
+    },
+
+    async getSubscription(id) {
+      if (this.failGet) throw this.failGet;
+      this.fetched.push(id);
+      if (this.getResults.has(id)) return this.getResults.get(id) ?? null;
+      return { ...this.snapshot, providerSubscriptionId: id, modifiedAt: new Date() };
+    },
+
+    async setSubscriptionOrg(id, orgId, userId) {
+      if (this.failMetadata) throw this.failMetadata;
+      this.metadataWrites.push({ id, orgId, userId });
+    },
+
+    verifyAndNormalizeWebhook() {
+      return this.nextEvent;
+    },
+  };
+}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -292,6 +292,20 @@ confirm `/health` and a real sync round-trip, then promote.
 > (Organization settings, or `PATCH /v1/organizations/:id` with `subscription_settings.allow_multiple_subscriptions: true`),
 > otherwise a customer's second vault upgrade is rejected at checkout.
 
+Billing needs no manual cleanup, and in particular none after a vault is deleted.
+`DELETE /api/orgs/:orgId` asks the provider to cancel at the **end of the current
+period** *before* it deletes anything: if the provider refuses, the vault is kept
+and the route answers `502 subscription_cancel_failed`. The `subscriptions` row
+then outlives the vault as a **tombstone** (migration 024 dropped the cascade
+from `organization` and added `deleted_at` / `org_name` / `owner_user_id`), so a
+late `subscription.*` webhook is stored and acknowledged instead of failing on a
+foreign key and being retried by the provider forever. Webhooks resolve their row
+by provider subscription id first, which is also what makes a transferred
+subscription land on the vault that now holds it. Tombstones are what the owner
+sees under "From deleted vaults", and `GET /api/billing/mine` re-reads stale
+active rows from the provider, so our Postgres and the provider converge on their
+own — never edit `subscriptions` by hand to fix a mismatch.
+
 See `app/apps/server/.env.example` for the same list with inline comments.
 
 ## Outbound email (password reset, invitations)

--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -101,12 +101,14 @@ n/a = synchronous or sub-100ms by construction.
 | Join by code | join → switch → reconcile | 1–5s | ✅ existing busy state |
 | New vault (menu) | create org → folder → seed | 1–3s | ✅ existing busy state |
 | Remove from device | local teardown | 0.2–1s | ✅ spinner |
-| Delete vault (permanent) | server delete + local teardown | 0.5–3s | ✅ spinner, behind a confirm |
+| Delete vault (permanent) | provider cancel-at-period-end (Pro only) → server delete + local teardown | 0.5–4s | ✅ spinner, behind a confirm that names the subscription end |
 | Delete local vault files | move folder to Trash | 0.2–2s | ✅ spinner, behind a confirm |
 | Invite member | server write + roster refresh | 0.3–1s | ✅ existing busy state |
 | Remove member | server write + ACL broadcast | 0.3–1s | ✅ spinner, behind a confirm |
 | Copy join code | clipboard | instant | ✅ existing "Copied" |
 | Manage subscription | billing portal + browser handoff | 1–4s | ✅ spinner |
+| Transfer subscription | server write + provider round trip (re-target, un-cancel) | 1–4s | ✅ spinner, behind a confirm |
+| Cancel subscription now | server write + provider round trip | 1–4s | ✅ spinner, behind a confirm |
 | Create / revoke MCP token | server write | 0.3–1s | ✅ spinner |
 | Import files / folder / Export vault | disk walk + registry | 1s–minutes | ✅ existing busy + counts |
 | Change vaults root | native picker + config write | fast | n/a |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,6 +19,9 @@ tags: [baalda, status, roadmap]
   port at `/sync` (single-port topology), and the repo ships a Dockerfile, Railway IaC at
   `app/.railway/railway.ts` (Dockerfile build, pre-deploy migrations + healthcheck), and [[DEPLOY]]. The managed backend is live at
   `https://api.baalda.com`; desktop releases ship via `v*` tags → signed installers → Tauri updater.
+- **Billing:** 🟢 Per-vault Pro via Polar, with the full subscription lifecycle (2026-09-09, #109–#111):
+  deleting a vault cancels at period end before it deletes, subscriptions survive as tombstones, and an
+  owner can transfer one between their vaults from Vault Settings → Billing.
 - **Next action:** Phase 4 polish / launch decisions (WYSIWYG, vector search, OAuth, iOS).
 
 > **Requirement coverage:** Phases 0–3 deliver **10 of the 12** core requirements,

--- a/docs/specs/04-team-collaboration.md
+++ b/docs/specs/04-team-collaboration.md
@@ -50,7 +50,8 @@ invitation   (id, organization_id, email, role, inviter_id,
 ```
 
 Roles for MVP — keep exactly three (matches Notion/Outline/Docmost): **owner** (billing, delete/
-transfer the vault), **admin** (manage members, invitations, settings), **member** (basic access).
+transfer the vault, and transfer the subscription between vaults they own), **admin** (manage
+members, invitations, settings), **member** (basic access).
 
 ## 3. Sharing & permissions
 


### PR DESCRIPTION
Closes #109, closes #110, closes #111.

## What
- **Delete = cancel first, or abort (#111).** `DELETE /api/orgs/:orgId` asks Polar to cancel at period end before destroying anything; a provider refusal keeps the vault and answers `502 subscription_cancel_failed`. The confirm dialog names the subscription and its end date. Better Auth's own org-delete endpoint is disabled.
- **Subscriptions outlive vaults (#109).** Migration 024 drops the `organization` cascade; the row survives as a tombstone (`deleted_at`, `org_name`, `owner_user_id`, plus `interval`/`amount`/`currency`). Late webhooks are stored and acknowledged instead of FK-failing and being retried forever.
- **Transfer.** `POST /api/billing/orgs/:orgId/transfer` moves a live subscription to another owned vault (from a live vault or a tombstone), un-cancelling at Polar when needed.
- **Subscriptions section in Vault Settings → Billing (#110).** Every vault with plan/status/renewal/price/seats/billing owner + Upgrade / Manage / Transfer, a "From deleted vaults" list with Transfer / Cancel now / Manage, and the free-vault counter. Fed by `GET /api/billing/mine`. The tab opens from a local vault too.
- **Polar and DB always agree.** `billing/store.ts` is the single writer; every provider mutation persists Polar's returned snapshot through the existing `event_ts` guard; webhooks resolve by provider subscription id first; `/mine` reconciles stale active rows. Checkout refuses a second subscription on a vault (`409 already_subscribed`).
- Docs: CLAUDE.md, DEPLOY, INTERACTIONS, STATUS, spec 04, baalda-guide skill, `.env.example` price typo.

## Tests
- Server: 47 files / 478 tests (34 new lifecycle cases + checkout guard), `tsc` clean — run against a scratch DB.
- Desktop: 78 files / 860 tests, `tsc` clean, build ok.

## Deploy notes
Migration 024 runs via the pipeline's pre-deploy step. No new env vars. After deploy, Polar's pending retries for the deleted vault in #109 land as a tombstone the owner can transfer from Billing.