### PR TITLE
Remove a folder from a teammate's disk when it is made private, not just its notes

### DIFF
--- a/app/apps/desktop/src-tauri/src/notefile.rs
+++ b/app/apps/desktop/src-tauri/src/notefile.rs
@@ -295,10 +295,28 @@ pub fn delete_folder_if_empty(vault: &Path, rel: &str) -> AppResult<bool> {
     if !abs.is_dir() {
         return Ok(false); // a file lives at this path; not ours to remove
     }
+    // Finder drops a `.DS_Store` into any folder it has shown, and Explorer
+    // does the same with `desktop.ini`/`Thumbs.db`. None of those is vault
+    // content — the walker never surfaces them — yet `remove_dir` refuses a
+    // directory holding one, which is exactly how a folder whose notes had all
+    // left kept sitting in the sidebar. Sweep ONLY those names, so a folder that
+    // holds anything else still stays put.
+    if let Ok(entries) = std::fs::read_dir(&abs) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if OS_METADATA_FILES.iter().any(|m| name == *m) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
     // Any failure (non-empty, permissions, races) means "leave it": a folder
     // that lingers is cosmetic, a reconcile pass that fails over it is not.
     Ok(std::fs::remove_dir(&abs).is_ok())
 }
+
+/// Per-folder metadata the OS's file browser writes on its own. Never vault
+/// content, so an otherwise-empty folder holding only these counts as empty.
+const OS_METADATA_FILES: &[&str] = &[".DS_Store", "desktop.ini", "Thumbs.db"];
 
 /// Delete a file or folder (recursively for folders).
 pub fn delete_path(vault: &Path, rel: &str) -> AppResult<()> {
@@ -643,5 +661,22 @@ mod tests {
         // Ignored dirs and traversal are refused loudly.
         assert!(delete_folder_if_empty(tmp.path(), ".context/trash").is_err());
         assert!(delete_folder_if_empty(tmp.path(), "../up").is_err());
+    }
+
+    #[test]
+    fn delete_folder_if_empty_treats_os_metadata_as_empty() {
+        // Finder had shown the folder, so `.DS_Store` is in it. That is not
+        // content: the folder is still removed. Any OTHER dotfile still blocks.
+        let tmp = tempfile::tempdir().unwrap();
+        ensure_folder(tmp.path(), "Getting Started").unwrap();
+        std::fs::write(tmp.path().join("Getting Started/.DS_Store"), b"\0").unwrap();
+        assert!(delete_folder_if_empty(tmp.path(), "Getting Started").unwrap());
+        assert!(!tmp.path().join("Getting Started").exists());
+
+        ensure_folder(tmp.path(), "Other").unwrap();
+        std::fs::write(tmp.path().join("Other/.DS_Store"), b"\0").unwrap();
+        std::fs::write(tmp.path().join("Other/.hidden-note"), "mine").unwrap();
+        assert!(!delete_folder_if_empty(tmp.path(), "Other").unwrap());
+        assert!(tmp.path().join("Other/.hidden-note").exists());
     }
 }

--- a/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inbound.test.ts
@@ -54,9 +54,67 @@ describe("planInbound — folders", () => {
 
   it("never deletes a local folder the server merely no longer lists", () => {
     // The folder listing is permission-filtered, so "absent" alone is
-    // irreducibly ambiguous — only a tombstone proves a delete.
+    // irreducibly ambiguous for a folder we never recorded a server id for: it
+    // could be a brand-new local folder. Only an id WE recorded (see the
+    // revocation cases below) or a tombstone lets the plan act.
     const p = plan({ localFolders: new Set(["Gone"]) });
     expect(p).toMatchObject({ createFolders: [], removeFolders: [], trash: [], renames: [] });
+  });
+
+  it("removes a recorded folder that left the listing without a tombstone — access revoked", () => {
+    // THE leftover-folder bug: an admin made "Getting Started" private. Its
+    // notes left as `revoked`, but the folder was neither tombstoned nor moved,
+    // so the emptied directory stayed in the teammate's sidebar forever.
+    const p = plan({
+      localFolders: new Set(["Getting Started", "Getting Started/Deep", "Concepts"]),
+      localFolderIds: new Map([
+        ["Getting Started", "f-gs"],
+        ["Getting Started/Deep", "f-deep"],
+        ["Concepts", "f-c"],
+      ]),
+      serverFolders: new Set(["Concepts"]),
+      serverFolderIds: new Map([["f-c", "Concepts"]]),
+    });
+    // Children first, so the subtree unwinds bottom-up.
+    expect(p.removeFolders).toEqual(["Getting Started/Deep", "Getting Started"]);
+    expect(p.rejected).toEqual([]);
+  });
+
+  it("leaves a revoked folder alone when the server did not answer about folder deletions", () => {
+    // `null` tombstones = "I don't know" — a truncated listing looks exactly
+    // like a mass revoke, and the safe reading of absence is then nothing.
+    const p = plan({
+      localFolders: new Set(["Getting Started"]),
+      localFolderIds: new Map([["Getting Started", "f-gs"]]),
+      folderTombstones: null,
+    });
+    expect(p.removeFolders).toEqual([]);
+  });
+
+  it("does not read a revoked folder as revoked once the server re-created its path", () => {
+    // Someone made a NEW "Getting Started" (fresh id) after ours went private:
+    // the directory on disk is now that folder's, and the outbound half adopts it.
+    const p = plan({
+      localFolders: new Set(["Getting Started"]),
+      localFolderIds: new Map([["Getting Started", "f-old"]]),
+      serverFolders: new Set(["Getting Started"]),
+      serverFolderIds: new Map([["f-new", "Getting Started"]]),
+    });
+    expect(p.removeFolders).toEqual([]);
+  });
+
+  it("refuses a mass folder revocation past the safety limit, and reports every one", () => {
+    const localFolders = new Set<string>();
+    const localFolderIds = new Map<string, string>();
+    for (let i = 0; i < 21; i++) {
+      localFolders.add(`F${i}`);
+      localFolderIds.set(`F${i}`, `f${i}`);
+    }
+    const p = plan({ localFolders, localFolderIds });
+    expect(p.removeFolders).toEqual([]);
+    expect(p.rejected).toHaveLength(21);
+    expect(p.rejected[0]).toMatchObject({ kind: "folder", path: "F0" });
+    expect(p.rejected[0].reason).toMatch(/exceeds the 20 safety limit/);
   });
 
   it("removes a local folder whose recorded id is tombstoned, children first", () => {
@@ -69,6 +127,10 @@ describe("planInbound — folders", () => {
         ["A/B", "fb"],
         ["Keep", "fk"],
       ]),
+      // `Keep` is still listed; a recorded id that is NEITHER listed nor
+      // tombstoned would be a revocation (its own cases above).
+      serverFolders: new Set(["Keep"]),
+      serverFolderIds: new Map([["fk", "Keep"]]),
       folderTombstones: new Set(["fa", "fb"]),
     });
     expect(p.removeFolders).toEqual(["A/B", "A"]);

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -540,6 +540,50 @@ describe("inbound folder deletion", () => {
     );
   });
 
+  it("removes a folder made private along with its notes, and does not re-adopt it", async () => {
+    // The reported bug: the Access page set "Getting Started" to Private. On the
+    // teammate's device the notes left as revoked, but the folder — neither
+    // tombstoned nor moved, merely absent from the permission-filtered listing —
+    // stayed in the sidebar as an empty shell, and the outbound half re-adopted
+    // its hidden id on every pull.
+    const disk = new FakeDisk();
+    disk.folders.add("Getting Started");
+    disk.notes.set("Getting Started/welcome.md", "d1");
+    const { api } = await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Getting Started/welcome.md" }],
+        folders: [{ id: "f1", path: "Getting Started" }],
+      },
+      // Nothing deleted: both tombstone lists are answered and empty.
+      then: { notes: [], tombstones: [], folders: [], folderTombstones: [] },
+    });
+
+    expect(disk.trashed.map((t) => t.from)).toEqual(["Getting Started/welcome.md"]);
+    expect(disk.folders.has("Getting Started")).toBe(false);
+    expect(vi.mocked(api.createFolder)).not.toHaveBeenCalled();
+  });
+
+  it("keeps a private folder that still holds unconfirmed content", async () => {
+    // Access can be taken away mid-edit. The note pass refuses to trash work this
+    // device never confirmed upstream, and the folder around it must then stay too.
+    const disk = new FakeDisk();
+    disk.folders.add("Getting Started");
+    disk.notes.set("Getting Started/mine.md", "d1");
+    disk.bodies.set("Getting Started/mine.md", "words nobody else has");
+    await twoPasses({
+      disk,
+      first: {
+        notes: [{ id: "d1", rel_path: "Getting Started/mine.md" }],
+        folders: [{ id: "f1", path: "Getting Started" }],
+      },
+      then: { notes: [], tombstones: [], folders: [], folderTombstones: [] },
+    });
+
+    expect(disk.trashed).toEqual([]);
+    expect(disk.folders.has("Getting Started")).toBe(true);
+  });
+
   it("removes the emptied old directory after a server-side folder move, and does not re-register it", async () => {
     const disk = new FakeDisk();
     disk.folders.add("Projects");

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -100,8 +100,11 @@ export interface InboundPlan {
   /** Folder paths to create locally, parents before children. */
   createFolders: string[];
   /**
-   * Local folder paths the server has DELETED (tombstoned by id), children
-   * before parents. The executor removes each one only if it is empty by then —
+   * Local folder paths that must leave this disk, children before parents: the
+   * server DELETED them (tombstoned by id), MOVED them elsewhere (the emptied
+   * old directory), or took this user's access away (the id vanished from the
+   * permission-filtered listing without a tombstone — a folder made private).
+   * The executor removes each one only if it is empty by then —
    * the notes inside leave via their own tombstones in {@link trash} first, and
    * a folder still holding anything (an unconfirmed orphan, a stray image, a
    * new local note) stays on disk and re-registers under a fresh id, which is
@@ -340,6 +343,54 @@ export function planInbound(input: InboundInput): InboundPlan {
         continue;
       }
       plan.removeFolders.push(path);
+    }
+  }
+  // A local folder whose recorded server id is neither listed nor tombstoned
+  // has left this user's VISIBLE set: the folder (or the share that made it
+  // reachable) was made private. `GET /api/folders` is permission-filtered, so
+  // the folder simply stops being listed — no tombstone, because nothing was
+  // deleted. Its notes leave via their own `revoked` entries below, and without
+  // this rule the emptied directory stayed in the sidebar forever ("Getting
+  // Started", contents gone, folder still there) and the outbound half kept
+  // re-adopting its hidden id on every pull.
+  //
+  // Same gates as a note revocation: the id must be one WE recorded (a folder
+  // with no server id was never agreed ours — absence then proves nothing), the
+  // server must have answered about deletions at all (`null` tombstones means
+  // "I don't know", and a truncated listing looks exactly like a mass revoke),
+  // and the path must not have been re-created server-side under a fresh id.
+  // Removal is still empty-only, so a folder holding anything the note pass
+  // refused to trash stays on disk. Capped like note revocations.
+  if (input.folderTombstones && input.serverFolderIds && input.localFolderIds) {
+    const revoked: string[] = [];
+    for (const [path, id] of input.localFolderIds) {
+      if (input.serverFolderIds.has(id)) continue; // listed (or moved) — handled above
+      if (input.folderTombstones.has(id)) continue; // deleted — handled above
+      if (!localFoldersCi.has(path.toLowerCase())) continue; // already gone locally
+      if (serverFoldersCi.has(path.toLowerCase())) continue; // re-created server-side
+      if (!isSafeFolderPath(path)) {
+        plan.rejected.push({
+          kind: "folder",
+          path,
+          docId: null,
+          reason: "unsafe local folder path",
+        });
+        continue;
+      }
+      revoked.push(path);
+    }
+    const cap = revokeCap(input.localFolderIds.size);
+    if (revoked.length > cap) {
+      for (const path of revoked) {
+        plan.rejected.push({
+          kind: "folder",
+          path,
+          docId: null,
+          reason: `refused: ${revoked.length} folder access removals in one pass exceeds the ${cap} safety limit`,
+        });
+      }
+    } else {
+      plan.removeFolders.push(...revoked);
     }
   }
   // Children before parents, so an emptied subtree unwinds bottom-up.

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -1008,12 +1008,14 @@ export class VaultRegistry {
       }
     }
 
-    // Folders the server has deleted, children before parents, AFTER the trash
-    // loop above has moved their notes out. Empty-only removal (`remove_dir`,
-    // never recursive): a folder still holding anything stays on disk and — its
-    // dead mapping dropped below — re-registers under a fresh id, because
-    // content must live somewhere. Either way the stale id leaves the map, so
-    // nothing can later rename/color/re-register against a deleted server row.
+    // Folders the server has deleted, moved away from, or taken this user's
+    // access to (made private: absent from the permission-filtered listing with
+    // no tombstone), children before parents, AFTER the trash loop above has
+    // moved their notes out. Empty-only removal (`remove_dir`, never recursive):
+    // a folder still holding anything stays on disk and — its dead mapping
+    // dropped below — re-registers under a fresh id, because content must live
+    // somewhere. Either way the stale id leaves the map, so nothing can later
+    // rename/color/re-register against a deleted server row.
     for (const path of plan.removeFolders) {
       if (this.stopRun()) break;
       try {


### PR DESCRIPTION
## Problem
On the Access page, making a **file** private removes it from the teammate's device. Making a **folder** private removed the notes inside but left the empty folder ("Getting Started") in their sidebar forever.

## Cause
`GET /api/folders` is permission-filtered, so a folder made private simply stops being listed — there is no tombstone because nothing was deleted. `planInbound` only removed local folders that were **tombstoned** or **moved**, so the revoked folder's notes left (as `revoked`) but the emptied directory stayed. Worse, the outbound half then saw it as "missing from the server" and re-adopted its hidden id on every pull.

## Fix
- `inbound.ts`: a local folder whose **recorded server id** is neither listed nor tombstoned has left the user's visible set → queued for removal (children first), with the same gates as a note revocation: the id must be one we recorded, the server must have answered about deletions (`null` tombstones ⇒ do nothing), the path must not have been re-created server-side, and removal stays empty-only. Capped like note revocations (`max(20, 50%)`).
- `notefile.rs`: `delete_folder_if_empty` now sweeps `.DS_Store` / `desktop.ini` / `Thumbs.db` before `remove_dir`, so a folder Finder has visited still counts as empty. Any other file still blocks removal.

## Tests
- planner: revoked folder removed children-first; `null` tombstones ⇒ untouched; re-created path ⇒ untouched; mass-revoke cap refuses and reports.
- apply (end to end): private folder + note leave together and the folder is not re-adopted; a folder holding unconfirmed local content stays.
- Rust: metadata-only folder removed, other dotfile blocks.

Desktop suite: 870 passed. `cargo test`: green.