### PR TITLE
Release v0.1.54

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.53",
+  "version": "0.1.54",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.53"
+version = "0.1.54"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump for the next production release. Carries the subscription lifecycle work (#109 #110 #111), the Settings polish, the checkout-success confirmation, and the private-folder cleanup fix (#114).