### PR TITLE
Remove a revoked note outright and say access was removed in the banner

### DIFF
--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -142,11 +142,17 @@ function RemovedBanner() {
  * where the local copy went, which is the difference between a scare and a note.
  */
 function DeletedByTeammateBanner() {
-  const trashedTo = useStore((s) => s.noteRemovedByTeammate);
+  const removed = useStore((s) => s.noteRemovedByTeammate);
   return (
-    <Banner show={!!trashedTo}>
+    <Banner show={!!removed}>
       <span>
-        A teammate deleted this note. Your copy was moved to <code>{trashedTo}</code>.
+        {removed?.reason === "revoked" ? (
+          <>Your access to this note was removed. It is no longer on this device.</>
+        ) : (
+          <>
+            A teammate deleted this note. Your copy was moved to <code>{removed?.trashedTo}</code>.
+          </>
+        )}
       </span>
       <div className="banner-actions">
         <button

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -47,6 +47,8 @@ class FakeDisk {
   /** relPath → body, for the emptiness check on unconfirmed notes. */
   bodies = new Map<string, string>();
   trashed: Array<{ from: string; to: string }> = [];
+  /** Paths removed outright (revocations) — never in the trash. */
+  deleted: string[] = [];
 
   tree(): TreeNode {
     const dirs = [...this.folders].map((f) => ({
@@ -116,6 +118,12 @@ function install(disk: FakeDisk) {
     disk.folders.delete(p);
     return true;
   }) as never);
+  vi.mocked(ipc.deletePath).mockImplementation((async (p: string) => {
+    if (!disk.notes.has(p)) throw new Error("path does not exist");
+    disk.notes.delete(p);
+    disk.bodies.delete(p);
+    disk.deleted.push(p);
+  }) as never);
   vi.mocked(ipc.trashNote).mockImplementation((async (p: string, stamp: string) => {
     if (!disk.notes.has(p)) throw new Error("path does not exist");
     disk.notes.delete(p);
@@ -160,7 +168,7 @@ function fakeApi(state: ServerState) {
 function recordingHost() {
   const released: string[] = [];
   const renamed: Array<{ from: string; to: string }> = [];
-  const removed: Array<{ path: string; trashedTo: string | null }> = [];
+  const removed: Array<{ path: string; trashedTo: string | null; reason: string }> = [];
   /** Paths the registry asked to fill in from a local CRDT after materializing.
    *  This host has no doc store, so it answers "nothing to fill in" — which is
    *  the fresh-device case, i.e. today's empty placeholder. */
@@ -170,7 +178,7 @@ function recordingHost() {
       released.push(docId);
     },
     notePathChanged: (_docId, from, to) => renamed.push({ from, to }),
-    noteRemoved: (_docId, path, trashedTo) => removed.push({ path, trashedTo }),
+    noteRemoved: (_docId, path, trashedTo, reason) => removed.push({ path, trashedTo, reason }),
     materializeContent: async (docId, path) => {
       hydrated.push({ docId, path });
       return false;
@@ -404,11 +412,13 @@ describe("inbound delete", () => {
     expect(ipc.trashNote).not.toHaveBeenCalled();
   });
 
-  it("REMOVES a file whose access was revoked, and stops re-registering it", async () => {
+  it("REMOVES a file whose access was revoked outright, and stops re-registering it", async () => {
     // `GET /api/notes` is ACL-filtered, so a revoked share looks like a delete;
-    // the tombstone set is what tells them apart. Both end with the file in the
-    // vault's recoverable trash — a revocation that leaves a readable `.md`
-    // behind is cosmetic, since the ex-reader can open it in any editor forever.
+    // the tombstone set is what tells them apart. A DELETED note goes to the
+    // vault trash (the undo for a deliberate removal); a REVOKED one is removed
+    // outright — a copy in `.context/trash` would hand the ex-reader exactly the
+    // readable `.md` the revocation exists to take away, and the server still
+    // holds the content, so nothing is lost.
     const disk = new FakeDisk();
     disk.notes.set("shared.md", "d1");
     const r = await twoPasses({
@@ -418,7 +428,11 @@ describe("inbound delete", () => {
     });
 
     expect(disk.notes.has("shared.md")).toBe(false);
-    expect(ipc.trashNote).toHaveBeenCalledWith("shared.md", expect.any(String), null);
+    expect(disk.deleted).toEqual(["shared.md"]);
+    expect(disk.trashed).toEqual([]);
+    expect(ipc.trashNote).not.toHaveBeenCalled();
+    // The UI learns WHY, so it can say "access removed" rather than "deleted".
+    expect(r.removed).toEqual([{ path: "shared.md", trashedTo: null, reason: "revoked" }]);
     // And it is NOT re-registered on the way out, which would resurrect it as an
     // unsyncable ghost.
     expect(vi.mocked(r.api.createNote)).not.toHaveBeenCalled();
@@ -559,7 +573,8 @@ describe("inbound folder deletion", () => {
       then: { notes: [], tombstones: [], folders: [], folderTombstones: [] },
     });
 
-    expect(disk.trashed.map((t) => t.from)).toEqual(["Getting Started/welcome.md"]);
+    expect(disk.deleted).toEqual(["Getting Started/welcome.md"]);
+    expect(disk.trashed).toEqual([]);
     expect(disk.folders.has("Getting Started")).toBe(false);
     expect(vi.mocked(api.createFolder)).not.toHaveBeenCalled();
   });

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -223,7 +223,12 @@ export class SyncManager implements InboundHost {
   private onRegistryChanged?: () => void;
   private onAclChangedListener?: () => void;
   private onNotePathChanged?: (docId: string, from: string, to: string) => void;
-  private onNoteRemoved?: (docId: string, path: string, trashedTo: string | null) => void;
+  private onNoteRemoved?: (
+    docId: string,
+    path: string,
+    trashedTo: string | null,
+    reason: "deleted" | "revoked",
+  ) => void;
   private onMemberJoined?: (name: string) => void;
   /** Mirrors the registry's {relPath → docId} map to the UI (coalesced). */
   private onRegistryMap?: (map: Record<string, string>) => void;
@@ -1326,14 +1331,24 @@ export class SyncManager implements InboundHost {
     }
   }
 
-  noteRemoved(docId: string, path: string, trashedTo: string | null): void {
-    this.onNoteRemoved?.(docId, path, trashedTo);
+  noteRemoved(
+    docId: string,
+    path: string,
+    trashedTo: string | null,
+    reason: "deleted" | "revoked",
+  ): void {
+    this.onNoteRemoved?.(docId, path, trashedTo, reason);
   }
 
   /** Called after an inbound rename lands on disk (store re-points the editor). */
   setInboundListeners(listeners: {
     onNotePathChanged?: (docId: string, from: string, to: string) => void;
-    onNoteRemoved?: (docId: string, path: string, trashedTo: string | null) => void;
+    onNoteRemoved?: (
+      docId: string,
+      path: string,
+      trashedTo: string | null,
+      reason: "deleted" | "revoked",
+    ) => void;
   }): void {
     this.onNotePathChanged = listeners.onNotePathChanged;
     this.onNoteRemoved = listeners.onNoteRemoved;

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -80,8 +80,11 @@ export interface InboundTrash {
    * `deleted` — the server tombstoned it: someone deleted the note.
    * `revoked` — it left the caller's readable set: access was taken away.
    *
-   * They execute identically (release the doc, move it to the vault trash) but
-   * carry different risk, so they get separate safety caps and separate
+   * Both release the doc and take the file off disk, but differently: a deleted
+   * note goes to the vault's recoverable trash (the undo for a deliberate
+   * removal), a revoked one is removed outright (the server still holds it, and
+   * a trash copy would keep the readable `.md` the revocation takes away). They
+   * also carry different risk, so they get separate safety caps and separate
    * wording when one is refused. A wrong `deleted` is a server bug destroying
    * work; a mass `revoked` is a routine admin action that happens to look the
    * same from here.

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -137,8 +137,18 @@ export interface InboundHost {
   releaseDoc(docId: string): Promise<void>;
   /** The file moved: re-point anything showing it (e.g. the open editor). */
   notePathChanged(docId: string, from: string, to: string): void;
-  /** The file is gone: close anything showing it. */
-  noteRemoved(docId: string, path: string, trashedTo: string | null): void;
+  /**
+   * The file is gone: close anything showing it. `trashedTo` is the vault-trash
+   * path for a `deleted` note; a `revoked` note is removed outright (the server
+   * still holds it, and an ex-reader must not keep a readable copy), so it is
+   * `null`.
+   */
+  noteRemoved(
+    docId: string,
+    path: string,
+    trashedTo: string | null,
+    reason: "deleted" | "revoked",
+  ): void;
   /**
    * A server-only note was just materialized as a 0-byte placeholder at `path`.
    * Fill it in from THIS DEVICE's local CRDT, if it has one, and resolve whether
@@ -925,12 +935,24 @@ export class VaultRegistry {
       await this.host?.releaseDoc(gone.docId);
       if (this.stale()) return { changedDisk, suppress: plan.suppress };
       try {
-        const dest = await ipc.trashNote(gone.path, stamp, this.epoch());
+        // A DELETED note goes to the vault's recoverable trash: someone chose to
+        // remove it, and the trash is the undo. A REVOKED note is removed
+        // outright: nothing was deleted (the server still holds every byte, and
+        // the note comes straight back if access is restored), while a copy in
+        // `.context/trash` would leave the ex-reader with exactly the readable
+        // `.md` the revocation exists to take away. `deletePath` is the same
+        // epoch-pinned Rust call the sidebar's own Delete uses.
+        let dest: string | null = null;
+        if (gone.reason === "revoked") {
+          await ipc.deletePath(gone.path, this.epoch());
+        } else {
+          dest = await ipc.trashNote(gone.path, stamp, this.epoch());
+        }
         changedDisk = true;
         // The file left, so the baseline entry goes with it — otherwise every
-        // later pass would keep trying to trash a path that isn't there.
+        // later pass would keep trying to remove a path that isn't there.
         this.baselineDocs.delete(gone.docId);
-        this.host?.noteRemoved(gone.docId, gone.path, dest);
+        this.host?.noteRemoved(gone.docId, gone.path, dest, gone.reason);
       } catch (e) {
         if (ipc.isVaultMismatch(e)) return { changedDisk, suppress: plan.suppress };
         this.recordFailure({

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -144,12 +144,15 @@ interface AppStore {
    */
   noteRemovedSynced: boolean;
   /**
-   * Set when the note that was open was deleted by a TEAMMATE (or an AI) and we
-   * applied that locally: the trash-relative path the local copy was moved to, so
-   * the UI can say where it went. Distinct from `noteRemoved`, which means "the
-   * file vanished from under us" (a Finder delete) and offers no recovery hint.
+   * Set when the note that was open left because of a TEAMMATE (or an AI) and we
+   * applied that locally. `deleted`: they deleted it, and `trashedTo` is the
+   * trash-relative path the local copy was moved to, so the UI can say where it
+   * went. `revoked`: our access was taken away — the file is removed outright
+   * (no local copy is kept; the server still has it) and `trashedTo` is `null`.
+   * Distinct from `noteRemoved`, which means "the file vanished from under us"
+   * (a Finder delete) and offers no recovery hint.
    */
-  noteRemovedByTeammate: string | null;
+  noteRemovedByTeammate: { reason: "deleted" | "revoked"; trashedTo: string | null } | null;
   /** Follow an inbound rename: re-point the open note (and its descendants). */
   followNoteRename: (from: string, to: string) => void;
   /**
@@ -1776,12 +1779,12 @@ export const useStore = create<AppStore>((set, get) => ({
     // CodeMirror bound to a destroyed Y.Doc throws on the next keystroke.
     syncManager.setInboundListeners({
       onNotePathChanged: (_docId, from, to) => get().followNoteRename(from, to),
-      onNoteRemoved: (_docId, path, trashedTo) => {
+      onNoteRemoved: (_docId, path, trashedTo, reason) => {
         get().pruneTabs([path]);
         const open = get().openNote;
         if (open && (open.path === path || open.path.startsWith(path + "/"))) {
           get().closeNote();
-          set({ noteRemovedByTeammate: trashedTo });
+          set({ noteRemovedByTeammate: { reason, trashedTo } });
         }
       },
     });


### PR DESCRIPTION
## Problem
When a note (or its folder) is made private, the teammate's device moved the file to `.context/trash/…` and showed "A teammate deleted this note. Your copy was moved to …". Nothing was deleted, and keeping a readable copy defeats the point of revoking access.

## Change
- `registry.ts`: a `revoked` note is now removed with `deletePath` (the same epoch-pinned Rust call the sidebar's Delete uses) instead of `trashNote`. Deleted notes still go to the vault trash. The server keeps the content, and restoring access re-materialises the note (existing round-trip test).
- `noteRemoved` carries a `reason` through `InboundHost` → `SyncManager` → store, and `noteRemovedByTeammate` becomes `{ reason, trashedTo }`.
- Banner: revoked → "Your access to this note was removed. It is no longer on this device."; deleted → unchanged.

## Tests
Apply tests assert the revoked file is deleted (not trashed) and the host receives `reason: "revoked"`; the private-folder test asserts the same. Desktop suite: 870 passed, tsc clean.