### PR TITLE
Release v0.1.55

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.54",
+  "version": "0.1.55",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.54"
+version = "0.1.55"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/apps/desktop/src/App.tsx
+++ b/app/apps/desktop/src/App.tsx
@@ -142,11 +142,17 @@ function RemovedBanner() {
  * where the local copy went, which is the difference between a scare and a note.
  */
 function DeletedByTeammateBanner() {
-  const trashedTo = useStore((s) => s.noteRemovedByTeammate);
+  const removed = useStore((s) => s.noteRemovedByTeammate);
   return (
-    <Banner show={!!trashedTo}>
+    <Banner show={!!removed}>
       <span>
-        A teammate deleted this note. Your copy was moved to <code>{trashedTo}</code>.
+        {removed?.reason === "revoked" ? (
+          <>Your access to this note was removed. It is no longer on this device.</>
+        ) : (
+          <>
+            A teammate deleted this note. Your copy was moved to <code>{removed?.trashedTo}</code>.
+          </>
+        )}
       </span>
       <div className="banner-actions">
         <button

--- a/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/inboundApply.test.ts
@@ -47,6 +47,8 @@ class FakeDisk {
   /** relPath → body, for the emptiness check on unconfirmed notes. */
   bodies = new Map<string, string>();
   trashed: Array<{ from: string; to: string }> = [];
+  /** Paths removed outright (revocations) — never in the trash. */
+  deleted: string[] = [];
 
   tree(): TreeNode {
     const dirs = [...this.folders].map((f) => ({
@@ -116,6 +118,12 @@ function install(disk: FakeDisk) {
     disk.folders.delete(p);
     return true;
   }) as never);
+  vi.mocked(ipc.deletePath).mockImplementation((async (p: string) => {
+    if (!disk.notes.has(p)) throw new Error("path does not exist");
+    disk.notes.delete(p);
+    disk.bodies.delete(p);
+    disk.deleted.push(p);
+  }) as never);
   vi.mocked(ipc.trashNote).mockImplementation((async (p: string, stamp: string) => {
     if (!disk.notes.has(p)) throw new Error("path does not exist");
     disk.notes.delete(p);
@@ -160,7 +168,7 @@ function fakeApi(state: ServerState) {
 function recordingHost() {
   const released: string[] = [];
   const renamed: Array<{ from: string; to: string }> = [];
-  const removed: Array<{ path: string; trashedTo: string | null }> = [];
+  const removed: Array<{ path: string; trashedTo: string | null; reason: string }> = [];
   /** Paths the registry asked to fill in from a local CRDT after materializing.
    *  This host has no doc store, so it answers "nothing to fill in" — which is
    *  the fresh-device case, i.e. today's empty placeholder. */
@@ -170,7 +178,7 @@ function recordingHost() {
       released.push(docId);
     },
     notePathChanged: (_docId, from, to) => renamed.push({ from, to }),
-    noteRemoved: (_docId, path, trashedTo) => removed.push({ path, trashedTo }),
+    noteRemoved: (_docId, path, trashedTo, reason) => removed.push({ path, trashedTo, reason }),
     materializeContent: async (docId, path) => {
       hydrated.push({ docId, path });
       return false;
@@ -404,11 +412,13 @@ describe("inbound delete", () => {
     expect(ipc.trashNote).not.toHaveBeenCalled();
   });
 
-  it("REMOVES a file whose access was revoked, and stops re-registering it", async () => {
+  it("REMOVES a file whose access was revoked outright, and stops re-registering it", async () => {
     // `GET /api/notes` is ACL-filtered, so a revoked share looks like a delete;
-    // the tombstone set is what tells them apart. Both end with the file in the
-    // vault's recoverable trash — a revocation that leaves a readable `.md`
-    // behind is cosmetic, since the ex-reader can open it in any editor forever.
+    // the tombstone set is what tells them apart. A DELETED note goes to the
+    // vault trash (the undo for a deliberate removal); a REVOKED one is removed
+    // outright — a copy in `.context/trash` would hand the ex-reader exactly the
+    // readable `.md` the revocation exists to take away, and the server still
+    // holds the content, so nothing is lost.
     const disk = new FakeDisk();
     disk.notes.set("shared.md", "d1");
     const r = await twoPasses({
@@ -418,7 +428,11 @@ describe("inbound delete", () => {
     });
 
     expect(disk.notes.has("shared.md")).toBe(false);
-    expect(ipc.trashNote).toHaveBeenCalledWith("shared.md", expect.any(String), null);
+    expect(disk.deleted).toEqual(["shared.md"]);
+    expect(disk.trashed).toEqual([]);
+    expect(ipc.trashNote).not.toHaveBeenCalled();
+    // The UI learns WHY, so it can say "access removed" rather than "deleted".
+    expect(r.removed).toEqual([{ path: "shared.md", trashedTo: null, reason: "revoked" }]);
     // And it is NOT re-registered on the way out, which would resurrect it as an
     // unsyncable ghost.
     expect(vi.mocked(r.api.createNote)).not.toHaveBeenCalled();
@@ -559,7 +573,8 @@ describe("inbound folder deletion", () => {
       then: { notes: [], tombstones: [], folders: [], folderTombstones: [] },
     });
 
-    expect(disk.trashed.map((t) => t.from)).toEqual(["Getting Started/welcome.md"]);
+    expect(disk.deleted).toEqual(["Getting Started/welcome.md"]);
+    expect(disk.trashed).toEqual([]);
     expect(disk.folders.has("Getting Started")).toBe(false);
     expect(vi.mocked(api.createFolder)).not.toHaveBeenCalled();
   });

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -223,7 +223,12 @@ export class SyncManager implements InboundHost {
   private onRegistryChanged?: () => void;
   private onAclChangedListener?: () => void;
   private onNotePathChanged?: (docId: string, from: string, to: string) => void;
-  private onNoteRemoved?: (docId: string, path: string, trashedTo: string | null) => void;
+  private onNoteRemoved?: (
+    docId: string,
+    path: string,
+    trashedTo: string | null,
+    reason: "deleted" | "revoked",
+  ) => void;
   private onMemberJoined?: (name: string) => void;
   /** Mirrors the registry's {relPath → docId} map to the UI (coalesced). */
   private onRegistryMap?: (map: Record<string, string>) => void;
@@ -1326,14 +1331,24 @@ export class SyncManager implements InboundHost {
     }
   }
 
-  noteRemoved(docId: string, path: string, trashedTo: string | null): void {
-    this.onNoteRemoved?.(docId, path, trashedTo);
+  noteRemoved(
+    docId: string,
+    path: string,
+    trashedTo: string | null,
+    reason: "deleted" | "revoked",
+  ): void {
+    this.onNoteRemoved?.(docId, path, trashedTo, reason);
   }
 
   /** Called after an inbound rename lands on disk (store re-points the editor). */
   setInboundListeners(listeners: {
     onNotePathChanged?: (docId: string, from: string, to: string) => void;
-    onNoteRemoved?: (docId: string, path: string, trashedTo: string | null) => void;
+    onNoteRemoved?: (
+      docId: string,
+      path: string,
+      trashedTo: string | null,
+      reason: "deleted" | "revoked",
+    ) => void;
   }): void {
     this.onNotePathChanged = listeners.onNotePathChanged;
     this.onNoteRemoved = listeners.onNoteRemoved;

--- a/app/apps/desktop/src/lib/sync/inbound.ts
+++ b/app/apps/desktop/src/lib/sync/inbound.ts
@@ -80,8 +80,11 @@ export interface InboundTrash {
    * `deleted` — the server tombstoned it: someone deleted the note.
    * `revoked` — it left the caller's readable set: access was taken away.
    *
-   * They execute identically (release the doc, move it to the vault trash) but
-   * carry different risk, so they get separate safety caps and separate
+   * Both release the doc and take the file off disk, but differently: a deleted
+   * note goes to the vault's recoverable trash (the undo for a deliberate
+   * removal), a revoked one is removed outright (the server still holds it, and
+   * a trash copy would keep the readable `.md` the revocation takes away). They
+   * also carry different risk, so they get separate safety caps and separate
    * wording when one is refused. A wrong `deleted` is a server bug destroying
    * work; a mass `revoked` is a routine admin action that happens to look the
    * same from here.

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -137,8 +137,18 @@ export interface InboundHost {
   releaseDoc(docId: string): Promise<void>;
   /** The file moved: re-point anything showing it (e.g. the open editor). */
   notePathChanged(docId: string, from: string, to: string): void;
-  /** The file is gone: close anything showing it. */
-  noteRemoved(docId: string, path: string, trashedTo: string | null): void;
+  /**
+   * The file is gone: close anything showing it. `trashedTo` is the vault-trash
+   * path for a `deleted` note; a `revoked` note is removed outright (the server
+   * still holds it, and an ex-reader must not keep a readable copy), so it is
+   * `null`.
+   */
+  noteRemoved(
+    docId: string,
+    path: string,
+    trashedTo: string | null,
+    reason: "deleted" | "revoked",
+  ): void;
   /**
    * A server-only note was just materialized as a 0-byte placeholder at `path`.
    * Fill it in from THIS DEVICE's local CRDT, if it has one, and resolve whether
@@ -925,12 +935,24 @@ export class VaultRegistry {
       await this.host?.releaseDoc(gone.docId);
       if (this.stale()) return { changedDisk, suppress: plan.suppress };
       try {
-        const dest = await ipc.trashNote(gone.path, stamp, this.epoch());
+        // A DELETED note goes to the vault's recoverable trash: someone chose to
+        // remove it, and the trash is the undo. A REVOKED note is removed
+        // outright: nothing was deleted (the server still holds every byte, and
+        // the note comes straight back if access is restored), while a copy in
+        // `.context/trash` would leave the ex-reader with exactly the readable
+        // `.md` the revocation exists to take away. `deletePath` is the same
+        // epoch-pinned Rust call the sidebar's own Delete uses.
+        let dest: string | null = null;
+        if (gone.reason === "revoked") {
+          await ipc.deletePath(gone.path, this.epoch());
+        } else {
+          dest = await ipc.trashNote(gone.path, stamp, this.epoch());
+        }
         changedDisk = true;
         // The file left, so the baseline entry goes with it — otherwise every
-        // later pass would keep trying to trash a path that isn't there.
+        // later pass would keep trying to remove a path that isn't there.
         this.baselineDocs.delete(gone.docId);
-        this.host?.noteRemoved(gone.docId, gone.path, dest);
+        this.host?.noteRemoved(gone.docId, gone.path, dest, gone.reason);
       } catch (e) {
         if (ipc.isVaultMismatch(e)) return { changedDisk, suppress: plan.suppress };
         this.recordFailure({

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -144,12 +144,15 @@ interface AppStore {
    */
   noteRemovedSynced: boolean;
   /**
-   * Set when the note that was open was deleted by a TEAMMATE (or an AI) and we
-   * applied that locally: the trash-relative path the local copy was moved to, so
-   * the UI can say where it went. Distinct from `noteRemoved`, which means "the
-   * file vanished from under us" (a Finder delete) and offers no recovery hint.
+   * Set when the note that was open left because of a TEAMMATE (or an AI) and we
+   * applied that locally. `deleted`: they deleted it, and `trashedTo` is the
+   * trash-relative path the local copy was moved to, so the UI can say where it
+   * went. `revoked`: our access was taken away — the file is removed outright
+   * (no local copy is kept; the server still has it) and `trashedTo` is `null`.
+   * Distinct from `noteRemoved`, which means "the file vanished from under us"
+   * (a Finder delete) and offers no recovery hint.
    */
-  noteRemovedByTeammate: string | null;
+  noteRemovedByTeammate: { reason: "deleted" | "revoked"; trashedTo: string | null } | null;
   /** Follow an inbound rename: re-point the open note (and its descendants). */
   followNoteRename: (from: string, to: string) => void;
   /**
@@ -1776,12 +1779,12 @@ export const useStore = create<AppStore>((set, get) => ({
     // CodeMirror bound to a destroyed Y.Doc throws on the next keystroke.
     syncManager.setInboundListeners({
       onNotePathChanged: (_docId, from, to) => get().followNoteRename(from, to),
-      onNoteRemoved: (_docId, path, trashedTo) => {
+      onNoteRemoved: (_docId, path, trashedTo, reason) => {
         get().pruneTabs([path]);
         const open = get().openNote;
         if (open && (open.path === path || open.path.startsWith(path + "/"))) {
           get().closeNote();
-          set({ noteRemovedByTeammate: trashedTo });
+          set({ noteRemovedByTeammate: { reason, trashedTo } });
         }
       },
     });

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -497,14 +497,16 @@ interface AppStore {
   closeLocalVault: () => void;
 
   // Resolving a vault's local folder (when none is bound yet)
-  /** Bind `path` to `orgId`, open it, and enable sync. */
-  /** Open `path` as `orgId`'s folder and bind them. `create` gates the mkdir —
+  /** Open `path` as `orgId`'s folder, bind them, paint the tree, and start sync
+   *  in the background (never awaited — see the body). `create` gates the mkdir —
    *  only paths that deliberately mint a NEW folder pass true; reopening a
-   *  remembered binding must not resurrect a folder the user moved away. */
+   *  remembered binding must not resurrect a folder the user moved away.
+   *  `deferSync` leaves sync to the caller, for the one path that has to
+   *  activate the org AFTER opening the folder (`setActiveOrganization`). */
   applyVaultFolder: (
     orgId: string,
     path: string,
-    opts?: { create?: boolean; seedIfEmpty?: boolean },
+    opts?: { create?: boolean; seedIfEmpty?: boolean; deferSync?: boolean },
   ) => Promise<void>;
   /**
    * Adopt a vault Rust has ALREADY opened (the native-picker commands open as
@@ -2249,9 +2251,11 @@ export const useStore = create<AppStore>((set, get) => ({
     const gen = ++orgSwitchGen;
     const superseded = () => orgSwitchGen !== gen;
 
-    // Announce the destination BEFORE the first await. A switch is many round
-    // trips (activate org → re-read session → roster → billing → open the folder
-    // → re-enable sync → reconcile), and until the folder actually swaps, the
+    // Announce the destination BEFORE the first await. A vault already on this
+    // device swaps its folder in a few IPCs (the fast path in `switchToOrg`),
+    // too quickly for the overlay's fade-in; one without a folder yet is many
+    // round trips (activate org → re-read session → roster → billing →
+    // rediscover or mint a folder), and until the folder actually swaps, the
     // sidebar still shows the vault you just left. Clicking a vault and watching
     // the old one sit there is indistinguishable from the click not registering,
     // so the chrome reads this and renames itself to the target at once.
@@ -2306,19 +2310,69 @@ export const useStore = create<AppStore>((set, get) => ({
       leaveVaultSync();
       set(vaultScopedSyncReset());
 
+      // FAST PATH — the vault is already on this device. Each vault owns its
+      // own local folder; when that folder is bound and still on disk, open it
+      // and paint its tree BEFORE any network round trip. The switch itself is
+      // local work (the folder IS the vault); activating the org, refreshing
+      // the roster and reconciling sync are what FOLLOW it, not what it waits
+      // for. Until this reordering the overlay stayed up through six serial
+      // requests plus the whole registry reconcile, so switching to a synced
+      // vault took seconds and grew with vault size while a local switch was
+      // instant.
+      //
+      // `deferSync`: sync must not start in there — `enableSyncForVault` reads
+      // the org from `session.activeOrganizationId`, which still names the
+      // vault we are LEAVING until the two calls below land. (Rust's
+      // `vault-opened` event meanwhile scopes the folder to that stale org via
+      // `setVault`; nothing reads a scope's org, and `syncManager.enable`
+      // re-begins the scope with the right one before any sync work.)
+      //
+      // A folder that is present but won't open falls through to the SAME
+      // prompt as before, but only after the org is active: the prompt's
+      // resolution enables sync from the session, so it must name this vault.
+      const bound = readOrgVaults()[organizationId];
+      const boundOk = !!bound && (await ipc.folderExists(bound).catch(() => false));
+      if (superseded()) return;
+      let openError: unknown = null;
+      if (boundOk) {
+        try {
+          await get().applyVaultFolder(organizationId, bound, { deferSync: true });
+        } catch (e) {
+          openError = e ?? new Error("open failed");
+        }
+        if (superseded()) return;
+        // The folder is open and the tree is painted: the switch is done as far
+        // as the user can tell. Lower the overlay now, not after the network
+        // tail (the `finally` above then has nothing left to do).
+        if (openError === null) set({ switchingVault: null });
+      }
+
       await authManager.api.setActiveOrganization(organizationId);
       if (superseded()) return;
       const session = await authManager.currentSession();
       if (superseded()) return;
       set({ session });
+
+      if (boundOk && openError === null) {
+        // Roster + seat usage feed the members and billing panels, not the tree,
+        // and the reconcile is the part that scales with the vault: none of them
+        // is worth making the user wait for. Each swallows its own errors and
+        // gates its state writes on this still being the open vault.
+        void get().refreshVault();
+        void get().refreshOrgBilling();
+        void get()
+          .enableSyncForVault()
+          .catch((e) => console.warn("[sync] enable after switch failed", e));
+        return;
+      }
+
       await get().refreshVault();
       if (superseded()) return;
       // Seat usage + plan are per-vault, so refresh on every switch.
       await get().refreshOrgBilling();
       if (superseded()) return;
 
-      // Each vault owns its own local folder. If one is already bound and still
-      // on disk, swap to it. If not, do NOT reuse the folder that's currently
+      // No local folder opened above. Do NOT reuse the folder that's currently
       // open — rediscover this vault's existing folder, or mint one.
       const org = get().organizations.find((o) => o.id === organizationId);
       const orgName = org?.name ?? "New vault";
@@ -2335,28 +2389,21 @@ export const useStore = create<AppStore>((set, get) => ({
         });
       };
 
-      const bound = readOrgVaults()[organizationId];
-      if (bound && (await ipc.folderExists(bound).catch(() => false))) {
-        if (superseded()) return;
-        try {
-          await get().applyVaultFolder(organizationId, bound);
-          return;
-        } catch (e) {
-          // The folder is present but wouldn't open (locked index, permissions,
-          // transient I/O). This used to fall through to the auto-folder path,
-          // which minted a full duplicate copy of the vault under the vaults
-          // root AND re-pointed the binding at it — a hiccup made permanent.
-          // Ask instead; the binding stays on the user's real folder.
-          console.warn("[vault] bound folder failed to open", e);
-          if (superseded()) return;
-          askForFolder({
-            text: `This vault's folder couldn't be opened: ${e instanceof Error ? e.message : String(e)}`,
-            path: bound,
-          });
-          return;
-        }
+      if (boundOk) {
+        // The folder is present but wouldn't open (locked index, permissions,
+        // transient I/O). This used to fall through to the auto-folder path,
+        // which minted a full duplicate copy of the vault under the vaults
+        // root AND re-pointed the binding at it — a hiccup made permanent.
+        // Ask instead; the binding stays on the user's real folder.
+        console.warn("[vault] bound folder failed to open", openError);
+        askForFolder({
+          text: `This vault's folder couldn't be opened: ${
+            openError instanceof Error ? openError.message : String(openError)
+          }`,
+          path: bound,
+        });
+        return;
       }
-      if (superseded()) return;
 
       // No binding, or the bound path is gone (folder moved/renamed in Finder,
       // cleared webview storage, another device). Before minting a folder, look
@@ -2750,14 +2797,31 @@ export const useStore = create<AppStore>((set, get) => ({
     });
     rememberOrgVault(orgId, v.path);
     rememberLastVault(orgId);
-    // Turn sync on BEFORE the tree reads. Those two awaits were the window in
-    // which another vault switch (or a `vault-opened` event, or StrictMode's
-    // double-open in dev) could make this call stale and skip sync entirely,
-    // leaving a freshly joined vault sitting there not syncing. The staleness
-    // check still guards the call itself — `enableSyncForVault` re-checks the
-    // epoch internally — but it is no longer gated behind work it doesn't need.
-    if (sameVault(get, v.epoch)) {
-      await get().enableSyncForVault({ seedIfEmpty: opts?.seedIfEmpty });
+    // Start sync BEFORE the tree reads, but never WAIT for it.
+    //
+    // Starting first: the two tree awaits were the window in which another
+    // vault switch (or a `vault-opened` event, or StrictMode's double-open in
+    // dev) could make this call stale and skip sync entirely, leaving a freshly
+    // joined vault sitting there not syncing. `enableSyncForVault` re-checks the
+    // epoch internally, so the staleness check still guards the call itself.
+    //
+    // Not waiting: this used to be awaited, so the sidebar kept showing the
+    // vault being LEFT until the whole registry reconcile had finished — a full
+    // walk of the vault plus several server listings, i.e. seconds that grew
+    // with vault size — while a local vault switched instantly. The folder on
+    // disk IS the vault; the tree below is a top-level directory listing that
+    // needs nothing from the server. Every state write the reconcile makes is
+    // epoch-gated, and it re-reads the tree itself to surface the notes it
+    // materialized, so nothing here depends on it finishing. (A note opened
+    // before it lands is re-attached by the editor when `syncEnabled` flips.)
+    //
+    // `deferSync`: `enableSyncForVault` reads the org from the SESSION, so the
+    // caller that opens the folder before activating the org must start sync
+    // itself once the session names the new vault.
+    if (!opts?.deferSync && sameVault(get, v.epoch)) {
+      void get()
+        .enableSyncForVault({ seedIfEmpty: opts?.seedIfEmpty })
+        .catch((e) => console.warn("[sync] enable failed", e));
     }
     await get().refreshTree();
     await get().refreshTitles();

--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -95,8 +95,8 @@ n/a = synchronous or sub-100ms by construction.
 
 | Action | Work | Latency | Feedback |
 | --- | --- | --- | --- |
-| Switch vault (menu row) | 6+ round trips, then folder swap | 1–5s | ✅ sidebar renames to target + spinner; tree fades and stops taking clicks |
-| Switch vault (settings) | same | 1–5s | ✅ per-button spinner + the above |
+| Switch vault (menu row) | folder already on device: 3 IPCs, tree swaps first; org activation + roster + reconcile follow in the background. No folder yet: 6+ round trips, then rediscover/mint | <0.2s (on-device) / 1–5s (no folder) | ✅ sidebar renames to target + spinner; tree fades and stops taking clicks (only visible on the no-folder path — the overlay's 180ms fade-in outlasts an on-device switch) |
+| Switch vault (settings) | same | same | ✅ per-button spinner + the above |
 | Accept invitation | accept → switch → bind folder → reconcile | 1–5s | ✅ spinner |
 | Join by code | join → switch → reconcile | 1–5s | ✅ existing busy state |
 | New vault (menu) | create org → folder → seed | 1–3s | ✅ existing busy state |


### PR DESCRIPTION
Promotes `staging` to production and bumps the four version files 0.1.54 → 0.1.55.

Ships:
- #118 — switching to an on-device synced vault opens the folder and paints the tree before any network call or reconcile; sync catches up in the background (was 1–5 s and grew with vault size).
- #117 — a revoked note is removed from the device outright instead of trashed, and the banner says access was removed.

Both verified on the staging app. Merge with "Create a merge commit", then fast-forward `staging` onto `main`.