### PR TITLE
Billing: replace the Transfer popover with a destination-picker dialog

### DIFF
--- a/.claude/skills/baalda-guide/references/faq.md
+++ b/.claude/skills/baalda-guide/references/faq.md
@@ -31,7 +31,8 @@ cancel it straight away, or open the billing portal.
 
 ## I deleted my Pro vault and made a new one. Can I move the subscription?
 Yes. Open Vault Settings → Billing, find it under "From deleted vaults", and choose **Transfer**.
-Pick the new vault (it has to be one you own that is not already on Pro) and it takes over the
+A dialog lists the vaults it can move to, with their member counts; pick the new vault (it has to
+be one you own that is not already on Pro), confirm, and it takes over the
 same price and the same billing period. Because the old vault was deleted, the subscription had
 been set to stop at the end of the period; transferring it starts it renewing again on the new
 vault. Only the owner can do this.

--- a/.claude/skills/baalda-guide/references/features.md
+++ b/.claude/skills/baalda-guide/references/features.md
@@ -194,10 +194,12 @@ collaborative apps (Notion, Confluence) keep your data in their database. Baalda
     kept in a "From deleted vaults" list so you can still move it, cancel it outright, or open
     the billing portal for it.
   - **Move a subscription to another vault** (owners only): Vault Settings → Billing → Transfer,
-    from a live vault or from one in "From deleted vaults". The target has to be a vault you own
-    that is not already on Pro. Same price, same billing period; if the subscription had been set
-    to end because its vault was deleted, transferring makes it renew again. The vault it came
-    from drops to Free.
+    from a live vault or from one in "From deleted vaults". Transfer opens a dialog that lists
+    every vault it can move to — each with its member count and Free plan — and explains what
+    happens to the vault it leaves; pick one and confirm. Only vaults you own that are not already
+    on Pro are offered (Transfer is greyed out with a reason when there are none). Same price, same
+    billing period; if the subscription had been set to end because its vault was deleted,
+    transferring makes it renew again. The vault it came from drops to Free.
   - The public pricing page (baalda.com/pricing) may still describe the Team plan as early access
     or "talk to us". The app is ahead of the page: tell people they can upgrade in-app now, and
     to use the pricing page as the contact route if they want to talk first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+- **Billing → Transfer is a dialog, not a one-item menu.** Clicking Transfer on
+  a Pro vault now opens a dialog that names the vault the subscription is
+  leaving, lists every eligible destination as a selectable card with its seat
+  count and Free plan, pre-selects the only candidate when there is just one,
+  and explains what happens to both vaults before the confirm. When some owned
+  vaults are missing it says why (already on Pro). `ConfirmDialog` gained a
+  `confirmDisabled` prop so the confirm waits for a pick.
+
 ### Added
 - **Tabs for open files.** Every note you open now stays open as a tab in a
   strip under the header — click to switch, × or middle-click to close, and

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -5706,14 +5706,51 @@ button.secondary:disabled {
   flex-wrap: wrap;
   justify-content: flex-end;
 }
-.billing-transfer-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
+/* ---- Transfer dialog ----
+   The destinations ride the upgrade dialog's selectable card, laid out as a
+   row (name left, seats right) inside the confirm dialog's centred body. The
+   list is left-aligned and full width so it reads as a form, not prose. */
+.transfer-targets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  width: 100%;
+  margin: var(--sp-2) 0;
+  text-align: left;
 }
-/* Vault names are names: the role menu's `capitalize` would rewrite them. */
-.context-menu.billing-transfer-menu li {
-  text-transform: none;
+.upgrade-plan-card.transfer-target {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  /* Room for the corner check on the right, on every row not just selected. */
+  padding-right: calc(var(--sp-4) + 28px);
+}
+.upgrade-plan-card.transfer-target.selected::after {
+  top: 50%;
+  transform: translateY(-50%);
+}
+.transfer-target-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.transfer-target-meta {
+  flex-shrink: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+.transfer-target.selected .transfer-target-meta {
+  color: var(--accent);
+}
+.confirm-body .transfer-targets-note {
+  font-size: var(--fs-sm);
+  color: var(--text-tertiary);
 }
 /* One line of prose introducing a section's list. */
 .billing-section-note {

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -42,7 +42,6 @@ import { AccountSettings } from "./AccountSettings";
 import { AsyncButton } from "./AsyncButton";
 import { AuthDialog } from "./AuthDialog";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { MenuSelect } from "./MenuSelect";
 import { canActOnMember } from "./memberRoles";
 import { RoleSelect } from "./RoleSelect";
 import { Avatar, SyncBadge } from "./Identity";
@@ -2291,13 +2290,15 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
   const [upgradeOrg, setUpgradeOrg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // A transfer waiting to be confirmed. It moves money between vaults, so it
-  // never fires straight off the picker.
+  // A transfer being set up: the source row's Transfer was clicked and the
+  // dialog is open. `targetOrgId` is the pick, null until one is made (or the
+  // only eligible vault, pre-picked). It moves money between vaults, so the
+  // dialog is where both the choice AND the confirmation happen — never a
+  // popover that fires on the first click.
   const [transfer, setTransfer] = useState<{
     sourceOrgId: string;
     sourceLabel: string;
-    targetOrgId: string;
-    targetName: string;
+    targetOrgId: string | null;
   } | null>(null);
   // An orphaned subscription waiting on a "cancel now" confirmation.
   const [cancelling, setCancelling] = useState<{ orgId: string; label: string } | null>(
@@ -2336,8 +2337,9 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
   // it, rather than closing over an error nobody sees. Neither re-throws — the
   // dialog's own AsyncButton has finished reporting by then.
   const runTransfer = async () => {
-    if (!transfer) return;
-    const { sourceOrgId, targetOrgId, targetName } = transfer;
+    if (!transfer || !transfer.targetOrgId) return;
+    const { sourceOrgId, targetOrgId } = transfer;
+    const targetName = vaults.find((v) => v.orgId === targetOrgId)?.name ?? "the vault";
     setError(null);
     try {
       await authManager.api.transferSubscription(sourceOrgId, targetOrgId);
@@ -2378,10 +2380,13 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
   const freeLimits = myBilling?.freeLimits ?? null;
 
   /**
-   * The Transfer control for one row: a picker over the eligible targets, or a
-   * disabled button that says why there are none. `value` is a LABEL, not a
-   * selection — nothing is currently chosen here, and MenuSelect renders the
-   * raw value whenever no option matches it.
+   * The Transfer control for one row. It opens the transfer dialog, where the
+   * eligible destinations are laid out with their seats and plan and the move
+   * is confirmed in the same place. With exactly one eligible vault it is
+   * pre-picked, so the common case is still one click plus a confirm.
+   *
+   * No eligible vault ⇒ a disabled control that says why, rather than a menu
+   * with nothing in it.
    */
   const transferControl = (sourceOrgId: string, sourceLabel: string) => {
     const targets = transferTargets(vaults, sourceOrgId);
@@ -2397,20 +2402,80 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
       );
     }
     return (
-      <MenuSelect
-        value={TRANSFER_TRIGGER_LABEL}
-        options={targets.map((t) => ({ value: t.orgId, label: t.name }))}
-        onSelect={(targetOrgId) => {
-          const target = targets.find((t) => t.orgId === targetOrgId);
-          if (!target) return;
-          setError(null);
-          setTransfer({ sourceOrgId, sourceLabel, targetOrgId, targetName: target.name });
-        }}
+      <button
+        type="button"
+        className="link-btn"
         disabled={busy}
-        ariaLabel={`Move ${sourceLabel}'s subscription to another vault`}
-        triggerClassName="link-btn billing-transfer-trigger"
-        menuClassName="billing-transfer-menu"
-      />
+        aria-label={`Move ${sourceLabel}'s subscription to another vault`}
+        onClick={() => {
+          setError(null);
+          setTransfer({
+            sourceOrgId,
+            sourceLabel,
+            targetOrgId: targets.length === 1 ? targets[0].orgId : null,
+          });
+        }}
+      >
+        Transfer
+      </button>
+    );
+  };
+
+  /**
+   * The transfer dialog body: the eligible destinations as selectable cards.
+   * Each card carries what the reader weighs when choosing — the vault's
+   * seats, and that it is on Free today — instead of a bare name.
+   */
+  const renderTransferDialog = () => {
+    if (!transfer) return null;
+    const targets = transferTargets(vaults, transfer.sourceOrgId);
+    const target = targets.find((t) => t.orgId === transfer.targetOrgId) ?? null;
+    // Owned vaults that are NOT offered, so the list's gaps are explained.
+    const skipped = vaults.filter(
+      (v) => v.orgId !== transfer.sourceOrgId && v.role === "owner" && !targets.includes(v),
+    ).length;
+    return (
+      <ConfirmDialog
+        tone="accent"
+        title={`Move Pro from ${transfer.sourceLabel}`}
+        confirmLabel={target ? `Move Pro to ${target.name}` : "Move subscription"}
+        confirmDisabled={!target}
+        onCancel={() => setTransfer(null)}
+        onConfirm={runTransfer}
+      >
+        <p>
+          Choose the vault that becomes Pro. It keeps the same billing period and
+          price. <strong>{transfer.sourceLabel}</strong> drops to Free — its members
+          and notes stay, but free-plan limits apply to it again.
+        </p>
+        <div className="transfer-targets" role="radiogroup" aria-label="Destination vault">
+          {targets.map((t) => {
+            const used = t.seats.members + t.seats.pendingInvitations;
+            const selected = t.orgId === transfer.targetOrgId;
+            return (
+              <button
+                key={t.orgId}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                className={`upgrade-plan-card transfer-target${selected ? " selected" : ""}`}
+                onClick={() => setTransfer({ ...transfer, targetOrgId: t.orgId })}
+              >
+                <span className="transfer-target-name">{t.name}</span>
+                <span className="transfer-target-meta">
+                  {used} of {t.seats.limit ?? "∞"} member{used === 1 ? "" : "s"} · Free
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        {skipped > 0 && (
+          <p className="transfer-targets-note">
+            Only vaults you own that aren't already on Pro are listed.
+          </p>
+        )}
+        {error && <div className="auth-error">{error}</div>}
+      </ConfirmDialog>
     );
   };
 
@@ -2660,25 +2725,7 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
         <UpgradeDialog orgId={upgradeOrg} onClose={() => setUpgradeOrg(null)} />
       )}
 
-      {transfer && (
-        <ConfirmDialog
-          tone="accent"
-          title={`Move Pro to ${transfer.targetName}?`}
-          confirmLabel="Move subscription"
-          onCancel={() => setTransfer(null)}
-          onConfirm={runTransfer}
-        >
-          <p>
-            <strong>{transfer.targetName}</strong> becomes Pro immediately, on the
-            same billing period and price.
-          </p>
-          <p>
-            <strong>{transfer.sourceLabel}</strong> drops to Free — its members and
-            notes stay, but free-plan limits apply to it again.
-          </p>
-          {error && <div className="auth-error">{error}</div>}
-        </ConfirmDialog>
-      )}
+      {renderTransferDialog()}
 
       {cancelling && (
         <ConfirmDialog
@@ -2709,13 +2756,6 @@ function formatDate(iso: string): string {
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
-
-/**
- * The MenuSelect trigger label for a transfer picker. Typed `string` rather
- * than the literal so it can never collide with an org-id option — it is a
- * label, not a value that could be selected.
- */
-const TRANSFER_TRIGGER_LABEL: string = "Transfer";
 
 /**
  * How a subscription row writes its date and price. Both formatters already

--- a/app/apps/desktop/src/components/ConfirmDialog.tsx
+++ b/app/apps/desktop/src/components/ConfirmDialog.tsx
@@ -16,6 +16,7 @@ export function ConfirmDialog({
   confirmLabel,
   cancelLabel = "Cancel",
   tone = "danger",
+  confirmDisabled = false,
   onConfirm,
   onCancel,
 }: {
@@ -24,6 +25,8 @@ export function ConfirmDialog({
   confirmLabel: string;
   cancelLabel?: string;
   tone?: "danger" | "accent";
+  /** Hold the confirm button until the body has what it needs (e.g. a pick). */
+  confirmDisabled?: boolean;
   onConfirm: () => Promise<unknown> | unknown;
   onCancel: () => void;
 }) {
@@ -65,6 +68,7 @@ export function ConfirmDialog({
           <AsyncButton
             className={`primary${tone === "danger" ? " danger" : ""}`}
             spinnerTone="on-accent"
+            disabled={confirmDisabled}
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,1 +1,1 @@
-- Fixed the sync badge flickering forever and re-syncing the same notes on every reload; edits that were stuck on one device now upload automatically
+- Moving a Pro subscription to another vault now opens a clear dialog that shows each eligible vault with its members and explains what changes, instead of a bare dropdown


### PR DESCRIPTION
## What

The **Transfer** control in Vault Settings → Billing was a `MenuSelect` popover that listed bare vault names (usually one) with no context. It is now a dialog:

- Title names the vault the subscription is leaving ("Move Pro from BenAI OS").
- Every eligible destination is a selectable card (reusing the upgrade dialog's card style) showing the vault name and `N of M members · Free`. With exactly one candidate it is pre-selected.
- The copy explains that the target keeps the same billing period and price and that the source drops to Free with members and notes intact.
- The confirm reads "Move Pro to <vault>" and stays disabled until a vault is picked; a footnote explains that only vaults you own that aren't already on Pro are listed when some were excluded.
- Rows with no eligible destination keep the disabled Transfer control and its tooltip.

## Supporting changes

- `ConfirmDialog` gained an optional `confirmDisabled` prop.
- Removed the now-unused `MenuSelect` import and the transfer-menu CSS; added `.transfer-target*` styles.
- Guide references, `CHANGELOG.md` (Unreleased → Changed) and `docs/RELEASE_NOTES.md` updated.

## Verification

- `tsc --noEmit` clean; desktop vitest suite passes (`lib/billing` 27/27).
- Not visually verified in a running build — please eyeball Billing → Transfer on staging.
