### PR TITLE
Leave a vault you don't own (#121)

### DIFF
--- a/.claude/skills/baalda-guide/references/faq.md
+++ b/.claude/skills/baalda-guide/references/faq.md
@@ -31,7 +31,8 @@ cancel it straight away, or open the billing portal.
 
 ## I deleted my Pro vault and made a new one. Can I move the subscription?
 Yes. Open Vault Settings → Billing, find it under "From deleted vaults", and choose **Transfer**.
-Pick the new vault (it has to be one you own that is not already on Pro) and it takes over the
+A dialog lists the vaults it can move to, with their member counts; pick the new vault (it has to
+be one you own that is not already on Pro), confirm, and it takes over the
 same price and the same billing period. Because the old vault was deleted, the subscription had
 been set to stop at the end of the period; transferring it starts it renewing again on the new
 vault. Only the owner can do this.

--- a/.claude/skills/baalda-guide/references/faq.md
+++ b/.claude/skills/baalda-guide/references/faq.md
@@ -21,6 +21,15 @@ not per person, with unlimited members. Only the vault owner or an admin pays; e
 needs a free account. baalda.com/pricing is the place to ask questions or talk to the team, but
 nobody has to wait for a call to get started.
 
+## Can I leave a vault someone else owns?
+Yes. Open Vault Settings → Vaults, click **Leave** next to the vault and confirm. You lose access
+straight away on every device you are signed in on, the vault leaves your switcher, and the folder
+on that device goes to the Trash rather than staying behind as a copy. The owner is emailed that
+you left (and you get a receipt) when the server sends email. Nobody else's access changes. If you
+want back in, ask the owner for a new invitation or join code. The owner of a vault cannot leave
+it; they delete it instead. If you only want the vault off one computer but want to stay a member,
+use **Remove from device**.
+
 ## What happens to my subscription if I delete a vault?
 Deleting the vault stops the billing, but not mid-month: it is set to finish at the end of the
 period you have already paid for, so there is no further charge and no refund needed. If Baalda

--- a/.claude/skills/baalda-guide/references/features.md
+++ b/.claude/skills/baalda-guide/references/features.md
@@ -94,6 +94,13 @@ collaborative apps (Notion, Confluence) keep your data in their database. Baalda
   pending invitation to paste into chat. Someone invited by email who uses the join code instead
   ends up in exactly the same place, with the invited role.
 - **Roles**: owner, admin, member.
+- **Leaving a vault** (members and admins): Vault Settings → Vaults → **Leave** on the vault, then
+  confirm. Access ends on all your devices at once, the vault disappears from your switcher and
+  recents, and its folder on that device moves to the Trash (it is not kept as a local copy). The
+  owner gets an email that you left and you get a receipt, on servers that send email. To come
+  back you need a new invitation or join code. The **owner cannot leave** — their way out is to
+  delete the vault. "Remove from device" is the gentler option: it only detaches the folder on
+  that one device and keeps your membership.
 - **Live presence**: coloured cursors and selections in the note, "who is viewing" avatars,
   and small presence dots in the sidebar showing who is in which note or folder. Ping a
   teammate to get their attention.

--- a/.claude/skills/baalda-guide/references/features.md
+++ b/.claude/skills/baalda-guide/references/features.md
@@ -194,10 +194,12 @@ collaborative apps (Notion, Confluence) keep your data in their database. Baalda
     kept in a "From deleted vaults" list so you can still move it, cancel it outright, or open
     the billing portal for it.
   - **Move a subscription to another vault** (owners only): Vault Settings → Billing → Transfer,
-    from a live vault or from one in "From deleted vaults". The target has to be a vault you own
-    that is not already on Pro. Same price, same billing period; if the subscription had been set
-    to end because its vault was deleted, transferring makes it renew again. The vault it came
-    from drops to Free.
+    from a live vault or from one in "From deleted vaults". Transfer opens a dialog that lists
+    every vault it can move to — each with its member count and Free plan — and explains what
+    happens to the vault it leaves; pick one and confirm. Only vaults you own that are not already
+    on Pro are offered (Transfer is greyed out with a reason when there are none). Same price, same
+    billing period; if the subscription had been set to end because its vault was deleted,
+    transferring makes it renew again. The vault it came from drops to Free.
   - The public pricing page (baalda.com/pricing) may still describe the Team plan as early access
     or "talk to us". The app is ahead of the page: tell people they can upgrade in-app now, and
     to use the pricing page as the contact route if they want to talk first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   `confirmDisabled` prop so the confirm waits for a pick.
 
 ### Added
+- **Leave a vault you don't own** (#121). Members and admins get a **Leave**
+  action in Vault Settings → Vaults. The server ends the membership the same way
+  an admin's removal does — membership row, shares granted to you, your live
+  sync sockets, and the vault is unpinned from your sessions — and, when email
+  is configured, tells the owner you left and sends you a receipt. On the
+  device you leave from the vault goes for good: out of the switcher and
+  recents, and its folder moves to the OS Trash instead of lingering as a local
+  copy. The owner is refused (`409 owner_cannot_leave`) and pointed at Delete.
+  New route `POST /api/orgs/:orgId/leave`; two new email templates.
 - **Tabs for open files.** Every note you open now stays open as a tab in a
   strip under the header — click to switch, × or middle-click to close, and
   closing the active tab lands on its neighbour. Tabs follow renames and moves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed
+- **Billing → Transfer is a dialog, not a one-item menu.** Clicking Transfer on
+  a Pro vault now opens a dialog that names the vault the subscription is
+  leaving, lists every eligible destination as a selectable card with its seat
+  count and Free plan, pre-selects the only candidate when there is just one,
+  and explains what happens to both vaults before the confirm. When some owned
+  vaults are missing it says why (already on Pro). `ConfirmDialog` gained a
+  `confirmDisabled` prop so the confirm waits for a pick.
+
 ### Added
 - **Tabs for open files.** Every note you open now stays open as a tab in a
   strip under the header — click to switch, × or middle-click to close, and

--- a/app/apps/desktop/src/App.css
+++ b/app/apps/desktop/src/App.css
@@ -5706,14 +5706,51 @@ button.secondary:disabled {
   flex-wrap: wrap;
   justify-content: flex-end;
 }
-.billing-transfer-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
+/* ---- Transfer dialog ----
+   The destinations ride the upgrade dialog's selectable card, laid out as a
+   row (name left, seats right) inside the confirm dialog's centred body. The
+   list is left-aligned and full width so it reads as a form, not prose. */
+.transfer-targets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  width: 100%;
+  margin: var(--sp-2) 0;
+  text-align: left;
 }
-/* Vault names are names: the role menu's `capitalize` would rewrite them. */
-.context-menu.billing-transfer-menu li {
-  text-transform: none;
+.upgrade-plan-card.transfer-target {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  /* Room for the corner check on the right, on every row not just selected. */
+  padding-right: calc(var(--sp-4) + 28px);
+}
+.upgrade-plan-card.transfer-target.selected::after {
+  top: 50%;
+  transform: translateY(-50%);
+}
+.transfer-target-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.transfer-target-meta {
+  flex-shrink: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+.transfer-target.selected .transfer-target-meta {
+  color: var(--accent);
+}
+.confirm-body .transfer-targets-note {
+  font-size: var(--fs-sm);
+  color: var(--text-tertiary);
 }
 /* One line of prose introducing a section's list. */
 .billing-section-note {

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -1358,6 +1358,11 @@ function VaultsTab() {
   >(null);
   // local-vault path whose file deletion is awaiting a second confirming click.
   const [confirmDeleteLocal, setConfirmDeleteLocal] = useState<string | null>(null);
+  // A vault the user is about to leave (#121). Always the full dialog: it has
+  // to say that the folder on this device goes too, which a row can't.
+  const [confirmLeave, setConfirmLeave] = useState<{ orgId: string; name: string } | null>(
+    null,
+  );
   const [actionError, setActionError] = useState<string | null>(null);
   // Free-plan vault-cap hit while creating — shows an upgrade nudge instead.
   const [limitNudge, setLimitNudge] = useState<{ kind: LimitKind; limit: number | null } | null>(
@@ -1389,6 +1394,10 @@ function VaultsTab() {
     members.find((m) => m.userId === session?.user.id)?.role === "owner";
   const canDelete = (orgId: string) =>
     orgId === activeOrgId ? isActiveOwner : true;
+  // Same uncertainty, mirrored: on the active row Leave is for non-owners
+  // only; elsewhere both are offered and the server's 409 settles it.
+  const canLeave = (orgId: string) =>
+    orgId === activeOrgId ? !isActiveOwner : true;
 
   const folderName = (orgId: string): string | null => {
     const p = bound[orgId];
@@ -1495,6 +1504,27 @@ function VaultsTab() {
       setActionError(message);
       // Destructive path: a failure here must never look like a success (#85).
       toast(`Couldn't delete the vault — ${message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Leave a vault someone else owns (confirmed above). Server first, then the
+  // vault leaves this device entirely; the dialog stays open on failure so the
+  // server's reason (an owner's 409, offline) has somewhere to show.
+  const leaveVault = async (orgId: string, name: string) => {
+    if (busy) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      await useStore.getState().leaveVault(orgId);
+      setBound(readOrgVaults());
+      setConfirmLeave(null);
+      toast(`You left ${name}.`, "neutral");
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setActionError(message);
+      toast(`Couldn't leave the vault — ${message}`, "error");
     } finally {
       setBusy(false);
     }
@@ -1655,6 +1685,19 @@ function VaultsTab() {
                   >
                     Remove from device
                   </AsyncButton>
+                  {canLeave(o.id) && (
+                    <button
+                      className="link-btn danger"
+                      disabled={busy}
+                      title="Leave this vault — you lose access and it is removed from this device"
+                      onClick={() => {
+                        setActionError(null);
+                        setConfirmLeave({ orgId: o.id, name: o.name });
+                      }}
+                    >
+                      Leave
+                    </button>
+                  )}
                   {canDelete(o.id) && (
                     <AsyncButton
                       className="link-btn danger"
@@ -1888,6 +1931,33 @@ function VaultsTab() {
       )}
 
       {upgradeOpen && <UpgradeDialog onClose={() => setUpgradeOpen(false)} />}
+
+      {confirmLeave && (
+        <ConfirmDialog
+          title={`Leave ${confirmLeave.name}?`}
+          confirmLabel="Leave vault"
+          onCancel={() => setConfirmLeave(null)}
+          onConfirm={() => leaveVault(confirmLeave.orgId, confirmLeave.name)}
+        >
+          <p>
+            You lose access to this vault on all your devices right away, and the
+            owner is told that you left.
+          </p>
+          <p>
+            {bound[confirmLeave.orgId] ? (
+              <>
+                Its folder on this device, <strong>{folderName(confirmLeave.orgId)}</strong>,
+                moves to the Trash.
+              </>
+            ) : (
+              "Nothing from it is stored on this device."
+            )}{" "}
+            The vault itself and everyone else's access are unchanged.
+          </p>
+          <p>To come back later, you'll need a new invitation or join code.</p>
+          {actionError && <div className="auth-error">{actionError}</div>}
+        </ConfirmDialog>
+      )}
 
       {subDelete && (
         <ConfirmDialog

--- a/app/apps/desktop/src/components/AccountMenu.tsx
+++ b/app/apps/desktop/src/components/AccountMenu.tsx
@@ -42,7 +42,6 @@ import { AccountSettings } from "./AccountSettings";
 import { AsyncButton } from "./AsyncButton";
 import { AuthDialog } from "./AuthDialog";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { MenuSelect } from "./MenuSelect";
 import { canActOnMember } from "./memberRoles";
 import { RoleSelect } from "./RoleSelect";
 import { Avatar, SyncBadge } from "./Identity";
@@ -2291,13 +2290,15 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
   const [upgradeOrg, setUpgradeOrg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // A transfer waiting to be confirmed. It moves money between vaults, so it
-  // never fires straight off the picker.
+  // A transfer being set up: the source row's Transfer was clicked and the
+  // dialog is open. `targetOrgId` is the pick, null until one is made (or the
+  // only eligible vault, pre-picked). It moves money between vaults, so the
+  // dialog is where both the choice AND the confirmation happen — never a
+  // popover that fires on the first click.
   const [transfer, setTransfer] = useState<{
     sourceOrgId: string;
     sourceLabel: string;
-    targetOrgId: string;
-    targetName: string;
+    targetOrgId: string | null;
   } | null>(null);
   // An orphaned subscription waiting on a "cancel now" confirmation.
   const [cancelling, setCancelling] = useState<{ orgId: string; label: string } | null>(
@@ -2336,8 +2337,9 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
   // it, rather than closing over an error nobody sees. Neither re-throws — the
   // dialog's own AsyncButton has finished reporting by then.
   const runTransfer = async () => {
-    if (!transfer) return;
-    const { sourceOrgId, targetOrgId, targetName } = transfer;
+    if (!transfer || !transfer.targetOrgId) return;
+    const { sourceOrgId, targetOrgId } = transfer;
+    const targetName = vaults.find((v) => v.orgId === targetOrgId)?.name ?? "the vault";
     setError(null);
     try {
       await authManager.api.transferSubscription(sourceOrgId, targetOrgId);
@@ -2378,10 +2380,13 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
   const freeLimits = myBilling?.freeLimits ?? null;
 
   /**
-   * The Transfer control for one row: a picker over the eligible targets, or a
-   * disabled button that says why there are none. `value` is a LABEL, not a
-   * selection — nothing is currently chosen here, and MenuSelect renders the
-   * raw value whenever no option matches it.
+   * The Transfer control for one row. It opens the transfer dialog, where the
+   * eligible destinations are laid out with their seats and plan and the move
+   * is confirmed in the same place. With exactly one eligible vault it is
+   * pre-picked, so the common case is still one click plus a confirm.
+   *
+   * No eligible vault ⇒ a disabled control that says why, rather than a menu
+   * with nothing in it.
    */
   const transferControl = (sourceOrgId: string, sourceLabel: string) => {
     const targets = transferTargets(vaults, sourceOrgId);
@@ -2397,20 +2402,80 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
       );
     }
     return (
-      <MenuSelect
-        value={TRANSFER_TRIGGER_LABEL}
-        options={targets.map((t) => ({ value: t.orgId, label: t.name }))}
-        onSelect={(targetOrgId) => {
-          const target = targets.find((t) => t.orgId === targetOrgId);
-          if (!target) return;
-          setError(null);
-          setTransfer({ sourceOrgId, sourceLabel, targetOrgId, targetName: target.name });
-        }}
+      <button
+        type="button"
+        className="link-btn"
         disabled={busy}
-        ariaLabel={`Move ${sourceLabel}'s subscription to another vault`}
-        triggerClassName="link-btn billing-transfer-trigger"
-        menuClassName="billing-transfer-menu"
-      />
+        aria-label={`Move ${sourceLabel}'s subscription to another vault`}
+        onClick={() => {
+          setError(null);
+          setTransfer({
+            sourceOrgId,
+            sourceLabel,
+            targetOrgId: targets.length === 1 ? targets[0].orgId : null,
+          });
+        }}
+      >
+        Transfer
+      </button>
+    );
+  };
+
+  /**
+   * The transfer dialog body: the eligible destinations as selectable cards.
+   * Each card carries what the reader weighs when choosing — the vault's
+   * seats, and that it is on Free today — instead of a bare name.
+   */
+  const renderTransferDialog = () => {
+    if (!transfer) return null;
+    const targets = transferTargets(vaults, transfer.sourceOrgId);
+    const target = targets.find((t) => t.orgId === transfer.targetOrgId) ?? null;
+    // Owned vaults that are NOT offered, so the list's gaps are explained.
+    const skipped = vaults.filter(
+      (v) => v.orgId !== transfer.sourceOrgId && v.role === "owner" && !targets.includes(v),
+    ).length;
+    return (
+      <ConfirmDialog
+        tone="accent"
+        title={`Move Pro from ${transfer.sourceLabel}`}
+        confirmLabel={target ? `Move Pro to ${target.name}` : "Move subscription"}
+        confirmDisabled={!target}
+        onCancel={() => setTransfer(null)}
+        onConfirm={runTransfer}
+      >
+        <p>
+          Choose the vault that becomes Pro. It keeps the same billing period and
+          price. <strong>{transfer.sourceLabel}</strong> drops to Free — its members
+          and notes stay, but free-plan limits apply to it again.
+        </p>
+        <div className="transfer-targets" role="radiogroup" aria-label="Destination vault">
+          {targets.map((t) => {
+            const used = t.seats.members + t.seats.pendingInvitations;
+            const selected = t.orgId === transfer.targetOrgId;
+            return (
+              <button
+                key={t.orgId}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                className={`upgrade-plan-card transfer-target${selected ? " selected" : ""}`}
+                onClick={() => setTransfer({ ...transfer, targetOrgId: t.orgId })}
+              >
+                <span className="transfer-target-name">{t.name}</span>
+                <span className="transfer-target-meta">
+                  {used} of {t.seats.limit ?? "∞"} member{used === 1 ? "" : "s"} · Free
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        {skipped > 0 && (
+          <p className="transfer-targets-note">
+            Only vaults you own that aren't already on Pro are listed.
+          </p>
+        )}
+        {error && <div className="auth-error">{error}</div>}
+      </ConfirmDialog>
     );
   };
 
@@ -2660,25 +2725,7 @@ function BillingTab({ canManage, isSynced }: { canManage: boolean; isSynced: boo
         <UpgradeDialog orgId={upgradeOrg} onClose={() => setUpgradeOrg(null)} />
       )}
 
-      {transfer && (
-        <ConfirmDialog
-          tone="accent"
-          title={`Move Pro to ${transfer.targetName}?`}
-          confirmLabel="Move subscription"
-          onCancel={() => setTransfer(null)}
-          onConfirm={runTransfer}
-        >
-          <p>
-            <strong>{transfer.targetName}</strong> becomes Pro immediately, on the
-            same billing period and price.
-          </p>
-          <p>
-            <strong>{transfer.sourceLabel}</strong> drops to Free — its members and
-            notes stay, but free-plan limits apply to it again.
-          </p>
-          {error && <div className="auth-error">{error}</div>}
-        </ConfirmDialog>
-      )}
+      {renderTransferDialog()}
 
       {cancelling && (
         <ConfirmDialog
@@ -2709,13 +2756,6 @@ function formatDate(iso: string): string {
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
-
-/**
- * The MenuSelect trigger label for a transfer picker. Typed `string` rather
- * than the literal so it can never collide with an org-id option — it is a
- * label, not a value that could be selected.
- */
-const TRANSFER_TRIGGER_LABEL: string = "Transfer";
 
 /**
  * How a subscription row writes its date and price. Both formatters already

--- a/app/apps/desktop/src/components/ConfirmDialog.tsx
+++ b/app/apps/desktop/src/components/ConfirmDialog.tsx
@@ -16,6 +16,7 @@ export function ConfirmDialog({
   confirmLabel,
   cancelLabel = "Cancel",
   tone = "danger",
+  confirmDisabled = false,
   onConfirm,
   onCancel,
 }: {
@@ -24,6 +25,8 @@ export function ConfirmDialog({
   confirmLabel: string;
   cancelLabel?: string;
   tone?: "danger" | "accent";
+  /** Hold the confirm button until the body has what it needs (e.g. a pick). */
+  confirmDisabled?: boolean;
   onConfirm: () => Promise<unknown> | unknown;
   onCancel: () => void;
 }) {
@@ -65,6 +68,7 @@ export function ConfirmDialog({
           <AsyncButton
             className={`primary${tone === "danger" ? " danger" : ""}`}
             spinnerTone="on-accent"
+            disabled={confirmDisabled}
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/app/apps/desktop/src/lib/api.ts
+++ b/app/apps/desktop/src/lib/api.ts
@@ -1035,6 +1035,20 @@ export class ApiClient {
   }
 
   /**
+   * Leave a vault you don't own (#121). The server drops the membership, purges
+   * shares granted directly to you, unpins the vault from your sessions and
+   * force-closes your live sync sockets — the same teardown as being removed by
+   * an admin. Throws ApiError 409 `owner_cannot_leave` for the owner (their exit
+   * is deleteRemoteVault) and 404 when you aren't a member.
+   */
+  async leaveVault(organizationId: string): Promise<void> {
+    await this.request<{ left: boolean }>(
+      "POST",
+      `/api/orgs/${encodeURIComponent(organizationId)}/leave`,
+    );
+  }
+
+  /**
    * Change a member's role (owner/admin). Same authz shape as removeMember:
    * an admin may only change plain members; nobody touches the owner or
    * themselves. The server force-closes the member's live sync sockets so the

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -476,6 +476,11 @@ interface AppStore {
   /** Detach a vault from THIS device (forget its folder, stop syncing it).
    *  Server data and membership are untouched — it can be re-opened later. */
   removeVaultLocally: (organizationId: string) => Promise<void>;
+  /** Leave a vault you don't own: end the membership on the server, then take
+   *  the vault off THIS device for good — switcher, recents, and its folder
+   *  (moved to the OS Trash, never deleted outright). Owners get the server's
+   *  409 and are pointed at Delete instead. */
+  leaveVault: (organizationId: string) => Promise<void>;
   /** Permanently delete a vault everywhere (owner only), then detach it.
    *  Hands back the server's report so the caller can say what became of the
    *  vault's subscription — deleting a Pro vault stops it at the END of the
@@ -2662,6 +2667,30 @@ export const useStore = create<AppStore>((set, get) => ({
       }
     }
     await get().refreshVault();
+  },
+
+  leaveVault: async (organizationId) => {
+    // Where this vault lives here, captured BEFORE the detach forgets it.
+    const path = readOrgVaults()[organizationId] ?? null;
+    // Server first: an owner's 409 (or being offline) must leave this device
+    // exactly as it was. Once this returns, the membership is gone everywhere.
+    await authManager.api.leaveVault(organizationId);
+    // Then the same detach a device-level removal does — switch off it if it
+    // is open, forget its folder binding, re-list the account's vaults.
+    await get().removeVaultLocally(organizationId);
+    // The server unpinned the vault from our session; pick that up so nothing
+    // here keeps asking about a vault we can no longer see.
+    const refreshed = await authManager.currentSession().catch(() => null);
+    if (refreshed) set({ session: refreshed });
+    // Finally the folder itself. A departed member should not keep a copy of
+    // the team's notes lying around, so unlike "Remove from device" this one
+    // goes — to the Trash, where a mistaken click is still recoverable. Never
+    // the folder that is open now (the detach above may have switched into it).
+    if (path && get().vault?.path !== path) {
+      await ipc.deleteVault(path).catch((e: unknown) => {
+        console.warn("[vault] left the vault but couldn't trash its folder", path, e);
+      });
+    }
   },
 
   deleteRemoteVault: async (organizationId) => {

--- a/app/apps/server/src/email/templates.ts
+++ b/app/apps/server/src/email/templates.ts
@@ -2,7 +2,7 @@ import { BRAND_NAME } from "../brand.js";
 import type { MailMessage } from "./mailer.js";
 
 /**
- * The three transactional emails the server sends. Deliberately plain: inline
+ * The transactional emails the server sends. Deliberately plain: inline
  * styles only, one column, a light background and a single black button —
  * what renders identically in Gmail, Outlook and Apple Mail, and what lands in
  * the inbox rather than the promotions tab. The plain-text twin is not an
@@ -22,7 +22,29 @@ export function esc(s: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function layout(opts: { title: string; intro: string; cta: string; url: string; outro: string }): string {
+/**
+ * One-column shell. The button and the "paste this link" fallback render only
+ * when there is a link to press — notification emails (a member left) have
+ * nothing to click and say so by leaving `cta`/`url` off.
+ */
+function layout(opts: {
+  title: string;
+  intro: string;
+  cta?: string;
+  url?: string;
+  outro: string;
+}): string {
+  const button =
+    opts.cta && opts.url
+      ? `<p style="margin:0 0 22px;">
+        <a href="${esc(opts.url)}" style="display:inline-block;background:#1c1c1a;color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;padding:12px 22px;border-radius:999px;">${esc(opts.cta)}</a>
+      </p>
+      `
+      : "";
+  const fallback = opts.url
+    ? `
+      <p style="font-size:12px;line-height:1.5;margin:18px 0 0;color:#8a8a84;word-break:break-all;">If the button doesn't work, paste this link into your browser:<br /><a href="${esc(opts.url)}" style="color:#6b6b66;">${esc(opts.url)}</a></p>`
+    : "";
   return `<!doctype html>
 <html lang="en">
 <body style="margin:0;padding:0;background:#f4f4f1;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1c1c1a;">
@@ -31,11 +53,7 @@ function layout(opts: { title: string; intro: string; cta: string; url: string; 
     <div style="background:#ffffff;border:1px solid #e6e5df;border-radius:14px;padding:30px 28px;">
       <h1 style="font-size:20px;font-weight:600;margin:0 0 12px;">${opts.title}</h1>
       <p style="font-size:15px;line-height:1.55;margin:0 0 22px;color:#3a3a37;">${opts.intro}</p>
-      <p style="margin:0 0 22px;">
-        <a href="${esc(opts.url)}" style="display:inline-block;background:#1c1c1a;color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;padding:12px 22px;border-radius:999px;">${esc(opts.cta)}</a>
-      </p>
-      <p style="font-size:13px;line-height:1.55;margin:0;color:#6b6b66;">${opts.outro}</p>
-      <p style="font-size:12px;line-height:1.5;margin:18px 0 0;color:#8a8a84;word-break:break-all;">If the button doesn't work, paste this link into your browser:<br /><a href="${esc(opts.url)}" style="color:#6b6b66;">${esc(opts.url)}</a></p>
+      ${button}<p style="font-size:13px;line-height:1.55;margin:0;color:#6b6b66;">${opts.outro}</p>${fallback}
     </div>
   </div>
 </body>
@@ -109,6 +127,57 @@ export function invitationEmail(input: {
     cta: "Accept invitation",
     url: input.url,
     outro: `This invitation expires ${esc(expires)}. Don't have ${esc(BRAND_NAME)} yet? <a href="https://baalda.com" style="color:#6b6b66;">Get it</a>, then open the link again.`,
+  });
+  return { to: input.to, subject, text, html };
+}
+
+/**
+ * To a vault's owner when a member leaves on their own (#121). Purely
+ * informational — there is nothing for the owner to do — so no button. Names
+ * the shares that were dropped, because that is the one side effect the owner
+ * might otherwise go looking for.
+ */
+export function memberLeftEmail(input: {
+  to: string;
+  organizationName: string;
+  memberName: string | null;
+  memberEmail: string;
+}): MailMessage {
+  const who = input.memberName?.trim() || input.memberEmail;
+  const subject = `${who} left ${input.organizationName}`;
+  const text = [
+    `${who} (${input.memberEmail}) left the vault "${input.organizationName}" on ${BRAND_NAME}.`,
+    ``,
+    `They no longer have access to any of its notes. Any folders or files that were shared with them directly have been un-shared.`,
+    ``,
+    `If this wasn't expected, you can invite them again from the vault's Members page.`,
+  ].join("\n");
+  const html = layout({
+    title: `${esc(who)} left ${esc(input.organizationName)}`,
+    intro: `<b>${esc(who)}</b> (${esc(input.memberEmail)}) left the vault <b>${esc(input.organizationName)}</b> on ${esc(BRAND_NAME)}. They no longer have access to any of its notes, and any folders or files that were shared with them directly have been un-shared.`,
+    outro: `If this wasn't expected, you can invite them again from the vault's Members page.`,
+  });
+  return { to: input.to, subject, text, html };
+}
+
+/**
+ * To the person who left, as a receipt (#121). Says where the vault went on
+ * their devices — removed, not kept — and how to come back.
+ */
+export function youLeftVaultEmail(input: { to: string; organizationName: string }): MailMessage {
+  const subject = `You left ${input.organizationName}`;
+  const text = [
+    `You left the vault "${input.organizationName}" on ${BRAND_NAME}.`,
+    ``,
+    `It has been removed from your devices and you no longer have access to its notes.`,
+    `To rejoin, ask the vault's owner for a new invitation or join code.`,
+    ``,
+    `If you didn't do this, change your password right away — someone else may have access to your account.`,
+  ].join("\n");
+  const html = layout({
+    title: `You left ${esc(input.organizationName)}`,
+    intro: `You left the vault <b>${esc(input.organizationName)}</b> on ${esc(BRAND_NAME)}. It has been removed from your devices and you no longer have access to its notes. To rejoin, ask the vault's owner for a new invitation or join code.`,
+    outro: `If you didn't do this, change your password right away — someone else may have access to your account.`,
   });
   return { to: input.to, subject, text, html };
 }

--- a/app/apps/server/src/http/routes/orgs.ts
+++ b/app/apps/server/src/http/routes/orgs.ts
@@ -11,6 +11,8 @@ import {
 } from "../../billing/store.js";
 import { announceMemberJoined } from "../../sync/member-events.js";
 import { billingEnabled } from "../../config.js";
+import { dispatchMail, emailEnabled } from "../../email/mailer.js";
+import { memberLeftEmail, youLeftVaultEmail } from "../../email/templates.js";
 import type { BillingProvider } from "../../billing/provider.js";
 
 /**
@@ -22,6 +24,12 @@ import type { BillingProvider } from "../../billing/provider.js";
  *    a 'member' of that vault (idempotent if already a member). A pending email
  *    invitation for the same address is consumed on the way in — same role,
  *    same end state as accepting it.
+ *  - POST   /api/orgs/:orgId/leave → a **member or admin** removes themselves
+ *    from a vault they don't own (#121). Same teardown as being removed by an
+ *    admin — membership row, direct shares, live sockets — plus the leaver's
+ *    sessions stop pointing at the vault, and the owner and the leaver are each
+ *    emailed when the server can send mail. The owner gets 409
+ *    `owner_cannot_leave`: their exit is DELETE below (or, one day, a transfer).
  *  - DELETE /api/orgs/:orgId → the vault **owner** permanently deletes the
  *    vault everywhere: members, invitations, note collections, folders, notes, files,
  *    shares, join codes, and MCP tokens cascade from the `organization` row;
@@ -95,6 +103,75 @@ async function resolveActiveOrg(
     [userId],
   );
   return rows.length === 1 ? rows[0].organizationId : null;
+}
+
+/**
+ * Take one user out of a vault. Shared by "admin removes a member" and "a member
+ * leaves" so the two can never drift — every hole this closes was found once
+ * already (#16):
+ *   1. delete the `member` row — their org-wide "Open" grant stops applying
+ *      (the resolver gates it on membership) and the next sync-token mint 403s;
+ *   2. purge their per-user shares — those are NOT membership-gated, so a folder
+ *      or file shared directly to them would survive step 1;
+ *   3. clear the vault from any of their sessions that had it active, so a
+ *      device of theirs that reloads doesn't come back asking for a vault it
+ *      can't see;
+ *   4. force-close live sockets so access dies now, not at token expiry.
+ *
+ * Shares the user *created for others* (`created_by`) are untouched — only
+ * grants TO this user (`principal_id`) go.
+ */
+async function revokeMembership(deps: OrgDeps, orgId: string, userId: string): Promise<void> {
+  // Snapshot the org's docs so we can kill any live sockets the departing
+  // member holds. closeConnections on a doc with no live socket is a cheap
+  // no-op, so covering every doc in the org is fine (this is rare).
+  const vaults = await pool.query<{ id: string }>(
+    "SELECT id FROM vaults WHERE organization_id = $1",
+    [orgId],
+  );
+  const vaultIds = vaults.rows.map((r) => r.id);
+  const docs = vaultIds.length
+    ? await pool.query<{ id: string; vault_id: string }>(
+        `SELECT id, vault_id FROM notes WHERE vault_id = ANY($1)
+         UNION ALL
+         SELECT id, vault_id FROM files WHERE vault_id = ANY($1)`,
+        [vaultIds],
+      )
+    : { rows: [] as Array<{ id: string; vault_id: string }> };
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(`DELETE FROM member WHERE "organizationId" = $1 AND "userId" = $2`, [
+      orgId,
+      userId,
+    ]);
+    await client.query(
+      `DELETE FROM shares
+        WHERE org_id = $1 AND principal_type = 'user' AND principal_id = $2`,
+      [orgId, userId],
+    );
+    await client.query(
+      `UPDATE session SET "activeOrganizationId" = NULL
+        WHERE "userId" = $1 AND "activeOrganizationId" = $2`,
+      [userId, orgId],
+    );
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  // Membership is gone, so a reconnect now fails at token mint (403). Kick the
+  // live sockets AFTER the delete so the auto-reconnect can't re-mint a token.
+  for (const d of docs.rows) deps.disconnectDoc(d.vault_id, d.id);
+  // …and tell the vault channel, which `disconnectDoc` cannot reach. Also after
+  // the commit, deliberately: the channel answers by re-running
+  // `listReadableDocsInVault`, which has to see the post-delete state to
+  // conclude the departed member may now read nothing.
+  for (const vaultId of vaultIds) deps.onAclChanged(vaultId);
 }
 
 export function createOrgRoutes(deps: OrgDeps): Hono {
@@ -384,8 +461,9 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
   //      or file shared directly to them would survive step 1 (see issue #16);
   //   3. force-close live sockets so access dies now, not at token expiry.
   // Owner can remove anyone but themselves; an admin can remove only plain members
-  // (not another admin or the owner). Self-removal ("leave") is intentionally not
-  // supported here yet.
+  // (not another admin or the owner). Self-removal is POST /orgs/:orgId/leave
+  // below — a different authz shape (any non-owner, only themselves) that
+  // shares the teardown, not the checks.
   orgRoutes.delete("/orgs/:orgId/members/:userId", async (c) => {
     const session = await getSession(c);
     if (!session) return c.json({ error: "Authentication required" }, 401);
@@ -411,56 +489,77 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
       return c.json({ error: "Only the owner can remove an admin" }, 403);
     }
 
-    // Snapshot the org's docs so we can kill any live sockets the removed member
-    // holds. closeConnections on a doc with no live socket is a cheap no-op, so
-    // covering every doc in the org is fine (member removal is rare).
-    const vaults = await pool.query<{ id: string }>(
-      "SELECT id FROM vaults WHERE organization_id = $1",
-      [orgId],
-    );
-    const vaultIds = vaults.rows.map((r) => r.id);
-    const docs = vaultIds.length
-      ? await pool.query<{ id: string; vault_id: string }>(
-          `SELECT id, vault_id FROM notes WHERE vault_id = ANY($1)
-           UNION ALL
-           SELECT id, vault_id FROM files WHERE vault_id = ANY($1)`,
-          [vaultIds],
-        )
-      : { rows: [] as Array<{ id: string; vault_id: string }> };
+    await revokeMembership(deps, orgId, targetUserId);
+    return c.json({ removed: true });
+  });
 
-    // Drop membership + direct grants together. `shares.org_id` scopes the
-    // purge to this org; shares the member *created for others* (created_by)
-    // are untouched — only grants TO this user (principal_id) are removed.
-    const client = await pool.connect();
-    try {
-      await client.query("BEGIN");
-      await client.query(
-        `DELETE FROM member WHERE "organizationId" = $1 AND "userId" = $2`,
-        [orgId, targetUserId],
+  // Leave a vault you don't own (#121). Any admin or member, any time, no
+  // approval — membership is theirs to end. The owner is refused with a 409
+  // that points at the exit they DO have (delete the vault): with no ownership
+  // transfer yet, an owner walking out would strand a vault nobody can manage
+  // or stop paying for.
+  orgRoutes.post("/orgs/:orgId/leave", async (c) => {
+    const session = await getSession(c);
+    if (!session) return c.json({ error: "Authentication required" }, 401);
+    const orgId = c.req.param("orgId");
+
+    const role = await orgRole(orgId, session.userId);
+    if (!role) return c.json({ error: "Unknown vault" }, 404);
+    if (role === "owner") {
+      return c.json(
+        {
+          error: "owner_cannot_leave",
+          message:
+            "You own this vault, so you can't leave it. Delete the vault instead, or hand it to someone else first.",
+        },
+        409,
       );
-      await client.query(
-        `DELETE FROM shares
-          WHERE org_id = $1 AND principal_type = 'user' AND principal_id = $2`,
-        [orgId, targetUserId],
-      );
-      await client.query("COMMIT");
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
-    } finally {
-      client.release();
     }
 
-    // Membership is gone, so a reconnect now fails at token mint (403). Kick the
-    // live sockets AFTER the delete so the auto-reconnect can't re-mint a token.
-    for (const d of docs.rows) deps.disconnectDoc(d.vault_id, d.id);
-    // …and tell the vault channel, which `disconnectDoc` cannot reach. Also after
-    // the commit, deliberately: the channel answers by re-running
-    // `listReadableDocsInVault`, which has to see the post-delete state to
-    // conclude the removed member may now read nothing.
-    for (const vaultId of vaultIds) deps.onAclChanged(vaultId);
+    // Names for the emails, read BEFORE the membership goes so the owner
+    // lookup still resolves through the org. `user.name` is NOT NULL but may
+    // be blank; the template falls back to the address.
+    const { rows: people } = await pool.query<{
+      role: string;
+      email: string;
+      name: string;
+      org_name: string;
+    }>(
+      `SELECT m.role, u.email, u.name, o.name AS org_name
+         FROM member m
+         JOIN "user" u ON u.id = m."userId"
+         JOIN organization o ON o.id = m."organizationId"
+        WHERE m."organizationId" = $1
+          AND (m.role = 'owner' OR m."userId" = $2)`,
+      [orgId, session.userId],
+    );
+    const owner = people.find((p) => p.role === "owner") ?? null;
+    const me = people.find((p) => p.email === session.email) ?? people.find((p) => p.role !== "owner") ?? null;
+    const orgName = people[0]?.org_name ?? "your vault";
 
-    return c.json({ removed: true });
+    await revokeMembership(deps, orgId, session.userId);
+
+    // Fire-and-forget, after the commit: a mail failure must never undo or
+    // block a leave, and nothing here is a link the reader has to follow.
+    if (emailEnabled()) {
+      if (owner) {
+        dispatchMail(
+          "member-left notice",
+          memberLeftEmail({
+            to: owner.email,
+            organizationName: orgName,
+            memberName: me?.name ?? null,
+            memberEmail: session.email,
+          }),
+        );
+      }
+      dispatchMail(
+        "you-left receipt",
+        youLeftVaultEmail({ to: session.email, organizationName: orgName }),
+      );
+    }
+
+    return c.json({ left: true });
   });
 
   // Change a member's role (owner/admin). Same authz shape as removal: owner

--- a/app/apps/server/tests/orgs-leave.test.ts
+++ b/app/apps/server/tests/orgs-leave.test.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../src/http/app.js";
+import { recordingAppDeps } from "./helpers/app.js";
+import { pool } from "../src/db/pool.js";
+import { resetDb } from "./helpers/db.js";
+import { createOrg, signUp } from "./helpers/auth.js";
+import { seedNote, seedVault, seedVaultGrant } from "./helpers/seed.js";
+import { listReadableDocsInVault } from "../src/permissions/vault-docs.js";
+import { __setMailerForTests, type MailMessage } from "../src/email/mailer.js";
+
+/**
+ * Leaving a vault you don't own (#121): POST /api/orgs/:orgId/leave.
+ *
+ * Shares its teardown with admin-removal (`revokeMembership`), so the
+ * assertions here mirror orgs-remove-member: membership row gone, direct
+ * shares purged, readable set empty, sockets kicked, ACL broadcast — plus what
+ * only a self-initiated exit has: the owner is refused, the leaver's active
+ * session is unpinned from the vault, and two emails go out.
+ */
+
+const rec = recordingAppDeps();
+const app = createApp(rec.deps);
+
+/** Every message the route handed to the mailer, in order. */
+const outbox: MailMessage[] = [];
+/** dispatchMail is fire-and-forget; let its microtask land before asserting. */
+const settle = () => new Promise((r) => setTimeout(r, 20));
+/** Sign-up verification emails ride the same mailer; only the leave mail counts. */
+const leaveMail = () => outbox.filter((m) => !m.subject.startsWith("Confirm your email"));
+
+function leave(token: string | null, orgId: string) {
+  const headers: Record<string, string> = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  return app.fetch(
+    new Request(`http://local/api/orgs/${encodeURIComponent(orgId)}/leave`, {
+      method: "POST",
+      headers,
+    }),
+  );
+}
+
+async function addMember(orgId: string, userId: string, role: "member" | "admin" = "member") {
+  await pool.query(
+    `INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+     VALUES ($1, $2, $3, $4, now())`,
+    [randomUUID(), orgId, userId, role],
+  );
+}
+
+async function memberCount(orgId: string, userId: string): Promise<number> {
+  const { rows } = await pool.query<{ c: number }>(
+    `SELECT count(*)::int AS c FROM member WHERE "organizationId" = $1 AND "userId" = $2`,
+    [orgId, userId],
+  );
+  return rows[0].c;
+}
+
+async function shareCount(orgId: string, principalId: string): Promise<number> {
+  const { rows } = await pool.query<{ c: number }>(
+    `SELECT count(*)::int AS c FROM shares
+      WHERE org_id = $1 AND principal_type = 'user' AND principal_id = $2`,
+    [orgId, principalId],
+  );
+  return rows[0].c;
+}
+
+async function grantFolder(orgId: string, userId: string) {
+  await pool.query(
+    `INSERT INTO shares
+       (id, org_id, resource_type, resource_id, principal_type, principal_id, permission)
+     VALUES ($1, $2, 'folder', $3, 'user', $4, 'edit')`,
+    [randomUUID(), orgId, randomUUID(), userId],
+  );
+}
+
+describe("leave a vault", () => {
+  beforeEach(async () => {
+    await resetDb();
+    rec.reset();
+    outbox.length = 0;
+    __setMailerForTests({
+      kind: "memory",
+      async send(msg) {
+        outbox.push(msg);
+      },
+    });
+  });
+  afterAll(async () => {
+    __setMailerForTests(null);
+    await pool.end();
+  });
+
+  it("a member leaves: row gone, their direct shares purged, others' kept, sockets kicked", async () => {
+    const owner = await signUp("owner@leave.io", undefined, "Olive Owner");
+    const org = await createOrg(owner, "Acme", "acme-leave1");
+    const member = await signUp("member@leave.io", undefined, "Max Member");
+    await addMember(org.id, member.userId);
+    const bystander = await signUp("bystander@leave.io");
+    await addMember(org.id, bystander.userId);
+    await grantFolder(org.id, member.userId);
+    await grantFolder(org.id, bystander.userId);
+
+    const vaultId = await seedVault(org.id);
+    await seedVaultGrant(org.id, "edit");
+    const noteId = await seedNote(vaultId, null, "Plan.md", owner.userId);
+    expect(await listReadableDocsInVault(member.userId, vaultId)).toContain(noteId);
+
+    const res = await leave(member.token, org.id);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ left: true });
+
+    expect(await memberCount(org.id, member.userId)).toBe(0);
+    expect(await shareCount(org.id, member.userId)).toBe(0);
+    expect(await memberCount(org.id, bystander.userId)).toBe(1);
+    expect(await shareCount(org.id, bystander.userId)).toBe(1);
+    expect((await listReadableDocsInVault(member.userId, vaultId)).size).toBe(0);
+
+    expect(rec.disconnected).toContainEqual({ vaultId, docId: noteId });
+    expect(rec.aclBroadcasts).toContain(vaultId);
+  });
+
+  it("an admin may leave too", async () => {
+    const owner = await signUp("owner@leave2.io");
+    const org = await createOrg(owner, "Acme", "acme-leave2");
+    const admin = await signUp("admin@leave2.io");
+    await addMember(org.id, admin.userId, "admin");
+
+    expect((await leave(admin.token, org.id)).status).toBe(200);
+    expect(await memberCount(org.id, admin.userId)).toBe(0);
+    // The owner is untouched.
+    expect(await memberCount(org.id, owner.userId)).toBe(1);
+  });
+
+  it("the owner cannot leave (409), nothing changes", async () => {
+    const owner = await signUp("owner@leave3.io");
+    const org = await createOrg(owner, "Acme", "acme-leave3");
+
+    const res = await leave(owner.token, org.id);
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "owner_cannot_leave" });
+    expect(await memberCount(org.id, owner.userId)).toBe(1);
+    expect(rec.aclBroadcasts).toEqual([]);
+    await settle();
+    expect(leaveMail()).toEqual([]);
+  });
+
+  it("a non-member gets 404; no session gets 401", async () => {
+    const owner = await signUp("owner@leave4.io");
+    const org = await createOrg(owner, "Acme", "acme-leave4");
+    const stranger = await signUp("stranger@leave4.io");
+
+    expect((await leave(stranger.token, org.id)).status).toBe(404);
+    expect((await leave(null, org.id)).status).toBe(401);
+  });
+
+  it("unpins the vault from the leaver's active session, and only theirs", async () => {
+    const owner = await signUp("owner@leave5.io");
+    const org = await createOrg(owner, "Acme", "acme-leave5");
+    const member = await signUp("member@leave5.io");
+    await addMember(org.id, member.userId);
+    await pool.query(`UPDATE session SET "activeOrganizationId" = $1 WHERE "userId" IN ($2, $3)`, [
+      org.id,
+      owner.userId,
+      member.userId,
+    ]);
+
+    expect((await leave(member.token, org.id)).status).toBe(200);
+
+    const active = async (userId: string) =>
+      (
+        await pool.query<{ a: string | null }>(
+          `SELECT "activeOrganizationId" AS a FROM session WHERE "userId" = $1`,
+          [userId],
+        )
+      ).rows.map((r) => r.a);
+    expect(await active(member.userId)).toEqual([null]);
+    expect(await active(owner.userId)).toEqual([org.id]);
+  });
+
+  it("emails the owner a notice and the leaver a receipt", async () => {
+    const owner = await signUp("owner@leave6.io", undefined, "Olive Owner");
+    const org = await createOrg(owner, "Design Team", "acme-leave6");
+    const member = await signUp("member@leave6.io", undefined, "Max Member");
+    await addMember(org.id, member.userId);
+
+    expect((await leave(member.token, org.id)).status).toBe(200);
+    await settle();
+
+    expect(leaveMail().map((m) => m.to).sort()).toEqual(["member@leave6.io", "owner@leave6.io"]);
+    const toOwner = leaveMail().find((m) => m.to === "owner@leave6.io")!;
+    expect(toOwner.subject).toBe("Max Member left Design Team");
+    expect(toOwner.text).toContain("member@leave6.io");
+    expect(toOwner.text).toContain("shared with them directly have been un-shared");
+    // Notification, not a call to action: no button, no link to paste.
+    expect(toOwner.html).not.toContain("paste this link");
+
+    const toMember = leaveMail().find((m) => m.to === "member@leave6.io")!;
+    expect(toMember.subject).toBe("You left Design Team");
+    expect(toMember.text).toContain("removed from your devices");
+    expect(toMember.text).toContain("new invitation or join code");
+  });
+
+  it("sends nothing when the server has no mailer", async () => {
+    __setMailerForTests(null);
+    const owner = await signUp("owner@leave7.io");
+    const org = await createOrg(owner, "Acme", "acme-leave7");
+    const member = await signUp("member@leave7.io");
+    await addMember(org.id, member.userId);
+
+    expect((await leave(member.token, org.id)).status).toBe(200);
+    await settle();
+    expect(leaveMail()).toEqual([]);
+  });
+
+  it("re-inviting someone who left works: the join code path admits them again", async () => {
+    const owner = await signUp("owner@leave8.io");
+    const org = await createOrg(owner, "Acme", "acme-leave8");
+    const member = await signUp("member@leave8.io");
+    await addMember(org.id, member.userId);
+    expect((await leave(member.token, org.id)).status).toBe(200);
+
+    // Owner fetches the vault's join code (active org = this one).
+    await pool.query(`UPDATE session SET "activeOrganizationId" = $1 WHERE "userId" = $2`, [
+      org.id,
+      owner.userId,
+    ]);
+    const codeRes = await app.fetch(
+      new Request("http://local/api/orgs/join-code", {
+        headers: { authorization: `Bearer ${owner.token}` },
+      }),
+    );
+    expect(codeRes.status).toBe(200);
+    const { code } = (await codeRes.json()) as { code: string };
+
+    const joinRes = await app.fetch(
+      new Request("http://local/api/orgs/join", {
+        method: "POST",
+        headers: { authorization: `Bearer ${member.token}`, "content-type": "application/json" },
+        body: JSON.stringify({ code }),
+      }),
+    );
+    expect(joinRes.status).toBe(200);
+    expect(await memberCount(org.id, member.userId)).toBe(1);
+  });
+});

--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -101,6 +101,7 @@ n/a = synchronous or sub-100ms by construction.
 | Join by code | join → switch → reconcile | 1–5s | ✅ existing busy state |
 | New vault (menu) | create org → folder → seed | 1–3s | ✅ existing busy state |
 | Remove from device | local teardown | 0.2–1s | ✅ spinner |
+| Leave vault | server leave (membership + shares + sockets) → local teardown → folder to Trash | 0.5–3s | ✅ spinner, behind a confirm that names the folder |
 | Delete vault (permanent) | provider cancel-at-period-end (Pro only) → server delete + local teardown | 0.5–4s | ✅ spinner, behind a confirm that names the subscription end |
 | Delete local vault files | move folder to Trash | 0.2–2s | ✅ spinner, behind a confirm |
 | Invite member | server write + roster refresh | 0.3–1s | ✅ existing busy state |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,1 +1,1 @@
-- Fixed the sync badge flickering forever and re-syncing the same notes on every reload; edits that were stuck on one device now upload automatically
+- Moving a Pro subscription to another vault now opens a clear dialog that shows each eligible vault with its members and explains what changes, instead of a bare dropdown

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,1 +1,2 @@
+- You can now leave a vault you don't own: Vault Settings → Vaults → Leave. The vault is removed from your devices, the owner is notified by email, and you get a receipt
 - Moving a Pro subscription to another vault now opens a clear dialog that shows each eligible vault with its members and explains what changes, instead of a bare dropdown


### PR DESCRIPTION
Implements #121. Stacked on #122 (merge that one first; this branch already contains it, so it merges cleanly afterwards).

## Server

- New `POST /api/orgs/:orgId/leave`. Any `admin` or `member` may leave at any time. The owner gets `409 owner_cannot_leave` with a message pointing at Delete. Non-member → 404, no session → 401.
- The teardown is factored into `revokeMembership()` and shared with the existing admin-removal route so the two cannot drift: delete the `member` row, purge shares granted **to** that user in the org (shares they created for others stay), clear `session.activeOrganizationId` for that user where it pointed at the vault, then `disconnectDoc` every doc and `onAclChanged` per collection, after the commit.
- Emails (only when `emailEnabled()`, fire-and-forget via `dispatchMail`): `memberLeftEmail` to the owner ("<name> left <vault>", notes that direct shares were un-shared) and `youLeftVaultEmail` to the leaver (removed from your devices; how to rejoin; change your password if this wasn't you). The email `layout()` now renders the button and the paste-this-link fallback only when there is a URL, since these are notifications with nothing to click.
- Tests: `tests/orgs-leave.test.ts` (8 cases): member leaves with shares purged / bystander untouched / readable set empty / sockets kicked / ACL broadcast; admin may leave; owner 409 with no side effects; 404/401; session unpinned for the leaver only; both emails with the expected subjects and copy; nothing sent without a mailer; re-joining by code afterwards works.

## Desktop

- `api.leaveVault()` and a `leaveVault` store action: server first (an owner's 409 or being offline leaves the device untouched), then the same detach as "Remove from device", then the session is re-read, then the vault's folder is moved to the OS Trash via the existing `delete_vault` command (never the folder that is currently open). The vault disappears from the switcher and recents.
- Vault Settings → Vaults: a **Leave** action next to Delete. On the active row it shows for non-owners only (the only row whose role we know); on other rows both are offered and the server decides, the same pattern Delete already uses. The confirm dialog names the folder that goes to the Trash, says the owner is told, and how to come back.

## Not in this PR

- Other signed-in devices of the leaver are not auto-cleaned. They lose access immediately (sockets closed, token mint 403s, session unpinned) but their folder stays until the user removes it. Auto-trashing a folder from a remote signal risked deleting the wrong account's folder on a shared machine, so it's left as a follow-up.
- Ownership transfer / owner leaving.

## Docs

Guide references (features + FAQ), `docs/INTERACTIONS.md`, `CHANGELOG.md` (Unreleased → Added) and `docs/RELEASE_NOTES.md` updated.

## Verification

- Server: `tsc` clean; 83/83 across the orgs, authz, invitations, email and billing suites on the scratch DB.
- Desktop: `tsc` clean; full vitest suite 870 passed.
- Not exercised in a running build.
