### PR TITLE
Add Coolify-friendly Compose deploy (fixes #97)

### DIFF
--- a/deploy/coolify/.env.example
+++ b/deploy/coolify/.env.example
@@ -1,0 +1,45 @@
+# Baalda self-host on Coolify — copy to .env and fill in. Only the first
+# three matter. Compose refuses to start if any is missing, rather than
+# booting a server with a guessable secret.
+
+# --- Required ---------------------------------------------------------------
+
+# Postgres password. Any long random string; it never leaves the Compose network.
+#   openssl rand -base64 24
+POSTGRES_PASSWORD=
+
+# Signs Better Auth sessions AND the per-doc sync JWTs. If this leaks, anyone can
+# mint a token for any note, so treat it like a database password. The server
+# REFUSES to boot in production if it is unset.
+#   openssl rand -base64 32
+JWT_SECRET=
+
+# The public HTTPS URL Coolify's proxy fronts this service on — what you type
+# into the desktop app's Server settings, and what Better Auth builds
+# invitation and email-verification links from. No trailing slash.
+BETTER_AUTH_URL=https://baalda.example.com
+
+# --- Optional ---------------------------------------------------------------
+
+# Google sign-in. Leave unset and the desktop app hides the Google button;
+# email + password keeps working.
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# Per-doc sync JWT lifetime, seconds. Default 600.
+# SYNC_TOKEN_TTL_SECONDS=600
+
+# Merge a note's update log into a snapshot once it exceeds this many updates.
+# COMPACTION_THRESHOLD=50
+
+# Extra browser origins allowed to call the API (comma-separated). The desktop
+# app's origins are always allowed, so you do not need this for normal use.
+# CORS_ORIGINS=
+
+# Multi-instance only. LEAVE UNSET for a single server.
+# REDIS_URL=redis://redis:6379
+
+# Billing is OFF unless POLAR_ACCESS_TOKEN is set, and OFF means no limits at
+# all: unlimited vaults, unlimited members. Self-hosters want it off. Leave this
+# block alone.
+# POLAR_ACCESS_TOKEN=

--- a/deploy/coolify/.env.example
+++ b/deploy/coolify/.env.example
@@ -1,22 +1,20 @@
-# Baalda self-host on Coolify — copy to .env and fill in. Only the first
-# three matter. Compose refuses to start if any is missing, rather than
-# booting a server with a guessable secret.
+# Baalda self-host on Coolify — reference only, Coolify does not read this
+# file. Paste the required variable(s) into the service's Environment
+# Variables tab (Production) in the Coolify UI instead.
+#
+# POSTGRES_PASSWORD and JWT_SECRET are NOT listed here: docker-compose.yml
+# generates both automatically via Coolify's magic env vars
+# (SERVICE_PASSWORD_POSTGRES, SERVICE_REALBASE64_64_JWT) — nothing to set.
 
 # --- Required ---------------------------------------------------------------
-
-# Postgres password. Any long random string; it never leaves the Compose network.
-#   openssl rand -base64 24
-POSTGRES_PASSWORD=
-
-# Signs Better Auth sessions AND the per-doc sync JWTs. If this leaks, anyone can
-# mint a token for any note, so treat it like a database password. The server
-# REFUSES to boot in production if it is unset.
-#   openssl rand -base64 32
-JWT_SECRET=
 
 # The public HTTPS URL Coolify's proxy fronts this service on — what you type
 # into the desktop app's Server settings, and what Better Auth builds
 # invitation and email-verification links from. No trailing slash.
+#
+# Set this AFTER a domain exists: docker-compose.yml's SERVICE_FQDN_SERVER
+# makes Coolify generate one on first deploy (Domains tab on the `server`
+# service) — copy that, prefix `https://`, paste it here, redeploy.
 BETTER_AUTH_URL=https://baalda.example.com
 
 # --- Optional ---------------------------------------------------------------

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -13,18 +13,21 @@ directory, which breaks `deploy/compose/docker-compose.yml`'s `context: ../..`
 1. **New Resource → Docker Compose**, point it at this repository.
 2. **Base Directory:** `/` (repo root).
 3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
-4. Deploy once. `POSTGRES_PASSWORD` and `JWT_SECRET` need nothing from
-   you — `docker-compose.yml` generates both via Coolify's magic env vars.
-   `BETTER_AUTH_URL` is required and starts **empty**; this first deploy is
-   only to get Coolify to generate the domain (next section) — it fails
-   until `BETTER_AUTH_URL` is set, which is expected.
-5. Open the `server` service → **Domains**, copy the generated
-   `https://<something>.sslip.io` (or set your own domain there first).
-   Then **Environment Variables → Production**, set `BETTER_AUTH_URL` to that
-   URL (`https://…`, no trailing slash, no port — TLS is on 443), and
-   redeploy. Coolify runs `postgres → migrate → server` in order (via
-   `depends_on` + `condition: service_completed_successfully`), so the server
-   never answers requests against an unmigrated schema.
+4. Deploy — no env vars to fill in first. `POSTGRES_PASSWORD` and
+   `JWT_SECRET` come from Coolify's magic env vars; `BETTER_AUTH_URL` starts
+   unset and the app falls back to a placeholder (`http://localhost:3010`)
+   rather than refusing to start, so the stack comes up on its own. Coolify
+   runs `postgres → migrate → server` in order (via `depends_on` +
+   `condition: service_completed_successfully`), so the server never answers
+   requests against an unmigrated schema.
+5. Once it's up: open the `server` service → **Domains**, copy the generated
+   `https://<something>.sslip.io` (or set your own domain there first). Then
+   **Environment Variables → Production**, set `BETTER_AUTH_URL` to that URL
+   (`https://…`, no trailing slash, no port — TLS is on 443), and redeploy.
+   This isn't a global Coolify setting — it's this one service's own env var,
+   same as `PORT` — so nothing else on the instance is affected. Until you do
+   this, auth/invitation emails and the desktop app's connect link point at
+   the placeholder instead of your real domain.
 
 ## Domain
 
@@ -46,15 +49,19 @@ container itself only ever speaks plain HTTP).
 If you're customizing this file, don't borrow bash's `${VAR:?error message}`
 pattern from `../compose/docker-compose.yml` for a required var — Coolify's
 compose parser gives `:?` a different meaning than bash does. `${VAR:?}`
-(nothing after the `?`) marks the var required and shows an empty field in the
-UI, but `${VAR:?some text}` treats `some text` as a **prefilled default
-value**, not an error message. Writing `${JWT_SECRET:?set JWT_SECRET in
-.env}` (our first attempt) meant an unset `JWT_SECRET` silently became the
-literal string `set JWT_SECRET in .env` instead of failing — every
+(nothing after the `?`) marks the var required **and blocks deployment**
+until it's filled in; `${VAR:?some text}` instead treats `some text` as a
+**prefilled default value**, not an error message. Writing `${JWT_SECRET:?set
+JWT_SECRET in .env}` (our first attempt) meant an unset `JWT_SECRET` silently
+became the literal string `set JWT_SECRET in .env` instead of failing — every
 downstream value built from it came out as garbage and the deploy failed with
-an opaque error nowhere near the actual cause. Use `${VAR:?}` for a var the
-user must type in, or a Coolify magic var (`SERVICE_PASSWORD_<ID>`, etc.) for
-one Coolify can generate itself.
+an opaque error nowhere near the actual cause. That's why `BETTER_AUTH_URL`
+below is plain `${BETTER_AUTH_URL}` with no `:?` at all, rather than
+`${BETTER_AUTH_URL:?}` — the latter is the "correct" required-var form, but it
+would block the very first deploy that's needed to learn the domain in the
+first place. Use `${VAR:?}` only for a var with no safe fallback the app can
+run with; use a Coolify magic var (`SERVICE_PASSWORD_<ID>`, etc.) for one
+Coolify can generate itself.
 
 Then in the desktop app: **account menu → Server settings →** your
 `BETTER_AUTH_URL` → **Save**. Create an account and you're synced.

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -13,13 +13,16 @@ directory, which breaks `deploy/compose/docker-compose.yml`'s `context: ../..`
 1. **New Resource → Docker Compose**, point it at this repository.
 2. **Base Directory:** `/` (repo root).
 3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
-4. Set the environment variables on the `server` and `migrate` services (or as
-   shared project variables — see [`.env.example`](.env.example)):
-   - `POSTGRES_PASSWORD`
-   - `JWT_SECRET` — `openssl rand -base64 32`
-   - `BETTER_AUTH_URL` — the public HTTPS URL Coolify's proxy fronts, e.g.
-     `https://baalda.example.com` (no trailing slash, no port — TLS is on 443)
-5. Deploy. Coolify runs `postgres → migrate → server` in order (via
+4. Deploy once. `POSTGRES_PASSWORD` and `JWT_SECRET` need nothing from
+   you — `docker-compose.yml` generates both via Coolify's magic env vars.
+   `BETTER_AUTH_URL` is required and starts **empty**; this first deploy is
+   only to get Coolify to generate the domain (next section) — it fails
+   until `BETTER_AUTH_URL` is set, which is expected.
+5. Open the `server` service → **Domains**, copy the generated
+   `https://<something>.sslip.io` (or set your own domain there first).
+   Then **Environment Variables → Production**, set `BETTER_AUTH_URL` to that
+   URL (`https://…`, no trailing slash, no port — TLS is on 443), and
+   redeploy. Coolify runs `postgres → migrate → server` in order (via
    `depends_on` + `condition: service_completed_successfully`), so the server
    never answers requests against an unmigrated schema.
 
@@ -32,17 +35,26 @@ already set your own) and assign it to *this* service's exposed port (`3010`)
 automatically on first deploy. `postgres` and `migrate` have no exposed port,
 so they're never offered a domain.
 
-If a domain doesn't get assigned automatically (older Coolify versions, or you
-skipped step 5's redeploy), do it by hand: open the `server` service →
-**Domains** → **Add domain**, set **Service:** `server` (not `migrate` or
-`postgres`), **Port:** `3010`, **Protocol:** `http` (Coolify's Traefik
-terminates TLS in front — the container itself only ever speaks plain HTTP).
+If a domain doesn't get assigned automatically (older Coolify versions), do it
+by hand: open the `server` service → **Domains** → **Add domain**, set
+**Service:** `server` (not `migrate` or `postgres`), **Port:** `3010`,
+**Protocol:** `http` (Coolify's Traefik terminates TLS in front — the
+container itself only ever speaks plain HTTP).
 
-Either way, once you have the domain, set **`BETTER_AUTH_URL`** to it with an
-`https://` scheme and no trailing slash (e.g.
-`https://server-abc123.your-coolify-host.sslip.io`) and redeploy — Better Auth
-builds invitation and verification links from that value, so a mismatch here
-breaks them.
+## A gotcha we hit testing this: `${VAR:?message}`
+
+If you're customizing this file, don't borrow bash's `${VAR:?error message}`
+pattern from `../compose/docker-compose.yml` for a required var — Coolify's
+compose parser gives `:?` a different meaning than bash does. `${VAR:?}`
+(nothing after the `?`) marks the var required and shows an empty field in the
+UI, but `${VAR:?some text}` treats `some text` as a **prefilled default
+value**, not an error message. Writing `${JWT_SECRET:?set JWT_SECRET in
+.env}` (our first attempt) meant an unset `JWT_SECRET` silently became the
+literal string `set JWT_SECRET in .env` instead of failing — every
+downstream value built from it came out as garbage and the deploy failed with
+an opaque error nowhere near the actual cause. Use `${VAR:?}` for a var the
+user must type in, or a Coolify magic var (`SERVICE_PASSWORD_<ID>`, etc.) for
+one Coolify can generate itself.
 
 Then in the desktop app: **account menu → Server settings →** your
 `BETTER_AUTH_URL` → **Save**. Create an account and you're synced.

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -8,26 +8,37 @@ because Coolify runs `docker compose` with the **repo root** as the project
 directory, which breaks `deploy/compose/docker-compose.yml`'s `context: ../..`
 (see [issue #97](https://github.com/naveedharri/baalda/issues/97)).
 
+> **Tested end-to-end** on a live Coolify instance: build → `postgres` →
+> `migrate` → `server` all healthy, a custom domain with a real Let's
+> Encrypt certificate, and the desktop app signing in and syncing notes
+> through it. The gotchas below are all things that broke during that test
+> and are now fixed in this file — read them if you're customizing it.
+
 ## Coolify setup
 
-1. **New Resource → Docker Compose**, point it at this repository.
+1. **New Resource → Docker Compose** (a public repo works with **Public Git
+   Repository**, no credentials needed), point it at this repository.
 2. **Base Directory:** `/` (repo root).
 3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
 4. Deploy — no env vars to fill in first. `POSTGRES_PASSWORD` and
-   `JWT_SECRET` come from Coolify's magic env vars; `BETTER_AUTH_URL` starts
-   unset and the app falls back to a placeholder (`http://localhost:3010`)
-   rather than refusing to start, so the stack comes up on its own. Coolify
-   runs `postgres → migrate → server` in order (via `depends_on` +
-   `condition: service_completed_successfully`), so the server never answers
-   requests against an unmigrated schema.
-5. Once it's up: open the `server` service → **Domains**, copy the generated
-   `https://<something>.sslip.io` (or set your own domain there first). Then
-   **Environment Variables → Production**, set `BETTER_AUTH_URL` to that URL
-   (`https://…`, no trailing slash, no port — TLS is on 443), and redeploy.
-   This isn't a global Coolify setting — it's this one service's own env var,
-   same as `PORT` — so nothing else on the instance is affected. Until you do
-   this, auth/invitation emails and the desktop app's connect link point at
-   the placeholder instead of your real domain.
+   `JWT_SECRET` come from Coolify's magic env vars; `BETTER_AUTH_URL`
+   resolves to a placeholder (`http://localhost:3010`) via the compose
+   file's own `${BETTER_AUTH_URL:-http://localhost:3010}` default, so the
+   stack comes up on its own. Coolify runs `postgres → migrate → server` in
+   order (via `depends_on` + `condition: service_completed_successfully`),
+   so the server never answers requests against an unmigrated schema.
+5. Once it's up: open the `server` service → **Domains**. A domain is
+   already there (Coolify auto-generated a free `*.sslip.io` one via
+   `SERVICE_FQDN_SERVER`) — use it, or **Add Domain** with your own (Service
+   `server`, Port `3010`, Protocol `https`; point the domain's DNS `A`
+   record at your Coolify server first, or the certificate can't be issued).
+6. **Environment Variables → Production** on the `server` service, set
+   `BETTER_AUTH_URL` to that domain (`https://…`, no trailing slash, no
+   port — TLS is on 443), and redeploy. This isn't a global Coolify
+   setting — it's this one service's own env var, same as `PORT` — so
+   nothing else on the instance is affected. Until you do this,
+   auth/invitation emails and the desktop app's connect link point at the
+   placeholder instead of your real domain.
 
 ## Domain
 
@@ -44,24 +55,50 @@ by hand: open the `server` service → **Domains** → **Add domain**, set
 **Protocol:** `http` (Coolify's Traefik terminates TLS in front — the
 container itself only ever speaks plain HTTP).
 
-## A gotcha we hit testing this: `${VAR:?message}`
+## Gotchas we hit testing this
 
-If you're customizing this file, don't borrow bash's `${VAR:?error message}`
-pattern from `../compose/docker-compose.yml` for a required var — Coolify's
-compose parser gives `:?` a different meaning than bash does. `${VAR:?}`
-(nothing after the `?`) marks the var required **and blocks deployment**
-until it's filled in; `${VAR:?some text}` instead treats `some text` as a
-**prefilled default value**, not an error message. Writing `${JWT_SECRET:?set
-JWT_SECRET in .env}` (our first attempt) meant an unset `JWT_SECRET` silently
-became the literal string `set JWT_SECRET in .env` instead of failing — every
-downstream value built from it came out as garbage and the deploy failed with
-an opaque error nowhere near the actual cause. That's why `BETTER_AUTH_URL`
-below is plain `${BETTER_AUTH_URL}` with no `:?` at all, rather than
-`${BETTER_AUTH_URL:?}` — the latter is the "correct" required-var form, but it
-would block the very first deploy that's needed to learn the domain in the
-first place. Use `${VAR:?}` only for a var with no safe fallback the app can
-run with; use a Coolify magic var (`SERVICE_PASSWORD_<ID>`, etc.) for one
-Coolify can generate itself.
+Three separate issues surfaced while getting this file working, in the order
+we hit them. All three are already fixed here — this is context for anyone
+customizing the file, or hitting a similar error.
+
+**1. `${VAR:?message}` means something different in Coolify than in bash.**
+Coolify's compose parser gives `:?` its own meaning: `${VAR:?}` (nothing after
+the `?`) marks the var required **and blocks deployment** until it's filled
+in; `${VAR:?some text}` instead treats `some text` as a **prefilled default
+value**, not an error message shown on a missing var. Writing
+`${JWT_SECRET:?set JWT_SECRET in .env}` (our first attempt, copied from
+`../compose/docker-compose.yml`, where it's correct — that's a plain
+`docker compose` CLI, which *does* implement bash's `:?` semantics) meant an
+unset `JWT_SECRET` silently became the literal string `set JWT_SECRET in
+.env` instead of failing. Every downstream value built from it came out as
+garbage and the deploy failed with an error nowhere near the real cause. Fix:
+use a Coolify magic var (`SERVICE_PASSWORD_64_<ID>`, etc.) for anything
+Coolify can generate itself, and plain `${VAR:-default}` (standard bash `:-`
+behavior — Coolify's docs confirm this one isn't special-cased) for anything
+else that needs a safe placeholder.
+
+**2. An unset `${VAR}` becomes an empty string in the container, not an
+absent key — the app's own fallback doesn't catch that.**
+`app/apps/server/src/config.ts`'s `required(name, fallback)` applies
+`fallback` via `??`, which only triggers on `undefined`/`null` — not on `""`.
+Coolify interpolates a genuinely-unset `${BETTER_AUTH_URL}` to an empty
+string in the container's environment rather than omitting the key, so the
+app saw `v = ""`, skipped the fallback, and threw `Missing required env var:
+BETTER_AUTH_URL` — crashing **both** `migrate` and `server` on startup,
+before either reached any Postgres-related code (this is what an opaque
+`migrate` `exit 1` with no other log actually was). Fix: supply the default
+in the compose interpolation itself — `${BETTER_AUTH_URL:-http://localhost:3010}`
+— so the container never sees an empty value in the first place; don't rely
+on an app-level fallback for a var Coolify might pass through empty.
+
+**3. A Coolify platform bug could corrupt a domain into `https://` with no
+host, and abort every deploy after that with `The string 'https://' is no
+valid url.`** This is
+[coollabsio/coolify#11664](https://github.com/coollabsio/coolify/issues/11664),
+fixed in **Coolify v4.3.19**. If you hit that exact error and your compose
+file has no `:?`/`:-` issues, update Coolify — the fix skips/heals a
+corrupted domain row at deploy time and prevents new corruption on save. Not
+something this file can work around.
 
 Then in the desktop app: **account menu → Server settings →** your
 `BETTER_AUTH_URL` → **Save**. Create an account and you're synced.

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -19,13 +19,30 @@ directory, which breaks `deploy/compose/docker-compose.yml`'s `context: ../..`
    - `JWT_SECRET` — `openssl rand -base64 32`
    - `BETTER_AUTH_URL` — the public HTTPS URL Coolify's proxy fronts, e.g.
      `https://baalda.example.com` (no trailing slash, no port — TLS is on 443)
-5. On the `server` service, set the domain to the same host as
-   `BETTER_AUTH_URL` and expose container port `3010`. Coolify's Traefik
-   handles TLS and WebSocket upgrade for you — the sync WebSocket rides the
-   same port at `/sync`, so there's nothing extra to route.
-6. Deploy. Coolify runs `postgres → migrate → server` in order (via
+5. Deploy. Coolify runs `postgres → migrate → server` in order (via
    `depends_on` + `condition: service_completed_successfully`), so the server
    never answers requests against an unmigrated schema.
+
+## Domain
+
+The `server` service declares `SERVICE_FQDN_SERVER` — Coolify's [magic env var
+convention](https://coolify.io/docs/knowledge-base/environment-variables) —
+which tells Coolify to generate a domain (a free `*.sslip.io` one, unless you
+already set your own) and assign it to *this* service's exposed port (`3010`)
+automatically on first deploy. `postgres` and `migrate` have no exposed port,
+so they're never offered a domain.
+
+If a domain doesn't get assigned automatically (older Coolify versions, or you
+skipped step 5's redeploy), do it by hand: open the `server` service →
+**Domains** → **Add domain**, set **Service:** `server` (not `migrate` or
+`postgres`), **Port:** `3010`, **Protocol:** `http` (Coolify's Traefik
+terminates TLS in front — the container itself only ever speaks plain HTTP).
+
+Either way, once you have the domain, set **`BETTER_AUTH_URL`** to it with an
+`https://` scheme and no trailing slash (e.g.
+`https://server-abc123.your-coolify-host.sslip.io`) and redeploy — Better Auth
+builds invitation and verification links from that value, so a mismatch here
+breaks them.
 
 Then in the desktop app: **account menu → Server settings →** your
 `BETTER_AUTH_URL` → **Save**. Create an account and you're synced.

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -1,0 +1,51 @@
+# Self-host the Baalda server on Coolify
+
+Same stack as [`deploy/compose`](../compose) (Postgres + migrate-before-start +
+single-port server), packaged so Coolify's Docker Compose build pack resolves
+the build context correctly. If you're running Compose directly on a VPS
+yourself, use [`deploy/compose`](../compose) instead — this directory exists
+because Coolify runs `docker compose` with the **repo root** as the project
+directory, which breaks `deploy/compose/docker-compose.yml`'s `context: ../..`
+(see [issue #97](https://github.com/naveedharri/baalda/issues/97)).
+
+## Coolify setup
+
+1. **New Resource → Docker Compose**, point it at this repository.
+2. **Base Directory:** `/` (repo root).
+3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
+4. Set the environment variables on the `server` and `migrate` services (or as
+   shared project variables — see [`.env.example`](.env.example)):
+   - `POSTGRES_PASSWORD`
+   - `JWT_SECRET` — `openssl rand -base64 32`
+   - `BETTER_AUTH_URL` — the public HTTPS URL Coolify's proxy fronts, e.g.
+     `https://baalda.example.com` (no trailing slash, no port — TLS is on 443)
+5. On the `server` service, set the domain to the same host as
+   `BETTER_AUTH_URL` and expose container port `3010`. Coolify's Traefik
+   handles TLS and WebSocket upgrade for you — the sync WebSocket rides the
+   same port at `/sync`, so there's nothing extra to route.
+6. Deploy. Coolify runs `postgres → migrate → server` in order (via
+   `depends_on` + `condition: service_completed_successfully`), so the server
+   never answers requests against an unmigrated schema.
+
+Then in the desktop app: **account menu → Server settings →** your
+`BETTER_AUTH_URL` → **Save**. Create an account and you're synced.
+
+## What comes up
+
+| Service | What it does |
+| --- | --- |
+| `postgres` | Postgres 16 on a named volume. Never exposed outside the Compose network. |
+| `migrate` | Runs `dist/db/migrate.js` to completion, *then* exits. |
+| `server` | Hono HTTP + Hocuspocus WS on **one** container port (`3010`), `expose`d (not published) — Coolify's proxy reaches it on the internal network. |
+
+## Differences from `deploy/compose`
+
+- `build.context: .` instead of `../..`, because Coolify's project directory
+  is the repo root, not this directory.
+- No `ports:` / `BIND_ADDR` — nothing is published to the host. Coolify's
+  Traefik terminates TLS and talks to the container directly, so there's no
+  loopback bind to configure.
+
+Everything else — the Postgres volume, the migrate-then-serve ordering, the
+optional env vars (Google sign-in, Redis, billing) — is identical. Full env
+var reference: [`docs/DEPLOY.md`](../../docs/DEPLOY.md).

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -45,16 +45,25 @@
 # and BETTER_AUTH_URL all came out as garbage and the deploy failed opaquely
 # downstream.
 #
-# BETTER_AUTH_URL is left with NO `:?` at all (just `${BETTER_AUTH_URL}`) so
-# the first deploy succeeds without any manual input — Coolify's own
-# `${VAR:?}` would block deployment entirely until the field is filled in
-# (see the same doc page), and the real public URL isn't known before this
-# first deploy generates a domain via SERVICE_FQDN_SERVER below anyway. The
-# app (app/apps/server/src/config.ts) treats an unset/empty BETTER_AUTH_URL
-# as `http://localhost:3010` rather than crashing, so the container comes up
-# fine with that placeholder. Once you have the real domain (Domains tab on
-# `server`), set BETTER_AUTH_URL to it — https://…, no trailing slash — and
-# redeploy; auth/invitation links are wrong until you do.
+# BETTER_AUTH_URL uses `${BETTER_AUTH_URL:-http://localhost:3010}` — a real
+# bash-style default (Coolify's docs confirm `:-` gets standard behavior,
+# unlike `:?`) — so the first deploy succeeds without any manual input, and
+# the real public URL isn't known before this first deploy generates a domain
+# via SERVICE_FQDN_SERVER below anyway.
+#
+# This can't be `${BETTER_AUTH_URL}` bare relying on the app's own fallback
+# (app/apps/server/src/config.ts's `required(name, fallback)`): Coolify
+# interpolates a genuinely-unset var to an EMPTY STRING in the container's
+# environment, not to an absent key. `required()` only applies its fallback
+# via `??`, which empty string does not trigger, so it throws `Missing
+# required env var: BETTER_AUTH_URL` and the process exits immediately —
+# this crashed BOTH `migrate` and `server` on startup, before either reached
+# any Postgres-related code. The default has to be supplied here, in the
+# compose interpolation, so the container never sees an empty value at all.
+#
+# Once you have the real domain (Domains tab on `server`), set
+# BETTER_AUTH_URL to it — https://…, no trailing slash — and redeploy;
+# auth/invitation links are wrong until you do.
 name: baalda
 
 x-server-image: &server-image
@@ -66,7 +75,7 @@ x-server-env: &server-env
   NODE_ENV: production
   DATABASE_URL: postgres://baalda:${SERVICE_PASSWORD_64_POSTGRES}@postgres:5432/baalda
   JWT_SECRET: ${SERVICE_REALBASE64_64_JWT}
-  BETTER_AUTH_URL: ${BETTER_AUTH_URL}
+  BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3010}
   PORT: "3010"
 
 services:

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -24,6 +24,23 @@
 # deploy, targeting its one exposed port. Without it Coolify still lets you
 # assign a domain by hand (Service → server, Port → 3010) in each service's
 # "Domains" settings, but won't pick the right service for you.
+#
+# POSTGRES_PASSWORD and JWT_SECRET are Coolify magic vars too
+# (SERVICE_PASSWORD_<ID> / SERVICE_REALBASE64_64_<ID>) — Coolify generates and
+# persists them per-deployment, so there is nothing to type in for either.
+#
+# ⚠️ Do NOT use bash's `${VAR:?error message}` here for a required var, even
+# though ../compose/docker-compose.yml does (and should keep doing, for a
+# plain `docker compose` CLI, which implements it correctly: fail fast with
+# your message if VAR is unset). Coolify's compose parser gives `:?` a
+# DIFFERENT meaning — https://coolify.io/docs/knowledge-base/docker/compose —
+# `${VAR:?}` marks VAR required (blank in the UI), while `${VAR:?text}` treats
+# `text` as a *prefilled default value*, not an error message. Using our old
+# guard clauses here meant an unset var silently became the literal string
+# "set POSTGRES_PASSWORD in .env" instead of failing — DATABASE_URL, JWT_SECRET
+# and BETTER_AUTH_URL all came out as garbage and the deploy failed opaquely
+# downstream. BETTER_AUTH_URL below uses the correct bare `${BETTER_AUTH_URL:?}`
+# instead, which Coolify shows as a required, empty field in its UI.
 name: baalda
 
 x-server-image: &server-image
@@ -33,9 +50,9 @@ x-server-image: &server-image
 
 x-server-env: &server-env
   NODE_ENV: production
-  DATABASE_URL: postgres://baalda:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/baalda
-  JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env — openssl rand -base64 32}
-  BETTER_AUTH_URL: ${BETTER_AUTH_URL:?set BETTER_AUTH_URL in .env — the public https URL Coolify's proxy fronts}
+  DATABASE_URL: postgres://baalda:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/baalda
+  JWT_SECRET: ${SERVICE_REALBASE64_64_JWT}
+  BETTER_AUTH_URL: ${BETTER_AUTH_URL:?}
   PORT: "3010"
 
 services:
@@ -44,7 +61,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: baalda
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
       POSTGRES_DB: baalda
     volumes:
       - baalda_pgdata:/var/lib/postgresql/data

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -26,8 +26,12 @@
 # "Domains" settings, but won't pick the right service for you.
 #
 # POSTGRES_PASSWORD and JWT_SECRET are Coolify magic vars too
-# (SERVICE_PASSWORD_<ID> / SERVICE_REALBASE64_64_<ID>) — Coolify generates and
-# persists them per-deployment, so there is nothing to type in for either.
+# (SERVICE_PASSWORD_64_<ID> / SERVICE_REALBASE64_64_<ID>) — Coolify generates
+# and persists them per-deployment, so there is nothing to type in for
+# either. POSTGRES_PASSWORD specifically uses the "_64" (symbols-free)
+# variant, not the bare SERVICE_PASSWORD_<ID> one — that one may include
+# characters like `@ : /` that are unsafe unescaped inside DATABASE_URL's
+# postgres:// connection string.
 #
 # ⚠️ Do NOT use bash's `${VAR:?error message}` here for a required var, even
 # though ../compose/docker-compose.yml does (and should keep doing, for a
@@ -60,7 +64,7 @@ x-server-image: &server-image
 
 x-server-env: &server-env
   NODE_ENV: production
-  DATABASE_URL: postgres://baalda:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/baalda
+  DATABASE_URL: postgres://baalda:${SERVICE_PASSWORD_64_POSTGRES}@postgres:5432/baalda
   JWT_SECRET: ${SERVICE_REALBASE64_64_JWT}
   BETTER_AUTH_URL: ${BETTER_AUTH_URL}
   PORT: "3010"
@@ -71,7 +75,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: baalda
-      POSTGRES_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_PASSWORD: ${SERVICE_PASSWORD_64_POSTGRES}
       POSTGRES_DB: baalda
     volumes:
       - baalda_pgdata:/var/lib/postgresql/data

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -17,6 +17,13 @@
 # No host ports are published here — Coolify's own proxy (Traefik) terminates
 # TLS and reaches the container directly on its internal network, so `server`
 # only needs to `expose` the port, not publish it.
+#
+# `server` declares SERVICE_FQDN_SERVER (Coolify's magic env var convention,
+# https://coolify.io/docs/knowledge-base/environment-variables) so Coolify
+# generates and assigns a domain to THIS service automatically on first
+# deploy, targeting its one exposed port. Without it Coolify still lets you
+# assign a domain by hand (Service → server, Port → 3010) in each service's
+# "Domains" settings, but won't pick the right service for you.
 name: baalda
 
 x-server-image: &server-image
@@ -61,7 +68,11 @@ services:
 
   server:
     <<: *server-image
-    environment: *server-env
+    environment:
+      <<: *server-env
+      # Bare (unset) magic var — Coolify generates a domain and assigns it to
+      # this service's exposed port. See the file-level comment above.
+      SERVICE_FQDN_SERVER:
     # No `ports:` — Coolify's proxy reaches the container on the internal
     # network. `expose` documents the port without publishing it to the host.
     expose:

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -1,0 +1,85 @@
+# Baalda server — Coolify / PaaS Compose bundle (server + Postgres).
+#
+# This is the same stack as ../compose/docker-compose.yml, adapted for
+# platforms (Coolify and similar) that run `docker compose` with the repo
+# root as the project directory, rather than the directory the compose file
+# lives in. That changes how a relative `build.context` resolves, which is
+# why this file is separate from ../compose/ instead of replacing it:
+#
+#   - ../compose/docker-compose.yml uses `context: ../..` and is meant to be
+#     run with `cd deploy/compose && docker compose up`, i.e. context
+#     resolves relative to the compose file.
+#   - This file uses `context: .` because Coolify's project directory *is*
+#     the repo root, so `.` already points at the right place. Point Coolify's
+#     "Base Directory" at the repo root (`/`) and its "Compose file location"
+#     at `/deploy/coolify/docker-compose.yml`.
+#
+# No host ports are published here — Coolify's own proxy (Traefik) terminates
+# TLS and reaches the container directly on its internal network, so `server`
+# only needs to `expose` the port, not publish it.
+name: baalda
+
+x-server-image: &server-image
+  build:
+    context: .
+    dockerfile: app/apps/server/Dockerfile
+
+x-server-env: &server-env
+  NODE_ENV: production
+  DATABASE_URL: postgres://baalda:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/baalda
+  JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env — openssl rand -base64 32}
+  BETTER_AUTH_URL: ${BETTER_AUTH_URL:?set BETTER_AUTH_URL in .env — the public https URL Coolify's proxy fronts}
+  PORT: "3010"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: baalda
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: baalda
+    volumes:
+      - baalda_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U baalda -d baalda"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  # Runs to completion, then the server starts. Same ordering guarantee as
+  # ../compose/docker-compose.yml: schema changes land before anything serves
+  # traffic.
+  migrate:
+    <<: *server-image
+    command: ["node", "dist/db/migrate.js"]
+    environment: *server-env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  server:
+    <<: *server-image
+    environment: *server-env
+    # No `ports:` — Coolify's proxy reaches the container on the internal
+    # network. `expose` documents the port without publishing it to the host.
+    expose:
+      - "3010"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - fetch('http://127.0.0.1:3010/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  baalda_pgdata:

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -39,8 +39,18 @@
 # guard clauses here meant an unset var silently became the literal string
 # "set POSTGRES_PASSWORD in .env" instead of failing — DATABASE_URL, JWT_SECRET
 # and BETTER_AUTH_URL all came out as garbage and the deploy failed opaquely
-# downstream. BETTER_AUTH_URL below uses the correct bare `${BETTER_AUTH_URL:?}`
-# instead, which Coolify shows as a required, empty field in its UI.
+# downstream.
+#
+# BETTER_AUTH_URL is left with NO `:?` at all (just `${BETTER_AUTH_URL}`) so
+# the first deploy succeeds without any manual input — Coolify's own
+# `${VAR:?}` would block deployment entirely until the field is filled in
+# (see the same doc page), and the real public URL isn't known before this
+# first deploy generates a domain via SERVICE_FQDN_SERVER below anyway. The
+# app (app/apps/server/src/config.ts) treats an unset/empty BETTER_AUTH_URL
+# as `http://localhost:3010` rather than crashing, so the container comes up
+# fine with that placeholder. Once you have the real domain (Domains tab on
+# `server`), set BETTER_AUTH_URL to it — https://…, no trailing slash — and
+# redeploy; auth/invitation links are wrong until you do.
 name: baalda
 
 x-server-image: &server-image
@@ -52,7 +62,7 @@ x-server-env: &server-env
   NODE_ENV: production
   DATABASE_URL: postgres://baalda:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/baalda
   JWT_SECRET: ${SERVICE_REALBASE64_64_JWT}
-  BETTER_AUTH_URL: ${BETTER_AUTH_URL:?}
+  BETTER_AUTH_URL: ${BETTER_AUTH_URL}
   PORT: "3010"
 
 services:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -245,17 +245,26 @@ terminates TLS and reaches the container on the internal network instead.
 2. **Base Directory:** `/` (repo root) — this is what makes `context: .` in
    the compose file resolve correctly.
 3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
-4. Required env vars on the `server`/`migrate` services: `POSTGRES_PASSWORD`,
-   `JWT_SECRET` (`openssl rand -base64 32`), `BETTER_AUTH_URL` (the public
-   HTTPS URL Coolify's proxy fronts, no trailing slash, no port).
+4. `POSTGRES_PASSWORD` and `JWT_SECRET` need nothing from you — the compose
+   file generates both via Coolify's magic env vars
+   (`SERVICE_PASSWORD_POSTGRES`, `SERVICE_REALBASE64_64_JWT`). Only
+   `BETTER_AUTH_URL` is a var you set, and it needs the domain from step 5
+   first, so deploy once to get there.
 5. Deploy — `migrate` must complete successfully before `server` starts, so a
    deploy never briefly answers requests against an old schema. `server`
    declares Coolify's `SERVICE_FQDN_SERVER` magic env var, so a domain
    (targeting its exposed port `3010`) is generated and assigned to it
    automatically; if that doesn't happen, assign one by hand (Service →
-   `server`, Port → `3010`, Protocol → `http`) and redeploy. Either way, once
-   you have the domain, set `BETTER_AUTH_URL` to it and redeploy — the sync
-   WebSocket rides the same port at `/sync`, so nothing else needs routing.
+   `server`, Port → `3010`, Protocol → `http`). Either way, once you have the
+   domain, set `BETTER_AUTH_URL` to it (`https://…`, no trailing slash, no
+   port) and redeploy — the sync WebSocket rides the same port at `/sync`, so
+   nothing else needs routing.
+
+   Don't reuse bash's `${VAR:?error message}` pattern here if you customize
+   this file — Coolify's compose parser reads the text after `:?` as a
+   *prefilled default value*, not an error message, so an unset var silently
+   becomes that literal text instead of failing loudly. Use bare `${VAR:?}`
+   for a var Coolify should require empty, as `BETTER_AUTH_URL` does.
 
 Full walkthrough and the differences from `deploy/compose`:
 [`deploy/coolify/README.md`](../deploy/coolify/README.md).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -227,6 +227,36 @@ curl -sL https://railway.com/deploy/baalda-server | grep -o '<title>[^<]*</title
 > and publishing it would push a public marketplace template built from production
 > — env values, domain and all. Always compose the template fresh, as above.
 
+## Option C: Coolify
+
+Coolify (and similar PaaS Docker Compose tools) run `docker compose` with the
+**repo root** as the project directory, not the directory the compose file
+lives in. That breaks [`deploy/compose/docker-compose.yml`](../deploy/compose)'s
+`build.context: ../..`, which assumes you run `cd deploy/compose && docker
+compose up` — Coolify instead resolves that path two directories *above* the
+repo root and the build fails with `lstat /app: no such file or directory`.
+
+[`deploy/coolify/docker-compose.yml`](../deploy/coolify) is the same stack
+(Postgres → migrate → server) with `build.context: .`, built for that project
+directory, and with no ports published — Coolify's own Traefik proxy
+terminates TLS and reaches the container on the internal network instead.
+
+1. **New Resource → Docker Compose**, point it at this repository (or your fork).
+2. **Base Directory:** `/` (repo root) — this is what makes `context: .` in
+   the compose file resolve correctly.
+3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
+4. Required env vars on the `server`/`migrate` services: `POSTGRES_PASSWORD`,
+   `JWT_SECRET` (`openssl rand -base64 32`), `BETTER_AUTH_URL` (the public
+   HTTPS URL Coolify's proxy fronts, no trailing slash, no port).
+5. On the `server` service, set the domain to that same host and expose
+   container port `3010`. The sync WebSocket rides the same port at `/sync`,
+   so nothing else needs routing.
+6. Deploy — `migrate` must complete successfully before `server` starts, so a
+   deploy never briefly answers requests against an old schema.
+
+Full walkthrough and the differences from `deploy/compose`:
+[`deploy/coolify/README.md`](../deploy/coolify/README.md).
+
 ## A staging instance
 
 Nothing in the server distinguishes staging from production — a staging instance

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -245,26 +245,30 @@ terminates TLS and reaches the container on the internal network instead.
 2. **Base Directory:** `/` (repo root) — this is what makes `context: .` in
    the compose file resolve correctly.
 3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
-4. `POSTGRES_PASSWORD` and `JWT_SECRET` need nothing from you — the compose
-   file generates both via Coolify's magic env vars
-   (`SERVICE_PASSWORD_POSTGRES`, `SERVICE_REALBASE64_64_JWT`). Only
-   `BETTER_AUTH_URL` is a var you set, and it needs the domain from step 5
-   first, so deploy once to get there.
-5. Deploy — `migrate` must complete successfully before `server` starts, so a
-   deploy never briefly answers requests against an old schema. `server`
-   declares Coolify's `SERVICE_FQDN_SERVER` magic env var, so a domain
-   (targeting its exposed port `3010`) is generated and assigned to it
-   automatically; if that doesn't happen, assign one by hand (Service →
-   `server`, Port → `3010`, Protocol → `http`). Either way, once you have the
-   domain, set `BETTER_AUTH_URL` to it (`https://…`, no trailing slash, no
-   port) and redeploy — the sync WebSocket rides the same port at `/sync`, so
-   nothing else needs routing.
+4. Deploy — no env vars to fill in first. `POSTGRES_PASSWORD` and
+   `JWT_SECRET` come from Coolify's magic env vars
+   (`SERVICE_PASSWORD_POSTGRES`, `SERVICE_REALBASE64_64_JWT`);
+   `BETTER_AUTH_URL` starts unset and the app falls back to a placeholder
+   rather than refusing to start, so the stack comes up on its own. `migrate`
+   must complete successfully before `server` starts, so a deploy never
+   briefly answers requests against an old schema. `server` also declares
+   Coolify's `SERVICE_FQDN_SERVER` magic env var, so a domain (targeting its
+   exposed port `3010`) is generated and assigned to it automatically; if
+   that doesn't happen, assign one by hand (Service → `server`, Port →
+   `3010`, Protocol → `http`).
+5. Once it's up, set `BETTER_AUTH_URL` to the real domain from step 4
+   (`https://…`, no trailing slash, no port) in the `server` service's own
+   Environment Variables — not a global Coolify setting — and redeploy. Until
+   then, auth/invitation links point at the placeholder instead. The sync
+   WebSocket rides the same port at `/sync`, so nothing else needs routing.
 
    Don't reuse bash's `${VAR:?error message}` pattern here if you customize
    this file — Coolify's compose parser reads the text after `:?` as a
    *prefilled default value*, not an error message, so an unset var silently
-   becomes that literal text instead of failing loudly. Use bare `${VAR:?}`
-   for a var Coolify should require empty, as `BETTER_AUTH_URL` does.
+   becomes that literal text instead of failing loudly. `${VAR:?}` (bare) also
+   *blocks deployment* until filled in, which is why `BETTER_AUTH_URL` above
+   deliberately has no `:?` at all — the domain isn't known before this first
+   deploy runs.
 
 Full walkthrough and the differences from `deploy/compose`:
 [`deploy/coolify/README.md`](../deploy/coolify/README.md).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -248,11 +248,14 @@ terminates TLS and reaches the container on the internal network instead.
 4. Required env vars on the `server`/`migrate` services: `POSTGRES_PASSWORD`,
    `JWT_SECRET` (`openssl rand -base64 32`), `BETTER_AUTH_URL` (the public
    HTTPS URL Coolify's proxy fronts, no trailing slash, no port).
-5. On the `server` service, set the domain to that same host and expose
-   container port `3010`. The sync WebSocket rides the same port at `/sync`,
-   so nothing else needs routing.
-6. Deploy — `migrate` must complete successfully before `server` starts, so a
-   deploy never briefly answers requests against an old schema.
+5. Deploy — `migrate` must complete successfully before `server` starts, so a
+   deploy never briefly answers requests against an old schema. `server`
+   declares Coolify's `SERVICE_FQDN_SERVER` magic env var, so a domain
+   (targeting its exposed port `3010`) is generated and assigned to it
+   automatically; if that doesn't happen, assign one by hand (Service →
+   `server`, Port → `3010`, Protocol → `http`) and redeploy. Either way, once
+   you have the domain, set `BETTER_AUTH_URL` to it and redeploy — the sync
+   WebSocket rides the same port at `/sync`, so nothing else needs routing.
 
 Full walkthrough and the differences from `deploy/compose`:
 [`deploy/coolify/README.md`](../deploy/coolify/README.md).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -240,35 +240,44 @@ repo root and the build fails with `lstat /app: no such file or directory`.
 (Postgres → migrate → server) with `build.context: .`, built for that project
 directory, and with no ports published — Coolify's own Traefik proxy
 terminates TLS and reaches the container on the internal network instead.
+Tested end-to-end on a live Coolify instance: build, all three services
+healthy, a custom domain with a real Let's Encrypt certificate, and the
+desktop app signing in and syncing through it.
 
-1. **New Resource → Docker Compose**, point it at this repository (or your fork).
+1. **New Resource → Docker Compose** (**Public Git Repository** works for a
+   public repo, no credentials needed), point it at this repository (or your fork).
 2. **Base Directory:** `/` (repo root) — this is what makes `context: .` in
    the compose file resolve correctly.
 3. **Docker Compose Location:** `/deploy/coolify/docker-compose.yml`.
 4. Deploy — no env vars to fill in first. `POSTGRES_PASSWORD` and
    `JWT_SECRET` come from Coolify's magic env vars
-   (`SERVICE_PASSWORD_POSTGRES`, `SERVICE_REALBASE64_64_JWT`);
-   `BETTER_AUTH_URL` starts unset and the app falls back to a placeholder
-   rather than refusing to start, so the stack comes up on its own. `migrate`
-   must complete successfully before `server` starts, so a deploy never
-   briefly answers requests against an old schema. `server` also declares
-   Coolify's `SERVICE_FQDN_SERVER` magic env var, so a domain (targeting its
-   exposed port `3010`) is generated and assigned to it automatically; if
-   that doesn't happen, assign one by hand (Service → `server`, Port →
-   `3010`, Protocol → `http`).
+   (`SERVICE_PASSWORD_64_POSTGRES`, `SERVICE_REALBASE64_64_JWT`);
+   `BETTER_AUTH_URL` resolves to a placeholder (`http://localhost:3010`) via
+   the compose file's own `:-` default, so the stack comes up on its own.
+   `migrate` must complete successfully before `server` starts, so a deploy
+   never briefly answers requests against an old schema. `server` also
+   declares Coolify's `SERVICE_FQDN_SERVER` magic env var, so a domain
+   (targeting its exposed port `3010`) is generated and assigned to it
+   automatically; if that doesn't happen, assign one by hand (Service →
+   `server`, Port → `3010`, Protocol → `https`, with the domain's DNS `A`
+   record already pointed at your Coolify server).
 5. Once it's up, set `BETTER_AUTH_URL` to the real domain from step 4
    (`https://…`, no trailing slash, no port) in the `server` service's own
    Environment Variables — not a global Coolify setting — and redeploy. Until
    then, auth/invitation links point at the placeholder instead. The sync
    WebSocket rides the same port at `/sync`, so nothing else needs routing.
 
-   Don't reuse bash's `${VAR:?error message}` pattern here if you customize
-   this file — Coolify's compose parser reads the text after `:?` as a
-   *prefilled default value*, not an error message, so an unset var silently
-   becomes that literal text instead of failing loudly. `${VAR:?}` (bare) also
-   *blocks deployment* until filled in, which is why `BETTER_AUTH_URL` above
-   deliberately has no `:?` at all — the domain isn't known before this first
-   deploy runs.
+   Three Coolify-specific gotchas this file already works around — see
+   [`deploy/coolify/README.md`](../deploy/coolify/README.md#gotchas-we-hit-testing-this)
+   for the full detail if you're customizing it: `${VAR:?text}` means
+   "prefilled default", not "error message", unlike bash; an unset `${VAR}`
+   reaches the container as an **empty string**, which this server's own env
+   fallback does not catch (the default has to live in the compose file's
+   `${VAR:-default}`, not in app code); and a since-fixed Coolify bug
+   ([#11664](https://github.com/coollabsio/coolify/issues/11664), fixed in
+   **v4.3.19**) could corrupt a saved domain into a bare `https://`, aborting
+   every deploy with `The string 'https://' is no valid url.` — if you hit
+   that exact error, update Coolify.
 
 Full walkthrough and the differences from `deploy/compose`:
 [`deploy/coolify/README.md`](../deploy/coolify/README.md).


### PR DESCRIPTION
deploy/compose/docker-compose.yml assumes it runs from deploy/compose/ (build.context: ../..), which Coolify breaks: it runs docker compose with the repo root as project directory, so that relative context resolves two directories above the repo root and the build fails.

Add deploy/coolify/docker-compose.yml with the same postgres -> migrate -> server stack, but build.context: . (correct once Coolify's Base Directory is set to the repo root) and no published ports (expose only) since Coolify's own Traefik proxy terminates TLS and reaches the container directly. deploy/compose/ is unchanged for the existing VPS + nginx/Caddy path.

Also add deploy/coolify/README.md + .env.example mirroring deploy/compose's, and document the setup in docs/DEPLOY.md as Option C: Coolify.

## What does this PR do?

Adds a Coolify-friendly Docker Compose deploy path (`deploy/coolify/`) alongside the existing `deploy/compose/`, without changing the latter. Fixes the build-context resolution failure described in #97 when deploying through Coolify (or any PaaS that runs `docker compose` with the repo root as project directory).

- `deploy/coolify/docker-compose.yml`: same `postgres → migrate → server` stack, `build.context: .` instead of `../..`, no published host ports (`expose` only — Coolify's Traefik reaches the container on the internal network and terminates TLS). `POSTGRES_PASSWORD` and `JWT_SECRET` are generated by Coolify's own magic env vars (`SERVICE_PASSWORD_64_POSTGRES`, `SERVICE_REALBASE64_64_JWT`) — nothing to type in. `server` declares `SERVICE_FQDN_SERVER` so Coolify auto-assigns it a domain. `BETTER_AUTH_URL` defaults to a placeholder via the compose file's own `${VAR:-default}` so the stack comes up with zero manual input on first deploy; you set the real one once the domain is known.
- `deploy/coolify/README.md` + `.env.example`: setup walkthrough mirroring `deploy/compose/`'s docs, plus a "Gotchas we hit testing this" section covering three Coolify-specific behaviors that aren't obvious from Coolify's own docs (see below).
- `docs/DEPLOY.md`: new "Option C: Coolify" section with the Coolify resource settings and a summary of the same gotchas.

**Status: tested end-to-end on a live Coolify instance (v4.3.19).** Build succeeded, `postgres` → `migrate` → `server` all came up healthy in order, a custom domain got a real Let's Encrypt certificate through Coolify's proxy, and the desktop app signed in and synced notes through it. Ready for review.

### Gotchas documented along the way (all already fixed in this PR, noted for reviewers/future maintainers)

1. **`${VAR:?text}` means something different in Coolify than in bash.** `${VAR:?}` (bare) marks a var required and *blocks deployment* until it's filled in the UI; `${VAR:?some text}` treats `some text` as a **prefilled default value**, not an error message shown on a missing var. `deploy/compose/docker-compose.yml`'s bash-style `${VAR:?message}` guards are correct there (plain `docker compose` CLI implements real bash semantics) but would silently produce garbage values under Coolify.
2. **An unset `${VAR}` reaches the container as an empty string, not an absent key.** The server's own `required(name, fallback)` in `config.ts` applies its fallback via `??`, which an empty string does not trigger — so relying on the app's fallback for a Coolify-interpolated var crashes it (`Missing required env var: ...`) instead of using the fallback. The default has to live in the compose file's `${VAR:-default}` interpolation instead.
3. **A (now-fixed) Coolify platform bug** ([coollabsio/coolify#11664](https://github.com/coollabsio/coolify/issues/11664), fixed in v4.3.19) could corrupt a saved domain into a bare `https://` with no host, aborting every subsequent deploy with `The string 'https://' is no valid url.` Unrelated to this repo; documented so a future self-hoster hitting that exact error knows to update Coolify rather than debug the compose file.

## Related issue

Closes #97

## Checklist

- [x] I discussed non-trivial changes in an issue first. (#97)
- [ ] Tests pass locally (`npm test` / `cargo test` as relevant). — N/A, this change only adds deploy config/docs, no application code.
- [ ] I added or updated tests for my change. — N/A, same reason.
- [x] New source files include `SPDX-License-Identifier: Apache-2.0`. — N/A, added files are Compose YAML / Markdown / `.env.example`, consistent with `deploy/compose/`'s existing files (none of which carry the header either).
- [x] No secrets, credentials, or `.env` files are committed.
- [x] I did not break the core invariants (doc_id identity, binary-only wire, `.context/` untouched, load-bearing debounce timings). — unrelated to this change (deploy config only).
