### PR TITLE
Release v0.1.58

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.57",
+  "version": "0.1.58",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.57"
+version = "0.1.58"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump across the four release files (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`) so the promotion to `main` ships and running apps auto-update.

Ships #134 — the note-doubling fix: `coldApply` no longer re-ingests the update it is about to apply, three more ingest races closed in `NoteBridge`, bridge teardown no longer drops un-persisted updates, and the size ceiling bounds the doc rather than each message.