### PR TITLE
Checkpoint capture counts skipped notes instead of logging one line each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -613,6 +613,19 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   the vault (switching vaults starts a fresh strip).
 
 ### Fixed
+- **One daily checkpoint could drown out every other server log.**
+  `captureCheckpoint` walked a vault's notes and `console.warn`ed a line per
+  note it skipped, for two reasons that are both ORDINARY at scale: a note
+  whose CRDT has not reached the server yet (every freshly-synced client has
+  thousands) and a note over `MAX_CHECKPOINT_DOC_BYTES`. On a 4,445-note vault
+  in production that was thousands of lines from one routine housekeeping pass,
+  which pushed the service past the host's 500 logs/sec ceiling — and over that
+  ceiling messages are DROPPED, so a scheduled snapshot could cost us the logs
+  for whatever else happened in that second. The two cases are now counted, not
+  narrated: at most five ids apiece are sampled and the remainder summarised
+  (`a, b, c …+97 more`) in a single line per vault that also reports how many of
+  the vault's notes were captured. Knowing which individual note was skipped was
+  never worth the rest of the log.
 - **A note could double one block of its own text, geometrically, until it was
   megabytes of one paragraph.** `vaultDocStore.coldApply` opens a TRANSIENT
   bridge for a background note — a fresh `Y.Doc`, so a fresh clientID every

--- a/app/apps/server/src/versions/checkpoints.ts
+++ b/app/apps/server/src/versions/checkpoints.ts
@@ -141,6 +141,18 @@ export async function captureCheckpoint(
   );
 
   let noteCount = 0;
+  // Counted, not logged per note. Both of these are ORDINARY for a large vault
+  // — a freshly-synced client has thousands of notes whose CRDT has not arrived
+  // yet — and a line apiece made one daily checkpoint emit thousands of them:
+  // in production a 4,445-note vault buried every other log line and tripped
+  // the host's 500 logs/sec ceiling, which DROPS messages. Losing the rest of
+  // the log to a routine housekeeping pass is worse than not knowing which
+  // individual note was skipped, so the ids are sampled and the rest counted.
+  let emptyCount = 0;
+  let oversizedCount = 0;
+  const skippedEmpty: string[] = [];
+  const skippedOversized: string[] = [];
+  const SAMPLE = 5;
   for (const note of structure.notes) {
     const raw = await opts.docWriter.peekContent(vaultId, note.id);
     // NUL would abort the whole checkpoint transaction (see `pgText`).
@@ -151,11 +163,13 @@ export async function captureCheckpoint(
     // data-loss this feature exists to prevent. Structure keeps the note; the
     // revert leaves its content alone.
     if (content == null) {
-      console.warn(`[checkpoints] no server content yet for ${note.id}; structure-only`);
+      if (skippedEmpty.length < SAMPLE) skippedEmpty.push(note.id);
+      emptyCount++;
       continue;
     }
     if (Buffer.byteLength(content, "utf8") > MAX_CHECKPOINT_DOC_BYTES) {
-      console.warn(`[checkpoints] skipping oversized doc ${note.id} in vault ${vaultId}`);
+      if (skippedOversized.length < SAMPLE) skippedOversized.push(note.id);
+      oversizedCount++;
       continue;
     }
     await db.query(
@@ -167,8 +181,28 @@ export async function captureCheckpoint(
     noteCount++;
   }
 
+  if (emptyCount > 0 || oversizedCount > 0) {
+    const parts: string[] = [];
+    if (emptyCount > 0) {
+      parts.push(`${emptyCount} with no server content yet (${sample(skippedEmpty, emptyCount)})`);
+    }
+    if (oversizedCount > 0) {
+      parts.push(`${oversizedCount} oversized (${sample(skippedOversized, oversizedCount)})`);
+    }
+    console.warn(
+      `[checkpoints] vault ${vaultId}: captured ${noteCount}/${structure.notes.length} notes; ` +
+        `structure-only for ${parts.join(", ")}`,
+    );
+  }
+
   await pruneCheckpoints(db, vaultId, [id, ...(opts.excludeFromPrune ?? [])]);
   return { id, noteCount };
+}
+
+/** `a, b, c …+97 more` — enough to chase one, never enough to flood. */
+function sample(ids: string[], total: number): string {
+  const more = total - ids.length;
+  return more > 0 ? `${ids.join(", ")} …+${more} more` : ids.join(", ");
 }
 
 /**


### PR DESCRIPTION
## Why

`captureCheckpoint` walked a vault's notes and `console.warn`ed a line for every note it skipped. Two reasons make a note skippable, and both are **ordinary** at scale:

- its CRDT has not reached the server yet (a freshly-synced client has thousands)
- it is over `MAX_CHECKPOINT_DOC_BYTES`

On a 4,445-note vault in production that meant thousands of lines from one routine housekeeping pass, pushing the service past the host's 500 logs/sec ceiling. Over that ceiling messages are **dropped**, so a scheduled snapshot could cost us the logs for everything else happening in that second.

## What changed

Both cases are counted rather than narrated. At most five ids apiece are sampled, the remainder summarised as `a, b, c …+97 more`, and the pass emits a single line per vault that also reports how many of the vault's notes were captured.

Knowing which individual note was skipped was never worth losing the rest of the log.

## Scope

Server-side logging only. No behaviour change to what is captured, skipped, or pruned.

## Testing

- `tests/checkpoints.test.ts` — 12 passed, against a scratch database
- `tsc --noEmit` clean on the server workspace

No user-visible surface, so `docs/RELEASE_NOTES.md` is unchanged. `CHANGELOG.md` Unreleased → Fixed has the entry.