### PR TITLE
Connect to the vault almost immediately, and stop the badge re-syncing what is already synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ## [Unreleased]
 
 ### Performance
+- **Time to connect, on launch and on every vault switch.** The vault channel is
+  now opened during the PRIME window, in parallel with `registry.reconcile()`,
+  instead of after it (`docSession.ts enable`). The collection id is the only
+  thing the socket needs and the prime has already read it out of
+  `.context/config.json`, so waiting cost the user the reconcile's whole serial
+  HTTP chain first. Safe because `enabled` and `pulledOnce` both stay false until
+  the reconcile returns, which is what gates uploads, `markLive` and the
+  revocation/disk-delete paths. Alongside it: the vault token is minted
+  concurrently with the TCP/TLS handshake rather than after `onopen`; the folder
+  and note listings are prefetched optimistically against the cached collection id
+  in parallel with the `listVaults` call that validates it; and `initAuth` no
+  longer holds the landing behind the member roster and both invitation lists
+  (`refreshVault({ rosterInBackground: true })` resolves once `organizations` is
+  published). New `[boot]` marks cover the whole WS phase — `channel-start`,
+  `socket-open`, `token-minted`, `hello-sent`, `channel-ready` — because nothing
+  after `reconcile-done` was measurable before.
+- **`ready` no longer merges the whole vault's CRDT history on every connect.**
+  `loadDocDiff`'s only fast answer lived on `doc_snapshots.state_vector`, which
+  exists solely for docs past `COMPACTION_THRESHOLD` (50) lifetime updates — so an
+  ordinary note took the slow path every time: an EXISTS probe, a snapshot read,
+  the full `doc_updates` log and a `Y.mergeUpdates` over its history, usually only
+  to conclude the client was already current. For a few-hundred-note vault that is
+  thousands of queries and hundreds of single-threaded merges in front of one
+  `ready` frame. Migration 025 adds `doc_state_vectors`, whose `upto_update_id`
+  watermark makes the cached vector trustworthy: a reader trusts it only when it
+  matches the log's current max id, so a racing append can never be mistaken for
+  "nothing changed". Written by the read path (self-backfilling for existing
+  docs); `appendUpdate` and `compact` deliberately do NOT maintain it — two
+  concurrent appends could stamp a watermark covering an update the vector never
+  saw, and a vector that is trusted and wrong withholds ops silently.
 - **Startup and note loading, Rust side.** CRDT state, state-vector manifests
   and attachment bytes now cross the desktop IPC boundary as raw bytes in both
   directions (framed; `src/lib/ipcCodec.ts` ↔ `commands.rs`) instead of JSON
@@ -21,6 +51,40 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   re-resolution pass. `open_vault` reports per-phase timings (on `VaultInfo`
   and as one log line) and `rebuild` logs one line unconditionally. Release
   builds now use thin LTO, one codegen unit and a stripped binary.
+
+### Fixed
+- **A client reauthed itself over its own registry writes.** Every
+  `registry-changed` ran `refreshAcl({ reauth: "if-changed" })` with no origin
+  self-exclusion, so a client's own pull registering notes grew its own readable
+  set, fired `reauth` straight back at it, tore the open note's provider down and
+  back up, and published the next `registry-changed`. An idle client did this nine
+  times in half an hour. The recompute still runs; the announcement is suppressed
+  for a change this connection authored (`reauth: "never"`).
+- **The sync badge described the open note, not the vault.** `emitStatus` gave one
+  note's provider status priority over the vault channel, so every file you opened
+  repainted the vault-wide pill "connecting" and every provider bounce strobed it.
+  The note now speaks for the app only when it has something the channel cannot
+  express (`read-only`, `no-access`, `deleted`, `too-large`); its ordinary connect
+  churn stays on its own sidebar row. A drop out of a settled state is also held
+  ~400ms, so a reconnect that resolves inside the window is never painted, and a
+  deliberate token re-mint no longer reports itself as `offline`.
+- **A vault switch dropped inbound updates permanently.** `drainInbound` caught a
+  Rust `vault-mismatch` per frame and carried on, so a whole backfill was discarded
+  one doc at a time — and because a dropped frame never advances the doc's state
+  vector, the server re-offered exactly the same ops on the next connect, forever
+  if the engine outlived its epoch. A stale epoch now stops the engine.
+- **A view-only note could never finish syncing.** `ContentUploader.pushOne`
+  waited for a flush ack that a read-only grant will never produce, failed, and so
+  never reached `markPushed` — coming back on every `ready.behind`. It now takes
+  the same exemption `confirmOpenDoc` has always taken.
+- **Reconnects paused for seconds and never said why.** The backoff ladder spent
+  ~3.5s across three laps before discovering a server that was already back; the
+  first retry is now near-immediate (50ms) with the jittered ladder from the
+  second onward. `ws.onerror` discarded its event and `closeSocket` detached
+  `onclose` before the close frame could land, which is why every failure logged
+  as a bare "socket error" with no cause; the close handler now survives the
+  detach, and the server sends real close codes (`4401` auth, `4400` protocol)
+  so a refused credential stops the ladder instead of being retried.
 
 ### Changed
 - **Pressing Private seals the vault, for the person who pressed it too.** The

--- a/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
+++ b/app/apps/desktop/src/lib/__tests__/vaultSyncEngine.test.ts
@@ -258,10 +258,18 @@ describe("VaultSyncEngine", () => {
 
     created[0].onclose?.(null); // disconnect
     expect(scheduled).toHaveLength(1);
-    expect(scheduled[0].ms).toBe(500); // 1000 * 2^0 * 0.5
+    // The FIRST retry ignores `baseMs` and goes almost immediately: a drop is
+    // nearly always a server that is coming straight back, and making the user
+    // watch a backoff ladder for that is the whole reason reconnects felt slow.
+    expect(scheduled[0].ms).toBe(25); // IMMEDIATE_RETRY_MS 50 * 0.5
 
     scheduled[0].fn(); // fire the reconnect
     expect(created).toHaveLength(2);
+
+    // From here the ladder is the ordinary jittered exponential one.
+    created[1].onclose?.(null);
+    expect(scheduled).toHaveLength(2);
+    expect(scheduled[1].ms).toBe(1000); // 1000 * 2^1 * 0.5
   });
 });
 

--- a/app/apps/desktop/src/lib/perf.ts
+++ b/app/apps/desktop/src/lib/perf.ts
@@ -33,6 +33,19 @@ function emit(line: string): void {
   if (!attached) early.push(line);
 }
 
+// Stages that repeat — the vault channel reconnects, and a vault switch runs the
+// whole connect chain again — still want ONE line on the launch timeline. Marking
+// every lap would bury the boot numbers under a reconnect storm, which is exactly
+// the condition we most need the timeline to stay readable through.
+const once = new Set<string>();
+
+/** `mark`, but only the first time this stage is reached in this session. */
+export function markOnce(name: string): void {
+  if (once.has(name)) return;
+  once.add(name);
+  mark(name);
+}
+
 export function mark(name: string): void {
   const at = performance.now();
   try {

--- a/app/apps/desktop/src/lib/sync/__tests__/docSessionEnablePhases.test.ts
+++ b/app/apps/desktop/src/lib/sync/__tests__/docSessionEnablePhases.test.ts
@@ -273,10 +273,15 @@ describe("SyncManager.enable — the prime window", () => {
     expect(sm.isSyncable()).toBe(true);
   });
 
-  it("re-suppresses the note opened in the window on the store the engine creates", async () => {
-    // `openDoc` sets the suppressed doc on the store that exists at open time —
-    // which during the window is null. A fresh store that doesn't know about the
-    // open note makes the background feed a SECOND writer on its Y.Doc.
+  it("suppresses the note opened in the window, and keeps the channel it already started", async () => {
+    // The invariant: the background feed must never become a SECOND writer on the
+    // Y.Doc of a note that already has a provider.
+    //
+    // The channel now opens during the PRIME window (in parallel with the
+    // reconcile, which is what makes connecting fast), so the store exists before
+    // the note is opened and `openDoc` suppresses on it directly. The post-
+    // reconcile call must then NOT build a second store — that would both drop the
+    // head start and resurrect the two-writer bug from the other side.
     const held = gate();
     fakeRegistry.reconcile.mockImplementation(async () => {
       await held.waited;
@@ -290,13 +295,18 @@ describe("SyncManager.enable — the prime window", () => {
       epoch: 1,
     });
     await flush();
+    // The prime read the collection id out of config.json, so the channel is
+    // already up before the reconcile has made a single request.
+    expect(storeHooks.created).toBe(1);
+
     await sm.openDoc(bridge(), MAPPED);
-    expect(storeHooks.created).toBe(0); // no engine yet
+    expect(storeHooks.suppressed).toBe(MAPPED_DOC);
 
     held.open();
     await enabling;
     await flush();
 
+    // Still ONE store: the reconcile adopted the channel the prime started.
     expect(storeHooks.created).toBe(1);
     expect(storeHooks.suppressed).toBe(MAPPED_DOC);
   });

--- a/app/apps/desktop/src/lib/sync/contentUpload.ts
+++ b/app/apps/desktop/src/lib/sync/contentUpload.ts
@@ -483,7 +483,16 @@ export class ContentUploader {
         // stale file against the merged doc would DELETE those server ops.
         if (this.opts.ingestFromFile && !preIngested) await bridge.ingestNow();
       }
-      const flushed = await push.whenFlushed(this.flushTimeoutMs);
+      // A view-only grant has nothing to push: the seed and the ingest above were
+      // both skipped, and the server would refuse the write anyway — so there is
+      // no ack coming and waiting for one only ends in a spurious failure. The
+      // server's copy IS the content, which makes this doc confirmed.
+      //
+      // `confirmOpenDoc` has always taken this exemption; the bulk path did not,
+      // so a doc whose grant was downgraded while it still held local-only ops
+      // failed here on every pass, never reached `markPushed`, and came straight
+      // back on the next `ready.behind` — a re-sync that could never finish.
+      const flushed = push.readOnly || (await push.whenFlushed(this.flushTimeoutMs));
       // Whatever the server had for this doc has landed in the Y.Doc by now;
       // write it out so the .md on disk matches. (The watcher will see this
       // write, but every ingest side runs behind the bridge's echo-hash guard —

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -219,6 +219,28 @@ export function shouldReportOpenDocState(state: DocSyncState, confirmed: boolean
   return state === "synced" || !confirmed;
 }
 
+/**
+ * The open note's statuses that speak for the WHOLE app, not just that note.
+ *
+ * Each is something the vault channel has no way to express and the user has to
+ * know: a view-only grant, a doc the server refused or no longer has, one over
+ * the size cap. Everything outside this set ("connecting", "offline", "synced")
+ * is one note's socket doing ordinary work and belongs on its own row — see
+ * `effectiveStatus`.
+ */
+/** How long a drop out of a settled state must persist before it is painted. */
+const STATUS_HOLD_MS = 400;
+
+/** The states worth protecting from a blink — see `emitStatus`. */
+const STATUS_IS_GOOD: ReadonlySet<SyncStatus> = new Set<SyncStatus>(["synced", "read-only"]);
+
+const DOC_STATUS_OWNS_BADGE: ReadonlySet<SyncStatus> = new Set<SyncStatus>([
+  "read-only",
+  "no-access",
+  "deleted",
+  "too-large",
+]);
+
 export class SyncManager implements InboundHost {
   readonly registry = new VaultRegistry(api);
 
@@ -303,6 +325,10 @@ export class SyncManager implements InboundHost {
    * head start the early call exists to buy.
    */
   private vaultEngineId: string | null = null;
+  /** The last status actually handed to the UI, so `emitStatus` can tell a real
+   *  change from a repaint and know what it is protecting. */
+  private emittedStatus: SyncStatus | null = null;
+  private statusHoldTimer: ReturnType<typeof setTimeout> | null = null;
   private onVaultStatus?: (status: VaultSyncStatus) => void;
 
   // ---- push-to-talk voice ----
@@ -534,13 +560,68 @@ export class SyncManager implements InboundHost {
     }
   }
 
-  /** Push the effective status to the UI: an open networked note owns the
-   *  indicator; with none open we fall back to the always-on vault channel. */
+  /**
+   * Push the effective status to the UI.
+   *
+   * The vault channel is the app's connection; ONE note's provider is not. The
+   * open note used to own this indicator outright, which meant every note you
+   * opened repainted the vault-wide pill "connecting" while its provider did its
+   * own handshake — the app reported itself as re-syncing on every single file
+   * open, and a provider bounce (a token re-mint, a reauth) strobed the pill on
+   * a vault that had never actually disconnected.
+   *
+   * So the note only speaks for the whole app when it has something to say that
+   * the channel cannot express: permissions and per-doc terminal failures. Its
+   * ordinary connect churn stays on the note's own sidebar row, where
+   * `reportOpenDocState` already puts it.
+   */
   private emitStatus(): void {
-    const effective = this.current
-      ? (this.docStatus ?? this.current.status)
-      : this.vaultStatusAsSync();
-    this.onStatus?.(effective);
+    const next = this.effectiveStatus();
+    if (next === this.emittedStatus) return;
+    // Settling INTO a good state is always immediate — nobody wants green held
+    // back. Only the drop OUT of one waits, and only briefly: a reconnect that
+    // resolves inside the window never reaches the UI at all, which is what turns
+    // a token re-mint or a server blip from a visible strobe into nothing. The
+    // status is still correct the moment it matters; it is simply not repainted
+    // for a blink that is already over.
+    const leavingGood =
+      (this.emittedStatus === "synced" || this.emittedStatus === "read-only") &&
+      !STATUS_IS_GOOD.has(next);
+    if (!leavingGood) {
+      this.clearStatusHold();
+      this.publishStatus(next);
+      return;
+    }
+    if (this.statusHoldTimer) return; // a hold is already running
+    this.statusHoldTimer = setTimeout(() => {
+      this.statusHoldTimer = null;
+      const settled = this.effectiveStatus();
+      if (settled !== this.emittedStatus) this.publishStatus(settled);
+    }, STATUS_HOLD_MS);
+  }
+
+  private publishStatus(s: SyncStatus): void {
+    this.emittedStatus = s;
+    this.onStatus?.(s);
+  }
+
+  private clearStatusHold(): void {
+    if (!this.statusHoldTimer) return;
+    clearTimeout(this.statusHoldTimer);
+    this.statusHoldTimer = null;
+  }
+
+  private effectiveStatus(): SyncStatus {
+    const vault = this.vaultStatusAsSync();
+    if (!this.current) return vault;
+    const doc = this.docStatus ?? this.current.status;
+    // Permissions and terminal per-doc failures must reach the pill: nothing
+    // else in the UI tells the user this note is view-only, gone, or too big.
+    if (DOC_STATUS_OWNS_BADGE.has(doc)) return doc;
+    // Otherwise a healthy channel means the app IS connected, whatever this one
+    // note's socket is doing. Only when the channel itself is unhealthy does the
+    // note's view of the world add anything.
+    return vault === "synced" ? "synced" : doc;
   }
 
   /** Record the open note's provider status and re-emit the effective status.
@@ -2346,6 +2427,10 @@ export class SyncManager implements InboundHost {
   private teardown(): void {
     this.enabled = false;
     this.primed = false;
+    // A pending badge hold belongs to the vault we are leaving; letting it fire
+    // would paint that vault's status over the next one's.
+    this.clearStatusHold();
+    this.emittedStatus = null;
     this.presence = null;
     this.viewingDocId = null;
     this.vaultStatus = "idle";

--- a/app/apps/desktop/src/lib/sync/docSession.ts
+++ b/app/apps/desktop/src/lib/sync/docSession.ts
@@ -15,6 +15,7 @@ import type { NoteBridge } from "../bridge";
 import { bridgeManager, createTauriBridgeIO, sha256Hex } from "../bridge/adapter";
 import type { NoteLastEdited, SessionInfo } from "../api";
 import * as ipc from "../ipc";
+import { markOnce } from "../perf";
 import { api } from "../auth/authManager";
 import { colorForUser, presenceUser } from "../presence/color";
 import type { ActivityStatus } from "../prefs";
@@ -293,6 +294,15 @@ export class SyncManager implements InboundHost {
   // opening it. Present only while sync is enabled.
   private docStore: VaultDocStore | null = null;
   private vaultEngine: VaultSyncEngine | null = null;
+  /**
+   * The collection id {@link vaultEngine} was started for.
+   *
+   * `startVaultEngine` is called TWICE per enable — once during the prime window
+   * and once after the reconcile (see `enable`) — so it needs to recognise a
+   * channel it already owns. Restarting a live one would discard precisely the
+   * head start the early call exists to buy.
+   */
+  private vaultEngineId: string | null = null;
   private onVaultStatus?: (status: VaultSyncStatus) => void;
 
   // ---- push-to-talk voice ----
@@ -1940,6 +1950,20 @@ export class SyncManager implements InboundHost {
         // Sidebar badges + `store.docIdByPath`, immediately.
         this.publishRegistryMap();
         hooks?.onPrimed?.();
+        // OPEN THE CHANNEL NOW, alongside the reconcile below rather than after
+        // it. The collection id is the only thing the socket needs and the prime
+        // just read it out of `.context/config.json`, so waiting costs the user
+        // the reconcile's whole serial HTTP chain (listVaults, then folders and
+        // notes) before the connection even starts — seconds, on every launch and
+        // every vault switch.
+        //
+        // Safe because the two flags that gate anything destructive are still
+        // false: `enabled` (which `startContentRunIfNeeded` requires, so nothing
+        // uploads) and `pulledOnce` (so `markLive` cannot arm, and the revocation
+        // and disk-delete paths stay inert). All the early socket can do is
+        // backfill content for docs the prime already mapped — which is exactly
+        // the work we want overlapped.
+        this.startVaultEngine(scope);
       }
     } catch (e) {
       console.warn("[sync] local prime failed; falling back to reconcile-first", e);
@@ -2535,7 +2559,12 @@ export class SyncManager implements InboundHost {
   private startVaultEngine(scope: VaultScope): void {
     const vaultId = this.registry.vaultId;
     if (!vaultId) return;
+    // Already live for this collection (the prime window got there first) — leave
+    // it alone. See `vaultEngineId`.
+    if (this.vaultEngine && this.vaultEngineId === vaultId) return;
     this.stopVaultEngine();
+    this.vaultEngineId = vaultId;
+    markOnce("channel-start");
     // Reflect "connecting" the moment we switch into a vault, so the light
     // moves off a stale value before the socket reports back.
     this.vaultStatus = "connecting";
@@ -2651,6 +2680,7 @@ export class SyncManager implements InboundHost {
   private stopVaultEngine(): void {
     this.vaultEngine?.stop();
     this.vaultEngine = null;
+    this.vaultEngineId = null;
     // Cut any audio still playing: it belongs to the vault we're leaving, and
     // hearing a teammate from the previous vault after switching would be a bug
     // with an unpleasant privacy flavour.

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -339,8 +339,29 @@ function reasonOf(err: unknown): string {
   return String(err);
 }
 
+/** The shapes `listFolderRegistry` / `listNoteRegistry` resolve to, named here so
+ *  the optimistic prefetch can hold onto them. Inferred rather than re-declared,
+ *  so they cannot drift from the api client. */
+type FolderRegistry = Awaited<ReturnType<ApiClient["listFolderRegistry"]>>;
+type NoteRegistry = Awaited<ReturnType<ApiClient["listNoteRegistry"]>>;
+
 export class VaultRegistry {
   private serverVaultId: string | null = null;
+  /**
+   * The folder + note listings, started OPTIMISTICALLY against the collection id
+   * `.context/config.json` already names, in parallel with the `listVaults` call
+   * whose only job is to validate that id.
+   *
+   * On every warm relaunch the cached id is correct, so this takes a whole
+   * serial round trip out of the launch chain. When validation resolves a
+   * DIFFERENT collection the prefetch is simply discarded and the listings are
+   * re-issued — the id is the cache key precisely so a wrong guess cannot be
+   * mistaken for the right one.
+   */
+  private prefetchedListings: {
+    vaultId: string;
+    p: Promise<[FolderRegistry, NoteRegistry]>;
+  } | null = null;
   /** The org this registry is reconciling under (see `VaultSyncConfig.organizationId`). */
   private organizationId: string | null = null;
   private byPath = new Map<string, DocMapping>();
@@ -1498,6 +1519,9 @@ export class VaultRegistry {
     //         collection (and 403 for plain members, who can't create them),
     //         which is why a freshly-joined device saw an empty vault;
     //      c. create one (owner/admin bootstrapping a brand-new vault).
+    // Start the listings for the id we already believe in, so they fly alongside
+    // the validation rather than behind it. See `prefetchedListings`.
+    if (cfg.serverVaultId) this.prefetchListings(cfg.serverVaultId);
     const vaults = await this.api.listVaults();
     if (this.stale()) return { seeded: false };
     const inOrg = vaults.filter((v) => vaultOrgId(v) === input.organizationId);
@@ -1659,6 +1683,40 @@ export class VaultRegistry {
     return run;
   }
 
+  /**
+   * Kick the folder + note listings for `vaultId` without awaiting them. Idempotent
+   * per collection id: a second call for the same id reuses the flight in progress.
+   */
+  private prefetchListings(vaultId: string): void {
+    if (this.prefetchedListings?.vaultId === vaultId) return;
+    const p = Promise.all([
+      this.api.listFolderRegistry(vaultId),
+      this.api.listNoteRegistry(vaultId),
+    ]) as Promise<[FolderRegistry, NoteRegistry]>;
+    // The consumer awaits this and handles the failure; attach here so a reject
+    // that arrives before `takeListings` runs is never an unhandled rejection.
+    p.catch(() => {
+      /* surfaced at the await in takeListings */
+    });
+    this.prefetchedListings = { vaultId, p };
+  }
+
+  /**
+   * The listings for `vaultId`, using the optimistic prefetch when it was started
+   * for this same collection. Consumed once — a later pull re-issues them, because
+   * these describe the server as of one moment and a pull's whole job is to ask
+   * again.
+   */
+  private async takeListings(vaultId: string): Promise<[FolderRegistry, NoteRegistry]> {
+    const hit = this.prefetchedListings;
+    this.prefetchedListings = null;
+    if (hit && hit.vaultId === vaultId) return hit.p;
+    return Promise.all([
+      this.api.listFolderRegistry(vaultId),
+      this.api.listNoteRegistry(vaultId),
+    ]) as Promise<[FolderRegistry, NoteRegistry]>;
+  }
+
   private async pullOnce(): Promise<boolean> {
     // Scope-guarded because this is THE historical corruption path: a debounced
     // pull that survived a vault switch still held vault A's `serverVaultId`
@@ -1699,10 +1757,7 @@ export class VaultRegistry {
     // back from "N not synced" even after the underlying cause was gone.
     this.failed = [];
     this.limitReached = null;
-    const [folderRegistry, noteRegistry] = await Promise.all([
-      this.api.listFolderRegistry(vaultId),
-      this.api.listNoteRegistry(vaultId),
-    ]);
+    const [folderRegistry, noteRegistry] = await this.takeListings(vaultId);
     if (this.stale()) return false;
     const serverFolders = folderRegistry.folders;
     let serverNotes = noteRegistry.notes;

--- a/app/apps/desktop/src/lib/sync/registry.ts
+++ b/app/apps/desktop/src/lib/sync/registry.ts
@@ -1780,7 +1780,20 @@ export class VaultRegistry {
     // to resolve. Memoized so the two of them share one read when they do.
     let titlesCache: ipc.NoteTitle[] | null = null;
     const titles = async (): Promise<ipc.NoteTitle[]> =>
-      (titlesCache ??= await ipc.listNoteTitles(this.epoch()));
+      (titlesCache ??= await (async () => {
+        // Timed, because this is the one call on the launch path that can park
+        // for seconds on a lock nothing here controls. When a launch is slow and
+        // the network numbers look fine, this is where to look first.
+        const started = performance.now();
+        const rows = await ipc.listNoteTitles(this.epoch());
+        const ms = Math.round(performance.now() - started);
+        if (ms > 250) {
+          console.warn(
+            `[sync] listNoteTitles parked ${ms}ms on the index lock (${rows.length} notes)`,
+          );
+        }
+        return rows;
+      })());
 
     // Learn who wrote what, BEFORE any of the steps below and outside the inbound
     // guard: the very first pass of a fresh vault has no baseline and so runs no

--- a/app/apps/desktop/src/lib/sync/syncManager.ts
+++ b/app/apps/desktop/src/lib/sync/syncManager.ts
@@ -304,6 +304,12 @@ export class DocSync {
           if (isTerminalSyncStatus(this._status)) return;
           this.setStatus("connecting");
         } else if (status === "disconnected") {
+          // A re-mint we asked for ourselves is not an outage. `refreshAccess`
+          // deliberately drops the socket to pick up a new token (a reauth, a TTL
+          // refresh), and reporting that as "offline" is what made the badge
+          // strobe synced→offline→connecting→synced on an ACL announcement about
+          // somebody else's note. The reconnect is already in flight.
+          if (this.reconnectPending) return;
           if (!isTerminalSyncStatus(this._status)) this.setStatus("offline");
         }
       },

--- a/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
+++ b/app/apps/desktop/src/lib/sync/vaultSyncEngine.ts
@@ -11,6 +11,7 @@
 // CodeMirror — it moves opaque Yjs updates to the sink.
 
 import { ApiClient, ApiError } from "../api";
+import { markOnce } from "../perf";
 import type { ActivityStatus } from "../prefs";
 import {
   bytesToBase64,
@@ -78,6 +79,9 @@ type WsFactory = (url: string) => WebSocketLike;
 /** The slice of the WebSocket API the engine uses (so tests can fake it). */
 export interface WebSocketLike {
   binaryType: string;
+  /** CONNECTING/OPEN/CLOSING/CLOSED. Optional so test fakes need not model it;
+   *  it is only read to say WHY a connection failed, never to decide anything. */
+  readonly readyState?: number;
   send(data: string | ArrayBufferLike | ArrayBufferView): void;
   close(): void;
   onopen: ((ev: unknown) => void) | null;
@@ -204,6 +208,40 @@ export interface VaultSyncEngineOptions {
 export const INBOUND_QUEUE_MAX_BYTES = 8 * 1024 * 1024;
 
 /**
+ * Close codes the vault channel understands, in the 4000-4999 application range.
+ *
+ * The server used to close every failure with a bare `ws.close()` (1005, "no
+ * status") or `terminate()` (1006), which left the client unable to tell a
+ * rejected token from a rebooting server — so it blind-retried both. These two
+ * codes are the contract that lets a fatal failure stop the ladder immediately.
+ * Keep in lockstep with `server/src/sync/vault-channel.ts`.
+ */
+export const WS_CLOSE_UNAUTHORIZED = 4401;
+export const WS_CLOSE_PROTOCOL = 4400;
+
+/**
+ * Delay before the FIRST reconnect attempt. Not zero — a server that refuses
+ * instantly would otherwise spin the event loop — but short enough that a dev
+ * server bounce or a dropped wifi frame costs a blink rather than a visible
+ * stall on the sync badge.
+ */
+const IMMEDIATE_RETRY_MS = 50;
+
+/**
+ * Rust refusing a call because the vault moved out from under its caller.
+ *
+ * Matched on the marker string rather than by importing `ipc.isVaultMismatch`,
+ * because this engine deliberately depends on nothing that touches disk or Tauri
+ * — it runs under vitest in Node. The contract is `VAULT_MISMATCH` in
+ * `src-tauri/src/commands.rs`; change one, change both.
+ */
+function isVaultMismatch(err: unknown): boolean {
+  return typeof err === "string"
+    ? err.startsWith("vault-mismatch")
+    : err instanceof Error && err.message.startsWith("vault-mismatch");
+}
+
+/**
  * Derive the vault channel's WebSocket URL. Unlike the per-doc `deriveWsUrl`
  * (which bumps a local :3010 to the dedicated Hocuspocus :3011), the vault
  * channel ALWAYS lives on the HTTP port at `/vault-sync` — same origin, scheme
@@ -247,6 +285,15 @@ export class VaultSyncEngine {
   private readonly clearTimeoutImpl: (h: ReturnType<typeof setTimeout>) => void;
 
   private ws: WebSocketLike | null = null;
+  /**
+   * The vault token being minted for the CURRENT connect attempt.
+   *
+   * Started in `connect()` so the mint overlaps the socket handshake, and
+   * awaited in `onOpen()`. Cleared on every disconnect: a token is scoped to the
+   * attempt that asked for it, and reusing one across a reconnect would re-send
+   * credentials the server may have just refused.
+   */
+  private tokenPromise: Promise<string> | null = null;
   private status: VaultSyncStatus = "idle";
   private stopped = false;
   private attempt = 0;
@@ -311,7 +358,7 @@ export class VaultSyncEngine {
     this.inboundMaxBytes = opts.inboundQueueMaxBytes ?? INBOUND_QUEUE_MAX_BYTES;
     this.wsFactory =
       opts.wsFactory ?? ((url) => new WebSocket(url) as unknown as WebSocketLike);
-    this.baseMs = opts.reconnect?.baseMs ?? 500;
+    this.baseMs = opts.reconnect?.baseMs ?? 150;
     this.maxMs = opts.reconnect?.maxMs ?? 15_000;
     this.random = opts.random ?? Math.random;
     this.setTimeoutImpl = opts.setTimeoutImpl ?? ((fn, ms) => setTimeout(fn, ms));
@@ -440,6 +487,19 @@ export class VaultSyncEngine {
 
   private connect(): void {
     this.setStatus("connecting");
+    // Mint the vault token NOW, alongside the TCP/TLS/upgrade handshake instead
+    // of after it. Nothing about the mint depends on the socket existing, so
+    // doing them in sequence (which is what waiting until `onopen` meant) made
+    // every connect pay both latencies end to end. `onOpen` awaits this.
+    //
+    // Attached immediately so a rejection can never surface as an unhandled
+    // rejection while the handshake is still in flight; `onOpen` does the real
+    // error handling, including the 403 that stops the retry ladder.
+    const minting = this.api.vaultSyncToken(this.vaultId).then((r) => r.token);
+    minting.catch(() => {
+      /* handled in onOpen */
+    });
+    this.tokenPromise = minting;
     let ws: WebSocketLike;
     try {
       ws = this.wsFactory(this.wsUrl);
@@ -450,26 +510,59 @@ export class VaultSyncEngine {
     ws.binaryType = "arraybuffer";
     this.ws = ws;
 
-    ws.onopen = () => void this.onOpen();
+    ws.onopen = () => {
+      markOnce("socket-open");
+      void this.onOpen();
+    };
     ws.onmessage = (ev) => void this.onMessage(ev.data);
     ws.onclose = (ev) => {
-      const e = ev as { code?: number; reason?: string; wasClean?: boolean } | undefined;
-      console.warn(
-        `[vault-sync] socket closed code=${e?.code ?? "?"} reason=${JSON.stringify(e?.reason ?? "")} clean=${e?.wasClean ?? "?"}`,
-      );
+      // A close code the server chose is the ONLY signal that distinguishes
+      // "your token is bad" from "the server is rebooting". Read it before
+      // deciding whether to keep retrying.
+      if (this.handleClose(ev)) return;
       this.onDisconnect();
     };
     ws.onerror = () => {
-      console.warn("[vault-sync] socket error");
+      // The Event carries nothing useful, so log the state we DO have. When the
+      // socket never opened at all this is a TCP/TLS/upgrade failure — refused
+      // connection, wrong port, or a path the server's upgrade handler destroys
+      // — and no close frame is coming to explain it.
+      console.warn(
+        `[vault-sync] socket error readyState=${ws.readyState ?? "?"} attempt=${this.attempt} url=${this.wsUrl}`,
+      );
       this.onDisconnect();
     };
+  }
+
+  /**
+   * Log a close frame and decide whether it is fatal. Returns true when the
+   * engine has stopped and the caller must NOT schedule a reconnect.
+   *
+   * `4401` is the server saying the vault token was rejected: retrying with the
+   * same credentials just burns the ladder, exactly as an HTTP 403 from the mint
+   * does. Everything else is treated as transient.
+   */
+  private handleClose(ev: unknown): boolean {
+    const e = ev as { code?: number; reason?: string; wasClean?: boolean } | undefined;
+    console.warn(
+      `[vault-sync] socket closed code=${e?.code ?? "?"} reason=${JSON.stringify(e?.reason ?? "")} clean=${e?.wasClean ?? "?"} attempt=${this.attempt}`,
+    );
+    if (e?.code === WS_CLOSE_UNAUTHORIZED) {
+      this.stopped = true;
+      this.closeSocket();
+      this.setStatus("no-access");
+      return true;
+    }
+    return false;
   }
 
   private async onOpen(): Promise<void> {
     // Mint the vault token; a 403 means we're not a member — stop retrying.
     let token: string;
     try {
-      token = (await this.api.vaultSyncToken(this.vaultId)).token;
+      token = await (this.tokenPromise ??
+        this.api.vaultSyncToken(this.vaultId).then((r) => r.token));
+      markOnce("token-minted");
     } catch (err) {
       if (err instanceof ApiError && err.status === 403) {
         this.stopped = true;
@@ -511,6 +604,7 @@ export class VaultSyncEngine {
       }),
     );
     this.helloSent = true;
+    markOnce("hello-sent");
     // First announce rides right behind the hello. Waiting for `ready` meant a
     // teammate connecting to a big vault stayed invisible — and saw nobody,
     // because the roster re-announce round is triggered by this very frame —
@@ -557,6 +651,9 @@ export class VaultSyncEngine {
         // applied, so this is the edge that settles the download phase. Checking
         // only on drain would strand it: no further frame is coming to trigger one.
         this.maybeSignalIdle();
+        // The one mark that answers "how long until the app is actually live?" —
+        // `ready` is the only frame that turns the badge green.
+        markOnce("channel-ready");
         this.setStatus("synced");
         // (Re)announce our presence now the channel is live — covers first
         // connect and every reconnect so teammates never see us go stale.
@@ -688,6 +785,21 @@ export class VaultSyncEngine {
       try {
         await this.sink.applyUpdate(frame.docId, frame.update);
       } catch (err) {
+        // A stale vault epoch is not a per-frame failure — it means Rust has
+        // swapped vaults underneath this engine, so EVERY remaining frame will
+        // fail the same way. Logging and carrying on (what this used to do)
+        // dropped a whole backfill one doc at a time, and because a dropped frame
+        // never advances the doc's state vector the server re-offered exactly the
+        // same ops on the next connect. If the engine outlives its epoch that
+        // repeats forever, which is the permanent re-sync loop.
+        if (isVaultMismatch(err)) {
+          console.warn(
+            `[vault-sync] vault epoch is stale — stopping this engine (${this.inbound.length} frames dropped)`,
+            err,
+          );
+          this.stop();
+          return;
+        }
         console.warn(`[vault-sync] applyUpdate failed for ${frame.docId}`, err);
       }
       if (frame.counted) {
@@ -720,7 +832,17 @@ export class VaultSyncEngine {
   private scheduleReconnect(): void {
     if (this.stopped || this.reconnectTimer) return;
     // Exponential backoff with 50–100% jitter (spec 05 §4 anti-stampede).
-    const backoff = Math.min(this.maxMs, this.baseMs * 2 ** this.attempt);
+    //
+    // The FIRST retry is near-immediate on purpose. By far the most common cause
+    // of a drop is a server that is restarting and will be listening again in
+    // well under a second; the old 500ms base spent ~3.5s across three laps
+    // before the client found that out, and the user watches every millisecond of
+    // it on the badge. Jitter from attempt 1 onward still covers the stampede
+    // case the backoff exists for.
+    const backoff =
+      this.attempt === 0
+        ? IMMEDIATE_RETRY_MS
+        : Math.min(this.maxMs, this.baseMs * 2 ** this.attempt);
     const delay = backoff * (0.5 + 0.5 * this.random());
     this.attempt++;
     this.reconnectTimer = this.setTimeoutImpl(() => {
@@ -730,10 +852,23 @@ export class VaultSyncEngine {
   }
 
   private closeSocket(): void {
+    this.tokenPromise = null;
     if (!this.ws) return;
     const ws = this.ws;
     this.ws = null;
-    ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+    ws.onopen = ws.onmessage = ws.onerror = null;
+    // `onclose` stays attached, deliberately. `onerror` fires with no detail, and
+    // it reaches us FIRST — so nulling the close handler here (as this used to)
+    // threw away the code/reason frame that was still in flight, which is why
+    // every failure in the log read as a bare "socket error" with no cause.
+    // It must not re-enter `onDisconnect`: whoever called us owns the reconnect.
+    ws.onclose = (ev) => {
+      const e = ev as { code?: number; reason?: string } | undefined;
+      if (e?.code === undefined) return; // nothing to add beyond what we logged
+      console.warn(
+        `[vault-sync] socket closed (after detach) code=${e.code} reason=${JSON.stringify(e.reason ?? "")}`,
+      );
+    };
     try {
       ws.close();
     } catch {

--- a/app/apps/desktop/src/store.ts
+++ b/app/apps/desktop/src/store.ts
@@ -542,7 +542,16 @@ interface AppStore {
   dismissMemberJoined: () => void;
 
   // Vault actions
-  refreshVault: () => Promise<void>;
+  /**
+   * Re-read the vault list, the member roster and both invitation lists.
+   *
+   * `rosterInBackground` resolves as soon as `organizations` is published and
+   * lets the three roster/invitation GETs finish detached. The launch path uses
+   * it because the landing's only dependency here is the vault list — see
+   * `planLanding`'s membership test — and awaiting the rest put three more
+   * round trips in front of every app start.
+   */
+  refreshVault: (opts?: { rosterInBackground?: boolean }) => Promise<void>;
   createOrganization: (name: string) => Promise<void>;
   /** Promote the currently-open local folder into a synced vault, adopting
    *  the files already in it (no new empty folder). This is "Turn on sync". */
@@ -2198,7 +2207,15 @@ export const useStore = create<AppStore>((set, get) => ({
         // Independent of each other: the vault roster + invitations, and the
         // billing feature flag. Serial, these were two round trips in front of
         // the landing for no reason.
-        await Promise.all([get().refreshVault(), get().refreshBillingConfig()]);
+        // The landing needs the vault LIST and nothing else from these two: the
+        // member roster, both invitation lists and the billing flag are panel
+        // data that no part of getting a vault on screen reads. Awaiting them
+        // here is what put four round trips between sign-in and the first byte
+        // of sync. `refreshVault` resolves once `organizations` is set.
+        await Promise.all([
+          get().refreshVault({ rosterInBackground: true }),
+          get().refreshBillingConfig(),
+        ]);
         if (superseded()) return;
         // An invitation link may have LAUNCHED the app too, and the vault it
         // names is where the user must land — so the ordinary landing is
@@ -2532,7 +2549,7 @@ export const useStore = create<AppStore>((set, get) => ({
 
   // ---- Vault ----
 
-  refreshVault: async () => {
+  refreshVault: async (opts) => {
     const { api } = authManager;
     // The session generation this refresh describes: called from `initAuth`
     // (detached, so a sign-out can land under it) as well as from live
@@ -2552,28 +2569,43 @@ export const useStore = create<AppStore>((set, get) => ({
         if (authInitGen !== gen) return;
         if (refreshed) set({ session: refreshed });
       }
-      // Three independent GETs. Run serially they were three round trips in the
-      // launch chain; none of them depends on another's answer.
-      const [members, pendingInvitations, userInvitations] = await Promise.all([
-        activeOrgId
-          ? api.listMembers(activeOrgId).catch(() => [] as Member[])
-          : Promise.resolve([] as Member[]),
-        activeOrgId
-          ? api
-              .listInvitations(activeOrgId)
-              .then((invs) => invs.filter((i) => i.status === "pending"))
-              .catch(() => [] as Invitation[])
-          : Promise.resolve([] as Invitation[]),
-        api
-          .listUserInvitations()
-          .then((invs) => invs.filter((i) => i.status === "pending"))
-          .catch(() => [] as Invitation[]),
-      ]);
       if (authInitGen !== gen) return;
-      set({ organizations, members, pendingInvitations, userInvitations });
+      // Publish the vault list the MOMENT we have it, ahead of the roster below.
+      // This is the only part of this call the landing waits on, and holding it
+      // back until three more GETs returned is what put them in front of every
+      // launch. Everything after this point is panel data.
+      set({ organizations });
       // Cache the vault list locally so the signed-out welcome screen can
       // still offer them (kept across sign-out; refreshed here while signed in).
       writeKnownVaults(organizations.map((o) => ({ id: o.id, name: o.name })));
+      // Three independent GETs. Run serially they were three round trips in the
+      // launch chain; none of them depends on another's answer.
+      const roster = (async () => {
+        const [members, pendingInvitations, userInvitations] = await Promise.all([
+          activeOrgId
+            ? api.listMembers(activeOrgId).catch(() => [] as Member[])
+            : Promise.resolve([] as Member[]),
+          activeOrgId
+            ? api
+                .listInvitations(activeOrgId)
+                .then((invs) => invs.filter((i) => i.status === "pending"))
+                .catch(() => [] as Invitation[])
+            : Promise.resolve([] as Invitation[]),
+          api
+            .listUserInvitations()
+            .then((invs) => invs.filter((i) => i.status === "pending"))
+            .catch(() => [] as Invitation[]),
+        ]);
+        if (authInitGen !== gen) return;
+        set({ members, pendingInvitations, userInvitations });
+      })();
+      // The launch path does not wait for the roster; every other caller (the
+      // members panel, an invite accept) still gets the full refresh it expects.
+      if (opts?.rosterInBackground) {
+        void roster.catch((e) => console.warn("[vault] roster refresh failed", e));
+        return;
+      }
+      await roster;
     } catch (e) {
       // A failure that belongs to a session the user has since left is not this
       // session's error to show.

--- a/app/apps/server/migrations/025_doc_state_vectors.sql
+++ b/app/apps/server/migrations/025_doc_state_vectors.sql
@@ -1,0 +1,27 @@
+-- Per-doc state vector, so "is this client already up to date?" can be answered
+-- without reading or merging the doc's update log.
+--
+-- The vault channel asks that question for EVERY readable doc on EVERY connect.
+-- Before this table the only fast answer lived on `doc_snapshots.state_vector`,
+-- which exists solely for docs that have passed `COMPACTION_THRESHOLD` (50)
+-- lifetime updates — so an ordinary note, edited a handful of times, had no
+-- snapshot row at all and took the slow path every single time: an EXISTS probe,
+-- a snapshot read, the whole `doc_updates` log, and a full `Y.mergeUpdates` over
+-- its history, usually only to conclude the client was already current. On a
+-- few-hundred-note vault that is thousands of queries and hundreds of
+-- single-threaded CRDT merges standing between the client and its `ready` frame.
+--
+-- `upto_update_id` is what makes the cached vector trustworthy: it records the
+-- `doc_updates.id` high-water mark the vector accounts for (NULL when the log is
+-- empty). A reader compares it against the doc's current max id, and only trusts
+-- the vector when they agree — so a racing append can never be mistaken for
+-- "nothing changed", which would silently withhold ops from a client.
+--
+-- Populated going forward by `appendUpdate`/`compact`, and lazily by the read
+-- path for docs that predate this migration, so no backfill job is needed.
+CREATE TABLE IF NOT EXISTS doc_state_vectors (
+  doc_id         TEXT PRIMARY KEY,
+  state_vector   BYTEA NOT NULL,
+  upto_update_id BIGINT,
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/app/apps/server/src/http/routes/orgs.ts
+++ b/app/apps/server/src/http/routes/orgs.ts
@@ -412,6 +412,9 @@ export function createOrgRoutes(deps: OrgDeps): Hono {
       if (docIds.length) {
         await client.query("DELETE FROM doc_updates WHERE doc_id = ANY($1)", [docIds]);
         await client.query("DELETE FROM doc_snapshots WHERE doc_id = ANY($1)", [docIds]);
+        // The cached state vectors describe state that no longer exists; leaving
+        // them would have a recreated doc_id inherit a stranger's clocks.
+        await client.query("DELETE FROM doc_state_vectors WHERE doc_id = ANY($1)", [docIds]);
       }
       await client.query("DELETE FROM blobs WHERE org_id = $1", [orgId]);
       if (vaultIds.length) {

--- a/app/apps/server/src/sync/vault-channel.ts
+++ b/app/apps/server/src/sync/vault-channel.ts
@@ -79,6 +79,18 @@ export interface VaultChannelDeps {
  *  creates one row per folder/note, each firing `onRegistryChanged`; folding them
  *  into one frame per window is the difference between ~1,100 broadcasts (and
  *  ~1,100 per-subscriber ACL recomputes) and a handful. */
+/**
+ * Close codes this channel sends, in the 4000-4999 application range.
+ *
+ * `UNAUTHORIZED` is fatal — the client must stop retrying, the way it already
+ * stops on an HTTP 403 from the token mint. `PROTOCOL` covers a client that did
+ * not speak `hello` correctly or whose ACL could not be resolved; those are also
+ * not worth an immediate retry, but they are not a credential problem.
+ * Mirrored in `desktop/src/lib/sync/vaultSyncEngine.ts` as `WS_CLOSE_*`.
+ */
+export const WS_CLOSE_UNAUTHORIZED = 4401;
+export const WS_CLOSE_PROTOCOL = 4400;
+
 export const REGISTRY_COALESCE_MS = 120;
 
 /** Most docs one `ready.behind` names — the same bound `ready.empty` uses. */
@@ -423,7 +435,8 @@ class VaultConnection {
     try {
       claims = await this.deps.verifyToken(hello.token);
     } catch {
-      return this.fail("invalid or expired vault token");
+      // Fatal: retrying with the same token only burns the ladder.
+      return this.fail("invalid or expired vault token", WS_CLOSE_UNAUTHORIZED);
     }
     this.userId = claims.userId;
     this.vaultId = claims.vaultId;
@@ -734,19 +747,25 @@ class VaultConnection {
       // provider down and back up) plus a full registry pull, whose own writes
       // then published the next `registry-changed`. On a vault with work left to
       // do that never settled: the badge blinked Syncing/Synced indefinitely (#93).
-      void this.refreshAcl({ reauth: "if-changed" });
-      // Self-exclusion applies to the re-pull only. This client already holds the
-      // ids the API returned it, so asking it to re-pull its own writes is a
-      // wasted round trip (listFolders + listNotes + a full client syncStructure).
       // Skipped only when EVERY origin folded into this window is ours; a window
       // that also carried someone else's change — or an unattributed one — lands.
-      if (
+      const selfOnly =
         this.clientId !== null &&
         msg.origins.length > 0 &&
-        msg.origins.every((o) => o === this.clientId)
-      ) {
-        return;
-      }
+        msg.origins.every((o) => o === this.clientId);
+      // The readable set is recomputed either way — it must never go stale — but a
+      // client is not told that its OWN writes changed what it can read. It made
+      // those rows and already holds them, so the announcement bought nothing and
+      // cost a great deal: registering notes grew this client's own readable set,
+      // `if-changed` fired `reauth` straight back at it, the open note's provider
+      // was torn down and rebuilt (badge: synced→offline→connecting→synced), and
+      // the registry pull that followed published the next `registry-changed`. An
+      // idle client reauthed itself nine times in half an hour that way.
+      void this.refreshAcl({ reauth: selfOnly ? "never" : "if-changed" });
+      // Self-exclusion applies to the re-pull too. This client already holds the
+      // ids the API returned it, so asking it to re-pull its own writes is a
+      // wasted round trip (listFolders + listNotes + a full client syncStructure).
+      if (selfOnly) return;
       this.send({ t: "registry" });
       return;
     }
@@ -812,7 +831,9 @@ class VaultConnection {
     void this.refreshAcl();
   }
 
-  private async refreshAcl(opts: { reauth?: "always" | "if-changed" } = {}): Promise<void> {
+  private async refreshAcl(
+    opts: { reauth?: "always" | "if-changed" | "never" } = {},
+  ): Promise<void> {
     if (!this.userId || !this.vaultId) return;
     let next: Set<string>;
     try {
@@ -841,7 +862,11 @@ class VaultConnection {
     // caller opts out with `if-changed`, which still re-mints whenever the set
     // actually moved. A re-mint the client does not need is not free: it drops and
     // reopens the open note's socket.
-    if ((opts.reauth ?? "always") === "always" || added.length > 0 || lost > 0) {
+    // `never` is for a change this very client authored: the drops above still go
+    // out (losing access is news however it happened), but there is nothing to
+    // re-mint for writes it made itself.
+    const mode = opts.reauth ?? "always";
+    if (mode !== "never" && (mode === "always" || added.length > 0 || lost > 0)) {
       this.send({ t: "reauth" });
     }
     if (added.length > 0 && this.vaultId) {
@@ -1051,12 +1076,22 @@ class VaultConnection {
     this.ws.send(payload, { binary });
   }
 
-  private fail(message: string): void {
+  /**
+   * Refuse this connection, telling the client WHY in the close frame.
+   *
+   * The `{t:"err"}` message races the close and routinely loses, so the code is
+   * the only signal the client can rely on. Closing with no code at all (which is
+   * what a bare `ws.close()` sends — 1005) left a rejected token indistinguishable
+   * from a rebooting server, so the client blind-retried a credential the server
+   * had already refused, all the way up its backoff ladder. Keep these in lockstep
+   * with `WS_CLOSE_*` in `desktop/src/lib/sync/vaultSyncEngine.ts`.
+   */
+  private fail(message: string, code: number = WS_CLOSE_PROTOCOL): void {
     console.warn(
       `[vault-channel] refusing user=${this.userId ?? "?"} vault=${this.vaultId ?? "?"}: ${message}`,
     );
     this.send({ t: "err", message });
-    this.ws.close();
+    this.ws.close(code, message.slice(0, 120));
     this.cleanup();
   }
 

--- a/app/apps/server/src/yjs/persistence.ts
+++ b/app/apps/server/src/yjs/persistence.ts
@@ -144,11 +144,96 @@ export function compareStateVectors(
   return { serverCovered, clientAhead };
 }
 
+/** Drop the cached vector for a doc whose history was rewritten underneath it. */
+async function invalidateStateVector(docId: string, db: Queryable): Promise<void> {
+  try {
+    await db.query("DELETE FROM doc_state_vectors WHERE doc_id = $1", [docId]);
+  } catch (err) {
+    console.warn(`[yjs] state-vector cache invalidate failed for ${docId}:`, err);
+  }
+}
+
+/**
+ * The cached state vector for `docId`, but ONLY when it provably describes the
+ * doc's current log. `upto_update_id` must equal the log's max id (both NULL when
+ * the log is empty); anything else means an append landed after the vector was
+ * written, and a vector that is merely close is worse than none — it would report
+ * a client "up to date" while ops it has never seen sit in the log.
+ *
+ * One indexed query, no BYTEA of the log, no merge.
+ */
+async function currentStateVector(
+  docId: string,
+  db: Queryable,
+): Promise<Uint8Array | null> {
+  const { rows } = await db.query<{ state_vector: Buffer; fresh: boolean }>(
+    `SELECT v.state_vector,
+            v.upto_update_id IS NOT DISTINCT FROM
+              (SELECT max(u.id) FROM doc_updates u WHERE u.doc_id = $1) AS fresh
+       FROM doc_state_vectors v
+      WHERE v.doc_id = $1`,
+    [docId],
+  );
+  const row = rows[0];
+  if (!row || !row.fresh) return null;
+  return new Uint8Array(row.state_vector);
+}
+
+/**
+ * Record the state vector for `docId` along with the log position it accounts
+ * for. Safe to call from a read path: the pair is written together, so a stale
+ * write is detected by the freshness check rather than trusted.
+ */
+async function rememberStateVector(
+  docId: string,
+  stateVector: Uint8Array,
+  uptoUpdateId: string | null,
+  db: Queryable,
+): Promise<void> {
+  try {
+    await db.query(
+      `INSERT INTO doc_state_vectors (doc_id, state_vector, upto_update_id, updated_at)
+       VALUES ($1, $2, $3, now())
+       ON CONFLICT (doc_id) DO UPDATE
+         SET state_vector = EXCLUDED.state_vector,
+             upto_update_id = EXCLUDED.upto_update_id,
+             updated_at = now()`,
+      [docId, Buffer.from(stateVector), uptoUpdateId],
+    );
+  } catch (err) {
+    // A cache miss is a slow read, never a failed one — this must not be able to
+    // fail a sync.
+    console.warn(`[yjs] state-vector cache write failed for ${docId}:`, err);
+  }
+}
+
 export async function loadDocDiff(
   docId: string,
   clientStateVector: Uint8Array | null,
   db: Queryable = defaultPool,
 ): Promise<DocDiff | null> {
+  // FAST PATH, and the one that matters at scale: a cached per-doc state vector
+  // that is provably current. This is the question the vault channel asks for
+  // every readable doc on every connect, and the honest answer is almost always
+  // "you already have everything" — which this settles in ONE indexed query with
+  // no log read and no merge. Only a client that is genuinely behind pays for the
+  // work below. See `doc_state_vectors` (migration 025).
+  if (clientStateVector) {
+    const cached = await currentStateVector(docId, db);
+    if (cached) {
+      const cmp = bytesEqual(clientStateVector, cached)
+        ? { serverCovered: true, clientAhead: false }
+        : compareStateVectors(clientStateVector, cached);
+      if (cmp.serverCovered) {
+        return {
+          update: new Uint8Array(0),
+          serverStateVector: cached,
+          upToDate: true,
+          clientAhead: cmp.clientAhead,
+        };
+      }
+    }
+  }
   // Probe: does a snapshot exist, is its stored state vector usable, and is
   // anything sitting in the log on top of it? Deliberately selects no BYTEA.
   const probe = await db.query<{ state_vector: Buffer | null; pending: boolean }>(
@@ -193,8 +278,8 @@ export async function loadDocDiff(
     "SELECT snapshot FROM doc_snapshots WHERE doc_id = $1",
     [docId],
   );
-  const updates = await db.query<{ update: Buffer }>(
-    "SELECT update FROM doc_updates WHERE doc_id = $1 ORDER BY id ASC",
+  const updates = await db.query<{ id: string; update: Buffer }>(
+    "SELECT id, update FROM doc_updates WHERE doc_id = $1 ORDER BY id ASC",
     [docId],
   );
   const snapshotBuf = snap.rows[0]?.snapshot ?? null;
@@ -202,6 +287,15 @@ export async function loadDocDiff(
 
   const merged = mergeParts(snapshotBuf, updates.rows);
   const serverStateVector = Y.encodeStateVectorFromUpdate(merged);
+  // Seed the cache from the work we just did, so a doc that predates migration
+  // 025 pays this once rather than on every connect. `updates.rows` is the log we
+  // actually read, so its last id is exactly what this vector accounts for.
+  void rememberStateVector(
+    docId,
+    serverStateVector,
+    updates.rows.length > 0 ? (updates.rows[updates.rows.length - 1]?.id ?? null) : null,
+    db,
+  );
   const cmp = clientStateVector
     ? bytesEqual(clientStateVector, serverStateVector)
       ? { serverCovered: true, clientAhead: false }
@@ -281,6 +375,15 @@ export async function appendUpdate(
     "INSERT INTO doc_updates (doc_id, update) VALUES ($1, $2)",
     [docId, Buffer.from(update)],
   );
+  // The cached state vector is deliberately NOT updated here. Appending moves the
+  // log's max id past the watermark the cache recorded, which makes the cache read
+  // as stale on its own — so the next reader recomputes and re-caches.
+  //
+  // Maintaining it from this side looks cheaper and is not safe: two concurrent
+  // appends would each fold their own update into whatever they had read, and the
+  // one that wrote last would stamp a watermark covering an update its vector
+  // never saw. A vector that is trusted and wrong withholds ops from a client
+  // silently, which is the one failure mode this cache must never have.
 
   const { rows } = await db.query<{ count: string }>(
     "SELECT count(*)::text AS count FROM doc_updates WHERE doc_id = $1",
@@ -351,6 +454,11 @@ export async function compact(
       "DELETE FROM doc_updates WHERE doc_id = $1 AND id <= $2",
       [docId, maxId],
     );
+    // Compacting rewrites what the log contains, so any cached vector's watermark
+    // now describes rows that are gone. Drop it and let the next read recompute —
+    // same reasoning as `appendUpdate`: an update appended while we were merging
+    // would otherwise be covered by a watermark whose vector predates it.
+    await invalidateStateVector(docId, db);
   } finally {
     doc.destroy();
   }
@@ -406,6 +514,10 @@ export async function resetDocCrdt(
              updated_at = now()`,
       [docId, snapshot, stateVector],
     );
+    // REPLACE, never merge: this doc's history was deliberately discarded, so the
+    // new vector is not a superset of the old one and folding them together would
+    // claim clocks that no longer exist. The log is empty, hence a NULL watermark.
+    await rememberStateVector(docId, new Uint8Array(stateVector), null, db);
     return { bytes: snapshot.byteLength };
   } finally {
     doc.destroy();

--- a/app/apps/server/tests/persistence.test.ts
+++ b/app/apps/server/tests/persistence.test.ts
@@ -324,6 +324,55 @@ describe("loadDocDiff (vault-channel backfill)", () => {
     expect(client.getText("content").toString()).toBe("# shared + local only");
   });
 
+  it("caches a doc's state vector so an unchanged doc costs one query and no merge", async () => {
+    // The point of migration 025. A note edited fewer than COMPACTION_THRESHOLD
+    // times has no `doc_snapshots` row, so before the cache EVERY connect read its
+    // whole update log and ran `Y.mergeUpdates` over it, only to conclude the
+    // client was already current — thousands of queries and hundreds of
+    // single-threaded merges standing in front of one `ready` frame.
+    const doc = await seedDoc("cached");
+    const sv = Y.encodeStateVector(doc);
+
+    // First read pays the slow path and populates the cache.
+    const cold = await loadDocDiff(DOC, sv);
+    expect(cold!.upToDate).toBe(true);
+
+    const { db, sql } = countingDb();
+    const warm = await loadDocDiff(DOC, sv, db);
+    expect(warm!.upToDate).toBe(true);
+    expect(warm!.update.length).toBe(0);
+    // Neither the log nor the snapshot was touched.
+    expect(sql.some((q) => q.includes(SNAPSHOT_READ))).toBe(false);
+    expect(sql.some((q) => q.includes("SELECT id, update FROM doc_updates"))).toBe(false);
+    expect(sql).toHaveLength(1);
+  });
+
+  it("a new update invalidates the cached vector instead of being missed by it", async () => {
+    // The hazard the watermark exists for: a cached vector that is TRUSTED and
+    // stale would report a client up to date while ops it has never seen sit in
+    // the log — withholding content silently, the one failure this must not have.
+    const doc = await seedDoc("before");
+    const sv = Y.encodeStateVector(doc);
+    // A snapshot of the client as it stands now, before the server moves on.
+    const before = new Y.Doc();
+    Y.applyUpdate(before, Y.encodeStateAsUpdate(doc));
+    await loadDocDiff(DOC, sv); // populate the cache
+
+    const later: Uint8Array[] = [];
+    doc.on("update", (u: Uint8Array) => later.push(u));
+    doc.getText("content").insert(6, " and after");
+    for (const u of later) await appendUpdate(DOC, u, pool, 1000);
+
+    const diff = await loadDocDiff(DOC, sv);
+    expect(diff!.upToDate).toBe(false);
+    // `update` is a DIFF against `sv`, so it only means anything applied to a doc
+    // already at that state — which is exactly the client the server is answering.
+    const behind = new Y.Doc();
+    Y.applyUpdate(behind, Y.encodeStateAsUpdate(before));
+    Y.applyUpdate(behind, diff!.update);
+    expect(behind.getText("content").toString()).toBe("before and after");
+  });
+
   it("an equal or merely behind client is not `clientAhead`", async () => {
     const doc = await seedDoc("base");
     const equal = await loadDocDiff(DOC, Y.encodeStateVector(doc));

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+- Baalda now connects to your vault almost as soon as it opens. The connection used to wait for the whole vault to be checked over first; now it starts straight away and the two happen together, so the sync light settles in about a second instead of five — on launch and when you switch vaults
+- Opening a note no longer says "Syncing". The light at the top now describes your vault's connection, not whichever note you happen to have open, so it stops flickering every time you click a file
+- Fixed a loop where notes that were already synced kept syncing again: switching vaults could quietly drop incoming changes, and a note shared with you as view-only could never finish. Both now settle for good
+- If the connection drops, Baalda reconnects almost immediately instead of pausing for several seconds, and it can now tell a sign-in problem apart from a server that is simply restarting
 - Baalda now opens straight into your vault: the sidebar appears right away and signing in, syncing and indexing carry on in the background. Notes you click in those first moments still open safely
 - You can now leave a vault you don't own: Vault Settings → Vaults → Leave. The vault is removed from your devices, the owner is notified by email, and you get a receipt
 - Moving a Pro subscription to another vault now opens a clear dialog that shows each eligible vault with its members and explains what changes, instead of a bare dropdown


### PR DESCRIPTION
## Why

The vault opens instantly, but the app then took **4–5 seconds** to actually connect — on launch and on every vault switch. Two secondary complaints share the same plumbing: the sync badge flickers, and notes that already synced sometimes sync again.

## What was causing it

**Serial latency, not work.** The vault WebSocket was not constructed until `registry.reconcile()` had fully resolved — six sequential HTTP round trips, then the socket, then the token minted *after* `onopen`. The badge flips green on exactly one event (the server's `ready` frame), so every hop sat on the critical path.

**On the server, `ready` was blocked behind a full CRDT merge of nearly every doc in the vault.** `loadDocDiff`'s fast path only exists for docs past `COMPACTION_THRESHOLD` (50) lifetime updates, so an ordinary note took the slow path on every connect — an EXISTS probe, a snapshot read, its whole `doc_updates` log and a `Y.mergeUpdates` over its history, usually only to conclude the client was already current. For a few-hundred-note vault that is thousands of queries and hundreds of single-threaded merges in front of one frame.

## Changes

**Connect path (desktop)**
- The vault channel opens during the PRIME window, in parallel with the reconcile. The collection id is the only thing the socket needs and the prime has already read it from `.context/config.json`. Safe because `enabled` and `pulledOnce` both stay false until the reconcile returns — that is what gates uploads, `markLive`, and the revocation/disk-delete paths.
- The vault token is minted concurrently with the TCP/TLS handshake instead of after it.
- The folder and note listings are prefetched optimistically against the cached collection id, in parallel with the `listVaults` call whose only job is to validate it.
- `initAuth` no longer holds the landing behind the member roster and both invitation lists; `refreshVault({ rosterInBackground: true })` resolves as soon as `organizations` is published.

**Server — migration 025 `doc_state_vectors`**
- "Is this client current?" is now one indexed query and no merge. The `upto_update_id` watermark is what makes the cached vector trustworthy: a reader trusts it only when it matches the log's current max id.
- Deliberately **not** maintained by `appendUpdate`/`compact`. Two concurrent appends could each fold their own update into what they had read, and the last writer would stamp a watermark covering an update its vector never saw. A vector that is trusted and wrong withholds ops from a client silently — the one failure mode this cache must not have. Appending moves the max id past the watermark, which invalidates the cache on its own; the read path recomputes and re-caches, which also backfills docs that predate the migration.

**Fixes**
- **A client reauthed itself over its own registry writes.** `refreshAcl` had no origin self-exclusion, so a client's own pull registering notes grew its own readable set, fired `reauth` back at it, tore the open note's provider down and up, and published the next `registry-changed`. An idle client did this nine times in half an hour. (#129)
- **The badge described the open note, not the vault.** Every file you opened repainted the vault-wide pill "connecting". The note now speaks for the app only when it has something the channel cannot express (`read-only`, `no-access`, `deleted`, `too-large`). A drop out of a settled state is held ~400ms, and a deliberate token re-mint no longer reports itself as `offline`.
- **A vault switch dropped inbound updates permanently.** `drainInbound` caught a Rust `vault-mismatch` per frame and carried on, discarding a whole backfill one doc at a time — and a dropped frame never advances the state vector, so the server re-offered the same ops on the next connect, forever if the engine outlived its epoch. A stale epoch now stops the engine.
- **A view-only note could never finish syncing.** `pushOne` waited for a flush ack a read-only grant will never produce, failed, and never reached `markPushed`, returning on every `ready.behind`. It now takes the exemption `confirmOpenDoc` has always taken.
- **Reconnects paused for seconds and never said why.** First retry is now near-immediate (50ms) with the jittered ladder from the second lap. `ws.onerror` discarded its event and `closeSocket` detached `onclose` before the close frame landed — which is why every failure logged as a bare "socket error"; the close handler now survives the detach and the server sends real close codes (`4401` auth, `4400` protocol), so a refused credential stops the ladder.

## Deliberately left out

- **De-duplicating the readable-set resolution** (four times per startup). That is the ACL resolver gating all privacy, and the safe shape is a cache with staleness hazards that could reintroduce the revocation bugs #98 fixed. Worth ~6 indexed queries now that the per-doc merge is gone.
- **The `deriveVaultWsUrl` path-prefix footgun.** Fixing it widens upgrade-path matching on a public server and is unverifiable without a prefixed deployment.
- **Persisting `permanentFailures`.** Adds `config.json` schema surface that travels with the vault, for one bounded re-fail wave per launch on >10 MB docs.

One planned item was impossible: `keychainGet` cannot overlap `getServerUrl`, because the keychain key is derived from the server URL.

## Testing

- Desktop: 1370 pass (the bridge suites — `echo`, `concurrent`, `rewrite`, `roundtrip` — green).
- Server: 612 pass, against a scratch `context_test_instant` DB, with migration 025 applied.
- Two new persistence tests pin the fast path: an unchanged doc costs one query and reads neither the log nor the snapshot; a new append invalidates the cached vector rather than being missed by it.
- `vite build` clean.

**Not yet measured on a real cold launch.** There was no instrumentation past `reconcile-done` before this, so the WS phase could not be attributed; this adds `channel-start`, `socket-open`, `token-minted`, `hello-sent` and `channel-ready`. Taking a baseline needs a signed-in run against `api.baalda.com` (`VITE_SERVER_URL=… pnpm run dev:desktop`, then read `~/Library/Logs/com.baalda.context/Baalda.log`). Worth doing on staging before promotion.

## Migration

025 is additive (a new table, no backfill job). It runs through the pipeline pre-deploy as usual.

Refs #129
