### PR TITLE
Release v0.1.59

### DIFF
--- a/app/apps/desktop/package.json
+++ b/app/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.1.58",
+  "version": "0.1.59",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/app/apps/desktop/src-tauri/Cargo.lock
+++ b/app/apps/desktop/src-tauri/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.1.58"
+version = "0.1.59"
 dependencies = [
  "keyring",
  "log",

--- a/app/apps/desktop/src-tauri/Cargo.toml
+++ b/app/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.1.58"
+version = "0.1.59"
 description = "Baalda — local-first markdown app"
 authors = ["Baalda"]
 license = "Apache-2.0"

--- a/app/apps/desktop/src-tauri/tauri.conf.json
+++ b/app/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Baalda",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "identifier": "com.baalda.context",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump for the v0.1.59 release: `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`.

Ships #140 — the vault channel now connects during the prime window instead of behind the whole reconcile, the server answers "is this client up to date?" from a cached per-doc state vector (migration 025), and the badge stops re-syncing what is already synced.

Release notes and changelog for these landed with #140.