### PR TITLE
Log the Coolify deploy path in the changelog and fix its env example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,24 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   now one mechanism for both.
 
 ### Added
+- **A Coolify deploy path for self-hosters** (`deploy/coolify/`, contributed by
+  [@JotaSXBR](https://github.com/JotaSXBR), #135, closes #97). Coolify — and any
+  PaaS that runs `docker compose` with the REPO ROOT as the project directory —
+  resolves `deploy/compose/docker-compose.yml`'s `context: ../..` two levels
+  ABOVE the repo root, so the build fails before it starts. The new file is the
+  same `postgres → migrate → server` stack with `context: .` and no published
+  ports (Coolify's own Traefik terminates TLS and reaches the container on the
+  internal network), leaving `deploy/compose/` untouched for the VPS + nginx path.
+  `POSTGRES_PASSWORD` and `JWT_SECRET` come from Coolify's magic env vars, so a
+  first deploy needs nothing typed in. Three Coolify-specific traps are documented
+  in `deploy/coolify/README.md` because none of them are obvious from Coolify's
+  docs: its parser reads `${VAR:?text}` as a PREFILLED DEFAULT, not bash's error
+  message, so our guard clauses would have become literal garbage values; an unset
+  `${VAR}` arrives as an EMPTY STRING rather than an absent key, which
+  `config.ts`'s `required(name, fallback)` does not catch (`??` only fires on
+  undefined), so the default has to live in the compose interpolation; and a
+  since-fixed Coolify bug (v4.3.19) could corrupt a saved domain into a bare
+  `https://`. Verified end-to-end on a live instance, desktop sync included.
 - **`ready.revoked` — the server STATES a revocation on every connect.** The
   vault channel's `ready` frame gained `revoked` / `revokedTruncated`
   (`sync/vault-protocol.ts`), the third of its doc lists after `empty` and

--- a/deploy/coolify/.env.example
+++ b/deploy/coolify/.env.example
@@ -4,7 +4,7 @@
 #
 # POSTGRES_PASSWORD and JWT_SECRET are NOT listed here: docker-compose.yml
 # generates both automatically via Coolify's magic env vars
-# (SERVICE_PASSWORD_POSTGRES, SERVICE_REALBASE64_64_JWT) — nothing to set.
+# (SERVICE_PASSWORD_64_POSTGRES, SERVICE_REALBASE64_64_JWT) — nothing to set.
 
 # --- Required ---------------------------------------------------------------
 


### PR DESCRIPTION
## Why

Follow-up to #135, which added `deploy/coolify/` but landed without a `CHANGELOG.md` entry, and whose `.env.example` header named `SERVICE_PASSWORD_POSTGRES` while the compose file it documents uses `SERVICE_PASSWORD_64_POSTGRES` — the symbol-free variant, chosen deliberately because the bare one can emit `@ : /`, which are unsafe unescaped inside `DATABASE_URL`'s `postgres://` string.

Both are comment-level, so neither could break a deploy; the env example one would just send a self-hoster looking for the wrong variable in Coolify's UI.

## What changed

- `CHANGELOG.md` Unreleased → Added: the Coolify path, credited to @JotaSXBR, with the three Coolify-specific traps recorded so the next person to touch that file does not rediscover them.
- `deploy/coolify/.env.example`: the magic var name now matches `docker-compose.yml`.

## Scope

Docs and a comment. No compose/YAML values change, no application code. `docs/RELEASE_NOTES.md` is unchanged — a self-host deploy option is not an in-app user-visible change.