### PR TITLE
Await the state-vector cache write and reset the cache between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -695,6 +695,31 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   the vault (switching vaults starts a fresh strip).
 
 ### Fixed
+- **The state-vector cache was seeded by a fire-and-forget write, and its test
+  raced it.** `loadDocDiff`'s slow path ended in `void rememberStateVector(...)`,
+  so the function RETURNED BEFORE the INSERT committed. `persistence.test.ts`'s
+  "caches a doc's state vector" does a cold read and then immediately a warm one
+  and asserts the warm read never touched the snapshot — which is only true if
+  the write won the race. It often did not: measured locally, the row was still
+  absent the instant the cold call returned **35 times out of 40**, and the
+  unmodified suite failed 3 runs in 8. That is the intermittent
+  `expected true to be false` at `persistence.test.ts:345` that reddened `main`
+  while the SAME commit passed on `staging`. Awaiting the write settles it (0 in
+  8). Nothing was ever wrong in production: the watermark guard means a late or
+  out-of-order write is either correct or correctly DISTRUSTED — a vector is
+  trusted only while `upto_update_id` still equals the log's `max(id)` — so no
+  client was served a stale vector. What the `void` did cost was real though:
+  the write escaped the pool's backpressure, so a big vault's first connect
+  fired a burst of unobserved INSERTs against the same connections `runPool`
+  was using for backfill reads.
+- **`doc_state_vectors` was never truncated between server tests.** It was
+  missing from `resetDb`'s table list while the table it describes,
+  `doc_updates`, is truncated WITH `RESTART IDENTITY` — so a row left by an
+  earlier test could carry a watermark that accidentally matched the next test's
+  rewound log, and `loadDocDiff` would then trust a vector belonging to a
+  different document. Not the cause of the flake above (adding it changed the
+  failure rate not at all), but a cache the code trusts has to be reset with the
+  log it describes.
 - **One daily checkpoint could drown out every other server log.**
   `captureCheckpoint` walked a vault's notes and `console.warn`ed a line per
   note it skipped, for two reasons that are both ORDINARY at scale: a note

--- a/app/apps/server/src/yjs/persistence.ts
+++ b/app/apps/server/src/yjs/persistence.ts
@@ -290,7 +290,15 @@ export async function loadDocDiff(
   // Seed the cache from the work we just did, so a doc that predates migration
   // 025 pays this once rather than on every connect. `updates.rows` is the log we
   // actually read, so its last id is exactly what this vector accounts for.
-  void rememberStateVector(
+  //
+  // AWAITED, not fire-and-forget. One INSERT is noise next to what this path has
+  // already spent — a snapshot BYTEA, the whole update log and a `Y.mergeUpdates`
+  // over it — and un-awaited it bought two problems. The write escaped the pool's
+  // backpressure, so a large vault's first connect fired a burst of unobserved
+  // INSERTs competing with `runPool`'s own backfill reads for the same
+  // connections. And the cache was not yet readable when this call returned, so
+  // the very next read of the same doc could still miss it and redo the merge.
+  await rememberStateVector(
     docId,
     serverStateVector,
     updates.rows.length > 0 ? (updates.rows[updates.rows.length - 1]?.id ?? null) : null,

--- a/app/apps/server/tests/helpers/db.ts
+++ b/app/apps/server/tests/helpers/db.ts
@@ -21,6 +21,11 @@ const TABLES = [
   "files",
   "folders",
   "vaults",
+  // Trusted by `loadDocDiff`'s fast path, and `RESTART IDENTITY` below rewinds
+  // `doc_updates`' ids — so a row left behind by an earlier test can have a
+  // watermark that accidentally matches the next test's fresh log, and a stale
+  // vector then reads as valid. It has to be reset with the log it describes.
+  "doc_state_vectors",
   "doc_updates",
   "doc_snapshots",
   "blobs",


### PR DESCRIPTION
## Why

CI was intermittently red on `persistence.test.ts:345` — `expected true to be false` in *"caches a doc's state vector so an unchanged doc costs one query and no merge"*. Commit `c35d12c` **passed on `staging` and failed on `main` at the same SHA**, which is the signature of a race rather than a regression.

`loadDocDiff`'s slow path ended in `void rememberStateVector(...)`, so it **returned before the INSERT committed**. The test does a cold read and then immediately a warm one, asserting the warm read never touched the snapshot — true only if the write won the race. Measured locally, it usually did not:

| | cache row absent when the cold call returns | suite failures |
| --- | --- | --- |
| before | **35 / 40** | **3 / 8 runs** |
| after | 0 / 40 | **0 / 8 runs** |

Full server suite on a scratch DB: **53 files, 612 tests, all passing**. `tsc --noEmit` clean.

## Production was never wrong — and this is not urgent

The watermark guard already makes a late or out-of-order write safe: `currentStateVector` trusts a cached vector only while `upto_update_id` still equals the log's `max(id)`, and the writer stamps the vector together with the exact log position it was computed from. A racing `appendUpdate` therefore makes the cache **correctly distrusted**, never trusted-and-stale. The failure mode that would matter — telling a client it is up to date while unseen ops sit in the log — cannot arise from this. No hotfix; this rides the next promotion.

What the `void` *did* cost is real, though, and is the reason to prefer `await` on its own merits: the write escaped the pool's backpressure, so a large vault's first connect fired a burst of unobserved INSERTs competing with `runPool`'s backfill reads for the same connections. And the cache was not readable when the call returned, so the next read of the same doc could miss it and redo the whole merge. The cost of awaiting lands only on the slow path, which has already paid a snapshot BYTEA, the full update log and a `Y.mergeUpdates` over it — one INSERT is noise beside that.

## Also: `doc_state_vectors` was never truncated between tests

It was missing from `resetDb`'s table list, while the table it describes (`doc_updates`) is truncated **with `RESTART IDENTITY`**. So a row left by an earlier test could carry a watermark that accidentally matched the next test's rewound log, and `loadDocDiff` would trust a vector belonging to a different document.

This was **not** the cause of the flake — adding the truncate changed the failure rate not at all (2/6 vs 3/8) — but a cache the code trusts has to be reset alongside the log it describes.

## Scope

Server only: one `await`, one test-helper table entry, plus comments recording why. No migration, no desktop code, no API or wire change, so no version bump. `docs/RELEASE_NOTES.md` unchanged — nothing here is visible in the app.